### PR TITLE
refactor: expose row diff adapter hooks

### DIFF
--- a/src/sqlbuild/adapter/base/base_adapter.py
+++ b/src/sqlbuild/adapter/base/base_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,7 @@ from sqlbuild.adapter.shared.models import (
     RelationInfo,
     RowDiffResult,
     RowDiffSampleRow,
+    RowDiffTolerance,
     RowDiffTolerances,
     SchemaDiffResult,
     StatementRecorder,
@@ -537,6 +539,118 @@ class BaseAdapter(StrictAdapter):
         raise NotImplementedError(
             "sample_side_only_rows requires an engine-specific implementation"
         )
+
+    def validate_row_diff_keys(
+        self,
+        connection: Any,
+        *,
+        relation_sql: str,
+        relation_label: str,
+        keys: tuple[str, ...],
+    ) -> None:
+        if not keys:
+            raise ValueError("row diff requires at least one unique_key column")
+        null_condition: str = " OR ".join(f"{key} IS NULL" for key in keys)
+        null_count_sql: str = (
+            f"SELECT COUNT(*) FROM ({relation_sql}) AS __key_check WHERE {null_condition}"
+        )
+        null_row: tuple[Any, ...] = self.execute(connection, null_count_sql).fetchone()
+        if int(null_row[0]) > 0:
+            raise ValueError(f"row diff {relation_label} relation contains null unique_key values")
+
+        key_list: str = ", ".join(keys)
+        duplicate_count_sql: str = (
+            f"SELECT COUNT(*) FROM ("
+            f"SELECT {key_list} FROM ({relation_sql}) AS __key_check "
+            f"GROUP BY {key_list} HAVING COUNT(*) > 1"
+            f") AS __duplicates"
+        )
+        duplicate_row: tuple[Any, ...] = self.execute(connection, duplicate_count_sql).fetchone()
+        if int(duplicate_row[0]) > 0:
+            raise ValueError(
+                f"row diff {relation_label} relation contains duplicate unique_key values"
+            )
+
+    def build_row_diff_equal_expression(
+        self,
+        *,
+        column: str,
+        column_info: ColumnInfo,
+        tolerances: RowDiffTolerances | None,
+    ) -> str:
+        tolerance: RowDiffTolerance | None = self.resolve_row_diff_tolerance(
+            column=column,
+            column_type=column_info.type,
+            tolerances=tolerances,
+        )
+        left_expression: str = f"__left.{column}"
+        right_expression: str = f"__right.{column}"
+        if tolerance is None:
+            return f"{left_expression} IS NOT DISTINCT FROM {right_expression}"
+        threshold_parts: list[str] = []
+        if tolerance.absolute is not None:
+            threshold_parts.append(self.format_row_diff_decimal_sql(tolerance.absolute))
+        if tolerance.relative is not None:
+            threshold_parts.append(
+                f"{self.format_row_diff_decimal_sql(tolerance.relative)} * "
+                f"GREATEST(ABS({left_expression}), ABS({right_expression}))"
+            )
+        threshold_sql: str = threshold_parts[0]
+        if len(threshold_parts) > 1:
+            threshold_sql = f"GREATEST({', '.join(threshold_parts)})"
+        return (
+            f"(({left_expression} IS NULL AND {right_expression} IS NULL) OR "
+            f"({left_expression} IS NOT NULL AND {right_expression} IS NOT NULL AND "
+            f"ABS({left_expression} - {right_expression}) <= {threshold_sql}))"
+        )
+
+    def resolve_row_diff_tolerance(
+        self,
+        *,
+        column: str,
+        column_type: str,
+        tolerances: RowDiffTolerances | None,
+    ) -> RowDiffTolerance | None:
+        if tolerances is None:
+            return None
+        column_tolerance: RowDiffTolerance | None = tolerances.by_column.get(column)
+        if column_tolerance is not None:
+            if self.normalize_row_diff_numeric_type(column_type) is None:
+                raise ValueError(f"row diff tolerance for non-numeric column '{column}' is invalid")
+            self.validate_row_diff_tolerance(
+                column=column,
+                tolerance=column_tolerance,
+            )
+            return column_tolerance
+        normalized_type: str | None = self.normalize_row_diff_numeric_type(column_type)
+        if normalized_type is None:
+            return None
+        type_tolerance: RowDiffTolerance | None = tolerances.by_type.get(normalized_type)
+        if type_tolerance is not None:
+            self.validate_row_diff_tolerance(
+                column=column,
+                tolerance=type_tolerance,
+            )
+        return type_tolerance
+
+    def validate_row_diff_tolerance(self, *, column: str, tolerance: RowDiffTolerance) -> None:
+        if tolerance.absolute is None and tolerance.relative is None:
+            raise ValueError(
+                f"row diff tolerance for column '{column}' must define absolute or relative"
+            )
+
+    def normalize_row_diff_numeric_type(self, column_type: str) -> str | None:
+        normalized: str = column_type.upper()
+        if any(token in normalized for token in ("DOUBLE", "FLOAT", "REAL")):
+            return "float"
+        if any(token in normalized for token in ("DECIMAL", "NUMERIC")):
+            return "decimal"
+        if "INT" in normalized:
+            return "integer"
+        return None
+
+    def format_row_diff_decimal_sql(self, value: Decimal) -> str:
+        return format(value, "f")
 
     def default_schema(self) -> str | None:
         """Return None — most adapters require explicit schema configuration."""

--- a/src/sqlbuild/integrations/duckdb/client.py
+++ b/src/sqlbuild/integrations/duckdb/client.py
@@ -613,13 +613,13 @@ class DuckDbAdapter(BaseAdapter):
         if cursor_filter:
             left_cte += f" WHERE {cursor_filter}"
             right_cte += f" WHERE {cursor_filter}"
-        self._validate_duckdb_row_diff_keys(
+        self.validate_row_diff_keys(
             connection,
             relation_sql=left_cte,
             relation_label="left",
             keys=keys,
         )
-        self._validate_duckdb_row_diff_keys(
+        self.validate_row_diff_keys(
             connection,
             relation_sql=right_cte,
             relation_label="right",
@@ -628,7 +628,7 @@ class DuckDbAdapter(BaseAdapter):
 
         join_condition: str = " AND ".join(f"__left.{k} = __right.{k}" for k in keys)
         column_equal_expressions: dict[str, str] = {
-            col: self._build_duckdb_row_equal_expression(
+            col: self.build_row_diff_equal_expression(
                 column=col,
                 column_info=left_columns_by_name[col],
                 tolerances=tolerances,
@@ -636,7 +636,7 @@ class DuckDbAdapter(BaseAdapter):
             for col in compare_columns
         }
         column_tolerances: dict[str, RowDiffTolerance | None] = {
-            col: self._resolve_duckdb_tolerance(
+            col: self.resolve_row_diff_tolerance(
                 column=col,
                 column_type=left_columns_by_name[col].type,
                 tolerances=tolerances,
@@ -746,20 +746,20 @@ class DuckDbAdapter(BaseAdapter):
         if cursor_filter:
             left_cte += f" WHERE {cursor_filter}"
             right_cte += f" WHERE {cursor_filter}"
-        self._validate_duckdb_row_diff_keys(
+        self.validate_row_diff_keys(
             connection,
             relation_sql=left_cte,
             relation_label="left",
             keys=keys,
         )
-        self._validate_duckdb_row_diff_keys(
+        self.validate_row_diff_keys(
             connection,
             relation_sql=right_cte,
             relation_label="right",
             keys=keys,
         )
         column_equal_expressions: dict[str, str] = {
-            col: self._build_duckdb_row_equal_expression(
+            col: self.build_row_diff_equal_expression(
                 column=col,
                 column_info=left_columns_by_name[col],
                 tolerances=tolerances,
@@ -844,13 +844,13 @@ class DuckDbAdapter(BaseAdapter):
         if cursor_filter:
             left_cte += f" WHERE {cursor_filter}"
             right_cte += f" WHERE {cursor_filter}"
-        self._validate_duckdb_row_diff_keys(
+        self.validate_row_diff_keys(
             connection,
             relation_sql=left_cte,
             relation_label="left",
             keys=keys,
         )
-        self._validate_duckdb_row_diff_keys(
+        self.validate_row_diff_keys(
             connection,
             relation_sql=right_cte,
             relation_label="right",
@@ -876,7 +876,7 @@ class DuckDbAdapter(BaseAdapter):
         rows: list[tuple[Any, ...]] = self.execute(connection, sample_sql).fetchall()
         return tuple(tuple((key, row[index]) for index, key in enumerate(keys)) for row in rows)
 
-    def _validate_duckdb_row_diff_keys(
+    def validate_row_diff_keys(
         self,
         connection: Any,
         *,
@@ -907,14 +907,14 @@ class DuckDbAdapter(BaseAdapter):
                 f"row diff {relation_label} relation contains duplicate unique_key values"
             )
 
-    @staticmethod
-    def _build_duckdb_row_equal_expression(
+    def build_row_diff_equal_expression(
+        self,
         *,
         column: str,
         column_info: ColumnInfo,
         tolerances: RowDiffTolerances | None,
     ) -> str:
-        tolerance: RowDiffTolerance | None = DuckDbAdapter._resolve_duckdb_tolerance(
+        tolerance: RowDiffTolerance | None = self.resolve_row_diff_tolerance(
             column=column,
             column_type=column_info.type,
             tolerances=tolerances,
@@ -925,10 +925,10 @@ class DuckDbAdapter(BaseAdapter):
             return f"{left_expression} IS NOT DISTINCT FROM {right_expression}"
         threshold_parts: list[str] = []
         if tolerance.absolute is not None:
-            threshold_parts.append(DuckDbAdapter._format_decimal_sql(tolerance.absolute))
+            threshold_parts.append(self.format_row_diff_decimal_sql(tolerance.absolute))
         if tolerance.relative is not None:
             threshold_parts.append(
-                f"{DuckDbAdapter._format_decimal_sql(tolerance.relative)} * "
+                f"{self.format_row_diff_decimal_sql(tolerance.relative)} * "
                 f"GREATEST(ABS({left_expression}), ABS({right_expression}))"
             )
         threshold_sql: str = threshold_parts[0]
@@ -940,8 +940,8 @@ class DuckDbAdapter(BaseAdapter):
             f"ABS({left_expression} - {right_expression}) <= {threshold_sql}))"
         )
 
-    @staticmethod
-    def _resolve_duckdb_tolerance(
+    def resolve_row_diff_tolerance(
+        self,
         *,
         column: str,
         column_type: str,
@@ -951,33 +951,31 @@ class DuckDbAdapter(BaseAdapter):
             return None
         column_tolerance: RowDiffTolerance | None = tolerances.by_column.get(column)
         if column_tolerance is not None:
-            if DuckDbAdapter._normalize_duckdb_numeric_type(column_type) is None:
+            if self.normalize_row_diff_numeric_type(column_type) is None:
                 raise ValueError(f"row diff tolerance for non-numeric column '{column}' is invalid")
-            DuckDbAdapter._validate_duckdb_tolerance(
+            self.validate_row_diff_tolerance(
                 column=column,
                 tolerance=column_tolerance,
             )
             return column_tolerance
-        normalized_type: str | None = DuckDbAdapter._normalize_duckdb_numeric_type(column_type)
+        normalized_type: str | None = self.normalize_row_diff_numeric_type(column_type)
         if normalized_type is None:
             return None
         type_tolerance: RowDiffTolerance | None = tolerances.by_type.get(normalized_type)
         if type_tolerance is not None:
-            DuckDbAdapter._validate_duckdb_tolerance(
+            self.validate_row_diff_tolerance(
                 column=column,
                 tolerance=type_tolerance,
             )
         return type_tolerance
 
-    @staticmethod
-    def _validate_duckdb_tolerance(*, column: str, tolerance: RowDiffTolerance) -> None:
+    def validate_row_diff_tolerance(self, *, column: str, tolerance: RowDiffTolerance) -> None:
         if tolerance.absolute is None and tolerance.relative is None:
             raise ValueError(
                 f"row diff tolerance for column '{column}' must define absolute or relative"
             )
 
-    @staticmethod
-    def _normalize_duckdb_numeric_type(column_type: str) -> str | None:
+    def normalize_row_diff_numeric_type(self, column_type: str) -> str | None:
         normalized: str = column_type.upper()
         if any(token in normalized for token in ("DOUBLE", "FLOAT", "REAL")):
             return "float"
@@ -987,6 +985,5 @@ class DuckDbAdapter(BaseAdapter):
             return "integer"
         return None
 
-    @staticmethod
-    def _format_decimal_sql(value: Decimal) -> str:
+    def format_row_diff_decimal_sql(self, value: Decimal) -> str:
         return format(value, "f")

--- a/src/sqlbuild/integrations/snowflake/client.py
+++ b/src/sqlbuild/integrations/snowflake/client.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 import csv
 import logging
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.adapter.shared.models import ColumnInfo, StatementRecorder
+from sqlbuild.adapter.shared.models import (
+    ColumnInfo,
+    RowDiffTolerance,
+    RowDiffTolerances,
+    StatementRecorder,
+)
 from sqlbuild.shared.helpers.diagnostics_logging import log_sql
 
 
@@ -365,6 +371,118 @@ class SnowflakeAdapter(BaseAdapter):
         statement: str
         for statement in statements:
             self.execute(connection, statement)
+
+    def validate_row_diff_keys(
+        self,
+        connection: Any,
+        *,
+        relation_sql: str,
+        relation_label: str,
+        keys: tuple[str, ...],
+    ) -> None:
+        if not keys:
+            raise ValueError("row diff requires at least one unique_key column")
+        null_condition: str = " OR ".join(f"{key} IS NULL" for key in keys)
+        null_count_sql: str = (
+            f"SELECT COUNT(*) FROM ({relation_sql}) AS __key_check WHERE {null_condition}"
+        )
+        null_row: tuple[Any, ...] = self.execute(connection, null_count_sql).fetchone()
+        if int(null_row[0]) > 0:
+            raise ValueError(f"row diff {relation_label} relation contains null unique_key values")
+
+        key_list: str = ", ".join(keys)
+        duplicate_count_sql: str = (
+            f"SELECT COUNT(*) FROM ("
+            f"SELECT {key_list} FROM ({relation_sql}) AS __key_check "
+            f"GROUP BY {key_list} HAVING COUNT(*) > 1"
+            f") AS __duplicates"
+        )
+        duplicate_row: tuple[Any, ...] = self.execute(connection, duplicate_count_sql).fetchone()
+        if int(duplicate_row[0]) > 0:
+            raise ValueError(
+                f"row diff {relation_label} relation contains duplicate unique_key values"
+            )
+
+    def build_row_diff_equal_expression(
+        self,
+        *,
+        column: str,
+        column_info: ColumnInfo,
+        tolerances: RowDiffTolerances | None,
+    ) -> str:
+        tolerance: RowDiffTolerance | None = self.resolve_row_diff_tolerance(
+            column=column,
+            column_type=column_info.type,
+            tolerances=tolerances,
+        )
+        left_expression: str = f"__left.{column}"
+        right_expression: str = f"__right.{column}"
+        if tolerance is None:
+            return f"{left_expression} IS NOT DISTINCT FROM {right_expression}"
+        threshold_parts: list[str] = []
+        if tolerance.absolute is not None:
+            threshold_parts.append(self.format_row_diff_decimal_sql(tolerance.absolute))
+        if tolerance.relative is not None:
+            threshold_parts.append(
+                f"{self.format_row_diff_decimal_sql(tolerance.relative)} * "
+                f"GREATEST(ABS({left_expression}), ABS({right_expression}))"
+            )
+        threshold_sql: str = threshold_parts[0]
+        if len(threshold_parts) > 1:
+            threshold_sql = f"GREATEST({', '.join(threshold_parts)})"
+        return (
+            f"(({left_expression} IS NULL AND {right_expression} IS NULL) OR "
+            f"({left_expression} IS NOT NULL AND {right_expression} IS NOT NULL AND "
+            f"ABS({left_expression} - {right_expression}) <= {threshold_sql}))"
+        )
+
+    def resolve_row_diff_tolerance(
+        self,
+        *,
+        column: str,
+        column_type: str,
+        tolerances: RowDiffTolerances | None,
+    ) -> RowDiffTolerance | None:
+        if tolerances is None:
+            return None
+        column_tolerance: RowDiffTolerance | None = tolerances.by_column.get(column)
+        if column_tolerance is not None:
+            if self.normalize_row_diff_numeric_type(column_type) is None:
+                raise ValueError(f"row diff tolerance for non-numeric column '{column}' is invalid")
+            self.validate_row_diff_tolerance(
+                column=column,
+                tolerance=column_tolerance,
+            )
+            return column_tolerance
+        normalized_type: str | None = self.normalize_row_diff_numeric_type(column_type)
+        if normalized_type is None:
+            return None
+        type_tolerance: RowDiffTolerance | None = tolerances.by_type.get(normalized_type)
+        if type_tolerance is not None:
+            self.validate_row_diff_tolerance(
+                column=column,
+                tolerance=type_tolerance,
+            )
+        return type_tolerance
+
+    def validate_row_diff_tolerance(self, *, column: str, tolerance: RowDiffTolerance) -> None:
+        if tolerance.absolute is None and tolerance.relative is None:
+            raise ValueError(
+                f"row diff tolerance for column '{column}' must define absolute or relative"
+            )
+
+    def normalize_row_diff_numeric_type(self, column_type: str) -> str | None:
+        normalized: str = column_type.upper()
+        if any(token in normalized for token in ("DOUBLE", "FLOAT", "REAL")):
+            return "float"
+        if any(token in normalized for token in ("DECIMAL", "NUMERIC", "NUMBER")):
+            return "decimal"
+        if "INT" in normalized:
+            return "integer"
+        return None
+
+    def format_row_diff_decimal_sql(self, value: Decimal) -> str:
+        return format(value, "f")
 
     def _initialize_session(
         self,


### PR DESCRIPTION
DuckDB incorrectly had some methods named personally for diffing, and Snowflake was missing them entirely (and BaseAdapter too). Snowflake still needs to actually be tested properly and have a suite added, but all the existing tests are otherwise passing, so this is the first stage of cleanup.