### PR TITLE
Feat/project local adapters

### DIFF
--- a/src/sqlbuild/adapter/shared/classes/connection.py
+++ b/src/sqlbuild/adapter/shared/classes/connection.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import contextlib
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Generator
 from typing import Any
 
 from sqlbuild.adapter.shared.models import QueryResult
 
 
-class ConnectionMixin:
+class ConnectionMixin(ABC):
     """Manages adapter connection lifecycle and transaction control."""
 
     @abstractmethod

--- a/src/sqlbuild/adapter/shared/classes/diff.py
+++ b/src/sqlbuild/adapter/shared/classes/diff.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Any
 
 from sqlbuild.adapter.shared.models import (
@@ -14,7 +14,7 @@ from sqlbuild.adapter.shared.models import (
 )
 
 
-class DiffMixin:
+class DiffMixin(ABC):
     """Compares relation data across environments."""
 
     @abstractmethod

--- a/src/sqlbuild/adapter/shared/classes/materialization.py
+++ b/src/sqlbuild/adapter/shared/classes/materialization.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
 from sqlbuild.adapter.shared.models import ColumnInfo, StatementRecorder
 
 
-class MaterializationMixin:
+class MaterializationMixin(ABC):
     """Executes SQL materialization operations against the warehouse."""
 
     @abstractmethod

--- a/src/sqlbuild/adapter/shared/classes/schema.py
+++ b/src/sqlbuild/adapter/shared/classes/schema.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Any
 
 from sqlbuild.adapter.shared.models import ColumnInfo, RelationInfo
 
 
-class SchemaMixin:
+class SchemaMixin(ABC):
     """Inspects warehouse schema and relation metadata."""
 
     @abstractmethod

--- a/src/sqlbuild/adapter/strict/strict_adapter.py
+++ b/src/sqlbuild/adapter/strict/strict_adapter.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from decimal import Decimal
+from typing import Any
 
 from sqlbuild.adapter.shared.classes.connection import ConnectionMixin
 from sqlbuild.adapter.shared.classes.diff import DiffMixin
 from sqlbuild.adapter.shared.classes.materialization import MaterializationMixin
 from sqlbuild.adapter.shared.classes.schema import SchemaMixin
+from sqlbuild.adapter.shared.models import (
+    ColumnInfo,
+    CursorValue,
+    RowDiffTolerance,
+    RowDiffTolerances,
+    StatementRecorder,
+)
 from sqlbuild.adapter.shared.types import FrameworkType, PromotionStrategy, TablePromotionMode
 
 
@@ -23,6 +32,229 @@ class StrictAdapter(
     The concrete defaults from ConnectionMixin (begin, commit, rollback,
     transaction, supports_transactions) are inherited but may be overridden.
     """
+
+    @abstractmethod
+    def supports_zero_copy_clone(self) -> bool:
+        """Return whether clone operations can use zero-copy semantics."""
+        ...
+
+    @abstractmethod
+    def supports_relation_age_metadata(self) -> bool:
+        """Return whether relation metadata includes reliable age information."""
+        ...
+
+    @abstractmethod
+    def recommended_max_sql_length(self) -> int | None:
+        """Return the recommended maximum SQL length for lightweight queries."""
+        ...
+
+    @abstractmethod
+    def describe_relation(self, connection: Any, relation: str) -> tuple[ColumnInfo, ...]:
+        """Return relation column metadata."""
+        ...
+
+    @abstractmethod
+    def query_column_names(self, connection: Any, sql: str) -> tuple[str, ...]:
+        """Return column names produced by a SQL query."""
+        ...
+
+    @abstractmethod
+    def build_cursor_filter(
+        self,
+        *,
+        cursor_column: str | None,
+        start_cursor: CursorValue | None,
+        end_cursor: CursorValue | None,
+    ) -> str:
+        """Build a WHERE clause fragment for cursor-bounded queries."""
+        ...
+
+    @abstractmethod
+    def schema_exists(
+        self,
+        connection: Any,
+        *,
+        database: str | None,
+        schema: str,
+    ) -> bool:
+        """Return whether the named schema exists in the warehouse."""
+        ...
+
+    @abstractmethod
+    def render_create_schema(
+        self,
+        *,
+        database: str | None,
+        schema: str,
+    ) -> tuple[str, ...]:
+        """Render SQL statements that create a schema if missing."""
+        ...
+
+    @abstractmethod
+    def render_create_table_as(self, *, target: str, sql: str) -> tuple[str, ...]:
+        """Render SQL statements that create or replace a table from a query."""
+        ...
+
+    @abstractmethod
+    def render_create_view_as(self, *, target: str, sql: str) -> tuple[str, ...]:
+        """Render SQL statements that create or replace a view from a query."""
+        ...
+
+    @abstractmethod
+    def render_append(
+        self, *, target: str, sql: str, columns: tuple[str, ...] | None = None
+    ) -> tuple[str, ...]:
+        """Render SQL statements that insert query rows into a target."""
+        ...
+
+    @abstractmethod
+    def render_delete_insert(
+        self,
+        *,
+        target: str,
+        sql: str,
+        unique_key: tuple[str, ...],
+        columns: tuple[str, ...] | None = None,
+    ) -> tuple[str, ...]:
+        """Render SQL statements for delete-insert by unique key."""
+        ...
+
+    @abstractmethod
+    def render_delete_insert_cursor(
+        self,
+        *,
+        target: str,
+        sql: str,
+        cursor_column: str,
+        cursor_start: str,
+        cursor_end: str,
+        columns: tuple[str, ...] | None = None,
+    ) -> tuple[str, ...]:
+        """Render SQL statements for cursor-bounded delete-insert."""
+        ...
+
+    @abstractmethod
+    def render_drop(self, *, target: str, if_exists: bool = True) -> tuple[str, ...]:
+        """Render SQL statements that drop a relation."""
+        ...
+
+    @abstractmethod
+    def render_rename(self, *, source: str, target: str) -> tuple[str, ...]:
+        """Render SQL statements that rename a relation."""
+        ...
+
+    @abstractmethod
+    def render_swap(self, *, left: str, right: str) -> tuple[str, ...]:
+        """Render SQL statements that swap two relations."""
+        ...
+
+    @abstractmethod
+    def render_clone(
+        self,
+        *,
+        source: str,
+        target: str,
+        hard_copy: bool = False,
+    ) -> tuple[str, ...]:
+        """Render SQL statements that clone or copy a relation."""
+        ...
+
+    @abstractmethod
+    def render_replace_table_from_relation(self, *, target: str, source: str) -> tuple[str, ...]:
+        """Render SQL statements that replace a target table from a source relation."""
+        ...
+
+    @abstractmethod
+    def replace_table_from_relation(
+        self,
+        connection: Any,
+        *,
+        target: str,
+        source: str,
+        statement_recorder: StatementRecorder,
+    ) -> None:
+        """Replace a target table from a source relation."""
+        ...
+
+    @abstractmethod
+    def render_add_columns(
+        self, *, target: str, columns: tuple[ColumnInfo, ...]
+    ) -> tuple[str, ...]:
+        """Render SQL statements that add columns to a table."""
+        ...
+
+    @abstractmethod
+    def render_drop_columns(self, *, target: str, column_names: tuple[str, ...]) -> tuple[str, ...]:
+        """Render SQL statements that drop columns from a table."""
+        ...
+
+    @abstractmethod
+    def render_alter_column_types(
+        self, *, target: str, columns: tuple[ColumnInfo, ...]
+    ) -> tuple[str, ...]:
+        """Render SQL statements that alter column types on a table."""
+        ...
+
+    @abstractmethod
+    def render_merge(
+        self,
+        *,
+        target: str,
+        sql: str,
+        unique_key: tuple[str, ...],
+        source_columns: tuple[str, ...] = (),
+    ) -> tuple[str, ...]:
+        """Render SQL statements that merge query rows into a target."""
+        ...
+
+    @abstractmethod
+    def validate_row_diff_keys(
+        self,
+        connection: Any,
+        *,
+        relation_sql: str,
+        relation_label: str,
+        keys: tuple[str, ...],
+    ) -> None:
+        """Validate row-diff unique keys for nulls and duplicates."""
+        ...
+
+    @abstractmethod
+    def build_row_diff_equal_expression(
+        self,
+        *,
+        column: str,
+        column_info: ColumnInfo,
+        tolerances: RowDiffTolerances | None,
+    ) -> str:
+        """Build a boolean equality expression for one row-diff column."""
+        ...
+
+    @abstractmethod
+    def resolve_row_diff_tolerance(
+        self,
+        *,
+        column: str,
+        column_type: str,
+        tolerances: RowDiffTolerances | None,
+    ) -> RowDiffTolerance | None:
+        """Resolve applicable row-diff tolerance for a column."""
+        ...
+
+    @abstractmethod
+    def validate_row_diff_tolerance(self, *, column: str, tolerance: RowDiffTolerance) -> None:
+        """Validate one row-diff tolerance definition."""
+        ...
+
+    @abstractmethod
+    def normalize_row_diff_numeric_type(self, column_type: str) -> str | None:
+        """Normalize one column type into a row-diff numeric family."""
+        ...
+
+    @abstractmethod
+    def format_row_diff_decimal_sql(self, value: Decimal) -> str:
+        """Format a decimal value for row-diff SQL."""
+        ...
 
     @abstractmethod
     def default_schema(self) -> str | None:

--- a/src/sqlbuild/cli/commands/main/audit.py
+++ b/src/sqlbuild/cli/commands/main/audit.py
@@ -38,7 +38,8 @@ def run_audit(
         resolve_effective_adapter_name(
             project_config=discovered_inputs.project_config,
             local_config=discovered_inputs.local_config,
-        )
+        ),
+        project_dir=effective_project_dir,
     )
     connection_config: dict[str, object] = resolve_project_connection_config(
         discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/cli/commands/main/build.py
+++ b/src/sqlbuild/cli/commands/main/build.py
@@ -52,7 +52,8 @@ def run_build(
         resolve_effective_adapter_name(
             project_config=discovered_inputs.project_config,
             local_config=discovered_inputs.local_config,
-        )
+        ),
+        project_dir=effective_project_dir,
     )
     connection_config: dict[str, object] = resolve_project_connection_config(
         discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/cli/commands/main/clone.py
+++ b/src/sqlbuild/cli/commands/main/clone.py
@@ -50,7 +50,9 @@ def run_clone(
         project_config=discovered_inputs.project_config,
         local_config=discovered_inputs.local_config,
     )
-    adapter: BaseAdapter = resolve_adapter(effective_adapter_name)
+    adapter: BaseAdapter = resolve_adapter(
+        effective_adapter_name, project_dir=effective_project_dir
+    )
 
     source_connection_config: dict[str, object] = resolve_environment_connection_config(
         discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/cli/commands/main/compile.py
+++ b/src/sqlbuild/cli/commands/main/compile.py
@@ -34,7 +34,8 @@ def run_compile(
         resolve_effective_adapter_name(
             project_config=discovered_inputs.project_config,
             local_config=discovered_inputs.local_config,
-        )
+        ),
+        project_dir=effective_project_dir,
     )
     pipeline_result: CompilePipelineResult = run_compile_pipeline(
         discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/cli/commands/main/diff.py
+++ b/src/sqlbuild/cli/commands/main/diff.py
@@ -65,7 +65,9 @@ def run_diff(
         project_config=discovered_inputs.project_config,
         local_config=discovered_inputs.local_config,
     )
-    adapter: BaseAdapter = resolve_adapter(effective_adapter_name)
+    adapter: BaseAdapter = resolve_adapter(
+        effective_adapter_name, project_dir=effective_project_dir
+    )
     left_project: Any
     right_project: Any
     selected_names: tuple[str, ...]

--- a/src/sqlbuild/cli/commands/main/janitor.py
+++ b/src/sqlbuild/cli/commands/main/janitor.py
@@ -53,7 +53,9 @@ def run_janitor(
         project_config=discovered_inputs.project_config,
         local_config=discovered_inputs.local_config,
     )
-    adapter: BaseAdapter = resolve_adapter(effective_adapter_name)
+    adapter: BaseAdapter = resolve_adapter(
+        effective_adapter_name, project_dir=effective_project_dir
+    )
     project: CompiledProject = compile_project(
         discovered_inputs=discovered_inputs,
         adapter=adapter,

--- a/src/sqlbuild/cli/commands/main/plan.py
+++ b/src/sqlbuild/cli/commands/main/plan.py
@@ -39,7 +39,8 @@ def run_plan(
         resolve_effective_adapter_name(
             project_config=discovered_inputs.project_config,
             local_config=discovered_inputs.local_config,
-        )
+        ),
+        project_dir=effective_project_dir,
     )
     pipeline_result: CompilePipelineResult = run_compile_pipeline(
         discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/cli/commands/main/query.py
+++ b/src/sqlbuild/cli/commands/main/query.py
@@ -36,7 +36,8 @@ def run_query(
         resolve_effective_adapter_name(
             project_config=discovered_inputs.project_config,
             local_config=discovered_inputs.local_config,
-        )
+        ),
+        project_dir=effective_project_dir,
     )
     connection_config: dict[str, object] = resolve_project_connection_config(
         discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/cli/commands/main/run.py
+++ b/src/sqlbuild/cli/commands/main/run.py
@@ -52,7 +52,8 @@ def run_run(
         resolve_effective_adapter_name(
             project_config=discovered_inputs.project_config,
             local_config=discovered_inputs.local_config,
-        )
+        ),
+        project_dir=effective_project_dir,
     )
     connection_config: dict[str, object] = resolve_project_connection_config(
         discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/cli/commands/main/seed.py
+++ b/src/sqlbuild/cli/commands/main/seed.py
@@ -37,7 +37,8 @@ def run_seed(
         resolve_effective_adapter_name(
             project_config=discovered_inputs.project_config,
             local_config=discovered_inputs.local_config,
-        )
+        ),
+        project_dir=effective_project_dir,
     )
     connection_config: dict[str, object] = resolve_project_connection_config(
         discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/cli/commands/main/shared/helpers/adapters.py
+++ b/src/sqlbuild/cli/commands/main/shared/helpers/adapters.py
@@ -2,32 +2,49 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import cast
+
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.types import BuiltinAdapter
+from sqlbuild.adapter.strict.strict_adapter import StrictAdapter
+from sqlbuild.shared.helpers.adapters import discover_project_adapters
 
 
-def resolve_adapter(adapter_name: str) -> BaseAdapter:
-    """Resolve an adapter name from project config to a built-in adapter instance."""
+def resolve_adapter(adapter_name: str, *, project_dir: Path | None = None) -> BaseAdapter:
+    """Resolve an adapter name from project config to an adapter instance."""
 
-    match adapter_name:
-        case BuiltinAdapter.DUCKDB:
-            from sqlbuild.integrations.duckdb.client import DuckDbAdapter
+    builtin_adapters: dict[str, type[BaseAdapter]] = _builtin_adapter_classes()
+    adapter_class: type[StrictAdapter] | None = None
+    if project_dir is not None:
+        local_adapters: dict[str, type[StrictAdapter]] = discover_project_adapters(
+            project_dir=project_dir,
+            reserved_names=frozenset(builtin_adapters),
+        )
+        adapter_class = local_adapters.get(adapter_name)
+    if adapter_class is None:
+        adapter_class = builtin_adapters.get(adapter_name)
+    if adapter_class is None:
+        available: tuple[str, ...] = tuple(sorted(builtin_adapters))
+        local_text: str = ""
+        if project_dir is not None:
+            local_text = " Project-local adapters are discovered from adapters/**/*.py."
+        raise ValueError(
+            f"Unknown adapter '{adapter_name}'. Available built-in adapters: "
+            f"{', '.join(available)}.{local_text}"
+        )
+    return cast(BaseAdapter, adapter_class())
 
-            return DuckDbAdapter()
-        case BuiltinAdapter.SNOWFLAKE:
-            from sqlbuild.integrations.snowflake.client import SnowflakeAdapter
 
-            return SnowflakeAdapter()
-        case BuiltinAdapter.BIGQUERY:
-            from sqlbuild.integrations.bigquery.client import BigQueryAdapter
+def _builtin_adapter_classes() -> dict[str, type[BaseAdapter]]:
+    from sqlbuild.integrations.bigquery.client import BigQueryAdapter
+    from sqlbuild.integrations.databricks.client import DatabricksAdapter
+    from sqlbuild.integrations.duckdb.client import DuckDbAdapter
+    from sqlbuild.integrations.snowflake.client import SnowflakeAdapter
 
-            return BigQueryAdapter()
-        case BuiltinAdapter.DATABRICKS:
-            from sqlbuild.integrations.databricks.client import DatabricksAdapter
-
-            return DatabricksAdapter()
-        case _:
-            available: str = ", ".join(a.value for a in BuiltinAdapter)
-            raise ValueError(
-                f"Unknown adapter '{adapter_name}'. Available built-in adapters: {available}"
-            )
+    return {
+        BuiltinAdapter.DUCKDB.value: DuckDbAdapter,
+        BuiltinAdapter.SNOWFLAKE.value: SnowflakeAdapter,
+        BuiltinAdapter.BIGQUERY.value: BigQueryAdapter,
+        BuiltinAdapter.DATABRICKS.value: DatabricksAdapter,
+    }

--- a/src/sqlbuild/cli/commands/main/test.py
+++ b/src/sqlbuild/cli/commands/main/test.py
@@ -37,7 +37,8 @@ def run_test(
         resolve_effective_adapter_name(
             project_config=discovered_inputs.project_config,
             local_config=discovered_inputs.local_config,
-        )
+        ),
+        project_dir=effective_project_dir,
     )
     connection_config: dict[str, object] = resolve_project_connection_config(
         discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/compiler/discovery/models.py
+++ b/src/sqlbuild/compiler/discovery/models.py
@@ -110,7 +110,7 @@ class DiscoveredDbtManifestFile:
 
 @dataclass(frozen=True)
 class DiscoveredAdapterFile:
-    """A detected project adapter.py file."""
+    """A detected project adapter Python file."""
 
     file_path: Path
     relative_path: Path

--- a/src/sqlbuild/shared/helpers/adapters.py
+++ b/src/sqlbuild/shared/helpers/adapters.py
@@ -1,0 +1,149 @@
+"""Discover project-local adapter classes."""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from types import ModuleType
+from typing import Any, cast
+
+from sqlbuild.adapter.base.base_adapter import BaseAdapter
+from sqlbuild.adapter.strict.strict_adapter import StrictAdapter
+from sqlbuild.shared.models import DiscoveredAdapter
+
+
+def discover_project_adapters(
+    *,
+    project_dir: Path,
+    reserved_names: frozenset[str] = frozenset(),
+) -> dict[str, type[StrictAdapter]]:
+    """Discover adapter classes from a project's adapters directory."""
+
+    adapters_dir: Path = project_dir / "adapters"
+    if not adapters_dir.is_dir():
+        return {}
+
+    discovered: dict[str, DiscoveredAdapter] = {}
+    file_path: Path
+    for file_path in _iter_adapter_files(adapters_dir):
+        module: ModuleType = _load_adapter_module(project_dir=project_dir, file_path=file_path)
+        adapter: DiscoveredAdapter
+        for adapter in _discover_module_adapters(module=module, file_path=file_path):
+            if adapter.adapter_name in reserved_names:
+                raise ValueError(
+                    f"Project-local adapter '{adapter.adapter_name}' in {file_path} "
+                    "shadows a built-in adapter name. Choose a distinct adapter_name."
+                )
+            previous: DiscoveredAdapter | None = discovered.get(adapter.adapter_name)
+            if previous is not None:
+                raise ValueError(
+                    f"Duplicate project-local adapter_name '{adapter.adapter_name}' in "
+                    f"{file_path} and {previous.file_path}"
+                )
+            discovered[adapter.adapter_name] = adapter
+
+    return {name: adapter.adapter_class for name, adapter in discovered.items()}
+
+
+def _iter_adapter_files(adapters_dir: Path) -> tuple[Path, ...]:
+    return tuple(
+        sorted(
+            file_path
+            for file_path in adapters_dir.rglob("*.py")
+            if _is_public_adapter_file(adapters_dir=adapters_dir, file_path=file_path)
+        )
+    )
+
+
+def _is_public_adapter_file(*, adapters_dir: Path, file_path: Path) -> bool:
+    relative_path: Path = file_path.relative_to(adapters_dir)
+    if file_path.name == "__init__.py":
+        return False
+    return not any(part.startswith("_") for part in relative_path.parts)
+
+
+def _load_adapter_module(*, project_dir: Path, file_path: Path) -> ModuleType:
+    module_name: str = _module_name_for_path(project_dir=project_dir, file_path=file_path)
+    spec: ModuleSpec | None = importlib.util.spec_from_file_location(
+        module_name,
+        file_path,
+    )
+    if spec is None or spec.loader is None:
+        raise ValueError(f"Could not load project-local adapter module from {file_path}")
+    module: ModuleType = importlib.util.module_from_spec(spec)
+    original_path: list[str] = list(sys.path)
+    sys.modules[module_name] = module
+    try:
+        sys.path.insert(0, str(project_dir))
+        spec.loader.exec_module(module)
+    except Exception as error:
+        raise ValueError(
+            f"Error importing project-local adapter module {file_path}: {error}"
+        ) from error
+    finally:
+        sys.path = original_path
+    return module
+
+
+def _module_name_for_path(*, project_dir: Path, file_path: Path) -> str:
+    relative_path: Path = file_path.relative_to(project_dir).with_suffix("")
+    normalized_parts: tuple[str, ...] = tuple(
+        _normalize_module_part(part) for part in relative_path.parts
+    )
+    return "sqlbuild_project_adapters." + ".".join(normalized_parts)
+
+
+def _normalize_module_part(part: str) -> str:
+    return "".join(
+        character if character.isalnum() or character == "_" else "_" for character in part
+    )
+
+
+def _discover_module_adapters(
+    *, module: ModuleType, file_path: Path
+) -> tuple[DiscoveredAdapter, ...]:
+    discovered: list[DiscoveredAdapter] = []
+    class_name: str
+    adapter_class: type[Any]
+    for class_name, adapter_class in inspect.getmembers(module, inspect.isclass):
+        if adapter_class.__module__ != module.__name__:
+            continue
+        adapter_name: Any = getattr(adapter_class, "adapter_name", None)
+        is_adapter_class: bool = issubclass(adapter_class, StrictAdapter)
+        if adapter_name is None and not is_adapter_class:
+            continue
+        if adapter_name is not None and not is_adapter_class:
+            raise ValueError(
+                f"Class {class_name} in {file_path} defines adapter_name but does not "
+                "subclass StrictAdapter"
+            )
+        if adapter_class in {StrictAdapter, BaseAdapter}:
+            continue
+        if adapter_name is None:
+            raise ValueError(
+                f"Adapter class {class_name} in {file_path} must define a non-empty "
+                "string adapter_name"
+            )
+        if not isinstance(adapter_name, str) or not adapter_name.strip():
+            raise ValueError(
+                f"Adapter class {class_name} in {file_path} must define a non-empty "
+                "string adapter_name"
+            )
+        if inspect.isabstract(adapter_class):
+            abstract_methods: frozenset[str] = cast(Any, adapter_class).__abstractmethods__
+            missing: str = ", ".join(sorted(abstract_methods))
+            raise ValueError(
+                f"Adapter class {class_name} in {file_path} is abstract and cannot be "
+                f"registered. Missing methods: {missing}"
+            )
+        discovered.append(
+            DiscoveredAdapter(
+                adapter_name=adapter_name.strip(),
+                adapter_class=cast(type[StrictAdapter], adapter_class),
+                file_path=file_path,
+            )
+        )
+    return tuple(discovered)

--- a/src/sqlbuild/shared/models.py
+++ b/src/sqlbuild/shared/models.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlbuild.adapter.strict.strict_adapter import StrictAdapter
+
+
+@dataclass(frozen=True)
+class DiscoveredAdapter:
+    """A discovered project-local adapter class."""
+
+    adapter_name: str
+    adapter_class: type[StrictAdapter]
+    file_path: Path

--- a/tests/e2e/src/sqlbuild/cli/commands/main/adapters/__init__.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Adapter CLI e2e tests."""

--- a/tests/e2e/src/sqlbuild/cli/commands/main/adapters/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/adapters/_test_types.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProjectLocalAdapterCliTestCase:
+    description: str
+    command: tuple[str, ...]
+    expected_stdout_fragment: str
+    expected_return_code: int = 0

--- a/tests/e2e/src/sqlbuild/cli/commands/main/adapters/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/adapters/helpers.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.e2e.src.sqlbuild.cli.commands.main.shared.helpers import prepare_inline_project
+
+
+def prepare_project_with_local_adapter(*, tmp_path: Path) -> Path:
+    """Prepare a project that selects a nested project-local DuckDB adapter."""
+
+    return prepare_inline_project(
+        tmp_path=tmp_path,
+        project_name="project_local_adapter",
+        repo_files={
+            "sqlbuild_project.yml": (
+                "name: project_local_adapter\n"
+                "adapter: duckdb_plus\n"
+                "connection:\n"
+                "  database: local.duckdb\n"
+            ),
+            "adapters/warehouse/duckdb_plus.py": (
+                "from sqlbuild.adapter.shared.models import QueryResult\n"
+                "from sqlbuild.integrations.duckdb.client import DuckDbAdapter\n\n\n"
+                "class DuckDbPlusAdapter(DuckDbAdapter):\n"
+                "    adapter_name = 'duckdb_plus'\n\n"
+                "    def query(self, connection, sql, *, limit):\n"
+                "        return QueryResult(\n"
+                "            columns=('adapter_name',),\n"
+                "            rows=((self.adapter_name,),),\n"
+                "            truncated=False,\n"
+                "        )\n"
+            ),
+        },
+    )

--- a/tests/e2e/src/sqlbuild/cli/commands/main/adapters/test_project_local_adapters.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/adapters/test_project_local_adapters.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.src.sqlbuild.cli.commands.main.adapters._test_types import (
+    ProjectLocalAdapterCliTestCase,
+)
+from tests.e2e.src.sqlbuild.cli.commands.main.adapters.helpers import (
+    prepare_project_with_local_adapter,
+)
+from tests.e2e.src.sqlbuild.cli.commands.main.shared.helpers import run_sqb
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ProjectLocalAdapterCliTestCase(
+            description="query uses nested project local adapter",
+            command=("query", "SELECT 'ignored' AS value", "--format", "csv"),
+            expected_stdout_fragment="duckdb_plus",
+        )
+    ],
+    ids=["query uses nested project local adapter"],
+)
+def test_given_project_local_adapter_when_running_query_then_uses_local_adapter(
+    tmp_path: Path,
+    test_case: ProjectLocalAdapterCliTestCase,
+) -> None:
+    project_dir: Path = prepare_project_with_local_adapter(tmp_path=tmp_path)
+
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=test_case.command,
+        project_dir=project_dir,
+    )
+
+    assert result.returncode == test_case.expected_return_code, result.stdout + result.stderr
+    assert test_case.expected_stdout_fragment in result.stdout

--- a/tests/unit/src/sqlbuild/adapter/discovery/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/adapter/discovery/main/_test_types.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ProjectAdapterDiscoveryTestCase:
+    description: str
+    files: dict[str, str]
+    expected_adapter_names: tuple[str, ...] = field(default_factory=tuple)
+    reserved_names: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class ProjectAdapterDiscoveryErrorTestCase:
+    description: str
+    files: dict[str, str]
+    expected_error_fragment: str
+    reserved_names: frozenset[str] = frozenset()

--- a/tests/unit/src/sqlbuild/adapter/discovery/main/helpers.py
+++ b/tests/unit/src/sqlbuild/adapter/discovery/main/helpers.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def write_project_files(*, project_dir: Path, files: dict[str, str]) -> None:
+    relative_path: str
+    contents: str
+    for relative_path, contents in files.items():
+        file_path: Path = project_dir / relative_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(contents, encoding="utf-8")

--- a/tests/unit/src/sqlbuild/adapter/discovery/main/test_discover.py
+++ b/tests/unit/src/sqlbuild/adapter/discovery/main/test_discover.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sqlbuild.adapter.strict.strict_adapter import StrictAdapter
+from sqlbuild.shared.helpers.adapters import discover_project_adapters
+from tests.unit.src.sqlbuild.adapter.discovery.main._test_types import (
+    ProjectAdapterDiscoveryErrorTestCase,
+    ProjectAdapterDiscoveryTestCase,
+)
+from tests.unit.src.sqlbuild.adapter.discovery.main.helpers import write_project_files
+
+VALID_DUCKDB_ADAPTER: str = """
+from sqlbuild.integrations.duckdb.client import DuckDbAdapter
+
+
+class DuckDbPlusAdapter(DuckDbAdapter):
+    adapter_name = "duckdb_plus"
+"""
+
+NESTED_DUCKDB_ADAPTER: str = """
+from sqlbuild.integrations.duckdb.client import DuckDbAdapter
+
+
+class NestedDuckDbAdapter(DuckDbAdapter):
+    adapter_name = "nested_duckdb"
+"""
+
+DISCOVERY_TEST_CASES: list[ProjectAdapterDiscoveryTestCase] = [
+    ProjectAdapterDiscoveryTestCase(
+        description="loads public adapter files recursively",
+        files={
+            "adapters/duckdb_plus.py": VALID_DUCKDB_ADAPTER,
+            "adapters/warehouse/nested.py": NESTED_DUCKDB_ADAPTER,
+        },
+        expected_adapter_names=("duckdb_plus", "nested_duckdb"),
+    ),
+    ProjectAdapterDiscoveryTestCase(
+        description="skips private files init files and private directories",
+        files={
+            "adapters/duckdb_plus.py": VALID_DUCKDB_ADAPTER,
+            "adapters/__init__.py": NESTED_DUCKDB_ADAPTER,
+            "adapters/_private.py": NESTED_DUCKDB_ADAPTER,
+            "adapters/_shared/nested.py": NESTED_DUCKDB_ADAPTER,
+        },
+        expected_adapter_names=("duckdb_plus",),
+    ),
+]
+
+DISCOVERY_ERROR_TEST_CASES: list[ProjectAdapterDiscoveryErrorTestCase] = [
+    ProjectAdapterDiscoveryErrorTestCase(
+        description="rejects duplicate adapter names",
+        files={
+            "adapters/one.py": VALID_DUCKDB_ADAPTER,
+            "adapters/two.py": VALID_DUCKDB_ADAPTER,
+        },
+        expected_error_fragment="Duplicate project-local adapter_name 'duckdb_plus'",
+    ),
+    ProjectAdapterDiscoveryErrorTestCase(
+        description="rejects built in adapter shadowing",
+        files={
+            "adapters/duckdb.py": VALID_DUCKDB_ADAPTER.replace("duckdb_plus", "duckdb"),
+        },
+        reserved_names=frozenset({"duckdb"}),
+        expected_error_fragment="shadows a built-in adapter name",
+    ),
+    ProjectAdapterDiscoveryErrorTestCase(
+        description="rejects adapter subclass without adapter name",
+        files={
+            "adapters/missing_name.py": """
+from sqlbuild.integrations.duckdb.client import DuckDbAdapter
+
+
+class MissingNameAdapter(DuckDbAdapter):
+    pass
+""",
+        },
+        expected_error_fragment="must define a non-empty string adapter_name",
+    ),
+    ProjectAdapterDiscoveryErrorTestCase(
+        description="rejects non adapter class with adapter name",
+        files={
+            "adapters/not_adapter.py": """
+class NotAdapter:
+    adapter_name = "not_adapter"
+""",
+        },
+        expected_error_fragment="defines adapter_name but does not subclass StrictAdapter",
+    ),
+    ProjectAdapterDiscoveryErrorTestCase(
+        description="reports import errors with file path",
+        files={"adapters/broken.py": "raise RuntimeError('boom')\n"},
+        expected_error_fragment="Error importing project-local adapter module",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    DISCOVERY_TEST_CASES,
+    ids=[case.description for case in DISCOVERY_TEST_CASES],
+)
+def test_given_project_adapter_files_when_discovering_then_returns_expected_adapters(
+    tmp_path: Path,
+    test_case: ProjectAdapterDiscoveryTestCase,
+) -> None:
+    write_project_files(project_dir=tmp_path, files=test_case.files)
+
+    adapters: dict[str, type[StrictAdapter]] = discover_project_adapters(
+        project_dir=tmp_path,
+        reserved_names=test_case.reserved_names,
+    )
+
+    assert tuple(sorted(adapters)) == tuple(sorted(test_case.expected_adapter_names))
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    DISCOVERY_ERROR_TEST_CASES,
+    ids=[case.description for case in DISCOVERY_ERROR_TEST_CASES],
+)
+def test_given_invalid_project_adapter_files_when_discovering_then_raises_clear_error(
+    tmp_path: Path,
+    test_case: ProjectAdapterDiscoveryErrorTestCase,
+) -> None:
+    write_project_files(project_dir=tmp_path, files=test_case.files)
+
+    with pytest.raises(ValueError, match=test_case.expected_error_fragment):
+        discover_project_adapters(
+            project_dir=tmp_path,
+            reserved_names=test_case.reserved_names,
+        )

--- a/tests/unit/src/sqlbuild/adapter/strict/_test_types.py
+++ b/tests/unit/src/sqlbuild/adapter/strict/_test_types.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StrictAdapterContractTestCase:
+    description: str
+    expected_missing_methods: frozenset[str]

--- a/tests/unit/src/sqlbuild/adapter/strict/test_strict_adapter.py
+++ b/tests/unit/src/sqlbuild/adapter/strict/test_strict_adapter.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any, cast
+
+import pytest
+
+from sqlbuild.adapter.base.base_adapter import BaseAdapter
+from sqlbuild.adapter.strict.strict_adapter import StrictAdapter
+from tests.unit.src.sqlbuild.adapter.strict._test_types import StrictAdapterContractTestCase
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        StrictAdapterContractTestCase(
+            description="strict adapter covers every public base adapter method",
+            expected_missing_methods=frozenset(),
+        )
+    ],
+    ids=["strict adapter covers every public base adapter method"],
+)
+def test_given_base_adapter_public_methods_when_checking_strict_contract_then_all_are_abstract(
+    test_case: StrictAdapterContractTestCase,
+) -> None:
+    base_public_methods: frozenset[str] = frozenset(
+        name
+        for name, value in BaseAdapter.__dict__.items()
+        if not name.startswith("_") and inspect.isfunction(value)
+    )
+
+    abstract_methods: frozenset[str] = cast(Any, StrictAdapter).__abstractmethods__
+    missing_methods: frozenset[str] = base_public_methods.difference(abstract_methods)
+
+    assert missing_methods == test_case.expected_missing_methods


### PR DESCRIPTION
Super powerful feature but just wanted to get other stuff done before releasing this. This lets you make your own adapters with no need for any sort of plugin system, by simply inheriting from BaseClass (or inheriting from an existing adapter) and overriding methods as you see fit. Naturally, this is all in python so the world is your oyster. This is probably one of the most important features for making this project extensible and ensuring that users have the ability to help themselves for obscure adapter support without needing me to officially support every engine under the sun.

Will update the docs later.