### PR TITLE
fix: enforce cascade backfill planning

### DIFF
--- a/src/sqlbuild/compiler/planner/helpers/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/helpers/plan_entry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import date, datetime
 from typing import Any
 
@@ -86,6 +87,7 @@ def plan_model(
     full_refresh: bool,
     start_cursor_override: str | None,
     end_cursor_override: str | None,
+    backfill_override: BackfillResult | None = None,
 ) -> tuple[ModelPlanEntry, tuple[PlanWarning, ...]]:
     """Build a plan entry and warnings for a single model."""
 
@@ -97,7 +99,13 @@ def plan_model(
         full_refresh=full_refresh,
     )
 
+    if backfill_override is not None:
+        change_result = replace(change_result, backfill=backfill_override)
+
     backfill: BackfillResult = change_result.backfill
+    suppress_runtime_cursor_bounds: bool = (
+        backfill_override is not None and backfill_override.action == BackfillAction.FULL
+    )
 
     resolved_sql: str = resolve_model_sql(
         adapter=adapter,
@@ -113,6 +121,7 @@ def plan_model(
         full_refresh=full_refresh,
         start_cursor_override=start_cursor_override,
         end_cursor_override=end_cursor_override,
+        suppress_runtime_cursor_bounds=suppress_runtime_cursor_bounds,
     )
 
     action: PlanAction
@@ -151,14 +160,16 @@ def plan_model(
     cursor_type: str | None = _get_config_str(model, "cursor_type")
     cursor_grain: str | None = _get_config_str(model, "cursor_grain")
     cursor_start: str | None = _get_cursor_start(model)
-    cursor_input_relations: tuple[CursorInputRelation, ...] = _build_cursor_input_relations(
-        model=model,
-        model_targets=model_targets,
-        models_by_name=models_by_name,
-        seed_targets=seed_targets,
-        source_map=source_map,
-        cursor_column=cursor_column,
-    )
+    cursor_input_relations: tuple[CursorInputRelation, ...] = ()
+    if not suppress_runtime_cursor_bounds:
+        cursor_input_relations = _build_cursor_input_relations(
+            model=model,
+            model_targets=model_targets,
+            models_by_name=models_by_name,
+            seed_targets=seed_targets,
+            source_map=source_map,
+            cursor_column=cursor_column,
+        )
     runtime_owned_cursor_bounds: bool = _has_model_backed_cursor_inputs(cursor_input_relations)
     cursor_bounds: CursorBounds | None = _compute_plan_cursor_bounds(
         model=model,

--- a/src/sqlbuild/compiler/planner/helpers/resolve/resolve.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/resolve.py
@@ -51,6 +51,7 @@ def resolve_model_sql(
     full_refresh: bool,
     start_cursor_override: str | None,
     end_cursor_override: str | None,
+    suppress_runtime_cursor_bounds: bool = False,
 ) -> str:
     """Resolve all references in a model's query SQL to produce executable SQL."""
 
@@ -66,6 +67,7 @@ def resolve_model_sql(
         end_cursor_override=end_cursor_override,
         model_targets=model_targets,
         seed_targets=seed_targets,
+        suppress_runtime_cursor_bounds=suppress_runtime_cursor_bounds,
     )
 
     cursor_inputs: dict[str, str] = _get_cursor_inputs(model)
@@ -110,6 +112,7 @@ def _compute_model_cursor_bounds(
     end_cursor_override: str | None,
     model_targets: dict[str, CompiledRelationTarget],
     seed_targets: dict[str, CompiledRelationTarget],
+    suppress_runtime_cursor_bounds: bool,
 ) -> CursorBounds | None:
     """Compute cursor bounds for a model if it is incremental with a cursor."""
 
@@ -119,6 +122,9 @@ def _compute_model_cursor_bounds(
     if materialized != MaterializationType.INCREMENTAL or cursor_column is None:
         return None
 
+    if full_refresh or suppress_runtime_cursor_bounds:
+        return None
+
     if has_model_backed_cursor_inputs(
         model=model,
         model_targets=model_targets,
@@ -126,9 +132,6 @@ def _compute_model_cursor_bounds(
         cursor_inputs=_get_cursor_inputs(model),
     ):
         return CursorBounds(start=MICROBATCH_START_SENTINEL, end=MICROBATCH_END_SENTINEL)
-
-    if full_refresh:
-        return None
 
     cursor_snapshot: ModelCursorSnapshot | None = snapshot.cursor_snapshots.get(model.name)
     if cursor_snapshot is None:

--- a/src/sqlbuild/compiler/planner/main/execution.py
+++ b/src/sqlbuild/compiler/planner/main/execution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
@@ -48,6 +49,7 @@ from sqlbuild.compiler.planner.helpers.sql_test_assembly import plan_test
 from sqlbuild.compiler.planner.helpers.warehouse_snapshot import gather_warehouse_snapshot
 from sqlbuild.compiler.planner.models import (
     AuditPlanEntry,
+    BackfillResult,
     CascadeResult,
     CursorOverrides,
     FunctionPlanEntry,
@@ -201,33 +203,28 @@ def build_execution_plan(
             model_cursor_types=model_cursor_types,
         )
         if cascade is not None:
-            entry = ModelPlanEntry(
-                key=entry.key,
-                name=entry.name,
-                relative_path=entry.relative_path,
-                materialization_type=entry.materialization_type,
-                action=entry.action,
-                reason=entry.reason,
-                target=entry.target,
-                fingerprint_query_sql=entry.fingerprint_query_sql,
-                resolved_sql=entry.resolved_sql,
-                logical_ddl=entry.logical_ddl,
-                incremental_strategy=entry.incremental_strategy,
-                incremental_mode=entry.incremental_mode,
-                cursor_column=entry.cursor_column,
-                cursor_type=entry.cursor_type,
-                cursor_grain=entry.cursor_grain,
-                cursor_start=entry.cursor_start,
-                cursor_bounds=entry.cursor_bounds,
-                type_enforcement=entry.type_enforcement,
-                pre_hook=entry.pre_hook,
-                post_hook=entry.post_hook,
-                previous_query_sql=entry.previous_query_sql,
-                schema_actions=entry.schema_actions,
-                schema_findings=entry.schema_findings,
-                backfill=entry.backfill,
-                cascade=cascade,
+            entry, warnings = plan_model(
+                model=model,
+                snapshot=snapshot,
+                adapter=adapter,
+                model_targets=model_targets,
+                models_by_name=models_by_name,
+                seed_targets=seed_targets,
+                function_targets=function_targets,
+                source_map=source_map,
+                source_warehouse_columns=source_warehouse_columns,
+                star_exclude_keyword=star_exclude_keyword,
+                sqlglot_enabled=sqlglot_enabled,
+                query_change_tracking=query_change_tracking,
+                full_refresh=full_refresh,
+                start_cursor_override=resolved_start,
+                end_cursor_override=resolved_end,
+                backfill_override=BackfillResult(
+                    action=cascade.effective_action,
+                    duration=cascade.effective_duration,
+                ),
             )
+            entry = replace(entry, cascade=cascade)
             effective_cascades[entry.name] = cascade
         else:
             effective_cascades[entry.name] = build_self_cascade(entry.backfill)

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/_test_types.py
@@ -104,6 +104,7 @@ class CliFailureBuildE2ETestCase:
     expected_exit_code: int
     expected_stderr_fragments: tuple[str, ...]
     expected_stdout_fragments: tuple[str, ...] = field(default_factory=tuple)
+    pre_commands: tuple[tuple[str, ...], ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_cursor_runtime_failures.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_cursor_runtime_failures.py
@@ -64,6 +64,7 @@ TEST_CASES: list[CliFailureBuildE2ETestCase] = [
         expected_exit_code=1,
         expected_stderr_fragments=(),
         expected_stdout_fragments=("missing_column",),
+        pre_commands=(("--no-color", "build", "--select", "+fact_orders"),),
     ),
     CliFailureBuildE2ETestCase(
         description="broken runtime-owned upstream relation fails at compile time",
@@ -125,6 +126,14 @@ def test_given_cursor_runtime_failure_projects_when_running_build_then_cli_fails
     connection: duckdb.DuckDBPyConnection = duckdb.connect(str(db_path))
     connection.execute(seed_file.read_text(encoding="utf-8"))
     connection.close()
+
+    pre_command: tuple[str, ...]
+    for pre_command in test_case.pre_commands:
+        pre_result: subprocess.CompletedProcess[str] = run_sqb(
+            command=pre_command,
+            project_dir=project_dir,
+        )
+        assert pre_result.returncode == 0, pre_result.stdout + pre_result.stderr
 
     result: subprocess.CompletedProcess[str] = run_sqb(
         command=test_case.command, project_dir=project_dir

--- a/tests/integration/src/sqlbuild/compiler/planner/main/test_build_execution_plan.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/test_build_execution_plan.py
@@ -256,39 +256,79 @@ def test_given_cursor_type_mismatch_when_building_plan_then_produces_warning(
     assert test_case.expected_warning_fragment in warning.message
 
 
+CASCADE_PLAN_TEST_CASES: list[BuildExecutionPlanTestCase] = [
+    BuildExecutionPlanTestCase(
+        description="upstream first run full cascades to existing downstream",
+        setup_sql=("CREATE TABLE staging.fact_orders AS SELECT 1 AS id",),
+        model_targets={
+            "stg_orders": "staging",
+            "fact_orders": "staging",
+        },
+        model_configs={
+            "stg_orders": {"materialized": "table"},
+            "fact_orders": {"materialized": "table"},
+        },
+        model_queries={
+            "stg_orders": "SELECT 1 AS id",
+            "fact_orders": "SELECT 1 AS id",
+        },
+        model_deps={"fact_orders": ("stg_orders",)},
+        full_refresh=False,
+        expected_action={
+            "stg_orders": PlanAction.CREATE_TABLE,
+            "fact_orders": PlanAction.CREATE_TABLE,
+        },
+        expected_reason={
+            "stg_orders": PlanReason.FIRST_RUN,
+            "fact_orders": PlanReason.FULL_REFRESH,
+        },
+        expected_cascade_action={"fact_orders": BackfillAction.FULL},
+        expected_cascade_root_cause={"fact_orders": "stg_orders"},
+    ),
+    BuildExecutionPlanTestCase(
+        description="upstream full cascade forces existing incremental downstream rebuild",
+        setup_sql=("CREATE TABLE staging.fact_orders AS SELECT 1 AS id",),
+        model_targets={
+            "stg_orders": "staging",
+            "fact_orders": "staging",
+        },
+        model_configs={
+            "stg_orders": {"materialized": "table"},
+            "fact_orders": {
+                "materialized": "incremental",
+                "incremental_strategy": "delete_insert",
+                "cursor": "id",
+                "cursor_type": "integer",
+                "unique_key": "id",
+            },
+        },
+        model_queries={
+            "stg_orders": "SELECT 1 AS id",
+            "fact_orders": "SELECT 1 AS id",
+        },
+        model_deps={"fact_orders": ("stg_orders",)},
+        full_refresh=False,
+        expected_action={
+            "stg_orders": PlanAction.CREATE_TABLE,
+            "fact_orders": PlanAction.CREATE_TABLE,
+        },
+        expected_reason={
+            "stg_orders": PlanReason.FIRST_RUN,
+            "fact_orders": PlanReason.FULL_REFRESH,
+        },
+        expected_ddl_fragments={
+            "fact_orders": "CREATE OR REPLACE TABLE staging.fact_orders AS",
+        },
+        expected_cascade_action={"fact_orders": BackfillAction.FULL},
+        expected_cascade_root_cause={"fact_orders": "stg_orders"},
+    ),
+]
+
+
 @pytest.mark.parametrize(
     "test_case",
-    [
-        BuildExecutionPlanTestCase(
-            description="upstream first run full cascades to existing downstream",
-            setup_sql=("CREATE TABLE staging.fact_orders AS SELECT 1 AS id",),
-            model_targets={
-                "stg_orders": "staging",
-                "fact_orders": "staging",
-            },
-            model_configs={
-                "stg_orders": {"materialized": "table"},
-                "fact_orders": {"materialized": "table"},
-            },
-            model_queries={
-                "stg_orders": "SELECT 1 AS id",
-                "fact_orders": "SELECT 1 AS id",
-            },
-            model_deps={"fact_orders": ("stg_orders",)},
-            full_refresh=False,
-            expected_action={
-                "stg_orders": PlanAction.CREATE_TABLE,
-                "fact_orders": PlanAction.CREATE_TABLE,
-            },
-            expected_reason={
-                "stg_orders": PlanReason.FIRST_RUN,
-                "fact_orders": PlanReason.NO_CHANGE,
-            },
-            expected_cascade_action={"fact_orders": BackfillAction.FULL},
-            expected_cascade_root_cause={"fact_orders": "stg_orders"},
-        ),
-    ],
-    ids=["upstream first run full cascades to existing downstream"],
+    CASCADE_PLAN_TEST_CASES,
+    ids=[case.description for case in CASCADE_PLAN_TEST_CASES],
 )
 def test_given_upstream_first_run_when_building_plan_then_cascades_to_downstream(
     test_case: BuildExecutionPlanTestCase,
@@ -314,6 +354,14 @@ def test_given_upstream_first_run_when_building_plan_then_cascades_to_downstream
     expected_action: PlanAction
     for model_name, expected_action in test_case.expected_action.items():
         assert entry_map[model_name].action == expected_action
+
+    expected_reason: PlanReason
+    for model_name, expected_reason in test_case.expected_reason.items():
+        assert entry_map[model_name].reason == expected_reason
+
+    expected_fragment: str
+    for model_name, expected_fragment in test_case.expected_ddl_fragments.items():
+        assert expected_fragment in entry_map[model_name].logical_ddl
 
     expected_cascade_action: BackfillAction
     for model_name, expected_cascade_action in test_case.expected_cascade_action.items():


### PR DESCRIPTION
## Summary
- Fixes cascade backfill enforcement so downstream models are replanned using the cascade’s effective backfill action instead of only attaching cascade metadata after planning.
- Ensures full upstream cascades force existing downstream table/incremental models to execute as full rebuilds.
- Preserves runtime cursor bound behavior for normal incremental builds while suppressing cursor-windowing for cascade-forced full rebuilds.