### PR TITLE
fix: use BigQuery copy promotion

### DIFF
--- a/src/sqlbuild/integrations/bigquery/client.py
+++ b/src/sqlbuild/integrations/bigquery/client.py
@@ -23,7 +23,12 @@ from sqlbuild.adapter.shared.models import (
     StatementRecorder,
 )
 from sqlbuild.adapter.shared.type_normalization import normalize_numeric_family, types_equal
-from sqlbuild.adapter.shared.types import CursorKind, FrameworkType, TablePromotionMode
+from sqlbuild.adapter.shared.types import (
+    CursorKind,
+    FrameworkType,
+    PromotionStrategy,
+    TablePromotionMode,
+)
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.shared.helpers.diagnostics_logging import log_sql
 
@@ -220,7 +225,10 @@ class BigQueryAdapter(BaseAdapter):
         return f"'{value}'"
 
     def default_table_promotion_mode(self) -> TablePromotionMode:
-        return TablePromotionMode.DIRECT
+        return TablePromotionMode.STAGED
+
+    def default_promotion_strategy(self) -> PromotionStrategy:
+        return PromotionStrategy.ATOMIC_REPLACE
 
     def supports_python_functions(self) -> bool:
         return True
@@ -326,6 +334,37 @@ class BigQueryAdapter(BaseAdapter):
     ) -> tuple[str, ...]:
         del hard_copy
         return self.render_create_table_as(target=target, sql=f"SELECT * FROM {source}")
+
+    def render_replace_table_from_relation(self, *, target: str, source: str) -> tuple[str, ...]:
+        return (
+            "-- BigQuery execution copies this relation to the destination table with "
+            "WRITE_TRUNCATE for staged atomic replace.\n"
+            f"CREATE OR REPLACE TABLE {self._quote_identifier_path(target)} AS "
+            f"SELECT * FROM {self._quote_identifier_path(source)}",
+        )
+
+    def replace_table_from_relation(
+        self,
+        connection: _BigQueryConnection,
+        *,
+        target: str,
+        source: str,
+        statement_recorder: StatementRecorder,
+    ) -> None:
+        from google.cloud import bigquery
+
+        source_table: str = self._strip_identifier_quotes(source)
+        destination_table: str = self._strip_identifier_quotes(target)
+        job_config: Any = bigquery.CopyJobConfig(
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        )
+        statement_recorder.record(f"COPY WRITE_TRUNCATE {source} TO {target}")
+        connection.client.copy_table(
+            source_table,
+            destination_table,
+            job_config=job_config,
+            location=connection.location,
+        ).result()
 
     def relation_exists(
         self,

--- a/tests/integration/src/sqlbuild/integrations/bigquery/_test_types.py
+++ b/tests/integration/src/sqlbuild/integrations/bigquery/_test_types.py
@@ -63,7 +63,9 @@ class BigQueryRowDiffSampleTestCase:
 class BigQueryBuildFlowTestCase:
     description: str
     seed_csv: str
+    staging_sql: str
     expected_rows: tuple[tuple[object, ...], ...]
+    expected_recorded_fragment: str
     expected_statement_count: int = 0
 
 

--- a/tests/integration/src/sqlbuild/integrations/bigquery/test_client.py
+++ b/tests/integration/src/sqlbuild/integrations/bigquery/test_client.py
@@ -489,13 +489,15 @@ def test_given_relations_when_sampling_side_only_rows_then_returns_expected_exam
     "test_case",
     [
         BigQueryBuildFlowTestCase(
-            description="loads seed csv and builds table from select sql",
+            description="loads seed csv and replaces table from select sql",
             seed_csv="id,name\n1,alice\n2,bob\n",
-            expected_rows=((1, "alice"), (2, "bob")),
-            expected_statement_count=2,
+            staging_sql="SELECT 3 AS id, 'carol' AS name",
+            expected_rows=((3, "carol"),),
+            expected_recorded_fragment="COPY WRITE_TRUNCATE",
+            expected_statement_count=4,
         )
     ],
-    ids=["loads seed csv and builds table from select sql"],
+    ids=["loads seed csv and replaces table from select sql"],
 )
 def test_given_seed_and_table_flow_when_materializing_then_returns_expected_rows(
     test_case: BigQueryBuildFlowTestCase,
@@ -520,6 +522,11 @@ def test_given_seed_and_table_flow_when_materializing_then_returns_expected_rows
         dataset=bigquery_dataset,
         name="built_table",
     )
+    staging_target: str = qualified_name(
+        project=bigquery_project,
+        dataset=bigquery_dataset,
+        name="built_table__staging",
+    )
     recorder: StatementRecorder = build_statement_recorder()
 
     adapter.load_seed(
@@ -535,6 +542,18 @@ def test_given_seed_and_table_flow_when_materializing_then_returns_expected_rows
         sql=f"SELECT id, name FROM {seed_target} ORDER BY id",
         statement_recorder=recorder,
     )
+    adapter.create_table_as(
+        connection,
+        target=staging_target,
+        sql=test_case.staging_sql,
+        statement_recorder=recorder,
+    )
+    adapter.replace_table_from_relation(
+        connection,
+        target=table_target,
+        source=staging_target,
+        statement_recorder=recorder,
+    )
 
     rows: tuple[tuple[object, ...], ...] = fetch_rows(
         adapter=adapter,
@@ -544,6 +563,7 @@ def test_given_seed_and_table_flow_when_materializing_then_returns_expected_rows
 
     assert rows == test_case.expected_rows
     assert len(recorder.snapshot()) == test_case.expected_statement_count
+    assert test_case.expected_recorded_fragment in recorder.snapshot()[-1].content
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
So BigQuery can be very expensive / unforgiving if you don't watch how you are handling your queries (well any warehouse can be like that, but BigQuery On Demand can just requires some slightly different behaviour + there is no built in atomic replace via SQL so you have to use the API to achieve same thing). We now use COPY with WRITE_TRUNCATE to allow us to check data before promotion for BQ, but not pay for the promotion of it to the prod table.