### PR TITLE
feat: enforce typed source columns by default

### DIFF
--- a/examples/waffle_shop/sources/raw.yml
+++ b/examples/waffle_shop/sources/raw.yml
@@ -6,6 +6,13 @@ sources:
       UNION ALL SELECT 3 AS id, 'Ann' AS first_name, 'Perkins' AS last_name, 'ann@pawnee.gov' AS email, CAST('2026-02-14 10:00:00' AS TIMESTAMP) AS created_at
       UNION ALL SELECT 4 AS id, 'Ben' AS first_name, 'Wyatt' AS last_name, 'ben@pawnee.gov' AS email, CAST('2026-03-01 07:30:00' AS TIMESTAMP) AS created_at
       UNION ALL SELECT 5 AS id, 'April' AS first_name, 'Ludgate' AS last_name, 'april@pawnee.gov' AS email, CAST('2026-03-15 11:00:00' AS TIMESTAMP) AS created_at
+    columns:
+      - name: id
+        type: INTEGER
+      - name: first_name
+      - name: last_name
+      - name: email
+      - name: created_at
 
   - name: raw_orders
     expression: |
@@ -30,3 +37,6 @@ sources:
       UNION ALL SELECT 6 AS id, 6 AS order_id, 750 AS amount_cents, 'debit_card' AS payment_method, CAST('2026-04-02 12:01:00' AS TIMESTAMP) AS paid_at, 'success' AS status
       UNION ALL SELECT 7 AS id, 7 AS order_id, 2200 AS amount_cents, 'credit_card' AS payment_method, CAST(NULL AS TIMESTAMP) AS paid_at, 'failed' AS status
       UNION ALL SELECT 8 AS id, 8 AS order_id, 950 AS amount_cents, 'cash' AS payment_method, CAST('2026-04-03 11:01:00' AS TIMESTAMP) AS paid_at, 'success' AS status
+    columns:
+      - name: amount_cents
+        type: INTEGER

--- a/src/sqlbuild/compiler/discovery/helpers/yml_sources.py
+++ b/src/sqlbuild/compiler/discovery/helpers/yml_sources.py
@@ -51,6 +51,25 @@ def _load_sources_payload(*, contents: str, file_path: Path) -> dict[str, object
 
 
 def _parse_source_entry(*, entry: dict[str, object], file_path: Path) -> SourceEntry:
+    columns: tuple[SourceColumnEntry, ...] = _parse_columns(entry=entry, file_path=file_path)
+    raw_type_enforcement: bool | None = optional_bool(
+        entry=entry,
+        key="type_enforcement",
+        file_path=file_path,
+        label="source",
+        error_class=SourceParseError,
+    )
+    type_enforcement: bool | None = raw_type_enforcement
+    expression: str | None = optional_non_empty_string(
+        entry=entry,
+        key="expression",
+        file_path=file_path,
+        label="source",
+        error_class=SourceParseError,
+    )
+    if type_enforcement is None and any(column.type is not None for column in columns):
+        type_enforcement = True
+
     source_entry: SourceEntry = SourceEntry(
         name=require_non_empty_string(
             entry=entry,
@@ -80,13 +99,7 @@ def _parse_source_entry(*, entry: dict[str, object], file_path: Path) -> SourceE
             label="source",
             error_class=SourceParseError,
         ),
-        expression=optional_non_empty_string(
-            entry=entry,
-            key="expression",
-            file_path=file_path,
-            label="source",
-            error_class=SourceParseError,
-        ),
+        expression=expression,
         description=optional_non_empty_string(
             entry=entry,
             key="description",
@@ -94,13 +107,7 @@ def _parse_source_entry(*, entry: dict[str, object], file_path: Path) -> SourceE
             label="source",
             error_class=SourceParseError,
         ),
-        type_enforcement=optional_bool(
-            entry=entry,
-            key="type_enforcement",
-            file_path=file_path,
-            label="source",
-            error_class=SourceParseError,
-        ),
+        type_enforcement=type_enforcement,
         meta=optional_mapping(
             entry=entry,
             key="meta",
@@ -108,7 +115,7 @@ def _parse_source_entry(*, entry: dict[str, object], file_path: Path) -> SourceE
             label="source",
             error_class=SourceParseError,
         ),
-        columns=_parse_columns(entry=entry, file_path=file_path),
+        columns=columns,
         audits=parse_audit_instances(
             entry=entry, file_path=file_path, label="source", error_class=SourceParseError
         ),

--- a/src/sqlbuild/compiler/planner/helpers/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/helpers/plan_entry.py
@@ -373,11 +373,17 @@ def gather_source_columns(
 ) -> dict[str, tuple[ColumnInfo, ...]]:
     """Gather warehouse columns for all declared sources."""
 
+    result: dict[str, tuple[ColumnInfo, ...]] = {}
     source_schemas: dict[str, set[str]] = {}
     source: CompiledSource
     for source in project.sources:
         entry: SourceEntry = source.source_entry
         if entry.expression is not None:
+            if entry.type_enforcement:
+                column_names: tuple[str, ...] = adapter.query_column_names(
+                    connection, entry.expression
+                )
+                result[entry.name] = tuple(ColumnInfo(name=name, type="") for name in column_names)
             continue
         schema: str | None = entry.schema
         if schema is None:
@@ -386,7 +392,6 @@ def gather_source_columns(
         db_key: str = db or ""
         source_schemas.setdefault(db_key, set()).add(schema)
 
-    result: dict[str, tuple[ColumnInfo, ...]] = {}
     db_key_iter: str
     schemas: set[str]
     for db_key_iter, schemas in source_schemas.items():

--- a/src/sqlbuild/compiler/planner/helpers/resolve/sources.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/sources.py
@@ -39,6 +39,7 @@ def resolve_source_references(
                 resolved_source = _build_expression_cast_subquery(
                     source_relation=resolved_source,
                     declared_columns=source_entry.columns,
+                    expression_columns=warehouse_cols,
                 )
             elif warehouse_cols is not None and warehouse_cols:
                 resolved_source = _build_relation_cast_subquery(
@@ -76,10 +77,18 @@ def _build_relation_cast_subquery(
     enforced_map: dict[str, str] = {
         col.name: col.type for col in declared_columns if col.type is not None
     }
+    warehouse_names: set[str] = {col.name for col in warehouse_columns}
+    missing_names: tuple[str, ...] = tuple(
+        col.name for col in declared_columns if col.name not in warehouse_names
+    )
+    if missing_names:
+        missing_columns: str = ", ".join(missing_names)
+        raise ValueError(
+            f"Source {qualified_name} declares columns not found in warehouse: {missing_columns}"
+        )
     if not enforced_map:
         return qualified_name
 
-    warehouse_names: set[str] = {col.name for col in warehouse_columns}
     cast_names: list[str] = [name for name in enforced_map if name in warehouse_names]
     if not cast_names:
         return qualified_name
@@ -103,18 +112,34 @@ def _build_expression_cast_subquery(
     *,
     source_relation: str,
     declared_columns: tuple[SourceColumnEntry, ...],
+    expression_columns: tuple[ColumnInfo, ...] | None,
 ) -> str:
-    """Build a CAST projection for expression sources using declared columns only."""
+    """Build a CAST projection for expression sources using probed column names."""
 
-    cast_expressions: list[str] = [
-        f"CAST({col.name} AS {col.type}) AS {col.name}"
-        for col in declared_columns
-        if col.type is not None
-    ]
-    if not cast_expressions:
+    enforced_map: dict[str, str] = {
+        col.name: col.type for col in declared_columns if col.type is not None
+    }
+    if not enforced_map:
         return source_relation
-    cast_clause: str = ", ".join(cast_expressions)
-    return f"(SELECT {cast_clause} FROM {source_relation})"
+    if expression_columns is None:
+        raise ValueError("Source expression type enforcement requires query output column metadata")
+
+    expression_names: tuple[str, ...] = tuple(col.name for col in expression_columns)
+    missing_names: tuple[str, ...] = tuple(
+        name for name in enforced_map if name not in expression_names
+    )
+    if missing_names:
+        missing_columns: str = ", ".join(missing_names)
+        raise ValueError(
+            f"Source expression declares typed columns not found in query output: {missing_columns}"
+        )
+
+    projections: list[str] = [
+        f"CAST({name} AS {enforced_map[name]}) AS {name}" if name in enforced_map else name
+        for name in expression_names
+    ]
+    projection_clause: str = ", ".join(projections)
+    return f"(SELECT {projection_clause} FROM {source_relation})"
 
 
 def _build_cursor_subquery(

--- a/tests/e2e/fixtures/waffle_shop/sources/raw.yml
+++ b/tests/e2e/fixtures/waffle_shop/sources/raw.yml
@@ -8,6 +8,13 @@ sources:
         (4, 'Ben', 'Wyatt', 'ben@pawnee.gov', TIMESTAMP '2026-03-01 07:30:00'),
         (5, 'April', 'Ludgate', 'april@pawnee.gov', TIMESTAMP '2026-03-15 11:00:00')
       ) AS raw_customers(id, first_name, last_name, email, created_at)
+    columns:
+      - name: id
+        type: INTEGER
+      - name: first_name
+      - name: last_name
+      - name: email
+      - name: created_at
 
   - name: raw_orders
     expression: |
@@ -36,3 +43,6 @@ sources:
         (7, 7, 2200, 'credit_card', NULL, 'failed'),
         (8, 8, 950, 'cash', TIMESTAMP '2026-04-03 11:01:00', 'success')
       ) AS raw_payments(id, order_id, amount_cents, payment_method, paid_at, status)
+    columns:
+      - name: amount_cents
+        type: INTEGER

--- a/tests/unit/src/sqlbuild/compiler/discovery/helpers/test_yml_sources.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/helpers/test_yml_sources.py
@@ -50,7 +50,7 @@ TEST_CASES: list[ParseSourcesYamlTestCase] = [
         expected_column_audit_names=((("not_null",), ("recency",)), ()),
     ),
     ParseSourcesYamlTestCase(
-        description="parses source expression escape hatch",
+        description="defaults expression source type enforcement from typed columns",
         contents="""
         sources:
           - name: raw_orders
@@ -64,10 +64,66 @@ TEST_CASES: list[ParseSourcesYamlTestCase] = [
         """,
         expected_source_names=("raw_orders",),
         expected_column_names=(("order_id", "status"),),
-        expected_type_enforcement_values=(None,),
+        expected_type_enforcement_values=(True,),
         expected_expressions=("SELECT 1 AS order_id, 'placed' AS status\n",),
         expected_source_audit_names=((),),
         expected_column_audit_names=(((), ()),),
+    ),
+    ParseSourcesYamlTestCase(
+        description="allows expression source type enforcement to opt in explicitly",
+        contents="""
+        sources:
+          - name: raw_orders
+            expression: |
+              SELECT 1 AS order_id, 'placed' AS status
+            type_enforcement: true
+            columns:
+              - name: order_id
+                type: INTEGER
+        """,
+        expected_source_names=("raw_orders",),
+        expected_column_names=(("order_id",),),
+        expected_type_enforcement_values=(True,),
+        expected_expressions=("SELECT 1 AS order_id, 'placed' AS status\n",),
+        expected_source_audit_names=((),),
+        expected_column_audit_names=(((),),),
+    ),
+    ParseSourcesYamlTestCase(
+        description="does not enforce source types for untyped column metadata",
+        contents="""
+        sources:
+          - name: raw_orders
+            schema: public
+            table: orders
+            columns:
+              - name: order_id
+                description: Stable order identifier.
+        """,
+        expected_source_names=("raw_orders",),
+        expected_column_names=(("order_id",),),
+        expected_type_enforcement_values=(None,),
+        expected_expressions=(None,),
+        expected_source_audit_names=((),),
+        expected_column_audit_names=(((),),),
+    ),
+    ParseSourcesYamlTestCase(
+        description="allows source columns to opt out of default type enforcement",
+        contents="""
+        sources:
+          - name: raw_orders
+            schema: public
+            table: orders
+            type_enforcement: false
+            columns:
+              - name: order_id
+                type: INTEGER
+        """,
+        expected_source_names=("raw_orders",),
+        expected_column_names=(("order_id",),),
+        expected_type_enforcement_values=(False,),
+        expected_expressions=(None,),
+        expected_source_audit_names=((),),
+        expected_column_audit_names=(((),),),
     ),
     ParseSourcesYamlTestCase(
         description="allows empty sources files with no declarations",

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/_test_types.py
@@ -23,6 +23,7 @@ from sqlbuild.compiler.planner.types import (
     PlanReason,
     WarningSeverity,
 )
+from sqlbuild.spec.models.source import SourceEntry
 
 
 @dataclass(frozen=True)
@@ -32,6 +33,15 @@ class BuildUpstreamDepsTestCase:
     source_names: tuple[str, ...]
     seed_names: tuple[str, ...]
     expected_upstream_keys: dict[str, tuple[str, ...]]
+
+
+@dataclass(frozen=True)
+class SourceColumnsTestCase:
+    description: str
+    source_entry: SourceEntry
+    adapter_column_names: tuple[str, ...]
+    expected_queried_sql: tuple[str, ...]
+    expected_source_column_names: tuple[str, ...]
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/helpers.py
@@ -159,6 +159,30 @@ def build_snapshot_from_relation_names(relation_names: tuple[str, ...]) -> Wareh
     return WarehouseSnapshot(existing_relations=existing_relations)
 
 
+def build_test_project_with_source_entry(source_entry: SourceEntry) -> CompiledProject:
+    """Build a minimal CompiledProject containing one source entry."""
+
+    source: CompiledSource = CompiledSource(
+        key=source_key(source_entry.name),
+        deps=(),
+        name=source_entry.name,
+        source_entry=source_entry,
+        source_file=DiscoveredSourceFile(
+            file_path=Path("sources/raw.yml"),
+            relative_path=Path("sources/raw.yml"),
+            contents="",
+            source_entries=(source_entry,),
+        ),
+    )
+    return CompiledProject(
+        run_id="test_run",
+        effective_environment_name=None,
+        effective_connection={},
+        effective_vars={},
+        sources=(source,),
+    )
+
+
 def _resolve_dep_key(name: str, source_names: set[str], seed_names: set[str]) -> CompiledObjectKey:
     """Resolve a dependency name to the correct key type."""
 

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/_test_types.py
@@ -38,6 +38,16 @@ class SourceResolutionTestCase:
 
 
 @dataclass(frozen=True)
+class SourceResolutionErrorTestCase:
+    description: str
+    query_sql: str
+    star_exclude_keyword: str
+    source_map: dict[str, SourceEntry]
+    source_warehouse_columns: dict[str, tuple[ColumnInfo, ...]]
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
 class RefResolutionTestCase:
     description: str
     query_sql: str

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_sources.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_sources.py
@@ -13,6 +13,7 @@ from sqlbuild.compiler.planner.models import CursorBounds
 from sqlbuild.integrations.duckdb.client import DuckDbAdapter
 from sqlbuild.spec.models.source import SourceColumnEntry, SourceEntry
 from tests.unit.src.sqlbuild.compiler.planner.helpers.resolve._test_types import (
+    SourceResolutionErrorTestCase,
     SourceResolutionTestCase,
 )
 
@@ -93,11 +94,41 @@ TEST_CASES: list[SourceResolutionTestCase] = [
                 ),
             ),
         },
-        source_warehouse_columns={},
+        source_warehouse_columns={
+            "raw_orders": (
+                ColumnInfo(name="order_id", type=""),
+                ColumnInfo(name="amount", type=""),
+            ),
+        },
         expected_sql=(
             "SELECT * FROM (SELECT CAST(order_id AS INTEGER) AS order_id, "
             "CAST(amount AS DECIMAL) AS amount "
             "FROM (SELECT '1' AS order_id, 12 AS amount))"
+        ),
+    ),
+    SourceResolutionTestCase(
+        description="partial expression source enforcement preserves untyped columns",
+        query_sql='SELECT * FROM __source("raw_payments")',
+        star_exclude_keyword="EXCLUDE",
+        source_map={
+            "raw_payments": SourceEntry(
+                name="raw_payments",
+                expression="SELECT 1 AS id, '1700' AS amount_cents, 'success' AS status",
+                type_enforcement=True,
+                columns=(SourceColumnEntry(name="amount_cents", type="INTEGER"),),
+            ),
+        },
+        source_warehouse_columns={
+            "raw_payments": (
+                ColumnInfo(name="id", type=""),
+                ColumnInfo(name="amount_cents", type=""),
+                ColumnInfo(name="status", type=""),
+            ),
+        },
+        expected_sql=(
+            "SELECT * FROM (SELECT id, "
+            "CAST(amount_cents AS INTEGER) AS amount_cents, status "
+            "FROM (SELECT 1 AS id, '1700' AS amount_cents, 'success' AS status))"
         ),
     ),
     SourceResolutionTestCase(
@@ -175,35 +206,6 @@ TEST_CASES: list[SourceResolutionTestCase] = [
         expected_sql="SELECT * FROM name_only",
     ),
     SourceResolutionTestCase(
-        description="enforcement skips columns not in warehouse",
-        query_sql='SELECT * FROM __source("partial_source")',
-        star_exclude_keyword="EXCLUDE",
-        source_map={
-            "partial_source": SourceEntry(
-                name="partial_source",
-                database="raw",
-                schema="public",
-                table="partial",
-                type_enforcement=True,
-                columns=(
-                    SourceColumnEntry(name="order_id", type="VARCHAR"),
-                    SourceColumnEntry(name="missing_col", type="INTEGER"),
-                ),
-            ),
-        },
-        source_warehouse_columns={
-            "partial_source": (
-                ColumnInfo(name="order_id", type="VARCHAR"),
-                ColumnInfo(name="amount", type="DECIMAL"),
-            ),
-        },
-        expected_sql=(
-            "SELECT * FROM (SELECT * EXCLUDE (order_id), "
-            "CAST(order_id AS VARCHAR) AS order_id "
-            "FROM raw.public.partial)"
-        ),
-    ),
-    SourceResolutionTestCase(
         description="all columns enforced uses plain SELECT without EXCLUDE",
         query_sql='SELECT * FROM __source("all_enforced")',
         star_exclude_keyword="EXCLUDE",
@@ -264,6 +266,75 @@ TEST_CASES: list[SourceResolutionTestCase] = [
     ),
 ]
 
+ERROR_TEST_CASES: list[SourceResolutionErrorTestCase] = [
+    SourceResolutionErrorTestCase(
+        description="raises when enforced source declares missing warehouse columns",
+        query_sql='SELECT * FROM __source("partial_source")',
+        star_exclude_keyword="EXCLUDE",
+        source_map={
+            "partial_source": SourceEntry(
+                name="partial_source",
+                database="raw",
+                schema="public",
+                table="partial",
+                type_enforcement=True,
+                columns=(
+                    SourceColumnEntry(name="order_id", type="VARCHAR"),
+                    SourceColumnEntry(name="missing_col", type="INTEGER"),
+                ),
+            ),
+        },
+        source_warehouse_columns={
+            "partial_source": (
+                ColumnInfo(name="order_id", type="VARCHAR"),
+                ColumnInfo(name="amount", type="DECIMAL"),
+            ),
+        },
+        expected_error_fragment=(
+            "Source raw.public.partial declares columns not found in warehouse: missing_col"
+        ),
+    ),
+    SourceResolutionErrorTestCase(
+        description="raises when expression source typed column is missing from query output",
+        query_sql='SELECT * FROM __source("raw_payments")',
+        star_exclude_keyword="EXCLUDE",
+        source_map={
+            "raw_payments": SourceEntry(
+                name="raw_payments",
+                expression="SELECT 1 AS id, 'success' AS status",
+                type_enforcement=True,
+                columns=(SourceColumnEntry(name="amount_cents", type="INTEGER"),),
+            ),
+        },
+        source_warehouse_columns={
+            "raw_payments": (
+                ColumnInfo(name="id", type=""),
+                ColumnInfo(name="status", type=""),
+            ),
+        },
+        expected_error_fragment=(
+            "Source expression declares typed columns not found in query output: amount_cents"
+        ),
+    ),
+    SourceResolutionErrorTestCase(
+        description="raises when expression source enforcement lacks query output metadata",
+        query_sql='SELECT * FROM __source("raw_payments")',
+        star_exclude_keyword="EXCLUDE",
+        source_map={
+            "raw_payments": SourceEntry(
+                name="raw_payments",
+                expression="SELECT 1 AS amount_cents",
+                type_enforcement=True,
+                columns=(SourceColumnEntry(name="amount_cents", type="INTEGER"),),
+            ),
+        },
+        source_warehouse_columns={},
+        expected_error_fragment=(
+            "Source expression type enforcement requires query output column metadata"
+        ),
+    ),
+]
+
 
 @pytest.mark.parametrize(
     "test_case",
@@ -286,3 +357,25 @@ def test_given_source_references_when_resolving_then_returns_expected_sql(
     )
 
     assert result == test_case.expected_sql
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    ERROR_TEST_CASES,
+    ids=[case.description for case in ERROR_TEST_CASES],
+)
+def test_given_invalid_source_references_when_resolving_then_raises_clear_error(
+    test_case: SourceResolutionErrorTestCase,
+) -> None:
+    with pytest.raises(ValueError, match=test_case.expected_error_fragment):
+        resolve_source_references(
+            query_sql=test_case.query_sql,
+            source_map=test_case.source_map,
+            source_warehouse_columns=test_case.source_warehouse_columns,
+            star_exclude_keyword=test_case.star_exclude_keyword,
+            cursor_bounds=None,
+            cursor_inputs={},
+            adapter=DuckDbAdapter(),
+            cursor_type=None,
+            lower_bound_inclusive=True,
+        )

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_source_columns.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_source_columns.py
@@ -1,0 +1,93 @@
+"""Tests for planner source column gathering."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sqlbuild.adapter.base.base_adapter import BaseAdapter
+from sqlbuild.adapter.shared.models import ColumnInfo
+from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.planner.helpers.plan_entry import gather_source_columns
+from sqlbuild.spec.models.source import SourceEntry
+from tests.unit.src.sqlbuild.compiler.planner.helpers._test_types import SourceColumnsTestCase
+from tests.unit.src.sqlbuild.compiler.planner.helpers.helpers import (
+    build_test_project_with_source_entry,
+)
+
+
+class _RecordingAdapter(BaseAdapter):
+    def __init__(self, column_names: tuple[str, ...]) -> None:
+        self.column_names: tuple[str, ...] = column_names
+        self.queried_sql: list[str] = []
+
+    def connect(self, config: dict[str, object]) -> object:
+        del config
+        return object()
+
+    def close(self, connection: Any) -> None:
+        del connection
+
+    def execute(self, connection: Any, sql: str) -> Any:
+        del connection, sql
+        raise AssertionError("execute should not be called")
+
+    def query_column_names(self, connection: Any, sql: str) -> tuple[str, ...]:
+        del connection
+        self.queried_sql.append(sql)
+        return self.column_names
+
+    def get_all_columns(
+        self,
+        connection: Any,
+        *,
+        database: str | None,
+        schemas: tuple[str, ...] | None,
+        names: tuple[str, ...] | None = None,
+    ) -> dict[str, tuple[ColumnInfo, ...]]:
+        del connection, database, schemas, names
+        return {}
+
+
+TEST_CASES: list[SourceColumnsTestCase] = [
+    SourceColumnsTestCase(
+        description="probes enforced expression source query output",
+        source_entry=SourceEntry(
+            name="raw_payments",
+            expression="SELECT 1 AS id, 1700 AS amount_cents, 'success' AS status",
+            type_enforcement=True,
+        ),
+        adapter_column_names=("id", "amount_cents", "status"),
+        expected_queried_sql=("SELECT 1 AS id, 1700 AS amount_cents, 'success' AS status",),
+        expected_source_column_names=("id", "amount_cents", "status"),
+    ),
+    SourceColumnsTestCase(
+        description="skips non-enforced expression source probe",
+        source_entry=SourceEntry(
+            name="raw_payments",
+            expression="SELECT 1 AS id, 1700 AS amount_cents",
+            type_enforcement=None,
+        ),
+        adapter_column_names=("id", "amount_cents"),
+        expected_queried_sql=(),
+        expected_source_column_names=(),
+    ),
+]
+
+
+@pytest.mark.parametrize("test_case", TEST_CASES, ids=[case.description for case in TEST_CASES])
+def test_given_sources_when_gathering_columns_then_returns_expected_source_columns(
+    test_case: SourceColumnsTestCase,
+) -> None:
+    project: CompiledProject = build_test_project_with_source_entry(test_case.source_entry)
+    adapter: _RecordingAdapter = _RecordingAdapter(test_case.adapter_column_names)
+
+    result: dict[str, tuple[ColumnInfo, ...]] = gather_source_columns(
+        project=project, adapter=adapter, connection=None
+    )
+
+    assert tuple(adapter.queried_sql) == test_case.expected_queried_sql
+    assert tuple(column.name for column in result.get("raw_payments", ())) == (
+        test_case.expected_source_column_names
+    )


### PR DESCRIPTION
Improving type enforcement semantics for sources so that they are more aligned with models (if a type is included in docs, it is enforced and validated + columns that are mentioned but untyped, we make sure those at least exist).