### PR TITLE
fix: validate declared inline source columns

### DIFF
--- a/src/sqlbuild/compiler/planner/helpers/resolve/sources.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/sources.py
@@ -126,12 +126,12 @@ def _build_expression_cast_subquery(
 
     expression_names: tuple[str, ...] = tuple(col.name for col in expression_columns)
     missing_names: tuple[str, ...] = tuple(
-        name for name in enforced_map if name not in expression_names
+        col.name for col in declared_columns if col.name not in expression_names
     )
     if missing_names:
         missing_columns: str = ", ".join(missing_names)
         raise ValueError(
-            f"Source expression declares typed columns not found in query output: {missing_columns}"
+            f"Source expression declares columns not found in query output: {missing_columns}"
         )
 
     projections: list[str] = [

--- a/src/sqlbuild/compiler/planner/helpers/resolve/sources.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/sources.py
@@ -34,6 +34,12 @@ def resolve_source_references(
             return match.group(0)
         resolved_source: str = render_source_relation(source_entry)
         warehouse_cols: tuple[ColumnInfo, ...] | None = source_warehouse_columns.get(source_name)
+        if source_entry.expression is None and warehouse_cols:
+            _validate_declared_columns(
+                qualified_name=resolved_source,
+                declared_columns=source_entry.columns,
+                available_columns=warehouse_cols,
+            )
         if source_entry.type_enforcement:
             if source_entry.expression is not None:
                 resolved_source = _build_expression_cast_subquery(
@@ -77,18 +83,10 @@ def _build_relation_cast_subquery(
     enforced_map: dict[str, str] = {
         col.name: col.type for col in declared_columns if col.type is not None
     }
-    warehouse_names: set[str] = {col.name for col in warehouse_columns}
-    missing_names: tuple[str, ...] = tuple(
-        col.name for col in declared_columns if col.name not in warehouse_names
-    )
-    if missing_names:
-        missing_columns: str = ", ".join(missing_names)
-        raise ValueError(
-            f"Source {qualified_name} declares columns not found in warehouse: {missing_columns}"
-        )
     if not enforced_map:
         return qualified_name
 
+    warehouse_names: set[str] = {col.name for col in warehouse_columns}
     cast_names: list[str] = [name for name in enforced_map if name in warehouse_names]
     if not cast_names:
         return qualified_name
@@ -105,6 +103,26 @@ def _build_relation_cast_subquery(
     exclude_list: str = ", ".join(cast_names)
     return (
         f"(SELECT * {star_exclude_keyword} ({exclude_list}), {cast_clause} FROM {qualified_name})"
+    )
+
+
+def _validate_declared_columns(
+    *,
+    qualified_name: str,
+    declared_columns: tuple[SourceColumnEntry, ...],
+    available_columns: tuple[ColumnInfo, ...],
+) -> None:
+    """Ensure declared relation source columns exist in warehouse metadata."""
+
+    available_names: set[str] = {col.name for col in available_columns}
+    missing_names: tuple[str, ...] = tuple(
+        col.name for col in declared_columns if col.name not in available_names
+    )
+    if not missing_names:
+        return
+    missing_columns: str = ", ".join(missing_names)
+    raise ValueError(
+        f"Source {qualified_name} declares columns not found in warehouse: {missing_columns}"
     )
 
 

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_sources.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_sources.py
@@ -313,7 +313,32 @@ ERROR_TEST_CASES: list[SourceResolutionErrorTestCase] = [
             ),
         },
         expected_error_fragment=(
-            "Source expression declares typed columns not found in query output: amount_cents"
+            "Source expression declares columns not found in query output: amount_cents"
+        ),
+    ),
+    SourceResolutionErrorTestCase(
+        description="raises when expression source untyped column is missing from query output",
+        query_sql='SELECT * FROM __source("raw_payments")',
+        star_exclude_keyword="EXCLUDE",
+        source_map={
+            "raw_payments": SourceEntry(
+                name="raw_payments",
+                expression="SELECT 1 AS id, 1700 AS amount_cents",
+                type_enforcement=True,
+                columns=(
+                    SourceColumnEntry(name="amount_cents", type="INTEGER"),
+                    SourceColumnEntry(name="status"),
+                ),
+            ),
+        },
+        source_warehouse_columns={
+            "raw_payments": (
+                ColumnInfo(name="id", type=""),
+                ColumnInfo(name="amount_cents", type=""),
+            ),
+        },
+        expected_error_fragment=(
+            "Source expression declares columns not found in query output: status"
         ),
     ),
     SourceResolutionErrorTestCase(

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_sources.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_sources.py
@@ -295,6 +295,32 @@ ERROR_TEST_CASES: list[SourceResolutionErrorTestCase] = [
         ),
     ),
     SourceResolutionErrorTestCase(
+        description="raises when untyped relation source metadata has missing columns",
+        query_sql='SELECT * FROM __source("partial_source")',
+        star_exclude_keyword="EXCLUDE",
+        source_map={
+            "partial_source": SourceEntry(
+                name="partial_source",
+                database="raw",
+                schema="public",
+                table="partial",
+                columns=(
+                    SourceColumnEntry(name="order_id"),
+                    SourceColumnEntry(name="missing_col"),
+                ),
+            ),
+        },
+        source_warehouse_columns={
+            "partial_source": (
+                ColumnInfo(name="order_id", type="VARCHAR"),
+                ColumnInfo(name="amount", type="DECIMAL"),
+            ),
+        },
+        expected_error_fragment=(
+            "Source raw.public.partial declares columns not found in warehouse: missing_col"
+        ),
+    ),
+    SourceResolutionErrorTestCase(
         description="raises when expression source typed column is missing from query output",
         query_sql='SELECT * FROM __source("raw_payments")',
         star_exclude_keyword="EXCLUDE",


### PR DESCRIPTION
Realised I missed something small in the last merge (when type enforcement is on, any declared column in yml, even if untyped, must at minimum exist - only exception is inline sources as those are more expensive to validate). Should have made new branch but just going to be lazy and reuse this.