### PR TITLE
fix: improve warehouse planning feedback

### DIFF
--- a/src/sqlbuild/cli/commands/main/build.py
+++ b/src/sqlbuild/cli/commands/main/build.py
@@ -10,7 +10,11 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.cli.commands.main.helpers.compile.target_writer import write_compile_target
 from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
+from sqlbuild.cli.commands.main.shared.helpers.connection_progress import (
+    ConnectionProgressReporter,
+)
 from sqlbuild.cli.commands.main.shared.helpers.plan_format import format_plan
+from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.progress import (
     BuildProgressCallbacks,
     format_build_footer,
@@ -49,17 +53,37 @@ def run_build(
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(
         project_dir=effective_project_dir
     )
+    adapter_name: str = resolve_effective_adapter_name(
+        project_config=discovered_inputs.project_config,
+        local_config=discovered_inputs.local_config,
+    )
     adapter: BaseAdapter = resolve_adapter(
-        resolve_effective_adapter_name(
-            project_config=discovered_inputs.project_config,
-            local_config=discovered_inputs.local_config,
-        ),
+        adapter_name,
         project_dir=effective_project_dir,
     )
     connection_config: dict[str, object] = resolve_project_connection_config(
         discovered_inputs=discovered_inputs,
         project_dir=effective_project_dir,
     )
+    use_color: bool = not no_color and supports_color()
+    progress_stream: TextIO = sys.stderr if debug else sys.stdout
+    connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
+        adapter_name=adapter_name,
+        stream=progress_stream,
+        use_color=use_color,
+    )
+    execution_connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
+        adapter_name=adapter_name,
+        stream=progress_stream,
+        blank_line_after_complete=True,
+        use_color=use_color,
+    )
+    planning_progress: PlanningProgressReporter = PlanningProgressReporter(
+        stream=progress_stream,
+        use_color=use_color,
+    )
+    progress_stream.write("\n")
+    progress_stream.flush()
     pipeline_result: CompilePipelineResult = run_compile_pipeline(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
@@ -70,10 +94,13 @@ def run_build(
         exclude=exclude,
         full_refresh=full_refresh,
         connection_config=connection_config,
+        on_connection_start=connection_progress.on_connection_start,
+        on_connection_complete=connection_progress.on_connection_complete,
+        on_connection_error=connection_progress.on_connection_error,
+        on_progress=planning_progress.on_progress,
     )
 
     plan_output: PlanOutput = pipeline_result.plan_output
-    use_color: bool = not no_color and supports_color()
     plan_stream: TextIO = sys.stderr if debug else sys.stdout
 
     plan_text: str = format_plan(plan_output, full_refresh=full_refresh, use_color=use_color)
@@ -90,7 +117,6 @@ def run_build(
     callbacks: BuildProgressCallbacks = BuildProgressCallbacks(
         plan=plan_output, use_color=use_color, verbose=verbose, debug=debug
     )
-    progress_stream: TextIO = sys.stderr if debug else sys.stdout
     effective_concurrency: int = (
         concurrency if concurrency is not None else pipeline_result.project.settings.max_concurrency
     )
@@ -116,6 +142,9 @@ def run_build(
         on_node_complete=callbacks.on_node_complete,
         on_sub_progress=callbacks.on_sub_progress,
         custom_materializations=pipeline_result.custom_materializations,
+        on_connection_start=execution_connection_progress.on_connection_start,
+        on_connection_complete=execution_connection_progress.on_connection_complete,
+        on_connection_error=execution_connection_progress.on_connection_error,
     )
     write_runtime_target(
         target_dir=effective_project_dir / "target",

--- a/src/sqlbuild/cli/commands/main/helpers/plan/formatter.py
+++ b/src/sqlbuild/cli/commands/main/helpers/plan/formatter.py
@@ -233,7 +233,11 @@ def _format_detail_entry(
 
     action_text: str = _action_text(entry)
     lines.append(f"  {blue_bold(entry.name):<40s} {action_text}")
-    _append_cursor_detail(lines, entry)
+    _append_cursor_detail(
+        lines,
+        entry,
+        show_range=entry.backfill.action != BackfillAction.FULL,
+    )
     _append_policy_line(lines, entry)
     _append_schema_diff(lines, entry)
     _append_query_diff(lines, entry)
@@ -245,20 +249,26 @@ def _format_upstream_changed_entry(lines: list[str], entry: ModelPlanEntry) -> N
     cascade: CascadeResult | None = entry.cascade
     action_text: str = _cascade_action_text(cascade)
     lines.append(f"  {blue_bold(entry.name):<40s} {action_text}")
-    _append_cursor_detail(lines, entry)
+    _append_cursor_detail(
+        lines,
+        entry,
+        show_range=cascade is None or cascade.effective_action != BackfillAction.FULL,
+    )
     if cascade is not None and cascade.root_cause is not None:
         cause_desc: str = _cascade_cause_description(cascade)
         lines.append(f"    cause: {cause_desc}")
 
 
-def _append_cursor_detail(lines: list[str], entry: ModelPlanEntry) -> None:
+def _append_cursor_detail(
+    lines: list[str], entry: ModelPlanEntry, *, show_range: bool = True
+) -> None:
     """Append cursor column, mode, and range detail lines."""
 
     if entry.cursor_column is not None:
         lines.append(f"    cursor: {entry.cursor_column}")
     if entry.incremental_mode == IncrementalMode.MICROBATCH:
         lines.append(f"    mode: {IncrementalMode.MICROBATCH.value}")
-    if entry.cursor_bounds is not None:
+    if show_range and entry.cursor_bounds is not None:
         lines.append(f"    range: {entry.cursor_bounds.start} \u2192 {entry.cursor_bounds.end}")
 
 
@@ -325,6 +335,10 @@ def _cascade_cause_description(cascade: CascadeResult) -> str:
     """Format the cause line content for an upstream-changed entry."""
 
     root: str = cascade.root_cause or "unknown"
+    if cascade.root_reason is not None:
+        reason_text: str = _plan_reason_text(cascade.root_reason)
+        if reason_text:
+            return f"{root} ({reason_text})"
     if cascade.effective_action == BackfillAction.FULL:
         return f"{root} (full)"
     if (
@@ -333,6 +347,20 @@ def _cascade_cause_description(cascade: CascadeResult) -> str:
     ):
         return f"{root} ({cascade.effective_duration})"
     return root
+
+
+def _plan_reason_text(reason: PlanReason) -> str:
+    """Format a plan reason for cascade cause output."""
+
+    if reason == PlanReason.QUERY_CHANGED:
+        return "query changed"
+    if reason == PlanReason.SCHEMA_CHANGED:
+        return "schema changed"
+    if reason == PlanReason.FIRST_RUN:
+        return "first run"
+    if reason == PlanReason.FULL_REFRESH:
+        return "full refresh"
+    return ""
 
 
 def _schema_change_suffix(entry: ModelPlanEntry) -> str:
@@ -376,16 +404,55 @@ def _format_functions(lines: list[str], plan: PlanOutput) -> None:
 
     if not plan.function_entries:
         return
+    changed_entries: list[FunctionPlanEntry] = [
+        entry for entry in plan.function_entries if entry.reason != PlanReason.NO_CHANGE
+    ]
+    unchanged_entries: list[FunctionPlanEntry] = [
+        entry for entry in plan.function_entries if entry.reason == PlanReason.NO_CHANGE
+    ]
+    if changed_entries:
+        lines.append("")
+        lines.append(green_bold(f"Function changed ({len(changed_entries)})"))
+        function_entry: FunctionPlanEntry
+        for function_entry in changed_entries:
+            _format_function_entry(lines, function_entry, show_details=True)
+    if not unchanged_entries:
+        return
     lines.append("")
-    lines.append(green_bold(f"Functions ({len(plan.function_entries)})"))
-    function_entry: FunctionPlanEntry
-    for function_entry in plan.function_entries:
-        function_kind: str = (
-            "table function"
-            if function_entry.return_columns
-            else f"{function_entry.language.value} udf"
-        )
-        lines.append(f"  {blue_bold(function_entry.name):<40s} {function_kind}")
+    lines.append(green_bold(f"Functions ({len(unchanged_entries)})"))
+    for function_entry in unchanged_entries:
+        _format_function_entry(lines, function_entry, show_details=False)
+
+
+def _format_function_entry(
+    lines: list[str], function_entry: FunctionPlanEntry, *, show_details: bool
+) -> None:
+    """Append one function line and optional change details."""
+
+    function_kind: str = (
+        "table function"
+        if function_entry.return_columns
+        else f"{function_entry.language.value} udf"
+    )
+    lines.append(f"  {blue_bold(function_entry.name):<40s} {function_kind}")
+    if not show_details:
+        return
+    if function_entry.reason == PlanReason.FIRST_RUN:
+        lines.append("    reason: first run")
+    elif function_entry.reason == PlanReason.FULL_REFRESH:
+        lines.append("    reason: full refresh")
+    elif function_entry.reason == PlanReason.QUERY_CHANGED:
+        if function_entry.backfill.action != BackfillAction.WARN_ONLY:
+            duration: str = function_entry.backfill.duration or "full"
+            policy_value: str = _backfill_value(function_entry.backfill.action, duration)
+            lines.append(f"    policy: query_change_backfill={policy_value}")
+        if function_entry.previous_query_sql is not None:
+            lines.append("    query diff:")
+            lines.extend(
+                _format_query_diff(
+                    function_entry.previous_query_sql, function_entry.fingerprint_query_sql
+                )
+            )
 
 
 def _format_warnings(lines: list[str], plan: PlanOutput) -> None:

--- a/src/sqlbuild/cli/commands/main/plan.py
+++ b/src/sqlbuild/cli/commands/main/plan.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+from typing import TextIO
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.cli.commands.main.helpers.plan.formatter import format_plan
 from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
+from sqlbuild.cli.commands.main.shared.helpers.connection_progress import (
+    ConnectionProgressReporter,
+)
 from sqlbuild.cli.commands.main.shared.helpers.json_output import format_plan_json
+from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compile import run_compile_pipeline
@@ -35,13 +41,31 @@ def run_plan(
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(
         project_dir=effective_project_dir
     )
+    adapter_name: str = resolve_effective_adapter_name(
+        project_config=discovered_inputs.project_config,
+        local_config=discovered_inputs.local_config,
+    )
     adapter: BaseAdapter = resolve_adapter(
-        resolve_effective_adapter_name(
-            project_config=discovered_inputs.project_config,
-            local_config=discovered_inputs.local_config,
-        ),
+        adapter_name,
         project_dir=effective_project_dir,
     )
+    connection_config: dict[str, object] = resolve_project_connection_config(
+        discovered_inputs=discovered_inputs, project_dir=effective_project_dir
+    )
+    use_color: bool = not no_color and not json_output and supports_color()
+    progress_stream: TextIO = sys.stderr if json_output else sys.stdout
+    connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
+        adapter_name=adapter_name,
+        stream=progress_stream,
+        use_color=use_color,
+    )
+    planning_progress: PlanningProgressReporter = PlanningProgressReporter(
+        stream=progress_stream,
+        use_color=use_color,
+    )
+    if not json_output:
+        progress_stream.write("\n")
+        progress_stream.flush()
     pipeline_result: CompilePipelineResult = run_compile_pipeline(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
@@ -51,9 +75,11 @@ def run_plan(
         full_refresh=full_refresh,
         select=select,
         exclude=exclude,
-        connection_config=resolve_project_connection_config(
-            discovered_inputs=discovered_inputs, project_dir=effective_project_dir
-        ),
+        connection_config=connection_config,
+        on_connection_start=connection_progress.on_connection_start,
+        on_connection_complete=connection_progress.on_connection_complete,
+        on_connection_error=connection_progress.on_connection_error,
+        on_progress=planning_progress.on_progress,
     )
 
     plan_output: PlanOutput = pipeline_result.plan_output
@@ -62,6 +88,5 @@ def run_plan(
         print(format_plan_json(plan_output))
         return 0
 
-    use_color: bool = not no_color and supports_color()
     print("\n" + format_plan(plan_output, full_refresh=full_refresh, use_color=use_color))
     return 0

--- a/src/sqlbuild/cli/commands/main/run.py
+++ b/src/sqlbuild/cli/commands/main/run.py
@@ -10,7 +10,11 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.cli.commands.main.helpers.compile.target_writer import write_compile_target
 from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
+from sqlbuild.cli.commands.main.shared.helpers.connection_progress import (
+    ConnectionProgressReporter,
+)
 from sqlbuild.cli.commands.main.shared.helpers.plan_format import format_plan
+from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.progress import (
     BuildProgressCallbacks,
     format_build_footer,
@@ -49,17 +53,37 @@ def run_run(
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(
         project_dir=effective_project_dir
     )
+    adapter_name: str = resolve_effective_adapter_name(
+        project_config=discovered_inputs.project_config,
+        local_config=discovered_inputs.local_config,
+    )
     adapter: BaseAdapter = resolve_adapter(
-        resolve_effective_adapter_name(
-            project_config=discovered_inputs.project_config,
-            local_config=discovered_inputs.local_config,
-        ),
+        adapter_name,
         project_dir=effective_project_dir,
     )
     connection_config: dict[str, object] = resolve_project_connection_config(
         discovered_inputs=discovered_inputs,
         project_dir=effective_project_dir,
     )
+    use_color: bool = not no_color and supports_color()
+    progress_stream: TextIO = sys.stderr if debug else sys.stdout
+    connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
+        adapter_name=adapter_name,
+        stream=progress_stream,
+        use_color=use_color,
+    )
+    execution_connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
+        adapter_name=adapter_name,
+        stream=progress_stream,
+        blank_line_after_complete=True,
+        use_color=use_color,
+    )
+    planning_progress: PlanningProgressReporter = PlanningProgressReporter(
+        stream=progress_stream,
+        use_color=use_color,
+    )
+    progress_stream.write("\n")
+    progress_stream.flush()
     pipeline_result: CompilePipelineResult = run_compile_pipeline(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
@@ -70,10 +94,13 @@ def run_run(
         exclude=exclude,
         full_refresh=full_refresh,
         connection_config=connection_config,
+        on_connection_start=connection_progress.on_connection_start,
+        on_connection_complete=connection_progress.on_connection_complete,
+        on_connection_error=connection_progress.on_connection_error,
+        on_progress=planning_progress.on_progress,
     )
 
     plan_output: PlanOutput = pipeline_result.plan_output
-    use_color: bool = not no_color and supports_color()
     plan_stream: TextIO = sys.stderr if debug else sys.stdout
 
     plan_text: str = format_plan(plan_output, full_refresh=full_refresh, use_color=use_color)
@@ -90,7 +117,6 @@ def run_run(
     callbacks: BuildProgressCallbacks = BuildProgressCallbacks(
         plan=plan_output, use_color=use_color, verbose=verbose, debug=debug
     )
-    progress_stream: TextIO = sys.stderr if debug else sys.stdout
     effective_concurrency: int = (
         concurrency if concurrency is not None else pipeline_result.project.settings.max_concurrency
     )
@@ -116,6 +142,9 @@ def run_run(
         on_node_complete=callbacks.on_node_complete,
         on_sub_progress=callbacks.on_sub_progress,
         custom_materializations=pipeline_result.custom_materializations,
+        on_connection_start=execution_connection_progress.on_connection_start,
+        on_connection_complete=execution_connection_progress.on_connection_complete,
+        on_connection_error=execution_connection_progress.on_connection_error,
     )
     write_runtime_target(
         target_dir=effective_project_dir / "target",

--- a/src/sqlbuild/cli/commands/main/shared/helpers/connection_progress.py
+++ b/src/sqlbuild/cli/commands/main/shared/helpers/connection_progress.py
@@ -1,0 +1,51 @@
+"""User-facing warehouse connection progress messages."""
+
+from __future__ import annotations
+
+from typing import TextIO
+
+from sqlbuild.shared.helpers.colors import dim
+
+
+class ConnectionProgressReporter:
+    """Render simple connection start, success, and failure messages."""
+
+    def __init__(
+        self,
+        *,
+        adapter_name: str,
+        stream: TextIO,
+        blank_line_after_complete: bool = False,
+        use_color: bool = False,
+    ) -> None:
+        self._adapter_name: str = adapter_name
+        self._stream: TextIO = stream
+        self._blank_line_after_complete: bool = blank_line_after_complete
+        self._use_color: bool = use_color
+
+    def on_connection_start(self, connection_count: int) -> None:
+        self._stream.write(f"{self._format_progress(self._start_message(connection_count))}\n")
+        self._stream.flush()
+
+    def on_connection_complete(self, connection_count: int, elapsed_seconds: float) -> None:
+        del connection_count
+        message: str = f"Connected to {self._adapter_name}. ({elapsed_seconds:.2f}s)"
+        self._stream.write(f"{self._format_progress(message)}\n")
+        if self._blank_line_after_complete:
+            self._stream.write("\n")
+        self._stream.flush()
+
+    def on_connection_error(self, connection_count: int, elapsed_seconds: float) -> None:
+        del connection_count
+        self._stream.write(
+            f"Failed to connect to {self._adapter_name} after {elapsed_seconds:.2f}s.\n"
+        )
+        self._stream.flush()
+
+    def _start_message(self, connection_count: int) -> str:
+        if connection_count <= 1:
+            return f"Connecting to {self._adapter_name}..."
+        return f"Connecting to {self._adapter_name} ({connection_count} connections)..."
+
+    def _format_progress(self, message: str) -> str:
+        return dim(message) if self._use_color else message

--- a/src/sqlbuild/cli/commands/main/shared/helpers/planning_progress.py
+++ b/src/sqlbuild/cli/commands/main/shared/helpers/planning_progress.py
@@ -1,0 +1,20 @@
+"""User-facing plan generation progress messages."""
+
+from __future__ import annotations
+
+from typing import TextIO
+
+from sqlbuild.shared.helpers.colors import dim
+
+
+class PlanningProgressReporter:
+    """Render simple planning phase progress messages."""
+
+    def __init__(self, *, stream: TextIO, use_color: bool = False) -> None:
+        self._stream: TextIO = stream
+        self._use_color: bool = use_color
+
+    def on_progress(self, message: str) -> None:
+        output: str = dim(message) if self._use_color else message
+        self._stream.write(f"{output}\n")
+        self._stream.flush()

--- a/src/sqlbuild/compiler/compile/helpers/assembly.py
+++ b/src/sqlbuild/compiler/compile/helpers/assembly.py
@@ -182,6 +182,7 @@ def _assemble_compiled_function(
         runtime_version=function_input.runtime_version,
         entry_point=function_input.entry_point,
         packages=function_input.packages,
+        query_change_backfill=function_input.query_change_backfill,
     )
 
 

--- a/src/sqlbuild/compiler/compile/helpers/attachment.py
+++ b/src/sqlbuild/compiler/compile/helpers/attachment.py
@@ -440,6 +440,13 @@ def build_sql_function_inputs(
                 references=references,
                 database=function_database,
                 schema=function_schema,
+                query_change_backfill=_parse_optional_function_header(
+                    header_values=header_values,
+                    key="query_change_backfill",
+                    effective_vars=effective_vars,
+                    relative_path=function_file.relative_path,
+                    language="SQL",
+                ),
             )
         )
     python_function_file: DiscoveredPythonFunctionFile
@@ -525,6 +532,13 @@ def build_sql_function_inputs(
             runtime_version=runtime_version,
             entry_point=entry_point,
             packages=packages,
+            query_change_backfill=_parse_optional_function_header(
+                header_values=header_values,
+                key="query_change_backfill",
+                effective_vars=effective_vars,
+                relative_path=python_function_file.relative_path,
+                language="Python",
+            ),
         )
         function_inputs.append(compile_input)
     return tuple(function_inputs)
@@ -657,6 +671,26 @@ def _parse_required_string_header(
     if not isinstance(raw_value, str) or not raw_value.strip():
         raise CompileInputError(f"{language} function file {relative_path} must declare {key}")
     return raw_value.strip()
+
+
+def _parse_optional_function_header(
+    *,
+    header_values: dict[str, object],
+    key: str,
+    effective_vars: dict[str, str],
+    relative_path: Path,
+    language: str,
+) -> str | None:
+    raw_value: object | None = header_values.get(key)
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, str) or not raw_value.strip():
+        raise CompileInputError(f"{language} function file {relative_path} {key} must be a string")
+    return _expand_function_header_value(
+        raw_value=raw_value.strip(),
+        effective_vars=effective_vars,
+        context_label=f"{language} function {relative_path} {key}",
+    )
 
 
 def _parse_python_packages(*, raw_packages: object | None, relative_path: Path) -> tuple[str, ...]:

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -149,6 +149,7 @@ class CompileSqlFunctionInput:
     runtime_version: str | None = None
     entry_point: str | None = None
     packages: tuple[str, ...] = field(default_factory=tuple)
+    query_change_backfill: str | None = None
 
 
 @dataclass(frozen=True)
@@ -312,6 +313,7 @@ class CompiledFunction:
     runtime_version: str | None = None
     entry_point: str | None = None
     packages: tuple[str, ...] = field(default_factory=tuple)
+    query_change_backfill: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/pipeline/main/compile.py
+++ b/src/sqlbuild/compiler/pipeline/main/compile.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+from collections.abc import Callable
 from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
@@ -39,6 +41,10 @@ def run_compile_pipeline(
     cursor_overrides: CursorOverrides | None = None,
     full_refresh: bool = False,
     connection_config: dict[str, object] | None = None,
+    on_connection_start: Callable[[int], None] | None = None,
+    on_connection_complete: Callable[[int, float], None] | None = None,
+    on_connection_error: Callable[[int, float], None] | None = None,
+    on_progress: Callable[[str], None] | None = None,
 ) -> CompilePipelineResult:
     """Run compile inputs, assembly, planning, and manifest generation."""
 
@@ -47,7 +53,17 @@ def run_compile_pipeline(
         if connection_config is not None
         else build_effective_connection_config(discovered_inputs=discovered_inputs)
     )
-    connection: Any = adapter.connect(effective_config)
+    if on_connection_start is not None:
+        on_connection_start(1)
+    start: float = time.monotonic()
+    try:
+        connection: Any = adapter.connect(effective_config)
+    except Exception:
+        if on_connection_error is not None:
+            on_connection_error(1, time.monotonic() - start)
+        raise
+    if on_connection_complete is not None:
+        on_connection_complete(1, time.monotonic() - start)
     try:
         return _build_result(
             discovered_inputs=discovered_inputs,
@@ -59,6 +75,7 @@ def run_compile_pipeline(
             exclude=exclude,
             cursor_overrides=cursor_overrides,
             full_refresh=full_refresh,
+            on_progress=on_progress,
         )
     finally:
         adapter.close(connection)
@@ -75,6 +92,7 @@ def _build_result(
     exclude: tuple[str, ...] = (),
     cursor_overrides: CursorOverrides | None = None,
     full_refresh: bool = False,
+    on_progress: Callable[[str], None] | None = None,
 ) -> CompilePipelineResult:
     project: CompiledProject = build_compiled_project(
         discovered_inputs=discovered_inputs,
@@ -114,6 +132,7 @@ def _build_result(
         deferred_relations=deferred_relations,
         cursor_overrides=cursor_overrides,
         full_refresh=full_refresh,
+        on_progress=on_progress,
     )
     loaded_macros: dict[str, LoadedMacro] = load_macros(discovered_inputs.macro_files)
     manifest: dict[str, object] = build_manifest(

--- a/src/sqlbuild/compiler/planner/helpers/cascade.py
+++ b/src/sqlbuild/compiler/planner/helpers/cascade.py
@@ -12,7 +12,7 @@ from sqlbuild.compiler.planner.models import (
     CascadeCause,
     CascadeResult,
 )
-from sqlbuild.compiler.planner.types import BackfillAction
+from sqlbuild.compiler.planner.types import BackfillAction, PlanReason
 
 _DURATION_PATTERN: re.Pattern[str] = re.compile(r"^(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")
 
@@ -56,18 +56,25 @@ def resolve_cascade(
     return CascadeResult(
         effective_action=winning.effective_action,
         effective_duration=winning.effective_duration,
-        root_cause=winning.model_name,
+        root_cause=winning.root_cause or winning.model_name,
+        root_reason=winning.root_reason,
         causes=tuple(candidates),
     )
 
 
-def build_self_cascade(backfill: BackfillResult) -> CascadeResult:
+def build_self_cascade(
+    backfill: BackfillResult,
+    *,
+    root_cause: str | None = None,
+    root_reason: PlanReason | None = None,
+) -> CascadeResult:
     """Build a CascadeResult representing a model's own backfill for the accumulator."""
 
     return CascadeResult(
         effective_action=backfill.action,
         effective_duration=backfill.duration,
-        root_cause=None,
+        root_cause=root_cause,
+        root_reason=root_reason,
         causes=(),
     )
 
@@ -98,6 +105,8 @@ def _gather_cascade_candidates(
                     model_name=key.name,
                     effective_action=upstream_cascade.effective_action,
                     effective_duration=upstream_cascade.effective_duration,
+                    root_cause=upstream_cascade.root_cause or key.name,
+                    root_reason=upstream_cascade.root_reason,
                 )
             )
             continue
@@ -115,6 +124,8 @@ def _gather_cascade_candidates(
                     model_name=key.name,
                     effective_action=upstream_cascade.effective_action,
                     effective_duration=upstream_cascade.effective_duration,
+                    root_cause=upstream_cascade.root_cause or key.name,
+                    root_reason=upstream_cascade.root_reason,
                 )
             )
         elif same_cursor_type:
@@ -123,6 +134,8 @@ def _gather_cascade_candidates(
                     model_name=key.name,
                     effective_action=upstream_cascade.effective_action,
                     effective_duration=upstream_cascade.effective_duration,
+                    root_cause=upstream_cascade.root_cause or key.name,
+                    root_reason=upstream_cascade.root_reason,
                 )
             )
 

--- a/src/sqlbuild/compiler/planner/helpers/function_fingerprints.py
+++ b/src/sqlbuild/compiler/planner/helpers/function_fingerprints.py
@@ -8,8 +8,9 @@ from sqlbuild.compiler.compile.models import (
     FunctionReturnColumn,
 )
 from sqlbuild.compiler.fingerprints.models import Fingerprint
+from sqlbuild.compiler.planner.helpers.changes.policy import resolve_query_change_backfill
 from sqlbuild.compiler.planner.models import BackfillResult, WarehouseSnapshot
-from sqlbuild.compiler.planner.types import BackfillAction
+from sqlbuild.compiler.planner.types import BackfillAction, PlanReason
 from sqlbuild.compiler.shared.helpers.hashing import compute_query_hash
 
 
@@ -42,16 +43,40 @@ def detect_function_backfill(
 ) -> BackfillResult:
     """Resolve a function definition change into a cascadeable backfill."""
 
+    result: tuple[PlanReason, BackfillResult] = detect_function_change(
+        function=function,
+        fingerprint_sql=fingerprint_sql,
+        snapshot=snapshot,
+        query_change_tracking=query_change_tracking,
+        full_refresh=full_refresh,
+    )
+    return result[1]
+
+
+def detect_function_change(
+    *,
+    function: CompiledFunction,
+    fingerprint_sql: str,
+    snapshot: WarehouseSnapshot,
+    query_change_tracking: bool,
+    full_refresh: bool,
+) -> tuple[PlanReason, BackfillResult]:
+    """Resolve function definition changes and downstream backfill policy."""
+
     if full_refresh:
-        return BackfillResult(action=BackfillAction.FULL)
+        return PlanReason.FULL_REFRESH, BackfillResult(action=BackfillAction.FULL)
     fingerprint: Fingerprint | None = snapshot.fingerprints.get(function.name)
     if fingerprint is None:
-        return BackfillResult(action=BackfillAction.FULL)
+        return PlanReason.FIRST_RUN, resolve_query_change_backfill(
+            query_change_backfill=function.query_change_backfill
+        )
     if not query_change_tracking:
-        return BackfillResult(action=BackfillAction.WARN_ONLY)
+        return PlanReason.NO_CHANGE, BackfillResult(action=BackfillAction.WARN_ONLY)
     if compute_query_hash(fingerprint_sql) != fingerprint.query_hash:
-        return BackfillResult(action=BackfillAction.FULL)
-    return BackfillResult(action=BackfillAction.WARN_ONLY)
+        return PlanReason.QUERY_CHANGED, resolve_query_change_backfill(
+            query_change_backfill=function.query_change_backfill
+        )
+    return PlanReason.NO_CHANGE, BackfillResult(action=BackfillAction.WARN_ONLY)
 
 
 def build_function_fingerprint_sql(

--- a/src/sqlbuild/compiler/planner/helpers/warehouse_snapshot.py
+++ b/src/sqlbuild/compiler/planner/helpers/warehouse_snapshot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -326,12 +327,18 @@ def _gather_cursor_snapshots(
         return {}
 
     queries: list[_CursorQuery] = _build_cursor_queries(cursor_models)
+    cursor_start: float = time.monotonic()
     results: dict[str, str] = _execute_cursor_queries_batched(
         queries=queries,
         connection=connection,
         execute=execute,
         on_progress=on_progress,
     )
+    if on_progress is not None:
+        total: int = len(queries)
+        on_progress(
+            f"Gathered cursor bounds ({total}/{total}). ({time.monotonic() - cursor_start:.2f}s)"
+        )
 
     return _assemble_cursor_snapshots(cursor_models=cursor_models, results=results)
 

--- a/src/sqlbuild/compiler/planner/main/execution.py
+++ b/src/sqlbuild/compiler/planner/main/execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from dataclasses import replace
 from typing import Any
@@ -25,7 +26,7 @@ from sqlbuild.compiler.planner.helpers.buildability import check_buildability
 from sqlbuild.compiler.planner.helpers.cascade import build_self_cascade, resolve_cascade
 from sqlbuild.compiler.planner.helpers.function_fingerprints import (
     build_compiled_function_fingerprint_sql,
-    detect_function_backfill,
+    detect_function_change,
 )
 from sqlbuild.compiler.planner.helpers.graph import (
     build_downstream_deps,
@@ -66,6 +67,7 @@ from sqlbuild.compiler.planner.models import (
     SqlTestPlanEntry,
     WarehouseSnapshot,
 )
+from sqlbuild.compiler.planner.types import BackfillAction, PlanReason
 from sqlbuild.spec.models.source import SourceEntry
 
 
@@ -108,6 +110,9 @@ def build_execution_plan(
     execution_order: tuple[CompiledObjectKey, ...] = topologically_order_keys(upstream_deps)
 
     execute: Any = adapter.execute
+    warehouse_start: float = time.monotonic()
+    if on_progress is not None:
+        on_progress("Inspecting warehouse state...")
     snapshot: WarehouseSnapshot = gather_warehouse_snapshot(
         project=project,
         adapter=adapter,
@@ -150,6 +155,10 @@ def build_execution_plan(
     source_warehouse_columns: dict[str, tuple[ColumnInfo, ...]] = gather_source_columns(
         project=project, adapter=adapter, connection=connection
     )
+    if on_progress is not None:
+        on_progress(f"Inspected warehouse state. ({time.monotonic() - warehouse_start:.2f}s)")
+        on_progress("Generating plan...")
+    plan_start: float = time.monotonic()
 
     sqlglot_enabled: bool = project.settings.sqlglot
     query_change_tracking: bool = project.settings.query_change_tracking
@@ -160,20 +169,30 @@ def build_execution_plan(
     model_cursor_types: dict[str, str | None] = {}
 
     function_fingerprint_sql: dict[str, str] = {}
+    function_reasons: dict[str, PlanReason] = {}
+    function_backfills: dict[str, BackfillResult] = {}
     function: CompiledFunction
     for function in project.functions:
         fingerprint_sql: str = build_compiled_function_fingerprint_sql(function)
         function_fingerprint_sql[function.name] = fingerprint_sql
         if function.key not in selected_keys:
             continue
-        function_backfill: BackfillResult = detect_function_backfill(
+        function_reason: PlanReason
+        function_backfill: BackfillResult
+        function_reason, function_backfill = detect_function_change(
             function=function,
             fingerprint_sql=fingerprint_sql,
             snapshot=snapshot,
             query_change_tracking=query_change_tracking,
             full_refresh=full_refresh,
         )
-        effective_cascades[function.name] = build_self_cascade(function_backfill)
+        function_reasons[function.name] = function_reason
+        function_backfills[function.name] = function_backfill
+        effective_cascades[function.name] = build_self_cascade(
+            function_backfill,
+            root_cause=function.name,
+            root_reason=function_reason,
+        )
 
     key: CompiledObjectKey
     for key in execution_order:
@@ -248,7 +267,11 @@ def build_execution_plan(
             entry = replace(entry, cascade=cascade)
             effective_cascades[entry.name] = cascade
         else:
-            effective_cascades[entry.name] = build_self_cascade(entry.backfill)
+            effective_cascades[entry.name] = build_self_cascade(
+                entry.backfill,
+                root_cause=entry.name,
+                root_reason=entry.reason,
+            )
 
         model_entries.append(entry)
         all_warnings.extend(warnings)
@@ -295,6 +318,10 @@ def build_execution_plan(
                 snapshot.fingerprints[function.name].query_sql
                 if function.name in snapshot.fingerprints
                 else None
+            ),
+            reason=function_reasons.get(function.name, PlanReason.NO_CHANGE),
+            backfill=function_backfills.get(
+                function.name, BackfillResult(action=BackfillAction.WARN_ONLY)
             ),
         )
         for function in project.functions
@@ -343,7 +370,7 @@ def build_execution_plan(
         k for k in execution_order if k in scoped_keys
     )
 
-    return PlanOutput(
+    plan_output: PlanOutput = PlanOutput(
         execution_order=scoped_order,
         model_entries=tuple(model_entries),
         seed_entries=tuple(seed_entries),
@@ -359,6 +386,9 @@ def build_execution_plan(
         function_targets=function_targets,
         source_map=source_map,
     )
+    if on_progress is not None:
+        on_progress(f"Generated plan. ({time.monotonic() - plan_start:.2f}s)")
+    return plan_output
 
 
 def _build_all_keys(project: CompiledProject) -> dict[str, CompiledObjectKey]:

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -167,6 +167,8 @@ class CascadeCause:
     model_name: str
     effective_action: BackfillAction
     effective_duration: str | None
+    root_cause: str | None = None
+    root_reason: PlanReason | None = None
 
 
 @dataclass(frozen=True)
@@ -176,7 +178,8 @@ class CascadeResult:
     effective_action: BackfillAction
     effective_duration: str | None
     root_cause: str | None
-    causes: tuple[CascadeCause, ...]
+    root_reason: PlanReason | None = None
+    causes: tuple[CascadeCause, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -284,6 +287,10 @@ class FunctionPlanEntry:
     entry_point: str | None = None
     packages: tuple[str, ...] = field(default_factory=tuple)
     previous_query_sql: str | None = None
+    reason: PlanReason = PlanReason.NO_CHANGE
+    backfill: BackfillResult = field(
+        default_factory=lambda: BackfillResult(action=BackfillAction.WARN_ONLY)
+    )
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/executor/pipeline/main/run.py
+++ b/src/sqlbuild/executor/pipeline/main/run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -43,19 +44,40 @@ def run_build_pipeline(
     custom_materializations: dict[str, Callable[..., MaterializationResult]] | None = None,
     environment: str = "",
     effective_vars: dict[str, str] | None = None,
+    on_connection_start: Callable[[int], None] | None = None,
+    on_connection_complete: Callable[[int, float], None] | None = None,
+    on_connection_error: Callable[[int, float], None] | None = None,
 ) -> BuildExecutionResult:
     """Execute a full build pipeline: resolve settings, open connections, run plan, close."""
 
     promotion_mode: TablePromotionMode = resolve_promotion_mode(settings=settings, adapter=adapter)
     effective_concurrency: int = max(1, max_concurrency)
     logger: logging.Logger = logging.getLogger("sqlbuild.executor.pipeline")
-    logger.debug("open scheduler connection")
-    scheduler_connection: Any = adapter.connect(connection_config)
     worker_connections: list[Any] = []
-    _i: int
-    for _i in range(effective_concurrency):
-        logger.debug("open worker connection index=%s", _i)
-        worker_connections.append(adapter.connect(connection_config))
+    scheduler_connection: Any | None = None
+    if on_connection_start is not None:
+        on_connection_start(effective_concurrency)
+    start: float = time.monotonic()
+    try:
+        logger.debug("open scheduler connection")
+        scheduler_connection = adapter.connect(connection_config)
+        _i: int
+        for _i in range(effective_concurrency):
+            logger.debug("open worker connection index=%s", _i)
+            worker_connections.append(adapter.connect(connection_config))
+    except Exception:
+        if on_connection_error is not None:
+            on_connection_error(effective_concurrency, time.monotonic() - start)
+        conn: Any
+        for _i, conn in enumerate(worker_connections):
+            logger.debug("close worker connection index=%s", _i)
+            adapter.close(conn)
+        if scheduler_connection is not None:
+            logger.debug("close scheduler connection")
+            adapter.close(scheduler_connection)
+        raise
+    if on_connection_complete is not None:
+        on_connection_complete(effective_concurrency, time.monotonic() - start)
     try:
         return execute_build_plan(
             plan=plan,
@@ -82,4 +104,5 @@ def run_build_pipeline(
             logger.debug("close worker connection index=%s", _i)
             adapter.close(conn)
         logger.debug("close scheduler connection")
-        adapter.close(scheduler_connection)
+        if scheduler_connection is not None:
+            adapter.close(scheduler_connection)

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_lifecycle_commands.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_lifecycle_commands.py
@@ -25,7 +25,7 @@ from tests.e2e.src.sqlbuild.cli.commands.main.shared.helpers import (
             expected_exit_code=0,
             expected_fresh_plan_fragments=(
                 "Plan ready (16 selected)",
-                "Functions (3)",
+                "Function changed (3)",
                 "customer_orders             table function",
                 "First run (12)",
             ),

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_query_propagation.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_query_propagation.py
@@ -182,6 +182,7 @@ TEST_CASES: list[QueryPropagationBuildE2ETestCase] = [
                 FUNCTION (
                   arguments (amount_cents INTEGER),
                   returns BOOLEAN,
+                  query_change_backfill full,
                 );
 
                 amount_cents > 100

--- a/tests/integration/src/sqlbuild/compiler/planner/helpers/test_warehouse_snapshot.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/helpers/test_warehouse_snapshot.py
@@ -267,7 +267,7 @@ CURSOR_SNAPSHOT_TEST_CASES: list[GatherCursorSnapshotTestCase] = [
                 upstream_maxes=("2024-02-01 00:00:00",),
             ),
         },
-        expected_progress_calls=1,
+        expected_progress_calls=2,
     ),
     GatherCursorSnapshotTestCase(
         description="gathers cursor bounds for first run with no target table",
@@ -287,7 +287,7 @@ CURSOR_SNAPSHOT_TEST_CASES: list[GatherCursorSnapshotTestCase] = [
                 upstream_maxes=("2024-02-01 00:00:00",),
             ),
         },
-        expected_progress_calls=1,
+        expected_progress_calls=2,
     ),
     GatherCursorSnapshotTestCase(
         description="skips cursor gathering when full refresh is true",
@@ -398,7 +398,7 @@ DEFERRED_CURSOR_TEST_CASES: list[GatherCursorSnapshotTestCase] = [
                 upstream_maxes=("2024-03-01 00:00:00",),
             ),
         },
-        expected_progress_calls=1,
+        expected_progress_calls=2,
     ),
     GatherCursorSnapshotTestCase(
         description="non-selected upstream reads cursor from deferred env",
@@ -422,7 +422,7 @@ DEFERRED_CURSOR_TEST_CASES: list[GatherCursorSnapshotTestCase] = [
                 upstream_maxes=("2024-06-01 00:00:00",),
             ),
         },
-        expected_progress_calls=1,
+        expected_progress_calls=2,
     ),
 ]
 

--- a/tests/integration/src/sqlbuild/compiler/planner/main/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/_test_types.py
@@ -42,6 +42,7 @@ class BuildExecutionPlanTestCase:
     function_targets: dict[str, str] = field(default_factory=dict)
     function_bodies: dict[str, str] = field(default_factory=dict)
     previous_function_bodies: dict[str, str] = field(default_factory=dict)
+    function_query_change_backfills: dict[str, str] = field(default_factory=dict)
     function_languages: dict[str, FunctionLanguage] = field(default_factory=dict)
     function_deps: dict[str, tuple[str, ...]] = field(default_factory=dict)
     select: tuple[str, ...] = ()
@@ -51,3 +52,4 @@ class BuildExecutionPlanTestCase:
     model_deps: dict[str, tuple[str, ...]] = field(default_factory=dict)
     expected_cascade_action: dict[str, BackfillAction] = field(default_factory=dict)
     expected_cascade_root_cause: dict[str, str] = field(default_factory=dict)
+    expected_progress_fragments: tuple[str, ...] = field(default_factory=tuple)

--- a/tests/integration/src/sqlbuild/compiler/planner/main/helpers.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/helpers.py
@@ -132,6 +132,7 @@ def build_project_from_test_case(
                 ),
                 language=language,
                 entry_point="main" if language == FunctionLanguage.PYTHON else None,
+                query_change_backfill=test_case.function_query_change_backfills.get(function_name),
             )
         )
 

--- a/tests/integration/src/sqlbuild/compiler/planner/main/test_build_execution_plan.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/test_build_execution_plan.py
@@ -31,6 +31,12 @@ BUILD_PLAN_TEST_CASES: list[BuildExecutionPlanTestCase] = [
         expected_action={"orders": PlanAction.CREATE_TABLE},
         expected_reason={"orders": PlanReason.FIRST_RUN},
         expected_ddl_fragments={"orders": "CREATE OR REPLACE TABLE staging.orders AS"},
+        expected_progress_fragments=(
+            "Inspecting warehouse state...",
+            "Inspected warehouse state. (",
+            "Generating plan...",
+            "Generated plan. (",
+        ),
     ),
     BuildExecutionPlanTestCase(
         description="existing table with no change always rebuilds",
@@ -142,12 +148,14 @@ def test_given_project_when_building_plan_then_produces_expected_output(
 
     project: Any = build_project_from_test_case(test_case)
 
+    progress_messages: list[str] = []
     plan: PlanOutput = build_execution_plan(
         project=project,
         adapter=adapter,
         connection=connection,
         full_refresh=test_case.full_refresh,
         select=test_case.select,
+        on_progress=progress_messages.append,
     )
 
     entry_map: dict[str, ModelPlanEntry] = {e.name: e for e in plan.model_entries}
@@ -173,6 +181,11 @@ def test_given_project_when_building_plan_then_produces_expected_output(
     expected_count: int = test_case.expected_model_count or len(test_case.expected_action)
     assert len(plan.model_entries) == expected_count
 
+    progress_output: str = "\n".join(progress_messages)
+    expected_progress_fragment: str
+    for expected_progress_fragment in test_case.expected_progress_fragments:
+        assert expected_progress_fragment in progress_output
+
 
 CURSOR_TYPE_MISMATCH_TEST_CASES: list[BuildExecutionPlanTestCase] = [
     BuildExecutionPlanTestCase(
@@ -195,6 +208,10 @@ CURSOR_TYPE_MISMATCH_TEST_CASES: list[BuildExecutionPlanTestCase] = [
         expected_warning_count=1,
         expected_warning_severity=WarningSeverity.WARNING,
         expected_warning_fragment="appears to be integer",
+        expected_progress_fragments=(
+            "Gathering cursor bounds (1/1)",
+            "Gathered cursor bounds (1/1). (",
+        ),
     ),
     BuildExecutionPlanTestCase(
         description="sqlglot cursor type mismatch produces error",
@@ -237,11 +254,13 @@ def test_given_cursor_type_mismatch_when_building_plan_then_produces_warning(
 
     project: Any = build_project_from_test_case(test_case)
 
+    progress_messages: list[str] = []
     plan: PlanOutput = build_execution_plan(
         project=project,
         adapter=adapter,
         connection=connection,
         full_refresh=test_case.full_refresh,
+        on_progress=progress_messages.append,
     )
 
     entry_map: dict[str, ModelPlanEntry] = {e.name: e for e in plan.model_entries}
@@ -256,6 +275,11 @@ def test_given_cursor_type_mismatch_when_building_plan_then_produces_warning(
     assert warning.severity == test_case.expected_warning_severity
     assert test_case.expected_warning_fragment is not None
     assert test_case.expected_warning_fragment in warning.message
+
+    progress_output: str = "\n".join(progress_messages)
+    expected_progress_fragment: str
+    for expected_progress_fragment in test_case.expected_progress_fragments:
+        assert expected_progress_fragment in progress_output
 
 
 CASCADE_PLAN_TEST_CASES: list[BuildExecutionPlanTestCase] = [
@@ -331,6 +355,7 @@ CASCADE_PLAN_TEST_CASES: list[BuildExecutionPlanTestCase] = [
         function_targets={"is_priority_order": "staging"},
         function_bodies={"is_priority_order": "value = 2"},
         previous_function_bodies={"is_priority_order": "value = 1"},
+        function_query_change_backfills={"is_priority_order": "full"},
         function_deps={"fact_orders": ("is_priority_order",)},
         model_configs={
             "fact_orders": {
@@ -363,6 +388,7 @@ CASCADE_PLAN_TEST_CASES: list[BuildExecutionPlanTestCase] = [
         previous_function_bodies={
             "is_priority_order_py": "def main(value: int) -> int:\n    return value + 1",
         },
+        function_query_change_backfills={"is_priority_order_py": "full"},
         function_deps={"fact_orders": ("is_priority_order_py",)},
         model_configs={
             "fact_orders": {

--- a/tests/unit/src/sqlbuild/cli/commands/main/plan/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/plan/helpers/helpers.py
@@ -116,6 +116,10 @@ def build_function_entry(
     *,
     name: str,
     language: FunctionLanguage = FunctionLanguage.SQL,
+    reason: PlanReason = PlanReason.NO_CHANGE,
+    backfill_action: BackfillAction = BackfillAction.WARN_ONLY,
+    backfill_duration: str | None = None,
+    previous_query_sql: str | None = None,
 ) -> FunctionPlanEntry:
     """Build a minimal FunctionPlanEntry for formatter tests."""
 
@@ -131,6 +135,9 @@ def build_function_entry(
         body_sql="return True",
         fingerprint_query_sql="return True",
         language=language,
+        previous_query_sql=previous_query_sql,
+        reason=reason,
+        backfill=BackfillResult(action=backfill_action, duration=backfill_duration),
     )
 
 

--- a/tests/unit/src/sqlbuild/cli/commands/main/plan/helpers/test_formatter.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/plan/helpers/test_formatter.py
@@ -155,6 +155,39 @@ TEST_CASES: list[FormatPlanTestCase] = [
         ),
     ),
     FormatPlanTestCase(
+        description="full rebuild hides cursor range placeholders",
+        plan_output=build_plan_output(
+            model_entries=(
+                build_model_entry(
+                    name="hourly_order_activity",
+                    action=PlanAction.CREATE_TABLE,
+                    reason=PlanReason.QUERY_CHANGED,
+                    materialization_type=MaterializationType.INCREMENTAL,
+                    backfill_action=BackfillAction.FULL,
+                    cursor_column="activity_hour",
+                    cursor_type="timestamp",
+                    incremental_mode="microbatch",
+                    cursor_bounds=CursorBounds(
+                        start="__SQB_CURSOR_START__",
+                        end="__SQB_CURSOR_END__",
+                    ),
+                    previous_query_sql="SELECT activity_hour FROM raw",
+                ),
+            ),
+        ),
+        expected_fragments=(
+            "hourly_order_activity",
+            "full rebuild",
+            "cursor: activity_hour",
+            "mode: microbatch",
+        ),
+        unexpected_fragments=(
+            "range:",
+            "__SQB_CURSOR_START__",
+            "__SQB_CURSOR_END__",
+        ),
+    ),
+    FormatPlanTestCase(
         description="upstream changed shows cascade cause",
         plan_output=build_plan_output(
             model_entries=(
@@ -250,6 +283,62 @@ TEST_CASES: list[FormatPlanTestCase] = [
             "is_completed_order_py",
             "python udf",
         ),
+    ),
+    FormatPlanTestCase(
+        description="function query change shows diff and policy",
+        plan_output=build_plan_output(
+            model_entries=(build_model_entry(name="orders", action=PlanAction.CREATE_TABLE),),
+            function_entries=(
+                build_function_entry(
+                    name="is_completed_order",
+                    language=FunctionLanguage.SQL,
+                    reason=PlanReason.QUERY_CHANGED,
+                    backfill_action=BackfillAction.FULL,
+                    previous_query_sql="returns=BOOLEAN\nbody=\norder_status = 'completed'",
+                ),
+            ),
+        ),
+        expected_fragments=(
+            "Function changed (1)",
+            "is_completed_order",
+            "sql udf",
+            "policy: query_change_backfill=full",
+            "query diff:",
+            "--- previous",
+            "+++ current",
+        ),
+    ),
+    FormatPlanTestCase(
+        description="upstream changed prefers root function query cause",
+        plan_output=build_plan_output(
+            model_entries=(
+                build_model_entry(
+                    name="daily_activity_rollup",
+                    action=PlanAction.CREATE_TABLE,
+                    reason=PlanReason.NO_CHANGE,
+                    cascade=CascadeResult(
+                        effective_action=BackfillAction.FULL,
+                        effective_duration=None,
+                        root_cause="is_completed_order",
+                        root_reason=PlanReason.QUERY_CHANGED,
+                        causes=(
+                            CascadeCause(
+                                model_name="hourly_order_activity",
+                                effective_action=BackfillAction.FULL,
+                                effective_duration=None,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        expected_fragments=(
+            "Upstream changed (1)",
+            "daily_activity_rollup",
+            "full rebuild",
+            "cause: is_completed_order (query changed)",
+        ),
+        unexpected_fragments=("cause: hourly_order_activity", "cause: is_completed_order (full)"),
     ),
     FormatPlanTestCase(
         description="warnings section shows warning messages",

--- a/tests/unit/src/sqlbuild/cli/commands/main/shared/helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/shared/helpers/_test_types.py
@@ -42,6 +42,27 @@ class BuildFooterTestCase:
 
 
 @dataclass(frozen=True)
+class ConnectionProgressTestCase:
+    description: str
+    connection_count: int
+    elapsed_seconds: float
+    expected_start: str
+    expected_complete: str
+    expected_error: str
+    blank_line_after_complete: bool = False
+    use_color: bool = False
+    expected_lines: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PlanningProgressTestCase:
+    description: str
+    messages: tuple[str, ...]
+    expected_output: str
+    use_color: bool = False
+
+
+@dataclass(frozen=True)
 class ResolveProjectConnectionConfigTestCase:
     description: str
     project_dir_name: str

--- a/tests/unit/src/sqlbuild/cli/commands/main/shared/helpers/test_connection_progress.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/shared/helpers/test_connection_progress.py
@@ -1,0 +1,97 @@
+"""Tests for warehouse connection progress messages."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+from sqlbuild.cli.commands.main.shared.helpers.connection_progress import (
+    ConnectionProgressReporter,
+)
+from sqlbuild.shared.helpers.colors import dim
+from tests.unit.src.sqlbuild.cli.commands.main.shared.helpers._test_types import (
+    ConnectionProgressTestCase,
+)
+
+CONNECTION_PROGRESS_TEST_CASES: list[ConnectionProgressTestCase] = [
+    ConnectionProgressTestCase(
+        description="single connection message omits count",
+        connection_count=1,
+        elapsed_seconds=0.034,
+        expected_start="Connecting to duckdb...",
+        expected_complete="Connected to duckdb. (0.03s)",
+        expected_error="Failed to connect to duckdb after 0.03s.",
+        expected_lines=(
+            "Connecting to duckdb...",
+            "Connected to duckdb. (0.03s)",
+            "Failed to connect to duckdb after 0.03s.",
+        ),
+    ),
+    ConnectionProgressTestCase(
+        description="multiple connection message includes count",
+        connection_count=8,
+        elapsed_seconds=18.424,
+        expected_start="Connecting to databricks (8 connections)...",
+        expected_complete="Connected to databricks. (18.42s)",
+        expected_error="Failed to connect to databricks after 18.42s.",
+        expected_lines=(
+            "Connecting to databricks (8 connections)...",
+            "Connected to databricks. (18.42s)",
+            "Failed to connect to databricks after 18.42s.",
+        ),
+    ),
+    ConnectionProgressTestCase(
+        description="execution connection completion can add spacing before progress rows",
+        connection_count=8,
+        elapsed_seconds=10.924,
+        expected_start="Connecting to databricks (8 connections)...",
+        expected_complete="Connected to databricks. (10.92s)",
+        expected_error="Failed to connect to databricks after 10.92s.",
+        blank_line_after_complete=True,
+        expected_lines=(
+            "Connecting to databricks (8 connections)...",
+            "Connected to databricks. (10.92s)",
+            "",
+            "Failed to connect to databricks after 10.92s.",
+        ),
+    ),
+    ConnectionProgressTestCase(
+        description="connection progress dims start and success when color is enabled",
+        connection_count=1,
+        elapsed_seconds=0.034,
+        expected_start="Connecting to duckdb...",
+        expected_complete="Connected to duckdb. (0.03s)",
+        expected_error="Failed to connect to duckdb after 0.03s.",
+        use_color=True,
+        expected_lines=(
+            dim("Connecting to duckdb..."),
+            dim("Connected to duckdb. (0.03s)"),
+            "Failed to connect to duckdb after 0.03s.",
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    CONNECTION_PROGRESS_TEST_CASES,
+    ids=[case.description for case in CONNECTION_PROGRESS_TEST_CASES],
+)
+def test_given_connection_progress_event_when_reporting_then_writes_expected_message(
+    test_case: ConnectionProgressTestCase,
+) -> None:
+    stream: StringIO = StringIO()
+    adapter_name: str = "databricks" if test_case.connection_count > 1 else "duckdb"
+    reporter: ConnectionProgressReporter = ConnectionProgressReporter(
+        adapter_name=adapter_name,
+        stream=stream,
+        blank_line_after_complete=test_case.blank_line_after_complete,
+        use_color=test_case.use_color,
+    )
+
+    reporter.on_connection_start(test_case.connection_count)
+    reporter.on_connection_complete(test_case.connection_count, test_case.elapsed_seconds)
+    reporter.on_connection_error(test_case.connection_count, test_case.elapsed_seconds)
+
+    assert stream.getvalue().splitlines() == list(test_case.expected_lines)

--- a/tests/unit/src/sqlbuild/cli/commands/main/shared/helpers/test_planning_progress.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/shared/helpers/test_planning_progress.py
@@ -1,0 +1,47 @@
+"""Tests for planning progress output."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
+from sqlbuild.shared.helpers.colors import dim
+from tests.unit.src.sqlbuild.cli.commands.main.shared.helpers._test_types import (
+    PlanningProgressTestCase,
+)
+
+PLANNING_PROGRESS_TEST_CASES: list[PlanningProgressTestCase] = [
+    PlanningProgressTestCase(
+        description="writes each planning message on its own line",
+        messages=("Inspecting warehouse state...", "Generating plan..."),
+        expected_output="Inspecting warehouse state...\nGenerating plan...\n",
+    ),
+    PlanningProgressTestCase(
+        description="dims planning messages when color is enabled",
+        messages=("Inspecting warehouse state...",),
+        expected_output=f"{dim('Inspecting warehouse state...')}\n",
+        use_color=True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    PLANNING_PROGRESS_TEST_CASES,
+    ids=[case.description for case in PLANNING_PROGRESS_TEST_CASES],
+)
+def test_given_planning_messages_when_reporting_then_writes_expected_output(
+    test_case: PlanningProgressTestCase,
+) -> None:
+    stream: StringIO = StringIO()
+    reporter: PlanningProgressReporter = PlanningProgressReporter(
+        stream=stream, use_color=test_case.use_color
+    )
+
+    message: str
+    for message in test_case.messages:
+        reporter.on_progress(message)
+
+    assert stream.getvalue() == test_case.expected_output

--- a/tests/unit/src/sqlbuild/compiler/compile/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_test_types.py
@@ -42,6 +42,9 @@ class BuildCompileInputsTestCase:
     expected_sql_function_runtime_versions: tuple[str | None, ...] = field(default_factory=tuple)
     expected_sql_function_entry_points: tuple[str | None, ...] = field(default_factory=tuple)
     expected_sql_function_packages: tuple[tuple[str, ...], ...] = field(default_factory=tuple)
+    expected_sql_function_query_change_backfills: tuple[str | None, ...] = field(
+        default_factory=tuple
+    )
     expected_model_references: tuple[tuple[tuple[str, str], ...], ...] = field(
         default_factory=tuple
     )

--- a/tests/unit/src/sqlbuild/compiler/compile/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_main.py
@@ -1052,6 +1052,7 @@ vars:
   cancelled_status: "'cancelled'"
   udf_database: analytics
   udf_schema: udf_dev
+  backfill_days: "30"
 
 environments:
   dev:
@@ -1064,7 +1065,8 @@ FUNCTION (
   database ${udf_database},
   schema ${udf_schema},
   arguments (order_status ${status_type}),
-  returns ${return_type}
+  returns ${return_type},
+  query_change_backfill bounded-${backfill_days}d
 );
 
 @status_match("order_status", "completed") AND order_status <> @cancelled_status
@@ -1093,6 +1095,7 @@ FUNCTION (
         expected_sql_function_runtime_versions=(None,),
         expected_sql_function_entry_points=(None,),
         expected_sql_function_packages=((),),
+        expected_sql_function_query_change_backfills=("bounded-30d",),
         expected_effective_environment_name="dev",
         expected_effective_connection={},
         expected_effective_vars={
@@ -1101,6 +1104,7 @@ FUNCTION (
             "cancelled_status": "'cancelled'",
             "udf_database": "analytics",
             "udf_schema": "udf_dev",
+            "backfill_days": "30",
         },
         expected_model_references=(),
         expected_audit_references=(),
@@ -1158,6 +1162,7 @@ WHERE customer_id = p_customer_id
         expected_sql_function_runtime_versions=(None,),
         expected_sql_function_entry_points=(None,),
         expected_sql_function_packages=((),),
+        expected_sql_function_query_change_backfills=(None,),
         expected_effective_environment_name=None,
         expected_effective_connection={},
         expected_effective_vars={},
@@ -1318,6 +1323,7 @@ def main(order_status):
         expected_sql_function_runtime_versions=("3.11",),
         expected_sql_function_entry_points=("main",),
         expected_sql_function_packages=(("faker",),),
+        expected_sql_function_query_change_backfills=(None,),
         expected_effective_environment_name="dev",
         expected_effective_connection={},
         expected_effective_vars={
@@ -1646,6 +1652,13 @@ def test_given_discovered_inputs_when_building_compile_inputs_then_it_attaches_m
     assert (
         tuple(function_input.packages for function_input in compile_inputs.sql_function_inputs)
         == test_case.expected_sql_function_packages
+    )
+    assert (
+        tuple(
+            function_input.query_change_backfill
+            for function_input in compile_inputs.sql_function_inputs
+        )
+        == test_case.expected_sql_function_query_change_backfills
     )
     assert (
         tuple(

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/_test_types.py
@@ -323,6 +323,27 @@ class ResolveCascadeTestCase:
 
 
 @dataclass(frozen=True)
+class ResolveCascadeRootCauseTestCase:
+    description: str
+    expected_action: BackfillAction
+    expected_root_cause: str
+    expected_root_reason: PlanReason
+    expected_immediate_cause: str
+
+
+@dataclass(frozen=True)
+class DetectFunctionChangeTestCase:
+    description: str
+    body_sql: str
+    previous_query_sql: str
+    query_change_backfill: str | None
+    expected_reason: PlanReason
+    expected_action: BackfillAction
+    expected_duration: str | None = None
+    existing_fingerprint: bool = True
+
+
+@dataclass(frozen=True)
 class ResolveAttachmentTestCase:
     description: str
     references: tuple[CompileSqlReference, ...]

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 from sqlbuild.adapter.shared.models import RelationInfo
@@ -17,6 +18,7 @@ from sqlbuild.compiler.compile.models import (
     CompiledSqlTest,
     CompileModelConfig,
     CompileSqlReference,
+    FunctionArgument,
 )
 from sqlbuild.compiler.compile.types import (
     AttachedAuditTargetKind,
@@ -32,6 +34,7 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlTestBlock,
     DiscoveredSqlTestFile,
 )
+from sqlbuild.compiler.fingerprints.models import Fingerprint
 from sqlbuild.compiler.planner.models import (
     BackfillResult,
     CascadeResult,
@@ -39,6 +42,7 @@ from sqlbuild.compiler.planner.models import (
     WarehouseSnapshot,
 )
 from sqlbuild.compiler.planner.types import BackfillAction
+from sqlbuild.compiler.shared.helpers.hashing import compute_query_hash
 from sqlbuild.spec.models.schema import SchemaSeedEntry
 from sqlbuild.spec.models.source import SourceEntry
 from tests.unit.src.sqlbuild.compiler.planner.helpers._test_types import (
@@ -538,6 +542,49 @@ def build_cascade_upstream_state(
         )
         cursor_types[name] = cursor_type
     return tuple(keys), cascades, cursor_types
+
+
+def build_compiled_function(
+    *, body_sql: str, query_change_backfill: str | None = None
+) -> CompiledFunction:
+    """Build a minimal compiled function for planner tests."""
+
+    return CompiledFunction(
+        key=CompiledObjectKey(
+            resource_type=CompiledResourceType.FUNCTION,
+            name="is_completed_order",
+        ),
+        deps=(),
+        name="is_completed_order",
+        relative_path=Path("functions/sql/is_completed_order.sql"),
+        arguments=(FunctionArgument(name="order_status", type="STRING"),),
+        returns="BOOLEAN",
+        body_sql=body_sql,
+        target=CompiledRelationTarget(
+            database=None,
+            schema="main",
+            name="is_completed_order",
+            qualified_name="main.is_completed_order",
+        ),
+        query_change_backfill=query_change_backfill,
+    )
+
+
+def build_fingerprint(*, query_sql: str) -> Fingerprint:
+    """Build a fingerprint with a hash matching the supplied query SQL."""
+
+    return Fingerprint(
+        model_name="is_completed_order",
+        target_database=None,
+        target_schema="main",
+        target_name="is_completed_order",
+        run_id="run-1",
+        query_hash=compute_query_hash(query_sql),
+        ast_hash=None,
+        schema_fingerprint="",
+        query_sql=query_sql,
+        ts=datetime(2026, 1, 1, tzinfo=UTC),
+    )
 
 
 def _stub_schema_file() -> DiscoveredSchemaFile:

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_cascade.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_cascade.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.helpers.cascade import (
     build_self_cascade,
     resolve_cascade,
@@ -13,8 +14,9 @@ from sqlbuild.compiler.planner.models import (
     BackfillResult,
     CascadeResult,
 )
-from sqlbuild.compiler.planner.types import BackfillAction
+from sqlbuild.compiler.planner.types import BackfillAction, PlanReason
 from tests.unit.src.sqlbuild.compiler.planner.helpers._test_types import (
+    ResolveCascadeRootCauseTestCase,
     ResolveCascadeTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.planner.helpers.helpers import (
@@ -245,3 +247,48 @@ def test_given_own_backfill_when_building_self_cascade_then_preserves_values(
     assert result.effective_duration == test_case.expected_duration
     assert result.root_cause is None
     assert result.causes == ()
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ResolveCascadeRootCauseTestCase(
+            description="multihop cascade preserves function root cause",
+            expected_action=BackfillAction.FULL,
+            expected_root_cause="is_completed_order",
+            expected_root_reason=PlanReason.QUERY_CHANGED,
+            expected_immediate_cause="hourly_order_activity",
+        )
+    ],
+    ids=["multihop cascade preserves function root cause"],
+)
+def test_given_multihop_cascade_when_resolving_then_preserves_root_cause(
+    test_case: ResolveCascadeRootCauseTestCase,
+) -> None:
+    hourly_key: CompiledObjectKey = CompiledObjectKey(
+        resource_type=CompiledResourceType.MODEL, name="hourly_order_activity"
+    )
+    upstream_keys: tuple[CompiledObjectKey, ...] = (hourly_key,)
+    effective_cascades: dict[str, CascadeResult] = {
+        "hourly_order_activity": build_self_cascade(
+            BackfillResult(action=BackfillAction.FULL),
+            root_cause="is_completed_order",
+            root_reason=PlanReason.QUERY_CHANGED,
+        )
+    }
+    model_cursor_types: dict[str, str | None] = {"hourly_order_activity": "timestamp"}
+
+    result: CascadeResult | None = resolve_cascade(
+        model_name="daily_activity_rollup",
+        own_backfill=BackfillResult(action=BackfillAction.WARN_ONLY),
+        own_cursor_type="timestamp",
+        upstream_keys=upstream_keys,
+        effective_cascades=effective_cascades,
+        model_cursor_types=model_cursor_types,
+    )
+
+    assert result is not None
+    assert result.effective_action == test_case.expected_action
+    assert result.root_cause == test_case.expected_root_cause
+    assert result.root_reason == test_case.expected_root_reason
+    assert result.causes[0].model_name == test_case.expected_immediate_cause

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_function_fingerprints.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_function_fingerprints.py
@@ -1,0 +1,96 @@
+"""Tests for function fingerprint change detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from sqlbuild.compiler.compile.models import CompiledFunction
+from sqlbuild.compiler.planner.helpers.function_fingerprints import (
+    build_compiled_function_fingerprint_sql,
+    detect_function_change,
+)
+from sqlbuild.compiler.planner.models import BackfillResult, WarehouseSnapshot
+from sqlbuild.compiler.planner.types import BackfillAction, PlanReason
+from tests.unit.src.sqlbuild.compiler.planner.helpers._test_types import (
+    DetectFunctionChangeTestCase,
+)
+from tests.unit.src.sqlbuild.compiler.planner.helpers.helpers import (
+    build_compiled_function,
+    build_fingerprint,
+)
+
+DETECT_FUNCTION_CHANGE_TEST_CASES: list[DetectFunctionChangeTestCase] = [
+    DetectFunctionChangeTestCase(
+        description="first run function without policy returns first run reason and warn only",
+        body_sql="order_status = 'completed'",
+        previous_query_sql="",
+        query_change_backfill=None,
+        expected_reason=PlanReason.FIRST_RUN,
+        expected_action=BackfillAction.WARN_ONLY,
+        existing_fingerprint=False,
+    ),
+    DetectFunctionChangeTestCase(
+        description="first run function with policy returns first run reason and bounded backfill",
+        body_sql="order_status = 'completed'",
+        previous_query_sql="",
+        query_change_backfill="bounded-30d",
+        expected_reason=PlanReason.FIRST_RUN,
+        expected_action=BackfillAction.BOUNDED,
+        expected_duration="30d",
+        existing_fingerprint=False,
+    ),
+    DetectFunctionChangeTestCase(
+        description="changed function with policy returns query reason and bounded backfill",
+        body_sql="order_status = 'completed'",
+        previous_query_sql="name=is_completed_order\nbody=\norder_status = 'complete'",
+        query_change_backfill="bounded-30d",
+        expected_reason=PlanReason.QUERY_CHANGED,
+        expected_action=BackfillAction.BOUNDED,
+        expected_duration="30d",
+    ),
+    DetectFunctionChangeTestCase(
+        description="changed function without policy returns query reason and warn only",
+        body_sql="order_status = 'completed'",
+        previous_query_sql="name=is_completed_order\nbody=\norder_status = 'complete'",
+        query_change_backfill=None,
+        expected_reason=PlanReason.QUERY_CHANGED,
+        expected_action=BackfillAction.WARN_ONLY,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    DETECT_FUNCTION_CHANGE_TEST_CASES,
+    ids=[case.description for case in DETECT_FUNCTION_CHANGE_TEST_CASES],
+)
+def test_given_function_fingerprint_when_detecting_change_then_returns_reason_and_backfill(
+    test_case: DetectFunctionChangeTestCase,
+) -> None:
+    function: CompiledFunction = build_compiled_function(
+        body_sql=test_case.body_sql,
+        query_change_backfill=test_case.query_change_backfill,
+    )
+    snapshot: WarehouseSnapshot = WarehouseSnapshot(
+        fingerprints=(
+            {"is_completed_order": build_fingerprint(query_sql=test_case.previous_query_sql)}
+            if test_case.existing_fingerprint
+            else {}
+        )
+    )
+
+    reason: PlanReason
+    backfill: BackfillResult
+    reason, backfill = detect_function_change(
+        function=function,
+        fingerprint_sql=build_compiled_function_fingerprint_sql(function),
+        snapshot=snapshot,
+        query_change_tracking=True,
+        full_refresh=False,
+    )
+
+    assert reason == test_case.expected_reason
+    assert backfill == BackfillResult(
+        action=test_case.expected_action,
+        duration=test_case.expected_duration,
+    )


### PR DESCRIPTION
This improves the real-warehouse `plan` / `build` / `run` experience, especially for Databricks where connection and planning work can take noticeable time (e.g. cold starts).

- Adds visible connection progress for planning and execution connection phases.
- Adds planning progress/timings for warehouse inspection, cursor bounds, and plan generation.
- Cleans up plan output for full rebuilds and function-driven cascades.
- Adds function `query_change_backfill` support so function changes only cascade downstream when explicitly configured. (prior to this, function changes by default were causing full cascades)

Beefy PR once again, but this is still early in the project so not _too_ concerned atm