### PR TITLE
fix: clarify CLI errors and DuckDB UDF fingerprints

### DIFF
--- a/src/sqlbuild/adapter/base/base_adapter.py
+++ b/src/sqlbuild/adapter/base/base_adapter.py
@@ -49,6 +49,12 @@ class BaseAdapter(StrictAdapter):
     def persists_python_functions(self) -> bool:
         return True
 
+    def python_functions_inherit_default_namespace(self) -> bool:
+        return True
+
+    def supports_unqualified_function_fingerprints(self) -> bool:
+        return False
+
     def supports_table_functions(self) -> bool:
         return False
 

--- a/src/sqlbuild/adapter/strict/strict_adapter.py
+++ b/src/sqlbuild/adapter/strict/strict_adapter.py
@@ -55,6 +55,16 @@ class StrictAdapter(
         ...
 
     @abstractmethod
+    def python_functions_inherit_default_namespace(self) -> bool:
+        """Return whether Python UDFs inherit default database/schema targets."""
+        ...
+
+    @abstractmethod
+    def supports_unqualified_function_fingerprints(self) -> bool:
+        """Return whether unqualified functions can store fingerprints elsewhere."""
+        ...
+
+    @abstractmethod
     def supports_table_functions(self) -> bool:
         """Return whether the adapter can create table function resources."""
         ...

--- a/src/sqlbuild/cli/commands/main/shared/helpers/progress.py
+++ b/src/sqlbuild/cli/commands/main/shared/helpers/progress.py
@@ -341,6 +341,7 @@ def format_build_footer(
             fail_count += 1
         elif function_result.status == ExecutionStatus.SKIPPED:
             skip_count += 1
+        warn_count += len(function_result.warning_messages)
 
     test_r: SqlTestExecutionResult
     for test_r in result.test_results:
@@ -462,6 +463,21 @@ def _format_warning_details(result: BuildExecutionResult) -> list[str]:
             for line in model_warnings:
                 lines.append(line)
             lines.append("")
+
+    function_result: FunctionExecutionResult
+    for function_result in result.function_results:
+        if not function_result.warning_messages:
+            continue
+        if not has_warnings:
+            lines.append("")
+            lines.append("Warnings:")
+            lines.append("")
+            has_warnings = True
+        lines.append(f"  {function_result.function_name}  (function)")
+        warning_msg: str
+        for warning_msg in function_result.warning_messages:
+            lines.append(f"    {warning_msg}")
+        lines.append("")
 
     return lines
 

--- a/src/sqlbuild/compiler/compile/helpers/assembly.py
+++ b/src/sqlbuild/compiler/compile/helpers/assembly.py
@@ -177,6 +177,12 @@ def _assemble_compiled_function(
             name=function_input.name,
             qualified_name=None,
         ),
+        fingerprint_target=CompiledRelationTarget(
+            database=function_input.fingerprint_database,
+            schema=function_input.fingerprint_schema,
+            name=function_input.name,
+            qualified_name=None,
+        ),
         language=function_input.language,
         source_file_path=function_input.function_file.file_path,
         runtime_version=function_input.runtime_version,

--- a/src/sqlbuild/compiler/compile/helpers/attachment.py
+++ b/src/sqlbuild/compiler/compile/helpers/attachment.py
@@ -316,6 +316,7 @@ def build_sql_function_inputs(
     adapter_name: str,
     macro_context: MacroContext,
     no_sql_validation: bool = False,
+    python_functions_inherit_default_namespace: bool = True,
 ) -> tuple[CompileSqlFunctionInput, ...]:
     """Attach and validate SQL function metadata."""
 
@@ -440,6 +441,8 @@ def build_sql_function_inputs(
                 references=references,
                 database=function_database,
                 schema=function_schema,
+                fingerprint_database=function_database,
+                fingerprint_schema=function_schema,
                 query_change_backfill=_parse_optional_function_header(
                     header_values=header_values,
                     key="query_change_backfill",
@@ -487,24 +490,28 @@ def build_sql_function_inputs(
         )
         raw_database = header_values.get("database")
         raw_schema = header_values.get("schema")
-        function_database = (
-            _expand_function_header_value(
+        function_database: str | None
+        if isinstance(raw_database, str):
+            function_database = _expand_function_header_value(
                 raw_value=raw_database,
                 effective_vars=effective_vars,
                 context_label=f"Python function {python_function_file.relative_path} database",
             )
-            if isinstance(raw_database, str)
-            else database
-        )
-        function_schema = (
-            _expand_function_header_value(
+        else:
+            function_database = database if python_functions_inherit_default_namespace else None
+        function_schema: str | None
+        if isinstance(raw_schema, str):
+            function_schema = _expand_function_header_value(
                 raw_value=raw_schema,
                 effective_vars=effective_vars,
                 context_label=f"Python function {python_function_file.relative_path} schema",
             )
-            if isinstance(raw_schema, str)
-            else schema
+        else:
+            function_schema = schema if python_functions_inherit_default_namespace else None
+        fingerprint_database: str | None = (
+            function_database if isinstance(raw_database, str) else database
         )
+        fingerprint_schema: str | None = function_schema if isinstance(raw_schema, str) else schema
         if not no_sql_validation and effective_settings.sql_validation:
             for argument in arguments:
                 validate_native_type(
@@ -528,6 +535,8 @@ def build_sql_function_inputs(
             body_sql=python_function_file.body_python,
             database=function_database,
             schema=function_schema,
+            fingerprint_database=fingerprint_database,
+            fingerprint_schema=fingerprint_schema,
             language=FunctionLanguage.PYTHON,
             runtime_version=runtime_version,
             entry_point=entry_point,

--- a/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
+++ b/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
@@ -43,6 +43,7 @@ def build_compile_inputs(
     cli_vars: dict[str, str] | None = None,
     run_id: str | None = None,
     no_sql_validation: bool = False,
+    python_functions_inherit_default_namespace: bool = True,
 ) -> CompileProjectInputs:
     """Attach discovered metadata into the first compile input snapshot."""
 
@@ -100,6 +101,7 @@ def build_compile_inputs(
         adapter_name=macro_context.adapter_name,
         macro_context=macro_context,
         no_sql_validation=no_sql_validation,
+        python_functions_inherit_default_namespace=(python_functions_inherit_default_namespace),
     )
     source_inputs: tuple[CompileSourceInput, ...] = build_source_inputs(
         discovered_inputs,

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -145,6 +145,8 @@ class CompileSqlFunctionInput:
     references: tuple[CompileSqlReference, ...] = field(default_factory=tuple)
     database: str | None = None
     schema: str | None = None
+    fingerprint_database: str | None = None
+    fingerprint_schema: str | None = None
     language: FunctionLanguage = FunctionLanguage.SQL
     runtime_version: str | None = None
     entry_point: str | None = None
@@ -306,6 +308,7 @@ class CompiledFunction:
     returns: str
     body_sql: str
     target: CompiledRelationTarget
+    fingerprint_target: CompiledRelationTarget
     return_columns: tuple[FunctionReturnColumn, ...] = field(default_factory=tuple)
     references: tuple[CompileSqlReference, ...] = field(default_factory=tuple)
     language: FunctionLanguage = FunctionLanguage.SQL

--- a/src/sqlbuild/compiler/discovery/helpers/yml_project.py
+++ b/src/sqlbuild/compiler/discovery/helpers/yml_project.py
@@ -103,6 +103,11 @@ def load_local_config(*, project_dir: Path) -> LocalConfig:
 
 
 def _load_yaml_mapping(*, file_path: Path) -> dict[str, object]:
+    if not file_path.exists():
+        raise ProjectConfigError(
+            f"Project config not found: {file_path}. Run sqb from a sqlbuild project "
+            "directory or pass --project-dir."
+        )
     contents: str = file_path.read_text(encoding="utf-8")
     try:
         payload: object = yaml.safe_load(contents)

--- a/src/sqlbuild/compiler/fingerprints/main/read.py
+++ b/src/sqlbuild/compiler/fingerprints/main/read.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 from collections.abc import Callable
 from datetime import datetime
 from typing import Any
@@ -42,7 +43,7 @@ def read_latest_fingerprints(
     latest: dict[str, Fingerprint] = {}
     row: tuple[Any, ...]
     for row in rows:
-        fingerprint: Fingerprint = _row_to_fingerprint(row)
+        fingerprint: Fingerprint = _row_to_fingerprint(row, qualified_name=qualified_name)
         model_name: str = fingerprint.model_name
         if model_name not in latest or fingerprint.ts > latest[model_name].ts:
             latest[model_name] = fingerprint
@@ -59,7 +60,7 @@ def _table_exists(*, connection: Any, execute: Any, qualified_name: str) -> bool
         return False
 
 
-def _row_to_fingerprint(row: tuple[Any, ...]) -> Fingerprint:
+def _row_to_fingerprint(row: tuple[Any, ...], *, qualified_name: str) -> Fingerprint:
     raw_ts: Any = row[9]
     ts: datetime = raw_ts if isinstance(raw_ts, datetime) else datetime.fromisoformat(str(raw_ts))
     raw_ast_hash: Any = row[6]
@@ -67,12 +68,20 @@ def _row_to_fingerprint(row: tuple[Any, ...]) -> Fingerprint:
     raw_target_database: Any = row[1]
     raw_target_schema: Any = row[2]
     raw_target_name: Any = row[3]
+    model_name: str = str(row[0])
     query_sql_storage: str = str(row[8])
-    query_sql: str = base64.b64decode(query_sql_storage.encode("ascii"), validate=True).decode(
-        "utf-8"
-    )
+    try:
+        query_sql: str = base64.b64decode(query_sql_storage.encode("ascii"), validate=True).decode(
+            "utf-8"
+        )
+    except (binascii.Error, UnicodeDecodeError) as error:
+        raise ValueError(
+            f"Invalid fingerprint query SQL storage for '{model_name}' in {qualified_name}: "
+            "expected base64-encoded UTF-8. This can happen after upgrading from an older "
+            f"sqlbuild version; delete or rebuild {qualified_name} to regenerate fingerprints."
+        ) from error
     return Fingerprint(
-        model_name=str(row[0]),
+        model_name=model_name,
         target_database=str(raw_target_database) if raw_target_database is not None else None,
         target_schema=str(raw_target_schema) if raw_target_schema is not None else None,
         target_name=str(raw_target_name) if raw_target_name is not None else None,

--- a/src/sqlbuild/compiler/pipeline/helpers/target_defaults.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/target_defaults.py
@@ -12,6 +12,7 @@ from sqlbuild.compiler.compile.models import (
     CompiledRelationTarget,
     CompiledSeed,
 )
+from sqlbuild.compiler.compile.types import FunctionLanguage
 
 
 def apply_target_defaults(
@@ -20,6 +21,7 @@ def apply_target_defaults(
     default_schema: str | None,
     default_database: str | None,
     render_qualified_name: Callable[..., str | None],
+    python_functions_inherit_default_namespace: bool,
 ) -> CompiledProject:
     """Apply adapter default schema/database to compiled project targets."""
 
@@ -50,8 +52,17 @@ def apply_target_defaults(
     functions: tuple[CompiledFunction, ...] = tuple(
         replace(
             f,
-            target=_resolve_target(
-                f.target,
+            target=_resolve_function_target(
+                function=f,
+                default_schema=default_schema,
+                default_database=default_database,
+                render_qualified_name=render_qualified_name,
+                python_functions_inherit_default_namespace=(
+                    python_functions_inherit_default_namespace
+                ),
+            ),
+            fingerprint_target=_resolve_target(
+                f.fingerprint_target,
                 default_schema,
                 default_database,
                 render_qualified_name,
@@ -60,6 +71,28 @@ def apply_target_defaults(
         for f in project.functions
     )
     return replace(project, models=models, seeds=seeds, functions=functions)
+
+
+def _resolve_function_target(
+    *,
+    function: CompiledFunction,
+    default_schema: str | None,
+    default_database: str | None,
+    render_qualified_name: Callable[..., str | None],
+    python_functions_inherit_default_namespace: bool,
+) -> CompiledRelationTarget:
+    apply_defaults: bool = (
+        function.language != FunctionLanguage.PYTHON or python_functions_inherit_default_namespace
+    )
+    resolved: CompiledRelationTarget = _resolve_target(
+        function.target,
+        default_schema if apply_defaults else None,
+        default_database if apply_defaults else None,
+        render_qualified_name,
+    )
+    if not apply_defaults and resolved.qualified_name is None:
+        return replace(resolved, qualified_name=resolved.name)
+    return resolved
 
 
 def _resolve_target(

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -25,12 +25,18 @@ def build_compiled_project(
         discovered_inputs,
         selected_environment=selected_environment,
         no_sql_validation=no_sql_validation,
+        python_functions_inherit_default_namespace=(
+            adapter.python_functions_inherit_default_namespace()
+        ),
     )
     project: CompiledProject = apply_target_defaults(
         assemble_project(compile_inputs),
         default_schema=adapter.default_schema(),
         default_database=adapter.default_database(),
         render_qualified_name=adapter.render_qualified_name,
+        python_functions_inherit_default_namespace=(
+            adapter.python_functions_inherit_default_namespace()
+        ),
     )
     validate_project_targets(
         adapter_name=resolve_effective_adapter_name(

--- a/src/sqlbuild/compiler/planner/helpers/resolve/sources.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/sources.py
@@ -43,6 +43,7 @@ def resolve_source_references(
         if source_entry.type_enforcement:
             if source_entry.expression is not None:
                 resolved_source = _build_expression_cast_subquery(
+                    source_name=source_entry.name,
                     source_relation=resolved_source,
                     declared_columns=source_entry.columns,
                     expression_columns=warehouse_cols,
@@ -128,6 +129,7 @@ def _validate_declared_columns(
 
 def _build_expression_cast_subquery(
     *,
+    source_name: str,
     source_relation: str,
     declared_columns: tuple[SourceColumnEntry, ...],
     expression_columns: tuple[ColumnInfo, ...] | None,
@@ -140,7 +142,10 @@ def _build_expression_cast_subquery(
     if not enforced_map:
         return source_relation
     if expression_columns is None:
-        raise ValueError("Source expression type enforcement requires query output column metadata")
+        raise ValueError(
+            f"Source expression '{source_name}' type enforcement requires query output "
+            "column metadata"
+        )
 
     expression_names: tuple[str, ...] = tuple(col.name for col in expression_columns)
     missing_names: tuple[str, ...] = tuple(
@@ -148,8 +153,10 @@ def _build_expression_cast_subquery(
     )
     if missing_names:
         missing_columns: str = ", ".join(missing_names)
+        available_columns: str = ", ".join(expression_names) if expression_names else "<none>"
         raise ValueError(
-            f"Source expression declares columns not found in query output: {missing_columns}"
+            f"Source expression '{source_name}' declares columns not found in query output: "
+            f"{missing_columns}. Available query output columns: {available_columns}"
         )
 
     projections: list[str] = [

--- a/src/sqlbuild/compiler/planner/main/execution.py
+++ b/src/sqlbuild/compiler/planner/main/execution.py
@@ -308,6 +308,7 @@ def build_execution_plan(
                 star_exclude_keyword=star_exclude_keyword,
             ),
             fingerprint_query_sql=function_fingerprint_sql[function.name],
+            fingerprint_target=function.fingerprint_target,
             return_columns=function.return_columns,
             language=function.language,
             source_file_path=function.source_file_path,

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -280,6 +280,7 @@ class FunctionPlanEntry:
     returns: str
     body_sql: str
     fingerprint_query_sql: str
+    fingerprint_target: CompiledRelationTarget
     return_columns: tuple[FunctionReturnColumn, ...] = field(default_factory=tuple)
     language: FunctionLanguage = FunctionLanguage.SQL
     source_file_path: Path | None = None

--- a/src/sqlbuild/executor/build/helpers/output.py
+++ b/src/sqlbuild/executor/build/helpers/output.py
@@ -313,6 +313,7 @@ def _format_summary_counts(
             fail_count += 1
         elif function_result.status == ExecutionStatus.SKIPPED:
             skip_count += 1
+        warn_count += len(function_result.warning_messages)
 
     test_result: SqlTestExecutionResult
     for test_result in result.test_results:
@@ -439,6 +440,20 @@ def _format_warning_details(result: BuildExecutionResult) -> list[str]:
             lines.append(f"  {model_result.model_name}")
             lines.extend(model_warnings)
             lines.append("")
+
+    function_result: FunctionExecutionResult
+    for function_result in result.function_results:
+        if not function_result.warning_messages:
+            continue
+        if not has_warnings:
+            lines.append("Warnings:")
+            lines.append("")
+            has_warnings = True
+        lines.append(f"  {function_result.function_name}  (function)")
+        warning_msg: str
+        for warning_msg in function_result.warning_messages:
+            lines.append(f"    {warning_msg}")
+        lines.append("")
 
     return lines
 

--- a/src/sqlbuild/executor/functions/main/execute.py
+++ b/src/sqlbuild/executor/functions/main/execute.py
@@ -73,6 +73,7 @@ def execute_function(
             run_id=run_id,
             query_change_tracking=query_change_tracking,
             warnings=warnings,
+            statement_recorder=statement_recorder,
         )
         return FunctionExecutionResult(
             function_name=function_entry.name,
@@ -98,18 +99,28 @@ def _try_write_function_fingerprint(
     run_id: str,
     query_change_tracking: bool,
     warnings: list[str],
+    statement_recorder: StatementRecorder,
 ) -> None:
     if not query_change_tracking:
         return
-    target_schema: str | None = entry.target.schema
-    if target_schema is None:
+    fingerprint_schema: str | None = entry.fingerprint_target.schema
+    target_is_unqualified: bool = entry.target.schema is None and entry.target.database is None
+    if target_is_unqualified and not adapter.supports_unqualified_function_fingerprints():
+        fingerprint_schema = None
+    if fingerprint_schema is None:
         warnings.append(
             "fingerprint write skipped for "
-            f"function '{entry.name}': target schema is missing while "
+            f"function '{entry.name}': fingerprint schema is missing while "
             "query_change_tracking is enabled"
         )
         return
     try:
+        adapter.ensure_schema(
+            connection,
+            database=entry.fingerprint_target.database,
+            schema=fingerprint_schema,
+            statement_recorder=statement_recorder,
+        )
         normalized_sql: str = " ".join(entry.fingerprint_query_sql.split())
         query_hash: str = hashlib.sha256(normalized_sql.encode()).hexdigest()
         schema_fp: str = hashlib.sha256(b"").hexdigest()
@@ -128,8 +139,8 @@ def _try_write_function_fingerprint(
         write_fingerprint(
             connection=connection,
             execute=adapter.execute,
-            database=entry.target.database,
-            schema=target_schema,
+            database=entry.fingerprint_target.database,
+            schema=fingerprint_schema,
             fingerprint=fingerprint,
             render_qualified_name=adapter.render_qualified_name,
             render_framework_type=adapter.render_framework_type,

--- a/src/sqlbuild/integrations/duckdb/client.py
+++ b/src/sqlbuild/integrations/duckdb/client.py
@@ -353,6 +353,12 @@ class DuckDbAdapter(BaseAdapter):
     def persists_python_functions(self) -> bool:
         return False
 
+    def python_functions_inherit_default_namespace(self) -> bool:
+        return False
+
+    def supports_unqualified_function_fingerprints(self) -> bool:
+        return True
+
     def supports_table_functions(self) -> bool:
         return True
 

--- a/tests/integration/src/sqlbuild/compiler/fingerprints/main/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/fingerprints/main/_test_types.py
@@ -49,3 +49,12 @@ class NullAstHashTestCase:
     schema: str
     fingerprint: Fingerprint
     expected_ast_hash_is_none: bool
+
+
+@dataclass(frozen=True)
+class InvalidQuerySqlStorageTestCase:
+    description: str
+    schema: str
+    model_name: str
+    raw_query_sql_storage: str
+    expected_error_fragments: tuple[str, ...]

--- a/tests/integration/src/sqlbuild/compiler/fingerprints/main/test_read_write.py
+++ b/tests/integration/src/sqlbuild/compiler/fingerprints/main/test_read_write.py
@@ -13,6 +13,7 @@ from sqlbuild.compiler.fingerprints.main.write import write_fingerprint
 from sqlbuild.compiler.fingerprints.models import Fingerprint, FingerprintSet
 from sqlbuild.integrations.duckdb.client import DuckDbAdapter
 from tests.integration.src.sqlbuild.compiler.fingerprints.main._test_types import (
+    InvalidQuerySqlStorageTestCase,
     LatestResolutionTestCase,
     NullAstHashTestCase,
     ReadNonExistentTableTestCase,
@@ -343,3 +344,70 @@ def test_given_null_ast_hash_when_writing_and_reading_then_ast_hash_is_none(
     latest: Fingerprint = result.fingerprints["orders"]
 
     assert (latest.ast_hash is None) == test_case.expected_ast_hash_is_none
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        InvalidQuerySqlStorageTestCase(
+            description="invalid legacy query sql storage raises contextual error",
+            schema="test_schema",
+            model_name="orders",
+            raw_query_sql_storage="SELECT 1",
+            expected_error_fragments=(
+                "Invalid fingerprint query SQL storage for 'orders'",
+                "expected base64-encoded UTF-8",
+                "delete or rebuild",
+                "_sqlbuild_fingerprints",
+            ),
+        )
+    ],
+    ids=["invalid legacy query sql storage raises contextual error"],
+)
+def test_given_invalid_query_sql_storage_when_reading_then_raises_contextual_error(
+    test_case: InvalidQuerySqlStorageTestCase,
+    connection: Any,
+    execute: Any,
+) -> None:
+    connection.execute(f"CREATE SCHEMA IF NOT EXISTS {test_case.schema}")
+    connection.execute(
+        f"CREATE TABLE {test_case.schema}.{FINGERPRINT_TABLE_NAME} ("
+        "model_name VARCHAR NOT NULL, "
+        "target_database VARCHAR, "
+        "target_schema VARCHAR, "
+        "target_name VARCHAR, "
+        "run_id VARCHAR NOT NULL, "
+        "query_hash VARCHAR NOT NULL, "
+        "ast_hash VARCHAR, "
+        "schema_fingerprint VARCHAR NOT NULL, "
+        "query_sql VARCHAR NOT NULL, "
+        "ts TIMESTAMP NOT NULL)"
+    )
+    connection.execute(
+        f"INSERT INTO {test_case.schema}.{FINGERPRINT_TABLE_NAME} VALUES "
+        "(?, NULL, ?, ?, ?, ?, NULL, ?, ?, ?)",
+        (
+            test_case.model_name,
+            test_case.schema,
+            test_case.model_name,
+            "run_001",
+            "hash_a",
+            "schema_a",
+            test_case.raw_query_sql_storage,
+            datetime(2026, 1, 15, 12, 0, 0),
+        ),
+    )
+
+    with pytest.raises(ValueError) as error_info:
+        read_latest_fingerprints(
+            connection=connection,
+            execute=execute,
+            database=None,
+            schema=test_case.schema,
+            render_qualified_name=RENDER_QUALIFIED_NAME,
+        )
+
+    message: str = str(error_info.value)
+    fragment: str
+    for fragment in test_case.expected_error_fragments:
+        assert fragment in message

--- a/tests/integration/src/sqlbuild/compiler/planner/main/helpers.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/helpers.py
@@ -130,6 +130,12 @@ def build_project_from_test_case(
                     name=function_name,
                     qualified_name=f"{target_schema}.{function_name}",
                 ),
+                fingerprint_target=CompiledRelationTarget(
+                    database=None,
+                    schema=target_schema,
+                    name=function_name,
+                    qualified_name=f"{target_schema}.{function_name}",
+                ),
                 language=language,
                 entry_point="main" if language == FunctionLanguage.PYTHON else None,
                 query_change_backfill=test_case.function_query_change_backfills.get(function_name),

--- a/tests/integration/src/sqlbuild/executor/build/test_build_execution.py
+++ b/tests/integration/src/sqlbuild/executor/build/test_build_execution.py
@@ -111,6 +111,11 @@ SUCCESS_TEST_CASES: list[BuildExecutionTestCase] = [
                 "SELECT value, is_positive FROM main.validated_orders ORDER BY value DESC",
                 (("abc", False), ("123", True)),
             ),
+            (
+                "SELECT model_name FROM main._sqlbuild_fingerprints "
+                "WHERE model_name = 'is_positive_int'",
+                (("is_positive_int",),),
+            ),
         ),
     ),
     BuildExecutionTestCase(
@@ -140,6 +145,51 @@ SUCCESS_TEST_CASES: list[BuildExecutionTestCase] = [
             (
                 "SELECT value, is_positive FROM main.validated_orders ORDER BY value DESC",
                 (("abc", False), ("123", True)),
+            ),
+        ),
+    ),
+    BuildExecutionTestCase(
+        description="duckdb python udf ignores inherited environment schema",
+        project_files={
+            "sqlbuild_project.yml": (
+                "name: demo\n"
+                "adapter: duckdb\n"
+                "default_environment: dev\n"
+                "connection:\n"
+                "  database: ':memory:'\n"
+                "environments:\n"
+                "  dev:\n"
+                "    schema: dev\n"
+            ),
+            "functions/python/is_positive_int.py": (
+                "from sqlbuild.functions import udf\n\n"
+                "@udf(\n"
+                "    arguments={'a_string': 'VARCHAR'},\n"
+                "    returns='BOOLEAN',\n"
+                "    runtime_version='3.11',\n"
+                ")\n"
+                "def main(a_string):\n"
+                "    return bool(a_string and a_string.isdigit())\n"
+            ),
+            "models/validated_orders.sql": (
+                "MODEL (materialized table);\n\n"
+                'SELECT value, __udf("is_positive_int")(value) AS is_positive '
+                "FROM (VALUES ('123'), ('abc')) AS input(value)"
+            ),
+        },
+        expected_status=BuildStatus.SUCCESS,
+        expected_success_count=2,
+        expected_model_statuses=(("validated_orders", ExecutionStatus.SUCCESS),),
+        expected_function_statuses=(("is_positive_int", ExecutionStatus.SUCCESS),),
+        expected_query_results=(
+            (
+                "SELECT value, is_positive FROM dev.validated_orders ORDER BY value DESC",
+                (("abc", False), ("123", True)),
+            ),
+            (
+                "SELECT model_name FROM dev._sqlbuild_fingerprints "
+                "WHERE model_name = 'is_positive_int'",
+                (("is_positive_int",),),
             ),
         ),
     ),

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/helpers.py
@@ -104,6 +104,12 @@ def build_target_writer_plan_output() -> PlanOutput:
                     name="is_completed_order",
                     qualified_name="analytics.is_completed_order",
                 ),
+                fingerprint_target=CompiledRelationTarget(
+                    database=None,
+                    schema="analytics",
+                    name="is_completed_order",
+                    qualified_name="analytics.is_completed_order",
+                ),
                 arguments=(FunctionArgument(name="order_status", type="VARCHAR"),),
                 returns="BOOLEAN",
                 body_sql="order_status = 'completed'",
@@ -114,6 +120,12 @@ def build_target_writer_plan_output() -> PlanOutput:
                 name="is_completed_order_py",
                 relative_path=Path("functions/python/is_completed_order_py.py"),
                 target=CompiledRelationTarget(
+                    database=None,
+                    schema="analytics",
+                    name="is_completed_order_py",
+                    qualified_name="analytics.is_completed_order_py",
+                ),
+                fingerprint_target=CompiledRelationTarget(
                     database=None,
                     schema="analytics",
                     name="is_completed_order_py",

--- a/tests/unit/src/sqlbuild/cli/commands/main/plan/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/plan/helpers/helpers.py
@@ -130,6 +130,9 @@ def build_function_entry(
         target=CompiledRelationTarget(
             database=None, schema="main", name=name, qualified_name=f"main.{name}"
         ),
+        fingerprint_target=CompiledRelationTarget(
+            database=None, schema="main", name=name, qualified_name=f"main.{name}"
+        ),
         arguments=(),
         returns="BOOLEAN",
         body_sql="return True",

--- a/tests/unit/src/sqlbuild/cli/commands/main/shared/helpers/test_progress.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/shared/helpers/test_progress.py
@@ -238,6 +238,29 @@ BUILD_FOOTER_TEST_CASES: list[BuildFooterTestCase] = [
             "failed to load seed CSV",
         ),
     ),
+    BuildFooterTestCase(
+        description="function warning appears in summary and warnings section",
+        result=BuildExecutionResult(
+            status=BuildStatus.SUCCESS,
+            function_results=(
+                FunctionExecutionResult(
+                    function_name="is_completed_order_py",
+                    status=ExecutionStatus.SUCCESS,
+                    warning_messages=("fingerprint write skipped",),
+                ),
+            ),
+            success_count=1,
+            warning_count=1,
+        ),
+        expected_fragments=(
+            "Completed with warnings.",
+            "PASS=1",
+            "WARN=1",
+            "Warnings:",
+            "is_completed_order_py  (function)",
+            "fingerprint write skipped",
+        ),
+    ),
 ]
 
 

--- a/tests/unit/src/sqlbuild/compiler/discovery/helpers/test_yml_project.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/helpers/test_yml_project.py
@@ -552,6 +552,25 @@ def test_given_invalid_project_config_file_when_loading_project_config_then_it_r
 
 @pytest.mark.parametrize(
     "test_case",
+    [
+        LoadProjectConfigErrorTestCase(
+            description="raises clear error when project config is missing",
+            project_file_contents="",
+            expected_error_fragment="Project config not found",
+        ),
+    ],
+    ids=["raises clear error when project config is missing"],
+)
+def test_given_missing_project_config_file_when_loading_project_config_then_it_raises_clear_error(
+    test_case: LoadProjectConfigErrorTestCase,
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match=test_case.expected_error_fragment):
+        load_project_config(project_dir=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "test_case",
     LOCAL_CONFIG_ERROR_TEST_CASES,
     ids=[case.description for case in LOCAL_CONFIG_ERROR_TEST_CASES],
 )

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/helpers.py
@@ -171,6 +171,9 @@ def build_test_project(
                 target=CompiledRelationTarget(
                     database=None, schema=None, name=function_name, qualified_name=None
                 ),
+                fingerprint_target=CompiledRelationTarget(
+                    database=None, schema=None, name=function_name, qualified_name=None
+                ),
             )
         )
 
@@ -561,6 +564,12 @@ def build_compiled_function(
         returns="BOOLEAN",
         body_sql=body_sql,
         target=CompiledRelationTarget(
+            database=None,
+            schema="main",
+            name="is_completed_order",
+            qualified_name="main.is_completed_order",
+        ),
+        fingerprint_target=CompiledRelationTarget(
             database=None,
             schema="main",
             name="is_completed_order",

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_sources.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_sources.py
@@ -339,7 +339,8 @@ ERROR_TEST_CASES: list[SourceResolutionErrorTestCase] = [
             ),
         },
         expected_error_fragment=(
-            "Source expression declares columns not found in query output: amount_cents"
+            "Source expression 'raw_payments' declares columns not found in query output: "
+            "amount_cents. Available query output columns: id, status"
         ),
     ),
     SourceResolutionErrorTestCase(
@@ -364,7 +365,8 @@ ERROR_TEST_CASES: list[SourceResolutionErrorTestCase] = [
             ),
         },
         expected_error_fragment=(
-            "Source expression declares columns not found in query output: status"
+            "Source expression 'raw_payments' declares columns not found in query output: "
+            "status. Available query output columns: id, amount_cents"
         ),
     ),
     SourceResolutionErrorTestCase(
@@ -381,7 +383,8 @@ ERROR_TEST_CASES: list[SourceResolutionErrorTestCase] = [
         },
         source_warehouse_columns={},
         expected_error_fragment=(
-            "Source expression type enforcement requires query output column metadata"
+            "Source expression 'raw_payments' type enforcement requires "
+            "query output column metadata"
         ),
     ),
 ]

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/sql_test_assembly/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/sql_test_assembly/helpers.py
@@ -168,6 +168,12 @@ def build_test_and_project(
                     name=function_name,
                     qualified_name=qualified_name,
                 ),
+                fingerprint_target=CompiledRelationTarget(
+                    database=None,
+                    schema="main",
+                    name=function_name,
+                    qualified_name=qualified_name,
+                ),
             )
         )
 

--- a/tests/unit/src/sqlbuild/executor/build/helpers/test_output.py
+++ b/tests/unit/src/sqlbuild/executor/build/helpers/test_output.py
@@ -242,6 +242,29 @@ TEST_CASES: list[BuildOutputTestCase] = [
         ),
     ),
     BuildOutputTestCase(
+        description="function warning appears in summary and warnings section",
+        result=BuildExecutionResult(
+            status=BuildStatus.SUCCESS,
+            function_results=(
+                FunctionExecutionResult(
+                    function_name="is_completed_order_py",
+                    status=ExecutionStatus.SUCCESS,
+                    warning_messages=("fingerprint write skipped",),
+                ),
+            ),
+            success_count=1,
+            warning_count=1,
+        ),
+        expected_output_fragments=(
+            "Completed with warnings.",
+            "PASS=1",
+            "WARN=1",
+            "Warnings:",
+            "is_completed_order_py  (function)",
+            "fingerprint write skipped",
+        ),
+    ),
+    BuildOutputTestCase(
         description="view model shows view type",
         result=BuildExecutionResult(
             status=BuildStatus.SUCCESS,


### PR DESCRIPTION
Fixes a few user-facing error and DuckDB UDF issues:

- Show a clean error when sqb runs outside a sqlbuild project.
- Improve source expression errors with the source name and available columns.
- Add a clearer message for legacy/non-base64 fingerprint rows after upgrade.
- Keep DuckDB Python UDFs unqualified while still storing their fingerprints in sqlbuild metadata.
- Make function warnings show consistently in build summaries/details.

I would like to think this is the last of the silly bugs I caused as a result of UDFs (was definitely ambitious having put them in today, but it seems to be looking better now).