### PR TITLE
feat: add lineage command

### DIFF
--- a/src/sqlbuild/cli/commands/main/entry.py
+++ b/src/sqlbuild/cli/commands/main/entry.py
@@ -102,6 +102,23 @@ def _build_parser() -> argparse.ArgumentParser:
     query_parser.add_argument(
         "--no-limit", dest="query_no_limit", action="store_true", default=False
     )
+    lineage_parser: argparse.ArgumentParser = subparsers.add_parser(CliCommand.LINEAGE)
+    lineage_parser.add_argument("lineage_target", nargs="?", metavar="target")
+    lineage_parser.add_argument("--no-sql-validation", action="store_true", default=False)
+    lineage_parser.add_argument(
+        "--format",
+        dest="lineage_format",
+        choices=("tree", "json", "list"),
+        default="tree",
+    )
+    lineage_parser.add_argument(
+        "--direction",
+        dest="lineage_direction",
+        choices=("upstream", "downstream", "both"),
+        default="upstream",
+    )
+    lineage_parser.add_argument("--depth", dest="lineage_depth", default="all")
+    add_select_args(lineage_parser)
     subparsers.add_parser(CliCommand.CLEAN)
     janitor_parser: argparse.ArgumentParser = subparsers.add_parser(CliCommand.JANITOR)
     janitor_parser.add_argument("--auto-approve", action="store_true", default=False)
@@ -119,6 +136,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     from sqlbuild.cli.commands.main.compile import run_compile
     from sqlbuild.cli.commands.main.diff import run_diff
     from sqlbuild.cli.commands.main.janitor import run_janitor
+    from sqlbuild.cli.commands.main.lineage import run_lineage
     from sqlbuild.cli.commands.main.plan import run_plan
     from sqlbuild.cli.commands.main.query import run_query
     from sqlbuild.cli.commands.main.run import run_run
@@ -136,6 +154,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         run_clone=run_clone,
         run_diff=run_diff,
         run_query=run_query,
+        run_lineage=run_lineage,
         run_janitor=run_janitor,
     )
     return _main_with_dependencies(argv=argv, handlers=handlers)
@@ -254,6 +273,17 @@ def _main_with_dependencies(
             return handlers.run_seed(
                 project_dir,
                 args.no_color,
+                tuple(args.select),
+                tuple(args.exclude),
+            )
+        if args.command == CliCommand.LINEAGE:
+            return handlers.run_lineage(
+                project_dir,
+                args.no_sql_validation,
+                args.lineage_target,
+                args.lineage_format,
+                args.lineage_direction,
+                args.lineage_depth,
                 tuple(args.select),
                 tuple(args.exclude),
             )

--- a/src/sqlbuild/cli/commands/main/helpers/entry/models.py
+++ b/src/sqlbuild/cli/commands/main/helpers/entry/models.py
@@ -41,6 +41,10 @@ class CliNamespace:
     query_format: str = "long"
     query_limit: int | None = 20
     query_no_limit: bool = False
+    lineage_target: str | None = None
+    lineage_format: str = "tree"
+    lineage_direction: str = "upstream"
+    lineage_depth: str = "all"
     full: bool = False
     schema_only: bool = False
     select: list[str] = field(default_factory=list)
@@ -128,4 +132,8 @@ class CliEntrypointHandlers:
         int,
     ]
     run_query: Callable[[Path | None, str | None, str, int | None], int]
+    run_lineage: Callable[
+        [Path | None, bool, str | None, str, str, str, tuple[str, ...], tuple[str, ...]],
+        int,
+    ]
     run_janitor: Callable[[Path | None, bool, bool, int | None], int]

--- a/src/sqlbuild/cli/commands/main/helpers/lineage/__init__.py
+++ b/src/sqlbuild/cli/commands/main/helpers/lineage/__init__.py
@@ -1,0 +1,1 @@
+"""Lineage command helpers."""

--- a/src/sqlbuild/cli/commands/main/helpers/lineage/models.py
+++ b/src/sqlbuild/cli/commands/main/helpers/lineage/models.py
@@ -1,0 +1,55 @@
+"""Lineage command models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sqlbuild.compiler.compile.models import CompiledObjectKey
+
+
+@dataclass(frozen=True)
+class LineageNode:
+    """One displayable lineage graph node."""
+
+    key: CompiledObjectKey
+    relative_path: str | None = None
+    qualified_name: str | None = None
+
+
+@dataclass(frozen=True)
+class LineageGraph:
+    """Selected lineage graph slice."""
+
+    nodes: tuple[LineageNode, ...]
+    edges: tuple[tuple[CompiledObjectKey, CompiledObjectKey], ...]
+    focus_keys: tuple[CompiledObjectKey, ...] = field(default_factory=tuple)
+    direction: str | None = None
+
+
+@dataclass(frozen=True)
+class LineageSelectionAnchors:
+    """Selector anchors used for optional post-selection depth trimming."""
+
+    upstream: frozenset[CompiledObjectKey] = field(default_factory=frozenset)
+    downstream: frozenset[CompiledObjectKey] = field(default_factory=frozenset)
+    retained: frozenset[CompiledObjectKey] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class ParsedLineageSelector:
+    """One parsed non-path lineage selector."""
+
+    kind: str
+    value: str
+    upstream: bool = False
+    downstream: bool = False
+
+
+@dataclass(frozen=True)
+class ParsedLineagePathSelector:
+    """One parsed path-between lineage selector."""
+
+    start_name: str
+    end_name: str
+    upstream: bool = False
+    downstream: bool = False

--- a/src/sqlbuild/cli/commands/main/helpers/lineage/output.py
+++ b/src/sqlbuild/cli/commands/main/helpers/lineage/output.py
@@ -1,0 +1,187 @@
+"""Lineage output formatting."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from sqlbuild.cli.commands.main.helpers.lineage.models import LineageGraph, LineageNode
+from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.shared.helpers.colors import blue_bold, bold, dim
+
+
+def format_lineage_json(graph: LineageGraph) -> str:
+    """Serialize lineage graph as stable JSON."""
+
+    payload: dict[str, object] = {
+        "nodes": [_serialize_node(node) for node in graph.nodes],
+        "edges": [
+            {"from": _node_id(upstream), "to": _node_id(downstream)}
+            for upstream, downstream in graph.edges
+        ],
+    }
+    if graph.focus_keys:
+        payload["focus"] = [_node_id(key) for key in graph.focus_keys]
+    if graph.direction is not None:
+        payload["direction"] = graph.direction
+    return json.dumps(payload, indent=2)
+
+
+def format_lineage_list(graph: LineageGraph, *, use_color: bool = True) -> str:
+    """Format lineage graph as an edge list."""
+
+    if not graph.edges:
+        return "\n".join(_format_key(node.key, use_color=use_color) for node in graph.nodes)
+    left_width: int = max(len(_node_id(upstream)) for upstream, _downstream in graph.edges)
+    return "\n".join(
+        f"{_format_key(upstream, use_color=use_color)}"
+        f"{' ' * (left_width - len(_node_id(upstream)))} "
+        f"{_style('->', dim, use_color=use_color)} "
+        f"{_format_key(downstream, use_color=use_color)}"
+        for upstream, downstream in graph.edges
+    )
+
+
+def format_lineage_tree(graph: LineageGraph, *, use_color: bool = True) -> str:
+    """Format lineage graph for humans."""
+
+    if len(graph.focus_keys) != 1 or graph.direction is None:
+        return _format_graph_summary(graph, use_color=use_color)
+    focus: CompiledObjectKey = graph.focus_keys[0]
+    node_by_key: dict[CompiledObjectKey, LineageNode] = {node.key: node for node in graph.nodes}
+    title: str = _style("Lineage", blue_bold, use_color=use_color)
+    direction: str = _style(graph.direction, dim, use_color=use_color)
+    lines: list[str] = [
+        f"{title}  {_format_node(node_by_key[focus], use_color=use_color)}  {direction}"
+    ]
+    if graph.direction in {"upstream", "both"}:
+        upstream: dict[CompiledObjectKey, list[CompiledObjectKey]] = {}
+        for parent, child in graph.edges:
+            upstream.setdefault(child, []).append(parent)
+        if graph.direction == "both":
+            lines.append(_style("upstream", blue_bold, use_color=use_color))
+        lines.extend(
+            _format_branch(
+                focus,
+                upstream,
+                node_by_key,
+                prefix="",
+                seen={focus},
+                use_color=use_color,
+            )
+        )
+    if graph.direction in {"downstream", "both"}:
+        downstream: dict[CompiledObjectKey, list[CompiledObjectKey]] = {}
+        for parent, child in graph.edges:
+            downstream.setdefault(parent, []).append(child)
+        if graph.direction == "both":
+            lines.append(_style("downstream", blue_bold, use_color=use_color))
+        lines.extend(
+            _format_branch(
+                focus,
+                downstream,
+                node_by_key,
+                prefix="",
+                seen={focus},
+                use_color=use_color,
+            )
+        )
+    return "\n".join(lines)
+
+
+def _format_graph_summary(graph: LineageGraph, *, use_color: bool) -> str:
+    title: str = _style("Lineage graph", blue_bold, use_color=use_color)
+    counts: str = _style(
+        f"({len(graph.nodes)} nodes, {len(graph.edges)} edges)", dim, use_color=use_color
+    )
+    lines: list[str] = [f"{title}  {counts}"]
+    if graph.edges:
+        lines.extend(
+            f"{_style('  - ', dim, use_color=use_color)}"
+            f"{_format_key(parent, use_color=use_color)} "
+            f"{_style('->', dim, use_color=use_color)} "
+            f"{_format_key(child, use_color=use_color)}"
+            for parent, child in graph.edges
+        )
+    else:
+        lines.extend(f"  {_format_node(node, use_color=use_color)}" for node in graph.nodes)
+    return "\n".join(lines)
+
+
+def _format_branch(
+    key: CompiledObjectKey,
+    deps: dict[CompiledObjectKey, list[CompiledObjectKey]],
+    node_by_key: dict[CompiledObjectKey, LineageNode],
+    *,
+    prefix: str,
+    seen: set[CompiledObjectKey],
+    use_color: bool,
+) -> list[str]:
+    lines: list[str] = []
+    children: list[CompiledObjectKey] = sorted(
+        deps.get(key, ()), key=lambda k: (str(k.resource_type), k.name)
+    )
+    if not children:
+        return lines
+    for index, child in enumerate(children):
+        is_last: bool = index == len(children) - 1
+        branch: str = "└── " if is_last else "├── "
+        child_prefix: str = "    " if is_last else "│   "
+        suffix: str = _style(" (already shown)", dim, use_color=use_color) if child in seen else ""
+        lines.append(
+            f"{_style(prefix + branch, dim, use_color=use_color)}"
+            f"{_format_node(node_by_key[child], use_color=use_color)}{suffix}"
+        )
+        if child in seen:
+            continue
+        lines.extend(
+            _format_branch(
+                child,
+                deps,
+                node_by_key,
+                prefix=prefix + child_prefix,
+                seen=seen | {child},
+                use_color=use_color,
+            )
+        )
+    return lines
+
+
+def _serialize_node(node: LineageNode) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": _node_id(node.key),
+        "name": node.key.name,
+        "resource_type": str(node.key.resource_type),
+    }
+    if node.relative_path is not None:
+        payload["relative_path"] = node.relative_path
+    if node.qualified_name is not None:
+        payload["qualified_name"] = node.qualified_name
+    return payload
+
+
+def _format_node(node: LineageNode, *, use_color: bool) -> str:
+    parts: list[str] = [
+        _style(str(node.key.resource_type), dim, use_color=use_color),
+        _style(node.key.name, bold, use_color=use_color),
+    ]
+    if node.relative_path is not None:
+        parts.append(_style(node.relative_path, dim, use_color=use_color))
+    return "  ".join(parts)
+
+
+def _format_key(key: CompiledObjectKey, *, use_color: bool) -> str:
+    return (
+        f"{_style(str(key.resource_type), dim, use_color=use_color)}:"
+        f"{_style(key.name, bold, use_color=use_color)}"
+    )
+
+
+def _node_id(key: CompiledObjectKey) -> str:
+    return f"{key.resource_type}:{key.name}"
+
+
+def _style(text: str, styler: Callable[[str], str], *, use_color: bool) -> str:
+    if not use_color:
+        return text
+    return styler(text)

--- a/src/sqlbuild/cli/commands/main/helpers/lineage/selection.py
+++ b/src/sqlbuild/cli/commands/main/helpers/lineage/selection.py
@@ -1,0 +1,517 @@
+"""Lineage graph selection helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from sqlbuild.cli.commands.main.helpers.lineage.models import (
+    LineageGraph,
+    LineageNode,
+    LineageSelectionAnchors,
+    ParsedLineagePathSelector,
+    ParsedLineageSelector,
+)
+from sqlbuild.cli.commands.main.shared.exceptions import CliUserError
+from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.pipeline.models import ProjectGraph
+
+
+def parse_depth(raw_depth: str) -> int | None:
+    """Parse a lineage depth value, returning None for unlimited traversal."""
+
+    if raw_depth == "all":
+        return None
+    try:
+        depth: int = int(raw_depth)
+    except ValueError:
+        raise CliUserError("--depth must be a non-negative integer or 'all'") from None
+    if depth < 0:
+        raise CliUserError("--depth must be a non-negative integer or 'all'")
+    return depth
+
+
+def select_target_lineage(
+    *,
+    graph: ProjectGraph,
+    target: str,
+    direction: str,
+    depth: int | None,
+) -> LineageGraph:
+    """Select lineage around one positional target."""
+
+    key: CompiledObjectKey | None = graph.all_keys.get(target)
+    if key is None:
+        raise CliUserError(f"Unknown lineage target '{target}'")
+
+    selected: set[CompiledObjectKey] = {key}
+    if direction in {"upstream", "both"}:
+        selected.update(_walk_bounded(anchors=(key,), deps=graph.upstream_deps, max_depth=depth))
+    if direction in {"downstream", "both"}:
+        selected.update(_walk_bounded(anchors=(key,), deps=graph.downstream_deps, max_depth=depth))
+    return build_lineage_graph(
+        project=graph.project,
+        upstream_deps=graph.upstream_deps,
+        selected_keys=frozenset(selected),
+        focus_keys=(key,),
+        direction=direction,
+    )
+
+
+def select_selector_lineage(
+    *,
+    graph: ProjectGraph,
+    select: tuple[str, ...],
+    exclude: tuple[str, ...],
+    depth: int | None,
+) -> LineageGraph:
+    """Select lineage using existing selector semantics."""
+
+    selected_keys: frozenset[CompiledObjectKey] = _resolve_selectors(
+        select=select,
+        exclude=exclude,
+        all_keys=graph.all_keys,
+        upstream=graph.upstream_deps,
+        downstream=graph.downstream_deps,
+        tag_index=graph.tag_index,
+        path_index=graph.path_index,
+    )
+    anchors: LineageSelectionAnchors = _resolve_selector_anchors(
+        select=select,
+        all_keys=graph.all_keys,
+        upstream_deps=graph.upstream_deps,
+        downstream_deps=graph.downstream_deps,
+        tag_index=graph.tag_index,
+        path_index=graph.path_index,
+        require_clear_anchors=depth is not None,
+    )
+    if depth is not None:
+        selected_keys = _trim_selected_keys(
+            selected_keys=selected_keys,
+            anchors=anchors,
+            upstream_deps=graph.upstream_deps,
+            downstream_deps=graph.downstream_deps,
+            max_depth=depth,
+        )
+    focus_keys: tuple[CompiledObjectKey, ...] = tuple(
+        sorted(anchors.upstream | anchors.downstream, key=_sort_key)
+    )
+    return build_lineage_graph(
+        project=graph.project,
+        upstream_deps=graph.upstream_deps,
+        selected_keys=selected_keys,
+        focus_keys=focus_keys,
+        direction=None,
+    )
+
+
+def build_lineage_graph(
+    *,
+    project: CompiledProject,
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    selected_keys: frozenset[CompiledObjectKey],
+    focus_keys: tuple[CompiledObjectKey, ...] = (),
+    direction: str | None = None,
+) -> LineageGraph:
+    """Build display nodes and selected edges."""
+
+    nodes: tuple[LineageNode, ...] = tuple(
+        _build_node(project, key) for key in sorted(selected_keys, key=_sort_key)
+    )
+    selected_edges: list[tuple[CompiledObjectKey, CompiledObjectKey]] = []
+    for downstream_key in sorted(selected_keys, key=_sort_key):
+        for upstream_key in upstream_deps.get(downstream_key, ()):
+            if upstream_key in selected_keys:
+                selected_edges.append((upstream_key, downstream_key))
+    return LineageGraph(
+        nodes=nodes,
+        edges=tuple(selected_edges),
+        focus_keys=focus_keys,
+        direction=direction,
+    )
+
+
+def _resolve_selector_anchors(
+    *,
+    select: tuple[str, ...],
+    all_keys: dict[str, CompiledObjectKey],
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    downstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    tag_index: dict[str, frozenset[CompiledObjectKey]],
+    path_index: dict[CompiledObjectKey, str],
+    require_clear_anchors: bool,
+) -> LineageSelectionAnchors:
+    upstream_anchors: set[CompiledObjectKey] = set()
+    downstream_anchors: set[CompiledObjectKey] = set()
+    retained: set[CompiledObjectKey] = set()
+
+    for raw_select in select:
+        for token in raw_select.split():
+            if "," in token and require_clear_anchors:
+                raise CliUserError("--depth cannot be combined with comma-intersection selectors")
+            parts: list[str] = token.split(",")
+            for part in parts:
+                parsed: ParsedLineageSelector | ParsedLineagePathSelector = _parse_selector(part)
+                if isinstance(parsed, ParsedLineagePathSelector):
+                    start_key: CompiledObjectKey = _lookup_name(parsed.start_name, all_keys)
+                    end_key: CompiledObjectKey = _lookup_name(parsed.end_name, all_keys)
+                    retained.update(_find_path_keys(start_key, end_key, downstream_deps))
+                    upstream_anchors.add(start_key)
+                    downstream_anchors.add(end_key)
+                    continue
+                if parsed.kind in {"tag", "path"}:
+                    if require_clear_anchors:
+                        raise CliUserError(
+                            "--depth requires name, source, seed, or path-between selectors"
+                        )
+                    matched: frozenset[CompiledObjectKey]
+                    if parsed.kind == "tag":
+                        matched = tag_index.get(parsed.value, frozenset())
+                    else:
+                        matched = _match_path(parsed.value, path_index)
+                    upstream_anchors.update(matched)
+                    downstream_anchors.update(matched)
+                    continue
+                key: CompiledObjectKey = _lookup_parsed_selector(parsed, all_keys)
+                if parsed.upstream:
+                    upstream_anchors.add(key)
+                if parsed.downstream:
+                    downstream_anchors.add(key)
+                if not parsed.upstream and not parsed.downstream:
+                    retained.add(key)
+    return LineageSelectionAnchors(
+        upstream=frozenset(upstream_anchors),
+        downstream=frozenset(downstream_anchors),
+        retained=frozenset(retained),
+    )
+
+
+def _trim_selected_keys(
+    *,
+    selected_keys: frozenset[CompiledObjectKey],
+    anchors: LineageSelectionAnchors,
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    downstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    max_depth: int,
+) -> frozenset[CompiledObjectKey]:
+    retained: set[CompiledObjectKey] = set(anchors.retained)
+    retained.update(anchors.upstream)
+    retained.update(anchors.downstream)
+    retained.update(
+        _walk_bounded(anchors=anchors.upstream, deps=upstream_deps, max_depth=max_depth)
+    )
+    retained.update(
+        _walk_bounded(anchors=anchors.downstream, deps=downstream_deps, max_depth=max_depth)
+    )
+    return frozenset(selected_keys & retained)
+
+
+def _walk_bounded(
+    *,
+    anchors: Iterable[CompiledObjectKey],
+    deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    max_depth: int | None,
+) -> frozenset[CompiledObjectKey]:
+    if max_depth is None:
+        result: set[CompiledObjectKey] = set()
+        for anchor in anchors:
+            result.update(_walk_all(anchor, deps))
+        return frozenset(result)
+    if max_depth == 0:
+        return frozenset()
+    visited: set[CompiledObjectKey] = set()
+    queue: list[tuple[CompiledObjectKey, int]] = [(anchor, 0) for anchor in anchors]
+    while queue:
+        current, current_depth = queue.pop(0)
+        if current_depth >= max_depth:
+            continue
+        for neighbor in deps.get(current, ()):
+            if neighbor in visited:
+                continue
+            visited.add(neighbor)
+            queue.append((neighbor, current_depth + 1))
+    return frozenset(visited)
+
+
+def _walk_all(
+    key: CompiledObjectKey,
+    deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+) -> frozenset[CompiledObjectKey]:
+    visited: set[CompiledObjectKey] = set()
+    stack: list[CompiledObjectKey] = [key]
+    while stack:
+        current: CompiledObjectKey = stack.pop()
+        for neighbor in deps.get(current, ()):
+            if neighbor in visited:
+                continue
+            visited.add(neighbor)
+            stack.append(neighbor)
+    return frozenset(visited)
+
+
+def _lookup_name(name: str, all_keys: dict[str, CompiledObjectKey]) -> CompiledObjectKey:
+    key: CompiledObjectKey | None = all_keys.get(name)
+    if key is None:
+        raise CliUserError(f"Unknown lineage target '{name}'")
+    return key
+
+
+def _resolve_selectors(
+    *,
+    select: tuple[str, ...],
+    exclude: tuple[str, ...],
+    all_keys: dict[str, CompiledObjectKey],
+    upstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    downstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    tag_index: dict[str, frozenset[CompiledObjectKey]],
+    path_index: dict[CompiledObjectKey, str],
+) -> frozenset[CompiledObjectKey]:
+    selected: set[CompiledObjectKey] = set()
+    for raw_select in select:
+        for token in raw_select.split():
+            selected.update(
+                _resolve_token(
+                    token=token,
+                    all_keys=all_keys,
+                    upstream=upstream,
+                    downstream=downstream,
+                    tag_index=tag_index,
+                    path_index=path_index,
+                )
+            )
+    excluded: set[CompiledObjectKey] = set()
+    for raw_exclude in exclude:
+        for token in raw_exclude.split():
+            excluded.update(
+                _resolve_token(
+                    token=token,
+                    all_keys=all_keys,
+                    upstream=upstream,
+                    downstream=downstream,
+                    tag_index=tag_index,
+                    path_index=path_index,
+                )
+            )
+    scoped: set[CompiledObjectKey] = selected - excluded
+    for key in tuple(scoped):
+        for upstream_key in _walk_all(key, upstream):
+            if upstream_key.resource_type == CompiledResourceType.FUNCTION:
+                scoped.add(upstream_key)
+    return frozenset(scoped)
+
+
+def _resolve_token(
+    *,
+    token: str,
+    all_keys: dict[str, CompiledObjectKey],
+    upstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    downstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    tag_index: dict[str, frozenset[CompiledObjectKey]],
+    path_index: dict[CompiledObjectKey, str],
+) -> frozenset[CompiledObjectKey]:
+    parts: list[str] = token.split(",")
+    resolved_parts: list[frozenset[CompiledObjectKey]] = [
+        _resolve_single(
+            raw=part,
+            all_keys=all_keys,
+            upstream=upstream,
+            downstream=downstream,
+            tag_index=tag_index,
+            path_index=path_index,
+        )
+        for part in parts
+    ]
+    result: frozenset[CompiledObjectKey] = resolved_parts[0]
+    for subsequent in resolved_parts[1:]:
+        result = result & subsequent
+    return result
+
+
+def _resolve_single(
+    *,
+    raw: str,
+    all_keys: dict[str, CompiledObjectKey],
+    upstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    downstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    tag_index: dict[str, frozenset[CompiledObjectKey]],
+    path_index: dict[CompiledObjectKey, str],
+) -> frozenset[CompiledObjectKey]:
+    parsed: ParsedLineageSelector | ParsedLineagePathSelector = _parse_selector(raw)
+    if isinstance(parsed, ParsedLineagePathSelector):
+        start_key: CompiledObjectKey = _lookup_name(parsed.start_name, all_keys)
+        end_key: CompiledObjectKey = _lookup_name(parsed.end_name, all_keys)
+        result: set[CompiledObjectKey] = set(_find_path_keys(start_key, end_key, downstream))
+        if parsed.upstream:
+            result.update(_walk_all(start_key, upstream))
+        if parsed.downstream:
+            result.update(_walk_all(end_key, downstream))
+        return frozenset(result)
+    if parsed.kind == "tag":
+        matched_keys: frozenset[CompiledObjectKey] = tag_index.get(parsed.value, frozenset())
+        if not matched_keys:
+            raise CliUserError(f"No models found with tag '{parsed.value}'")
+        return _apply_selector_expansion(matched_keys, parsed, upstream, downstream)
+    if parsed.kind == "path":
+        matched_keys = _match_path(parsed.value, path_index)
+        if not matched_keys:
+            raise CliUserError(f"No models found under path '{parsed.value}'.")
+        return _apply_selector_expansion(matched_keys, parsed, upstream, downstream)
+    key: CompiledObjectKey = _lookup_parsed_selector(parsed, all_keys)
+    return _apply_selector_expansion(frozenset({key}), parsed, upstream, downstream)
+
+
+def _apply_selector_expansion(
+    matched_keys: frozenset[CompiledObjectKey],
+    parsed: ParsedLineageSelector,
+    upstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    downstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+) -> frozenset[CompiledObjectKey]:
+    result: set[CompiledObjectKey] = set(matched_keys)
+    for key in matched_keys:
+        if parsed.upstream:
+            result.update(_walk_all(key, upstream))
+        if parsed.downstream:
+            result.update(_walk_all(key, downstream))
+    return frozenset(result)
+
+
+def _parse_selector(raw: str) -> ParsedLineageSelector | ParsedLineagePathSelector:
+    stripped: str = raw.strip()
+    if not stripped:
+        raise CliUserError("Empty selector")
+    upstream: bool = stripped.startswith("+")
+    downstream: bool = stripped.endswith("+")
+    core: str = stripped.lstrip("+").rstrip("+")
+    if "~" in core:
+        start_name, end_name = (part.strip() for part in core.split("~", 1))
+        if not start_name or not end_name:
+            raise CliUserError(f"Path selector '{stripped}' requires names on both sides of '~'")
+        return ParsedLineagePathSelector(
+            start_name=start_name,
+            end_name=end_name,
+            upstream=upstream,
+            downstream=downstream,
+        )
+    if not core:
+        raise CliUserError(f"Selector '{stripped}' has no name after removing '+' markers")
+    if ":" in core:
+        prefix, value = core.split(":", 1)
+        if prefix not in {"seed", "source", "tag", "path"}:
+            raise CliUserError(f"Unknown selector type '{prefix}' in '{stripped}'")
+        if not value:
+            raise CliUserError(f"Selector '{stripped}' has empty value after ':'")
+        return ParsedLineageSelector(
+            kind=prefix,
+            value=value,
+            upstream=upstream,
+            downstream=downstream,
+        )
+    if "/" in core:
+        return ParsedLineageSelector(
+            kind="path",
+            value=core.strip("/"),
+            upstream=upstream,
+            downstream=downstream,
+        )
+    return ParsedLineageSelector(
+        kind="name",
+        value=core,
+        upstream=upstream,
+        downstream=downstream,
+    )
+
+
+def _lookup_parsed_selector(
+    parsed: ParsedLineageSelector,
+    all_keys: dict[str, CompiledObjectKey],
+) -> CompiledObjectKey:
+    key: CompiledObjectKey | None = all_keys.get(parsed.value)
+    if key is None:
+        raise CliUserError(f"Unknown lineage target '{parsed.value}'")
+    if parsed.kind == "source" and key.resource_type != CompiledResourceType.SOURCE:
+        raise CliUserError(f"Unknown lineage source '{parsed.value}'")
+    if parsed.kind == "seed" and key.resource_type != CompiledResourceType.SEED:
+        raise CliUserError(f"Unknown lineage seed '{parsed.value}'")
+    return key
+
+
+def _find_path_keys(
+    start: CompiledObjectKey,
+    end: CompiledObjectKey,
+    downstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+) -> frozenset[CompiledObjectKey]:
+    reachable_from_start: frozenset[CompiledObjectKey] = _walk_all(start, downstream)
+    if end not in reachable_from_start:
+        raise CliUserError(
+            f"'{end.resource_type}:{end.name}' is not downstream of "
+            f"'{start.resource_type}:{start.name}'"
+        )
+    upstream: dict[CompiledObjectKey, list[CompiledObjectKey]] = {}
+    for key, dep_keys in downstream.items():
+        for dep_key in dep_keys:
+            upstream.setdefault(dep_key, []).append(key)
+    upstream_from_end: set[CompiledObjectKey] = set()
+    stack: list[CompiledObjectKey] = [end]
+    while stack:
+        current: CompiledObjectKey = stack.pop()
+        if current in upstream_from_end:
+            continue
+        upstream_from_end.add(current)
+        for parent in upstream.get(current, ()):
+            if parent in reachable_from_start or parent == start:
+                stack.append(parent)
+    return frozenset(reachable_from_start & upstream_from_end | {start, end})
+
+
+def _match_path(
+    folder: str,
+    path_index: dict[CompiledObjectKey, str],
+) -> frozenset[CompiledObjectKey]:
+    prefix: str = folder + "/"
+    return frozenset(
+        key
+        for key, model_folder in path_index.items()
+        if model_folder == folder or model_folder.startswith(prefix)
+    )
+
+
+def _build_node(project: CompiledProject, key: CompiledObjectKey) -> LineageNode:
+    for model in project.models:
+        if model.key == key:
+            return LineageNode(
+                key=key,
+                relative_path=str(model.relative_path),
+                qualified_name=model.target.qualified_name,
+            )
+    for seed in project.seeds:
+        if seed.key == key:
+            return LineageNode(
+                key=key,
+                relative_path=str(seed.seed_file.relative_path),
+                qualified_name=seed.target.qualified_name,
+            )
+    for source in project.sources:
+        if source.key == key:
+            return LineageNode(
+                key=key,
+                relative_path=str(source.source_file.relative_path),
+                qualified_name=_source_relation_name(source.source_entry),
+            )
+    return LineageNode(key=key)
+
+
+def _source_relation_name(source: object) -> str | None:
+    database: str | None = getattr(source, "database", None)
+    schema: str | None = getattr(source, "schema", None)
+    table: str | None = getattr(source, "table", None)
+    if table is None:
+        return None
+    if database is not None and schema is not None:
+        return f"{database}.{schema}.{table}"
+    if schema is not None:
+        return f"{schema}.{table}"
+    return table
+
+
+def _sort_key(key: CompiledObjectKey) -> tuple[str, str]:
+    return (str(key.resource_type), key.name)

--- a/src/sqlbuild/cli/commands/main/lineage.py
+++ b/src/sqlbuild/cli/commands/main/lineage.py
@@ -1,0 +1,87 @@
+"""CLI lineage command entry point."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlbuild.adapter.base.base_adapter import BaseAdapter
+from sqlbuild.cli.commands.main.helpers.lineage.models import LineageGraph
+from sqlbuild.cli.commands.main.helpers.lineage.output import (
+    format_lineage_json,
+    format_lineage_list,
+    format_lineage_tree,
+)
+from sqlbuild.cli.commands.main.helpers.lineage.selection import (
+    parse_depth,
+    select_selector_lineage,
+    select_target_lineage,
+)
+from sqlbuild.cli.commands.main.shared.exceptions import CliUserError
+from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
+from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.compiler.pipeline.main.graph import build_project_graph
+from sqlbuild.compiler.pipeline.models import ProjectGraph
+from sqlbuild.shared.helpers.colors import supports_color
+from sqlbuild.spec.models.project import resolve_effective_adapter_name
+
+
+def run_lineage(
+    project_dir: Path | None,
+    no_sql_validation: bool = False,
+    target: str | None = None,
+    output_format: str = "tree",
+    direction: str = "upstream",
+    depth: str = "all",
+    select: tuple[str, ...] = (),
+    exclude: tuple[str, ...] = (),
+) -> int:
+    """Execute the lineage command."""
+
+    if target is not None and select:
+        raise CliUserError("lineage accepts either a target or --select, not both")
+    if target is None and not select:
+        raise CliUserError("lineage requires a target or --select")
+    if exclude and not select:
+        raise CliUserError("--exclude can only be used with --select")
+
+    parsed_depth: int | None = parse_depth(depth)
+    effective_project_dir: Path = project_dir if project_dir is not None else Path.cwd()
+    discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(
+        project_dir=effective_project_dir
+    )
+    adapter: BaseAdapter = resolve_adapter(
+        resolve_effective_adapter_name(
+            project_config=discovered_inputs.project_config,
+            local_config=discovered_inputs.local_config,
+        ),
+        project_dir=effective_project_dir,
+    )
+    graph: ProjectGraph = build_project_graph(
+        discovered_inputs=discovered_inputs,
+        adapter=adapter,
+        no_sql_validation=no_sql_validation,
+    )
+    lineage_graph: LineageGraph
+    if target is not None:
+        lineage_graph = select_target_lineage(
+            graph=graph,
+            target=target,
+            direction=direction,
+            depth=parsed_depth,
+        )
+    else:
+        lineage_graph = select_selector_lineage(
+            graph=graph,
+            select=select,
+            exclude=exclude,
+            depth=parsed_depth,
+        )
+
+    if output_format == "json":
+        print(format_lineage_json(lineage_graph))
+    elif output_format == "list":
+        print("\n" + format_lineage_list(lineage_graph, use_color=supports_color()) + "\n")
+    else:
+        print("\n" + format_lineage_tree(lineage_graph, use_color=supports_color()) + "\n")
+    return 0

--- a/src/sqlbuild/cli/commands/main/shared/types.py
+++ b/src/sqlbuild/cli/commands/main/shared/types.py
@@ -15,6 +15,7 @@ class CliCommand(StrEnum):
     SEED = "seed"
     CLONE = "clone"
     DIFF = "diff"
+    LINEAGE = "lineage"
     QUERY = "query"
     CLEAN = "clean"
     JANITOR = "janitor"

--- a/src/sqlbuild/compiler/pipeline/helpers/graph.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/graph.py
@@ -1,0 +1,114 @@
+"""Static compiled project graph helpers."""
+
+from __future__ import annotations
+
+from sqlbuild.compiler.compile.models import (
+    CompiledFunction,
+    CompiledModel,
+    CompiledObjectKey,
+    CompiledProject,
+    CompiledSeed,
+    CompiledSource,
+)
+from sqlbuild.compiler.compile.types import CompiledResourceType
+
+
+def build_static_upstream_deps(
+    project: CompiledProject,
+) -> dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]]:
+    """Return static lineage edges keyed by object key."""
+
+    upstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] = {}
+    model: CompiledModel
+    for model in project.models:
+        upstream[model.key] = model.deps
+    source: CompiledSource
+    for source in project.sources:
+        upstream[source.key] = source.deps
+    seed: CompiledSeed
+    for seed in project.seeds:
+        upstream[seed.key] = seed.deps
+    function: CompiledFunction
+    for function in project.functions:
+        upstream[function.key] = function.deps
+    return _filter_lineage_deps(upstream)
+
+
+def build_static_downstream_deps(
+    upstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+) -> dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]]:
+    """Return downstream edges keyed by upstream object key."""
+
+    downstream: dict[CompiledObjectKey, list[CompiledObjectKey]] = {}
+    for key in upstream:
+        downstream.setdefault(key, [])
+    for key, dep_keys in upstream.items():
+        for dep_key in dep_keys:
+            downstream.setdefault(dep_key, []).append(key)
+    return {
+        key: tuple(sorted(values, key=lambda obj: (str(obj.resource_type), obj.name)))
+        for key, values in downstream.items()
+    }
+
+
+def build_static_tag_index(project: CompiledProject) -> dict[str, frozenset[CompiledObjectKey]]:
+    """Build a tag-to-keys lookup from compiled model configs."""
+
+    index: dict[str, set[CompiledObjectKey]] = {}
+    for model in project.models:
+        for tag in _as_string_list(model.config.values.get("tags")):
+            index.setdefault(tag, set()).add(model.key)
+    return {tag: frozenset(keys) for tag, keys in index.items()}
+
+
+def build_static_path_index(project: CompiledProject) -> dict[CompiledObjectKey, str]:
+    """Build a key-to-folder lookup from compiled model relative paths."""
+
+    index: dict[CompiledObjectKey, str] = {}
+    for model in project.models:
+        parent: str = str(model.relative_path.parent)
+        index[model.key] = _strip_models_prefix(parent)
+    return index
+
+
+def build_static_all_keys(project: CompiledProject) -> dict[str, CompiledObjectKey]:
+    """Build selector lookup keys for all named graph resources."""
+
+    keys: dict[str, CompiledObjectKey] = {}
+    for model in project.models:
+        keys[model.name] = model.key
+    for source in project.sources:
+        keys[source.name] = source.key
+    for seed in project.seeds:
+        keys[seed.name] = seed.key
+    for function in project.functions:
+        keys[function.name] = function.key
+    return keys
+
+
+def _filter_lineage_deps(
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+) -> dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]]:
+    """Remove virtual execution-order nodes that are not lineage dependencies."""
+
+    return {
+        key: tuple(dep for dep in deps if dep.resource_type != CompiledResourceType.SQL_TEST)
+        for key, deps in upstream_deps.items()
+        if key.resource_type != CompiledResourceType.SQL_TEST
+    }
+
+
+def _strip_models_prefix(path: str) -> str:
+    if path.startswith("models/"):
+        return path[len("models/") :]
+    if path == "models":
+        return ""
+    return path
+
+
+def _as_string_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, tuple):
+        return [str(item) for item in value]
+    return []

--- a/src/sqlbuild/compiler/pipeline/main/graph.py
+++ b/src/sqlbuild/compiler/pipeline/main/graph.py
@@ -1,0 +1,45 @@
+"""Build the static compiled project dependency graph."""
+
+from __future__ import annotations
+
+from sqlbuild.adapter.base.base_adapter import BaseAdapter
+from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.compiler.pipeline.helpers.graph import (
+    build_static_all_keys,
+    build_static_downstream_deps,
+    build_static_path_index,
+    build_static_tag_index,
+    build_static_upstream_deps,
+)
+from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
+from sqlbuild.compiler.pipeline.models import ProjectGraph
+
+
+def build_project_graph(
+    *,
+    discovered_inputs: DiscoveredProjectInputs,
+    adapter: BaseAdapter,
+    no_sql_validation: bool = False,
+) -> ProjectGraph:
+    """Build the static dependency graph for a compiled project."""
+
+    project: CompiledProject = build_compiled_project(
+        discovered_inputs=discovered_inputs,
+        adapter=adapter,
+        no_sql_validation=no_sql_validation,
+    )
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] = (
+        build_static_upstream_deps(project)
+    )
+    downstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] = (
+        build_static_downstream_deps(upstream_deps)
+    )
+    return ProjectGraph(
+        project=project,
+        upstream_deps=upstream_deps,
+        downstream_deps=downstream_deps,
+        tag_index=build_static_tag_index(project),
+        path_index=build_static_path_index(project),
+        all_keys=build_static_all_keys(project),
+    )

--- a/src/sqlbuild/compiler/pipeline/models.py
+++ b/src/sqlbuild/compiler/pipeline/models.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
 from sqlbuild.compiler.planner.models import ModelPlanEntry, PlanOutput, SeedPlanEntry
 
 
@@ -31,3 +31,15 @@ class ClonePipelineResult:
     target_seed_entries: tuple[SeedPlanEntry, ...] = field(default_factory=tuple)
     source_model_entries: tuple[ModelPlanEntry, ...] = field(default_factory=tuple)
     source_seed_entries: tuple[SeedPlanEntry, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ProjectGraph:
+    """Static compiled project graph without warehouse state."""
+
+    project: CompiledProject
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]]
+    downstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]]
+    tag_index: dict[str, frozenset[CompiledObjectKey]]
+    path_index: dict[CompiledObjectKey, str]
+    all_keys: dict[str, CompiledObjectKey]

--- a/tests/e2e/src/sqlbuild/cli/commands/main/lineage/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/lineage/_test_types.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LineageCliTestCase:
+    description: str
+    command: tuple[str, ...]
+    expected_exit_code: int
+    expected_node_ids: tuple[str, ...]
+    expected_edge_ids: tuple[str, ...]

--- a/tests/e2e/src/sqlbuild/cli/commands/main/lineage/test_lineage.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/lineage/test_lineage.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.src.sqlbuild.cli.commands.main.lineage._test_types import LineageCliTestCase
+from tests.e2e.src.sqlbuild.cli.commands.main.shared.helpers import prepare_waffle_shop, run_sqb
+
+LINEAGE_CLI_TEST_CASES: list[LineageCliTestCase] = [
+    LineageCliTestCase(
+        description="renders upstream fact orders lineage json without warehouse tables",
+        command=("lineage", "fact_orders", "--format", "json"),
+        expected_exit_code=0,
+        expected_node_ids=(
+            "function:is_completed_order",
+            "function:is_completed_order_py",
+            "model:fact_orders",
+            "model:stg_orders",
+            "model:stg_payments",
+            "seed:waffle_types",
+            "source:raw_orders",
+            "source:raw_payments",
+        ),
+        expected_edge_ids=(
+            "function:is_completed_order->model:fact_orders",
+            "function:is_completed_order_py->model:fact_orders",
+            "model:stg_orders->model:fact_orders",
+            "seed:waffle_types->model:fact_orders",
+            "model:stg_payments->model:fact_orders",
+            "source:raw_orders->model:stg_orders",
+            "source:raw_payments->model:stg_payments",
+        ),
+    ),
+    LineageCliTestCase(
+        description="renders path-between selector lineage as json",
+        command=(
+            "lineage",
+            "--select",
+            "fact_orders~daily_activity_rollup",
+            "--format",
+            "json",
+        ),
+        expected_exit_code=0,
+        expected_node_ids=(
+            "function:is_completed_order",
+            "function:is_completed_order_py",
+            "model:daily_activity_rollup",
+            "model:fact_orders",
+            "model:hourly_order_activity",
+        ),
+        expected_edge_ids=(
+            "model:hourly_order_activity->model:daily_activity_rollup",
+            "function:is_completed_order->model:fact_orders",
+            "function:is_completed_order_py->model:fact_orders",
+            "model:fact_orders->model:hourly_order_activity",
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    LINEAGE_CLI_TEST_CASES,
+    ids=[case.description for case in LINEAGE_CLI_TEST_CASES],
+)
+def test_given_lineage_command_when_running_then_outputs_expected_json_graph(
+    test_case: LineageCliTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_waffle_shop(tmp_path)
+
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=test_case.command,
+        project_dir=project_dir,
+    )
+
+    assert result.returncode == test_case.expected_exit_code, result.stdout + result.stderr
+    payload: dict[str, object] = json.loads(result.stdout)
+    node_ids: tuple[str, ...] = tuple(node["id"] for node in payload["nodes"])  # type: ignore[index]
+    edge_ids: tuple[str, ...] = tuple(
+        f"{edge['from']}->{edge['to']}"
+        for edge in payload["edges"]  # type: ignore[index]
+    )
+    assert node_ids == test_case.expected_node_ids
+    assert edge_ids == test_case.expected_edge_ids

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/helpers.py
@@ -25,5 +25,6 @@ def build_handlers(**overrides: Any) -> CliEntrypointHandlers:
         run_clone=overrides.get("run_clone", noop_handler),
         run_diff=overrides.get("run_diff", noop_handler),
         run_query=overrides.get("run_query", noop_handler),
+        run_lineage=overrides.get("run_lineage", noop_handler),
         run_janitor=overrides.get("run_janitor", noop_handler),
     )

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -282,6 +282,66 @@ def test_given_query_command_arguments_when_running_with_dependencies_then_it_di
     "test_case",
     [
         MainTestCase(
+            description="dispatches lineage command through injected handler",
+            argv=[
+                "lineage",
+                "fact_orders",
+                "--direction",
+                "both",
+                "--depth",
+                "2",
+                "--format",
+                "json",
+            ],
+            expected_exit_code=11,
+        )
+    ],
+    ids=["dispatches lineage command through injected handler"],
+)
+def test_given_lineage_command_arguments_when_running_with_dependencies_then_it_dispatches_handler(
+    test_case: MainTestCase,
+) -> None:
+    received_args: list[
+        tuple[Path | None, bool, str | None, str, str, str, tuple[str, ...], tuple[str, ...]]
+    ] = []
+
+    def run_lineage(
+        project_dir: Path | None,
+        no_sql_validation: bool,
+        target: str | None,
+        output_format: str,
+        direction: str,
+        depth: str,
+        select: tuple[str, ...],
+        exclude: tuple[str, ...],
+    ) -> int:
+        received_args.append(
+            (
+                project_dir,
+                no_sql_validation,
+                target,
+                output_format,
+                direction,
+                depth,
+                select,
+                exclude,
+            )
+        )
+        return test_case.expected_exit_code
+
+    exit_code: int = _main_with_dependencies(
+        argv=test_case.argv,
+        handlers=build_handlers(run_lineage=run_lineage),
+    )
+
+    assert exit_code == test_case.expected_exit_code
+    assert received_args == [(None, False, "fact_orders", "json", "both", "2", (), ())]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MainTestCase(
             description="passes verbose flag to diff handler",
             argv=[
                 "diff",

--- a/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/__init__.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/__init__.py
@@ -1,0 +1,1 @@
+"""Lineage helper tests."""

--- a/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/_test_types.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LineageSelectionTestCase:
+    description: str
+    target: str
+    direction: str
+    depth: int | None
+    expected_node_ids: tuple[str, ...]
+    expected_edge_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class LineageSelectorDepthErrorTestCase:
+    description: str
+    select: tuple[str, ...]
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
+class LineageOutputTestCase:
+    description: str
+    output_format: str
+    expected_output: str

--- a/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/helpers.py
@@ -1,0 +1,172 @@
+"""Helpers for lineage helper tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from sqlbuild.cli.commands.main.helpers.lineage.models import LineageNode
+from sqlbuild.compiler.compile.models import (
+    CompiledModel,
+    CompiledObjectKey,
+    CompiledProject,
+    CompiledRelationTarget,
+    CompiledSeed,
+    CompiledSource,
+    CompileModelConfig,
+)
+from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.discovery.models import (
+    DiscoveredSchemaFile,
+    DiscoveredSeedFile,
+    DiscoveredSourceFile,
+)
+from sqlbuild.compiler.pipeline.models import ProjectGraph
+from sqlbuild.spec.models.project import SettingsConfig
+from sqlbuild.spec.models.schema import SchemaSeedEntry
+from sqlbuild.spec.models.source import SourceEntry
+
+
+def build_lineage_test_graph() -> ProjectGraph:
+    """Build a small static graph for lineage tests."""
+
+    raw_orders_key: CompiledObjectKey = CompiledObjectKey(CompiledResourceType.SOURCE, "raw_orders")
+    stg_orders_key: CompiledObjectKey = CompiledObjectKey(CompiledResourceType.MODEL, "stg_orders")
+    fact_orders_key: CompiledObjectKey = CompiledObjectKey(
+        CompiledResourceType.MODEL, "fact_orders"
+    )
+    daily_rollup_key: CompiledObjectKey = CompiledObjectKey(
+        CompiledResourceType.MODEL, "daily_rollup"
+    )
+    waffle_types_key: CompiledObjectKey = CompiledObjectKey(
+        CompiledResourceType.SEED, "waffle_types"
+    )
+
+    schema_file: DiscoveredSchemaFile = DiscoveredSchemaFile(
+        file_path=Path("schema.yml"),
+        relative_path=Path("schema.yml"),
+        contents="",
+        model_entries=(),
+        seed_entries=(),
+    )
+    project: CompiledProject = CompiledProject(
+        run_id="test-run",
+        effective_environment_name=None,
+        effective_connection={},
+        effective_vars={},
+        settings=SettingsConfig(),
+        models=(
+            _model("stg_orders", stg_orders_key, (raw_orders_key,), "models/stg_orders.sql"),
+            _model(
+                "fact_orders",
+                fact_orders_key,
+                (stg_orders_key, waffle_types_key),
+                "models/fact_orders.sql",
+            ),
+            _model(
+                "daily_rollup",
+                daily_rollup_key,
+                (fact_orders_key,),
+                "models/daily_rollup.sql",
+            ),
+        ),
+        sources=(
+            CompiledSource(
+                key=raw_orders_key,
+                deps=(),
+                name="raw_orders",
+                source_entry=SourceEntry(name="raw_orders", table="raw_orders"),
+                source_file=DiscoveredSourceFile(
+                    file_path=Path("sources/raw.yml"),
+                    relative_path=Path("sources/raw.yml"),
+                    contents="",
+                    source_entries=(),
+                ),
+            ),
+        ),
+        seeds=(
+            CompiledSeed(
+                key=waffle_types_key,
+                deps=(),
+                name="waffle_types",
+                seed_file=DiscoveredSeedFile(
+                    file_path=Path("seeds/waffle_types.csv"),
+                    relative_path=Path("seeds/waffle_types.csv"),
+                ),
+                schema_entry=SchemaSeedEntry(name="waffle_types"),
+                schema_file=schema_file,
+                target=_target("waffle_types"),
+            ),
+        ),
+    )
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] = {
+        raw_orders_key: (),
+        waffle_types_key: (),
+        stg_orders_key: (raw_orders_key,),
+        fact_orders_key: (stg_orders_key, waffle_types_key),
+        daily_rollup_key: (fact_orders_key,),
+    }
+    downstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] = {
+        raw_orders_key: (stg_orders_key,),
+        waffle_types_key: (fact_orders_key,),
+        stg_orders_key: (fact_orders_key,),
+        fact_orders_key: (daily_rollup_key,),
+        daily_rollup_key: (),
+    }
+    return ProjectGraph(
+        project=project,
+        upstream_deps=upstream_deps,
+        downstream_deps=downstream_deps,
+        tag_index={"marts": frozenset({fact_orders_key, daily_rollup_key})},
+        path_index={
+            stg_orders_key: "staging",
+            fact_orders_key: "marts",
+            daily_rollup_key: "marts",
+        },
+        all_keys={
+            "raw_orders": raw_orders_key,
+            "waffle_types": waffle_types_key,
+            "stg_orders": stg_orders_key,
+            "fact_orders": fact_orders_key,
+            "daily_rollup": daily_rollup_key,
+        },
+    )
+
+
+def node_ids(graph_nodes: Iterable[LineageNode]) -> tuple[str, ...]:
+    return tuple(f"{node.key.resource_type}:{node.key.name}" for node in graph_nodes)
+
+
+def edge_ids(
+    graph_edges: Iterable[tuple[CompiledObjectKey, CompiledObjectKey]],
+) -> tuple[str, ...]:
+    return tuple(
+        f"{parent.resource_type}:{parent.name}->{child.resource_type}:{child.name}"
+        for parent, child in graph_edges
+    )
+
+
+def _model(
+    name: str,
+    key: CompiledObjectKey,
+    deps: tuple[CompiledObjectKey, ...],
+    relative_path: str,
+) -> CompiledModel:
+    return CompiledModel(
+        key=key,
+        deps=deps,
+        name=name,
+        relative_path=Path(relative_path),
+        query_sql="SELECT 1",
+        config=CompileModelConfig(),
+        target=_target(name),
+    )
+
+
+def _target(name: str) -> CompiledRelationTarget:
+    return CompiledRelationTarget(
+        database=None,
+        schema="main",
+        name=name,
+        qualified_name=f"main.{name}",
+    )

--- a/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/test_output.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/test_output.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from sqlbuild.cli.commands.main.helpers.lineage.models import LineageGraph
+from sqlbuild.cli.commands.main.helpers.lineage.output import (
+    format_lineage_list,
+    format_lineage_tree,
+)
+from sqlbuild.cli.commands.main.helpers.lineage.selection import select_target_lineage
+from sqlbuild.compiler.pipeline.models import ProjectGraph
+from tests.unit.src.sqlbuild.cli.commands.main.helpers.lineage._test_types import (
+    LineageOutputTestCase,
+)
+from tests.unit.src.sqlbuild.cli.commands.main.helpers.lineage.helpers import (
+    build_lineage_test_graph,
+)
+
+LINEAGE_OUTPUT_TEST_CASES: list[LineageOutputTestCase] = [
+    LineageOutputTestCase(
+        description="renders tree output with branch glyphs and metadata",
+        output_format="tree",
+        expected_output=(
+            "Lineage  model  fact_orders  models/fact_orders.sql  upstream\n"
+            "├── model  stg_orders  models/stg_orders.sql\n"
+            "│   └── source  raw_orders  sources/raw.yml\n"
+            "└── seed  waffle_types  seeds/waffle_types.csv"
+        ),
+    ),
+    LineageOutputTestCase(
+        description="renders list output as aligned edge list",
+        output_format="list",
+        expected_output=(
+            "model:stg_orders  -> model:fact_orders\n"
+            "seed:waffle_types -> model:fact_orders\n"
+            "source:raw_orders -> model:stg_orders"
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    LINEAGE_OUTPUT_TEST_CASES,
+    ids=[case.description for case in LINEAGE_OUTPUT_TEST_CASES],
+)
+def test_given_lineage_graph_when_formatting_then_returns_expected_human_output(
+    test_case: LineageOutputTestCase,
+) -> None:
+    graph: ProjectGraph = build_lineage_test_graph()
+    lineage_graph: LineageGraph = select_target_lineage(
+        graph=graph,
+        target="fact_orders",
+        direction="upstream",
+        depth=None,
+    )
+
+    renderers: dict[str, Callable[[LineageGraph], str]] = {
+        "tree": lambda graph: format_lineage_tree(graph, use_color=False),
+        "list": lambda graph: format_lineage_list(graph, use_color=False),
+    }
+    result: str = renderers[test_case.output_format](lineage_graph)
+
+    assert result == test_case.expected_output

--- a/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/test_selection.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/test_selection.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import pytest
+
+from sqlbuild.cli.commands.main.helpers.lineage.models import LineageGraph
+from sqlbuild.cli.commands.main.helpers.lineage.selection import (
+    select_selector_lineage,
+    select_target_lineage,
+)
+from sqlbuild.cli.commands.main.shared.exceptions import CliUserError
+from sqlbuild.compiler.pipeline.models import ProjectGraph
+from tests.unit.src.sqlbuild.cli.commands.main.helpers.lineage._test_types import (
+    LineageSelectionTestCase,
+    LineageSelectorDepthErrorTestCase,
+)
+from tests.unit.src.sqlbuild.cli.commands.main.helpers.lineage.helpers import (
+    build_lineage_test_graph,
+    edge_ids,
+    node_ids,
+)
+
+SELECTION_TEST_CASES: list[LineageSelectionTestCase] = [
+    LineageSelectionTestCase(
+        description="limits downstream target lineage to one hop",
+        target="fact_orders",
+        direction="downstream",
+        depth=1,
+        expected_node_ids=("model:daily_rollup", "model:fact_orders"),
+        expected_edge_ids=("model:fact_orders->model:daily_rollup",),
+    ),
+    LineageSelectionTestCase(
+        description="keeps full upstream target lineage",
+        target="fact_orders",
+        direction="upstream",
+        depth=None,
+        expected_node_ids=(
+            "model:fact_orders",
+            "model:stg_orders",
+            "seed:waffle_types",
+            "source:raw_orders",
+        ),
+        expected_edge_ids=(
+            "model:stg_orders->model:fact_orders",
+            "seed:waffle_types->model:fact_orders",
+            "source:raw_orders->model:stg_orders",
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    SELECTION_TEST_CASES,
+    ids=[case.description for case in SELECTION_TEST_CASES],
+)
+def test_given_target_lineage_request_when_selecting_then_returns_expected_subgraph(
+    test_case: LineageSelectionTestCase,
+) -> None:
+    graph: ProjectGraph = build_lineage_test_graph()
+
+    result: LineageGraph = select_target_lineage(
+        graph=graph,
+        target=test_case.target,
+        direction=test_case.direction,
+        depth=test_case.depth,
+    )
+
+    assert node_ids(result.nodes) == test_case.expected_node_ids
+    assert edge_ids(result.edges) == test_case.expected_edge_ids
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        LineageSelectionTestCase(
+            description="trims expanded name selector to requested depth",
+            target="unused",
+            direction="unused",
+            depth=1,
+            expected_node_ids=("model:fact_orders", "model:stg_orders", "seed:waffle_types"),
+            expected_edge_ids=(
+                "model:stg_orders->model:fact_orders",
+                "seed:waffle_types->model:fact_orders",
+            ),
+        )
+    ],
+    ids=["trims expanded name selector to requested depth"],
+)
+def test_given_expanded_selector_with_depth_when_selecting_then_trims_selected_subgraph(
+    test_case: LineageSelectionTestCase,
+) -> None:
+    graph: ProjectGraph = build_lineage_test_graph()
+
+    result: LineageGraph = select_selector_lineage(
+        graph=graph,
+        select=("+fact_orders",),
+        exclude=(),
+        depth=test_case.depth,
+    )
+
+    assert node_ids(result.nodes) == test_case.expected_node_ids
+    assert edge_ids(result.edges) == test_case.expected_edge_ids
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        LineageSelectorDepthErrorTestCase(
+            description="rejects tag selector with depth",
+            select=("tag:marts+",),
+            expected_error_fragment=(
+                "--depth requires name, source, seed, or path-between selectors"
+            ),
+        )
+    ],
+    ids=["rejects tag selector with depth"],
+)
+def test_given_unclear_selector_anchor_with_depth_when_selecting_then_raises_user_error(
+    test_case: LineageSelectorDepthErrorTestCase,
+) -> None:
+    graph: ProjectGraph = build_lineage_test_graph()
+
+    with pytest.raises(CliUserError) as error:
+        select_selector_lineage(
+            graph=graph,
+            select=test_case.select,
+            exclude=(),
+            depth=1,
+        )
+
+    assert test_case.expected_error_fragment in str(error.value)

--- a/uv.lock
+++ b/uv.lock
@@ -1523,7 +1523,7 @@ wheels = [
 
 [[package]]
 name = "sqlbuild"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Useful feature to have in general, however, I actually suspect this feature will be most useful for people using CLI agents if they need to get understanding of the dependency graph of a project. Most lineage is always done via the UI, but having an easy to consume form via the CLI is great for programmatic use as well, and deserves to be a first class feature in my eyes.