### PR TITLE
Feat/sql interpolation contract

### DIFF
--- a/examples/waffle_shop/materializations/partition_tracked.py
+++ b/examples/waffle_shop/materializations/partition_tracked.py
@@ -59,8 +59,8 @@ def materialize(ctx: MaterializationContext) -> MaterializationResult:
     partition_value: str
     for i, partition_value in enumerate(stale):
         next_day: str = _next_date(partition_value)
-        partition_sql: str = ctx.sql.replace("@@partition_start", f"'{partition_value}'").replace(
-            "@@partition_end", f"'{next_day}'"
+        partition_sql: str = ctx.sql.replace("@@@partition_start", f"'{partition_value}'").replace(
+            "@@@partition_end", f"'{next_day}'"
         )
 
         if ctx.on_progress is not None:

--- a/examples/waffle_shop/models/marts/daily_order_partitioned.sql
+++ b/examples/waffle_shop/models/marts/daily_order_partitioned.sql
@@ -29,6 +29,6 @@ SELECT
   SUM(o.quantity) AS waffles_ordered,
   COUNT(DISTINCT o.customer_id) AS unique_customers
 FROM __ref("stg_orders") o
-WHERE CAST(o.ordered_at AS DATE) >= CAST(@@partition_start AS DATE)
-  AND CAST(o.ordered_at AS DATE) < CAST(@@partition_end AS DATE)
+WHERE CAST(o.ordered_at AS DATE) >= CAST(@@@partition_start AS DATE)
+  AND CAST(o.ordered_at AS DATE) < CAST(@@@partition_end AS DATE)
 GROUP BY CAST(o.ordered_at AS DATE)

--- a/src/sqlbuild/compiler/compile/constants.py
+++ b/src/sqlbuild/compiler/compile/constants.py
@@ -21,10 +21,10 @@ GENERIC_AUDIT_DIRECTORY_NAME: str = "generic"
 TEMPLATE_PATTERN: re.Pattern[str] = re.compile(r"\$\{([^{}]+)\}")
 MACRO_CALL_PATTERN: re.Pattern[str] = re.compile(r"@[A-Za-z_][A-Za-z0-9_]*\s*\(")
 GENERIC_AUDIT_QUOTED_PARAMETER_PATTERN: re.Pattern[str] = re.compile(
-    r"@'(?P<name>[A-Za-z_][A-Za-z0-9_]*)'"
+    r"(?<!@)@'(?P<name>[A-Za-z_][A-Za-z0-9_]*)'"
 )
 GENERIC_AUDIT_RAW_PARAMETER_PATTERN: re.Pattern[str] = re.compile(
-    r"@(?!')(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?!\s*\()"
+    r"(?<!@)@(?!')(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?!\s*\()"
 )
 EXPECTED_TEST_CTE_PREFIX: str = "__expected__"
 REF_TEST_CTE_PREFIX: str = "__ref__"

--- a/src/sqlbuild/compiler/compile/helpers/attachment.py
+++ b/src/sqlbuild/compiler/compile/helpers/attachment.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import fields
+from dataclasses import fields, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
@@ -29,8 +29,8 @@ from sqlbuild.compiler.compile.helpers.model_config_validation import (
 )
 from sqlbuild.compiler.compile.helpers.refs import extract_sql_references
 from sqlbuild.compiler.compile.helpers.sql_vars import (
+    expand_authored_sql,
     substitute_sql_vars,
-    validate_var_macro_collision,
 )
 from sqlbuild.compiler.compile.helpers.sqlglot_validation import (
     validate_function_sql_syntax,
@@ -113,7 +113,6 @@ def build_model_inputs(
     """Attach schema metadata to discovered model files."""
 
     loaded_macros: dict[str, LoadedMacro] = load_project_macros(discovered_inputs.macro_files)
-    validate_var_macro_collision(effective_vars=effective_vars, loaded_macros=loaded_macros)
     known_model_names: set[str] = build_known_ref_names(discovered_inputs)
     known_seed_names: set[str] = build_known_seed_names(discovered_inputs)
     known_source_names: set[str] = build_known_source_names(discovered_inputs)
@@ -140,6 +139,7 @@ def build_model_inputs(
             effective_environment_name=effective_environment_name,
             run_id=run_id,
         )
+        # Keep the interpolated-but-unexpanded form for SQL test macro mocks.
         var_substituted_sql: str = substitute_sql_vars(
             sql=model_file.query_sql,
             file_path=model_file.file_path,
@@ -207,6 +207,7 @@ def build_model_inputs(
             values=expand_model_hook_macros(
                 values=effective_config.values,
                 file_path=model_file.file_path,
+                effective_vars=effective_vars,
                 loaded_macros=loaded_macros,
                 macro_context=macro_context,
             ),
@@ -387,14 +388,10 @@ def build_sql_function_inputs(
             if isinstance(raw_schema, str)
             else schema
         )
-        var_substituted_body_sql: str = substitute_sql_vars(
+        expanded_body_sql: str = expand_authored_sql(
             sql=function_file.body_sql,
             file_path=function_file.file_path,
             effective_vars=effective_vars,
-        )
-        expanded_body_sql: str = expand_sql_macros(
-            sql=var_substituted_body_sql,
-            file_path=function_file.file_path,
             loaded_macros=loaded_macros,
             macro_context=macro_context,
         )
@@ -825,11 +822,14 @@ def _expand_function_environment_value(
 def build_source_inputs(
     discovered_inputs: DiscoveredProjectInputs,
     *,
+    effective_vars: dict[str, str],
     effective_settings: SettingsConfig,
+    macro_context: MacroContext,
     no_sql_validation: bool = False,
 ) -> tuple[CompileSourceInput, ...]:
     """Normalize discovered source declarations into one collection."""
 
+    loaded_macros: dict[str, LoadedMacro] = load_project_macros(discovered_inputs.macro_files)
     source_inputs: list[CompileSourceInput] = []
     sql_validation_enabled: bool = (
         effective_settings.sqlglot and effective_settings.sql_validation and not no_sql_validation
@@ -837,7 +837,14 @@ def build_source_inputs(
     source_file: DiscoveredSourceFile
     for source_file in discovered_inputs.source_files:
         source_entry: SourceEntry
-        for source_entry in source_file.source_entries:
+        for raw_source_entry in source_file.source_entries:
+            source_entry = expand_source_entry_templates(
+                source_entry=raw_source_entry,
+                file_path=source_file.file_path,
+                effective_vars=effective_vars,
+                loaded_macros=loaded_macros,
+                macro_context=macro_context,
+            )
             source_expression: str | None = source_entry.expression
             should_validate_expression: bool = (
                 source_expression is not None and sql_validation_enabled
@@ -855,6 +862,164 @@ def build_source_inputs(
                 )
             )
     return tuple(source_inputs)
+
+
+def expand_source_entry_templates(
+    *,
+    source_entry: SourceEntry,
+    file_path: Path,
+    effective_vars: dict[str, str],
+    loaded_macros: dict[str, LoadedMacro],
+    macro_context: MacroContext,
+) -> SourceEntry:
+    """Apply config templating and SQL interpolation to source metadata."""
+
+    expression: str | None = None
+    if source_entry.expression is not None:
+        expression = expand_authored_sql(
+            sql=source_entry.expression,
+            file_path=file_path,
+            effective_vars=effective_vars,
+            loaded_macros=loaded_macros,
+            macro_context=macro_context,
+        )
+    return replace(
+        source_entry,
+        database=_expand_source_template_value(
+            raw_value=source_entry.database,
+            effective_vars=effective_vars,
+            context_label=f"source {source_entry.name} database",
+        ),
+        schema=_expand_source_template_value(
+            raw_value=source_entry.schema,
+            effective_vars=effective_vars,
+            context_label=f"source {source_entry.name} schema",
+        ),
+        table=_expand_source_template_value(
+            raw_value=source_entry.table,
+            effective_vars=effective_vars,
+            context_label=f"source {source_entry.name} table",
+        ),
+        expression=expression,
+        description=_expand_source_template_value(
+            raw_value=source_entry.description,
+            effective_vars=effective_vars,
+            context_label=f"source {source_entry.name} description",
+        ),
+        meta=cast(
+            dict[str, object],
+            _expand_source_template_object(
+                value=source_entry.meta,
+                effective_vars=effective_vars,
+                context_label=f"source {source_entry.name} meta",
+            ),
+        ),
+        columns=tuple(
+            expand_source_column_templates(
+                source_name=source_entry.name,
+                column=column,
+                effective_vars=effective_vars,
+            )
+            for column in source_entry.columns
+        ),
+        audits=tuple(
+            expand_schema_audit_instance_templates(
+                audit_instance=audit_instance,
+                effective_vars=effective_vars,
+                context_label=f"source {source_entry.name} audit {audit_instance.definition_name}",
+            )
+            for audit_instance in source_entry.audits
+        ),
+    )
+
+
+def expand_source_column_templates(
+    *, source_name: str, column: SourceColumnEntry, effective_vars: dict[str, str]
+) -> SourceColumnEntry:
+    return replace(
+        column,
+        type=_expand_source_template_value(
+            raw_value=column.type,
+            effective_vars=effective_vars,
+            context_label=f"source {source_name} column {column.name} type",
+        ),
+        description=_expand_source_template_value(
+            raw_value=column.description,
+            effective_vars=effective_vars,
+            context_label=f"source {source_name} column {column.name} description",
+        ),
+        meta=cast(
+            dict[str, object],
+            _expand_source_template_object(
+                value=column.meta,
+                effective_vars=effective_vars,
+                context_label=f"source {source_name} column {column.name} meta",
+            ),
+        ),
+        audits=tuple(
+            expand_schema_audit_instance_templates(
+                audit_instance=audit_instance,
+                effective_vars=effective_vars,
+                context_label=(
+                    f"source {source_name} column {column.name} audit "
+                    f"{audit_instance.definition_name}"
+                ),
+            )
+            for audit_instance in column.audits
+        ),
+    )
+
+
+def expand_schema_audit_instance_templates(
+    *,
+    audit_instance: SchemaAuditInstance,
+    effective_vars: dict[str, str],
+    context_label: str,
+) -> SchemaAuditInstance:
+    return replace(
+        audit_instance,
+        arguments=cast(
+            dict[str, object],
+            _expand_source_template_object(
+                value=audit_instance.arguments,
+                effective_vars=effective_vars,
+                context_label=f"{context_label} arguments",
+            ),
+        ),
+        description=_expand_source_template_value(
+            raw_value=audit_instance.description,
+            effective_vars=effective_vars,
+            context_label=f"{context_label} description",
+        ),
+    )
+
+
+def _expand_source_template_value(
+    *, raw_value: str | None, effective_vars: dict[str, str], context_label: str
+) -> str | None:
+    if raw_value is None:
+        return None
+    return str(
+        _expand_source_template_object(
+            value=raw_value,
+            effective_vars=effective_vars,
+            context_label=context_label,
+        )
+    )
+
+
+def _expand_source_template_object(
+    *, value: object, effective_vars: dict[str, str], context_label: str
+) -> object:
+    return expand_template_data(
+        value,
+        variables=effective_vars,
+        context_values={},
+        context_label=context_label,
+        allow_context=False,
+        preserve_context_tokens=False,
+        preserve_unknown_context=False,
+    )
 
 
 def build_test_inputs(
@@ -875,14 +1040,10 @@ def build_test_inputs(
     for test_file in discovered_inputs.test_files:
         test_block: DiscoveredSqlTestBlock
         for test_block in test_file.blocks:
-            var_substituted_body: str = substitute_sql_vars(
+            expanded_sql_body: str = expand_authored_sql(
                 sql=test_block.sql_body,
                 file_path=test_file.file_path,
                 effective_vars=vars_for_substitution,
-            )
-            expanded_sql_body: str = expand_sql_macros(
-                sql=var_substituted_body,
-                file_path=test_file.file_path,
                 loaded_macros=loaded_macros,
                 macro_context=macro_context,
             )
@@ -964,6 +1125,7 @@ def build_audit_inputs(
     effective_settings: SettingsConfig,
     model_inputs: tuple[CompileModelInput, ...],
     source_inputs: tuple[CompileSourceInput, ...],
+    effective_vars: dict[str, str],
     macro_context: MacroContext,
     generic_audit_definitions: dict[str, tuple[DiscoveredAuditFile, DiscoveredAuditBlock]]
     | None = None,
@@ -985,9 +1147,10 @@ def build_audit_inputs(
             continue
         audit_block: DiscoveredAuditBlock
         for audit_block in audit_file.blocks:
-            expanded_sql_body: str = expand_sql_macros(
+            expanded_sql_body: str = expand_authored_sql(
                 sql=audit_block.sql_body,
                 file_path=audit_file.file_path,
+                effective_vars=effective_vars,
                 loaded_macros=loaded_macros,
                 macro_context=macro_context,
             )
@@ -1034,6 +1197,7 @@ def build_audit_inputs(
                 known_source_names=known_source_names,
                 default_audit_severity=default_audit_severity,
                 default_audit_run_scope=default_audit_run_scope,
+                effective_vars=effective_vars,
                 macro_context=macro_context,
             )
         )
@@ -1049,6 +1213,7 @@ def build_audit_inputs(
                 known_source_names=known_source_names,
                 default_audit_severity=default_audit_severity,
                 default_audit_run_scope=default_audit_run_scope,
+                effective_vars=effective_vars,
                 macro_context=macro_context,
             )
         )
@@ -1065,6 +1230,7 @@ def build_model_attached_audit_inputs(
     known_source_names: set[str],
     default_audit_severity: str | None,
     default_audit_run_scope: str | None,
+    effective_vars: dict[str, str],
     macro_context: MacroContext,
 ) -> tuple[CompileAuditInput, ...]:
     """Render schema-attached model audits into compile audit inputs."""
@@ -1096,6 +1262,7 @@ def build_model_attached_audit_inputs(
                 known_source_names=known_source_names,
                 default_audit_severity=default_audit_severity,
                 default_audit_run_scope=default_audit_run_scope,
+                effective_vars=effective_vars,
                 macro_context=macro_context,
             )
         )
@@ -1121,6 +1288,7 @@ def build_model_attached_audit_inputs(
                     known_source_names=known_source_names,
                     default_audit_severity=default_audit_severity,
                     default_audit_run_scope=default_audit_run_scope,
+                    effective_vars=effective_vars,
                     macro_context=macro_context,
                 )
             )
@@ -1137,6 +1305,7 @@ def build_source_attached_audit_inputs(
     known_source_names: set[str],
     default_audit_severity: str | None,
     default_audit_run_scope: str | None,
+    effective_vars: dict[str, str],
     macro_context: MacroContext,
 ) -> tuple[CompileAuditInput, ...]:
     """Render source-attached audits into compile audit inputs."""
@@ -1162,6 +1331,7 @@ def build_source_attached_audit_inputs(
                 known_source_names=known_source_names,
                 default_audit_severity=default_audit_severity,
                 default_audit_run_scope=default_audit_run_scope,
+                effective_vars=effective_vars,
                 macro_context=macro_context,
             )
         )
@@ -1187,6 +1357,7 @@ def build_source_attached_audit_inputs(
                     known_source_names=known_source_names,
                     default_audit_severity=default_audit_severity,
                     default_audit_run_scope=default_audit_run_scope,
+                    effective_vars=effective_vars,
                     macro_context=macro_context,
                 )
             )
@@ -1208,6 +1379,7 @@ def build_attached_audit_input(
     known_source_names: set[str],
     default_audit_severity: str | None,
     default_audit_run_scope: str | None,
+    effective_vars: dict[str, str],
     macro_context: MacroContext,
 ) -> CompileAuditInput:
     """Render one attached generic audit instance into a compile audit input."""
@@ -1231,9 +1403,10 @@ def build_attached_audit_input(
         owner_file=owner_file,
         definition_name=audit_instance.definition_name,
     )
-    expanded_sql_body: str = expand_sql_macros(
+    expanded_sql_body: str = expand_authored_sql(
         sql=rendered_sql_body,
         file_path=definition[0].file_path,
+        effective_vars=effective_vars,
         loaded_macros=loaded_macros,
         macro_context=macro_context,
     )
@@ -1896,10 +2069,11 @@ def expand_model_hook_macros(
     *,
     values: dict[str, object],
     file_path: Path,
+    effective_vars: dict[str, str],
     loaded_macros: dict[str, LoadedMacro],
     macro_context: MacroContext,
 ) -> dict[str, object]:
-    """Expand macros only within executable hook SQL strings."""
+    """Expand SQL interpolation and macros within executable hook SQL strings."""
 
     expanded_values: dict[str, object] = dict(values)
     hook_key: str
@@ -1910,6 +2084,7 @@ def expand_model_hook_macros(
         expanded_values[hook_key] = expand_sql_macros_in_value(
             value=raw_hook_value,
             file_path=file_path,
+            effective_vars=effective_vars,
             loaded_macros=loaded_macros,
             macro_context=macro_context,
         )
@@ -1920,15 +2095,17 @@ def expand_sql_macros_in_value(
     *,
     value: object,
     file_path: Path,
+    effective_vars: dict[str, str],
     loaded_macros: dict[str, LoadedMacro],
     macro_context: MacroContext,
 ) -> object:
-    """Recursively expand macros inside supported SQL hook container shapes."""
+    """Recursively expand SQL interpolation and macros in hook container shapes."""
 
     if isinstance(value, str):
-        return expand_sql_macros(
+        return expand_authored_sql(
             sql=value,
             file_path=file_path,
+            effective_vars=effective_vars,
             loaded_macros=loaded_macros,
             macro_context=macro_context,
         )
@@ -1937,6 +2114,7 @@ def expand_sql_macros_in_value(
             expand_sql_macros_in_value(
                 value=item,
                 file_path=file_path,
+                effective_vars=effective_vars,
                 loaded_macros=loaded_macros,
                 macro_context=macro_context,
             )
@@ -1947,6 +2125,7 @@ def expand_sql_macros_in_value(
             expand_sql_macros_in_value(
                 value=item,
                 file_path=file_path,
+                effective_vars=effective_vars,
                 loaded_macros=loaded_macros,
                 macro_context=macro_context,
             )

--- a/src/sqlbuild/compiler/compile/helpers/model_config_validation.py
+++ b/src/sqlbuild/compiler/compile/helpers/model_config_validation.py
@@ -221,18 +221,18 @@ def validate_placeholder_config(
     query_sql: str,
     custom_materialization_names: frozenset[str],
 ) -> None:
-    """Validate @@placeholder usage and placeholders config consistency."""
+    """Validate @@@placeholder usage and placeholders config consistency."""
 
     import re
 
     materialized: str | None = _str(config, "materialized")
     is_custom: bool = materialized is not None and materialized in custom_materialization_names
     placeholders_config: object | None = config.values.get("placeholders")
-    sql_placeholders: frozenset[str] = frozenset(re.findall(r"@@(\w+)", query_sql))
+    sql_placeholders: frozenset[str] = frozenset(re.findall(r"@@@(\w+)", query_sql))
 
     if not is_custom and sql_placeholders:
         raise CompileInputError(
-            f"model '{model_name}': @@placeholders are only allowed on custom materializations"
+            f"model '{model_name}': @@@placeholders are only allowed on custom materializations"
         )
     if not is_custom and placeholders_config is not None:
         raise CompileInputError(
@@ -250,7 +250,7 @@ def validate_placeholder_config(
     if missing_defaults:
         sorted_missing: str = ", ".join(sorted(missing_defaults))
         raise CompileInputError(
-            f"model '{model_name}': @@placeholders without default values "
+            f"model '{model_name}': @@@placeholders without default values "
             f"in placeholders config: {sorted_missing}"
         )
 

--- a/src/sqlbuild/compiler/compile/helpers/sql_vars.py
+++ b/src/sqlbuild/compiler/compile/helpers/sql_vars.py
@@ -1,11 +1,12 @@
-"""SQL project variable substitution (@name without parens)."""
+"""SQL project variable and environment interpolation helpers."""
 
 from __future__ import annotations
 
-import re
+import os
 from pathlib import Path
 
 from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.compiler.compile.helpers.macros import expand_sql_macros
 from sqlbuild.compiler.compile.helpers.sql_scanning import (
     is_identifier_character as _is_identifier_continue,
 )
@@ -17,10 +18,9 @@ from sqlbuild.compiler.compile.helpers.sql_scanning import (
     skip_line_comment,
     skip_quoted_text,
 )
-from sqlbuild.compiler.compile.models import LoadedMacro
+from sqlbuild.compiler.compile.models import LoadedMacro, MacroContext
 
-_CONTEXT: str = "Variable substitution"
-_VAR_PATTERN: re.Pattern[str] = re.compile(r"@([a-zA-Z_][a-zA-Z0-9_]*)")
+_CONTEXT: str = "SQL interpolation"
 
 
 def validate_var_macro_collision(
@@ -39,19 +39,42 @@ def validate_var_macro_collision(
         )
 
 
+def expand_authored_sql(
+    *,
+    sql: str,
+    file_path: Path,
+    effective_vars: dict[str, str],
+    loaded_macros: dict[str, LoadedMacro],
+    macro_context: MacroContext,
+) -> str:
+    """Apply SQL interpolation and macro expansion to authored SQL text."""
+
+    interpolated_sql: str = substitute_sql_vars(
+        sql=sql,
+        file_path=file_path,
+        effective_vars=effective_vars,
+    )
+    return expand_sql_macros(
+        sql=interpolated_sql,
+        file_path=file_path,
+        loaded_macros=loaded_macros,
+        macro_context=macro_context,
+    )
+
+
 def substitute_sql_vars(
     *,
     sql: str,
     file_path: Path,
     effective_vars: dict[str, str],
 ) -> str:
-    """Replace bare @name references with project variable values.
+    """Replace @@name and @@ENV:NAME references in SQL text.
 
-    Only replaces @name that is NOT followed by '(' (those are macro calls).
-    Skips quoted strings and comments.
+    Interpolation works inside quoted SQL strings. Comments are preserved as
+    authored. Deferred @@@name placeholders are preserved for later phases.
     """
 
-    if "@" not in sql or not effective_vars:
+    if "@@" not in sql:
         return sql
 
     parts: list[str] = []
@@ -60,7 +83,13 @@ def substitute_sql_vars(
         character: str = sql[cursor]
         if character in {"'", '"', "`"}:
             end: int = skip_quoted_text(sql=sql, start=cursor, context=_CONTEXT)
-            parts.append(sql[cursor:end])
+            parts.append(
+                _interpolate_sql_segment(
+                    segment=sql[cursor:end],
+                    file_path=file_path,
+                    effective_vars=effective_vars,
+                )
+            )
             cursor = end
             continue
         if sql.startswith("--", cursor):
@@ -73,27 +102,103 @@ def substitute_sql_vars(
             parts.append(sql[cursor:end])
             cursor = end
             continue
-        if character == "@" and cursor + 1 < len(sql) and _is_identifier_start(sql[cursor + 1]):
-            name_start: int = cursor + 1
-            name_end: int = name_start + 1
-            while name_end < len(sql) and _is_identifier_continue(sql[name_end]):
-                name_end += 1
-            paren_check: int = name_end
-            while paren_check < len(sql) and sql[paren_check].isspace():
-                paren_check += 1
-            if paren_check < len(sql) and sql[paren_check] == "(":
-                parts.append(sql[cursor:name_end])
-                cursor = name_end
-                continue
-            var_name: str = sql[name_start:name_end]
-            if var_name not in effective_vars:
-                raise CompileInputError(
-                    f"unknown project variable '@{var_name}' in '{file_path}'. "
-                    f"Available vars: {', '.join(sorted(effective_vars)) or 'none'}"
-                )
-            parts.append(effective_vars[var_name])
-            cursor = name_end
+        if sql.startswith("@@", cursor):
+            rendered_token: str
+            next_cursor: int
+            rendered_token, next_cursor = _render_interpolation_token(
+                sql=sql,
+                start=cursor,
+                file_path=file_path,
+                effective_vars=effective_vars,
+            )
+            parts.append(rendered_token)
+            cursor = next_cursor
             continue
         parts.append(character)
         cursor += 1
     return "".join(parts)
+
+
+def _interpolate_sql_segment(
+    *,
+    segment: str,
+    file_path: Path,
+    effective_vars: dict[str, str],
+) -> str:
+    if "@@" not in segment:
+        return segment
+    parts: list[str] = []
+    cursor: int = 0
+    while cursor < len(segment):
+        if segment.startswith("@@", cursor):
+            rendered_token: str
+            next_cursor: int
+            rendered_token, next_cursor = _render_interpolation_token(
+                sql=segment,
+                start=cursor,
+                file_path=file_path,
+                effective_vars=effective_vars,
+            )
+            parts.append(rendered_token)
+            cursor = next_cursor
+            continue
+        parts.append(segment[cursor])
+        cursor += 1
+    return "".join(parts)
+
+
+def _render_interpolation_token(
+    *,
+    sql: str,
+    start: int,
+    file_path: Path,
+    effective_vars: dict[str, str],
+) -> tuple[str, int]:
+    if sql.startswith("@@@", start):
+        name_start: int = start + 3
+        if name_start < len(sql) and _is_identifier_start(sql[name_start]):
+            name_end: int = _consume_identifier(sql=sql, start=name_start)
+            return sql[start:name_end], name_end
+        return "@@@", start + 3
+
+    token_start: int = start + 2
+    if sql.startswith("ENV:", token_start):
+        env_name_start: int = token_start + len("ENV:")
+        env_name_end: int = _consume_env_name(sql=sql, start=env_name_start)
+        if env_name_end == env_name_start:
+            raise CompileInputError(f"invalid environment interpolation token in '{file_path}'")
+        env_name: str = sql[env_name_start:env_name_end]
+        if env_name not in os.environ:
+            raise CompileInputError(
+                f"unknown environment variable '@@ENV:{env_name}' in '{file_path}'"
+            )
+        return os.environ[env_name], env_name_end
+
+    if sql.startswith("CTX:", token_start):
+        raise CompileInputError(f"SQL text in '{file_path}' does not allow @@CTX templates")
+
+    if token_start < len(sql) and _is_identifier_start(sql[token_start]):
+        name_end = _consume_identifier(sql=sql, start=token_start)
+        var_name: str = sql[token_start:name_end]
+        if var_name not in effective_vars:
+            raise CompileInputError(
+                f"unknown project variable '@@{var_name}' in '{file_path}'. "
+                f"Available vars: {', '.join(sorted(effective_vars)) or 'none'}"
+            )
+        return effective_vars[var_name], name_end
+
+    return "@@", start + 2
+
+
+def _consume_identifier(*, sql: str, start: int) -> int:
+    cursor: int = start + 1
+    while cursor < len(sql) and _is_identifier_continue(sql[cursor]):
+        cursor += 1
+    return cursor
+
+
+def _consume_env_name(*, sql: str, start: int) -> int:
+    cursor: int = start
+    while cursor < len(sql) and (sql[cursor].isalnum() or sql[cursor] == "_"):
+        cursor += 1
+    return cursor

--- a/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
+++ b/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
@@ -19,7 +19,7 @@ _UDF_PATTERN: re.Pattern[str] = re.compile(r'__udf\("([A-Za-z_][A-Za-z0-9_]*)"\)
 _TABLE_FUNCTION_PATTERN: re.Pattern[str] = re.compile(
     r'__table_function\("([A-Za-z_][A-Za-z0-9_]*)"\)\s*(?=\()'
 )
-_PLACEHOLDER_PATTERN: re.Pattern[str] = re.compile(r"@@(\w+)")
+_PLACEHOLDER_PATTERN: re.Pattern[str] = re.compile(r"@@@(\w+)")
 
 
 def infer_columns_with_sqlglot(
@@ -70,7 +70,7 @@ def infer_columns_with_sqlglot(
 
 
 def substitute_placeholder_defaults(query_sql: str, placeholders: dict[str, str]) -> str:
-    """Replace @@name tokens with their default values for SQLGlot parsing."""
+    """Replace @@@name tokens with their default values for SQLGlot parsing."""
 
     if not placeholders:
         return query_sql

--- a/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
+++ b/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
@@ -112,7 +112,9 @@ def build_compile_inputs(
     )
     source_inputs: tuple[CompileSourceInput, ...] = build_source_inputs(
         discovered_inputs,
+        effective_vars=effective_vars,
         effective_settings=effective_settings,
+        macro_context=macro_context,
         no_sql_validation=no_sql_validation,
     )
     test_inputs: tuple[CompileSqlTestInput, ...] = build_test_inputs(
@@ -133,6 +135,7 @@ def build_compile_inputs(
         effective_settings=effective_settings,
         model_inputs=model_inputs,
         source_inputs=source_inputs,
+        effective_vars=effective_vars,
         macro_context=macro_context,
         generic_audit_definitions=generic_audit_definitions,
     )

--- a/tests/e2e/fixtures/waffle_shop/materializations/partition_tracked.py
+++ b/tests/e2e/fixtures/waffle_shop/materializations/partition_tracked.py
@@ -59,8 +59,8 @@ def materialize(ctx: MaterializationContext) -> MaterializationResult:
     partition_value: str
     for i, partition_value in enumerate(stale):
         next_day: str = _next_date(partition_value)
-        partition_sql: str = ctx.sql.replace("@@partition_start", f"'{partition_value}'").replace(
-            "@@partition_end", f"'{next_day}'"
+        partition_sql: str = ctx.sql.replace("@@@partition_start", f"'{partition_value}'").replace(
+            "@@@partition_end", f"'{next_day}'"
         )
 
         if ctx.on_progress is not None:

--- a/tests/e2e/fixtures/waffle_shop/models/marts/daily_order_partitioned.sql
+++ b/tests/e2e/fixtures/waffle_shop/models/marts/daily_order_partitioned.sql
@@ -29,6 +29,6 @@ SELECT
   SUM(o.quantity) AS waffles_ordered,
   COUNT(DISTINCT o.customer_id) AS unique_customers
 FROM __ref("stg_orders") o
-WHERE CAST(o.ordered_at AS DATE) >= CAST(@@partition_start AS DATE)
-  AND CAST(o.ordered_at AS DATE) < CAST(@@partition_end AS DATE)
+WHERE CAST(o.ordered_at AS DATE) >= CAST(@@@partition_start AS DATE)
+  AND CAST(o.ordered_at AS DATE) < CAST(@@@partition_end AS DATE)
 GROUP BY CAST(o.ordered_at AS DATE)

--- a/tests/e2e/src/sqlbuild/cli/commands/main/audit/test_audit.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/audit/test_audit.py
@@ -20,7 +20,7 @@ from tests.e2e.src.sqlbuild.cli.commands.main.shared.helpers import (
         AuditE2ETestCase(
             description="audit runs all audits against built relations and all pass",
             expected_exit_code=0,
-            expected_stdout_fragment="PASS=26",
+            expected_stdout_fragment="PASS=28",
         ),
     ],
     ids=["audit runs all audits against built relations and all pass"],

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_lifecycle_commands.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_lifecycle_commands.py
@@ -30,7 +30,7 @@ from tests.e2e.src.sqlbuild.cli.commands.main.shared.helpers import (
                 "First run (12)",
             ),
             expected_test_fragment="PASS=2  FAIL=0  TOTAL=2",
-            expected_audit_fragment="PASS=26  WARN=0  FAIL=0  TOTAL=26",
+            expected_audit_fragment="PASS=28  WARN=0  FAIL=0  TOTAL=28",
             expected_run_fragment="Completed successfully.",
             expected_rerun_reasons={
                 "stg_orders": "no_change",

--- a/tests/integration/src/sqlbuild/executor/build/custom/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/build/custom/helpers.py
@@ -288,8 +288,8 @@ def build_partition_tracking_fn() -> Callable[[MaterializationContext], Material
 
         target_exists: bool = ctx.existing_relation is not None
         if not target_exists:
-            full_sql: str = ctx.sql.replace("@@partition_start", "'2024-01-01'")
-            full_sql = full_sql.replace("@@partition_end", "'2024-01-04'")
+            full_sql: str = ctx.sql.replace("@@@partition_start", "'2024-01-01'")
+            full_sql = full_sql.replace("@@@partition_end", "'2024-01-04'")
             ctx.log("building initial partition range")
             ctx.adapter.create_table_as(
                 ctx.connection,
@@ -304,8 +304,8 @@ def build_partition_tracking_fn() -> Callable[[MaterializationContext], Material
                 )
             return MaterializationResult(relation=ctx.target)
 
-        full_range_sql: str = ctx.sql.replace("@@partition_start", "'2024-01-01'").replace(
-            "@@partition_end", "'2024-01-04'"
+        full_range_sql: str = ctx.sql.replace("@@@partition_start", "'2024-01-01'").replace(
+            "@@@partition_end", "'2024-01-04'"
         )
         cursor: Any = ctx.execute_sql(
             f"SELECT DISTINCT {partition_col} FROM ({full_range_sql}) sub "
@@ -317,8 +317,8 @@ def build_partition_tracking_fn() -> Callable[[MaterializationContext], Material
         stale: str
         for stale in stale_partitions:
             next_day: str = stale[:8] + str(int(stale[8:]) + 1).zfill(2)
-            partition_sql: str = ctx.sql.replace("@@partition_start", f"'{stale}'")
-            partition_sql = partition_sql.replace("@@partition_end", f"'{next_day}'")
+            partition_sql: str = ctx.sql.replace("@@@partition_start", f"'{stale}'")
+            partition_sql = partition_sql.replace("@@@partition_end", f"'{next_day}'")
             ctx.adapter.append(
                 ctx.connection,
                 target=ctx.target,
@@ -354,14 +354,14 @@ def build_existing_relation_capture_fn(
 def build_placeholder_execution_fn(
     substitutions: dict[str, str],
 ) -> Callable[[MaterializationContext], MaterializationResult]:
-    """Build a materialize function that substitutes @@placeholders and executes."""
+    """Build a materialize function that substitutes @@@placeholders and executes."""
 
     def materialize(ctx: MaterializationContext) -> MaterializationResult:
         sql: str = ctx.sql
         placeholder_name: str
         placeholder_value: str
         for placeholder_name, placeholder_value in substitutions.items():
-            sql = sql.replace(f"@@{placeholder_name}", placeholder_value)
+            sql = sql.replace(f"@@@{placeholder_name}", placeholder_value)
         ctx.adapter.create_table_as(
             ctx.connection,
             target=ctx.target,

--- a/tests/integration/src/sqlbuild/executor/build/custom/test_advanced_custom_materialization.py
+++ b/tests/integration/src/sqlbuild/executor/build/custom/test_advanced_custom_materialization.py
@@ -96,7 +96,7 @@ def test_given_partition_tracked_materialization_when_first_run_then_builds_all_
     entry: ModelPlanEntry = build_custom_plan_entry(
         sql=(
             "SELECT event_day, event_id FROM main.raw_events "
-            "WHERE event_day >= @@partition_start AND event_day < @@partition_end"
+            "WHERE event_day >= @@@partition_start AND event_day < @@@partition_end"
         ),
         reason=PlanReason.FIRST_RUN,
         custom_config={
@@ -227,20 +227,20 @@ def test_given_custom_materialization_when_target_state_varies_then_existing_rel
 
 PLACEHOLDER_EXECUTION_TEST_CASES: list[PlaceholderExecutionTestCase] = [
     PlaceholderExecutionTestCase(
-        description="@@placeholders substituted and SQL executes against database",
+        description="@@@placeholders substituted and SQL executes against database",
         model_sql=(
             "SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, name) "
-            "WHERE id >= @@start_id AND id < @@end_id"
+            "WHERE id >= @@@start_id AND id < @@@end_id"
         ),
         placeholders={"start_id": "1", "end_id": "4"},
         substitutions={"start_id": "2", "end_id": "4"},
         expected_row_count=2,
     ),
     PlaceholderExecutionTestCase(
-        description="@@placeholder with string values and quoting",
+        description="@@@placeholder with string values and quoting",
         model_sql=(
             "SELECT * FROM (VALUES ('alice', 10), ('bob', 20), ('charlie', 30)) AS t(name, score) "
-            "WHERE name = @@target_name"
+            "WHERE name = @@@target_name"
         ),
         placeholders={"target_name": "'alice'"},
         substitutions={"target_name": "'bob'"},

--- a/tests/unit/src/sqlbuild/compiler/compile/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_test_types.py
@@ -16,6 +16,24 @@ class BuildCompileInputsTestCase:
     expected_effective_environment_name: str | None
     expected_effective_connection: dict[str, object]
     expected_effective_vars: dict[str, str]
+    expected_source_expressions: tuple[str | None, ...] | None = None
+    expected_source_relations: tuple[tuple[str | None, str | None, str | None], ...] | None = None
+    expected_model_schema_descriptions: tuple[str | None, ...] | None = None
+    expected_model_column_metadata: (
+        tuple[
+            tuple[
+                tuple[
+                    str,
+                    str | None,
+                    str | None,
+                    tuple[tuple[str, dict[str, object]], ...],
+                ],
+                ...,
+            ],
+            ...,
+        ]
+        | None
+    ) = None
     expected_effective_sqlglot: bool = True
     expected_effective_sql_validation: bool = True
     expected_effective_max_concurrency: int = 1

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/_test_types.py
@@ -146,6 +146,7 @@ class SubstituteSqlVarsTestCase:
     sql: str
     effective_vars: dict[str, str]
     expected_sql: str
+    environment_variables: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_model_config_validation.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_model_config_validation.py
@@ -521,7 +521,7 @@ PLACEHOLDER_VALID_TEST_CASES: list[PlaceholderConfigValidTestCase] = [
             "materialized": "partition_tracked",
             "placeholders": {"partition_start": "'2020-01-01'", "partition_end": "'2099-12-31'"},
         },
-        query_sql="SELECT * FROM t WHERE d >= @@partition_start AND d < @@partition_end",
+        query_sql="SELECT * FROM t WHERE d >= @@@partition_start AND d < @@@partition_end",
         custom_materialization_names=frozenset({"partition_tracked"}),
     ),
     PlaceholderConfigValidTestCase(
@@ -534,6 +534,12 @@ PLACEHOLDER_VALID_TEST_CASES: list[PlaceholderConfigValidTestCase] = [
         description="built-in table materialization without placeholders",
         config_values={"materialized": "table"},
         query_sql="SELECT * FROM t",
+        custom_materialization_names=frozenset(),
+    ),
+    PlaceholderConfigValidTestCase(
+        description="built-in table materialization ignores compile-time interpolation tokens",
+        config_values={"materialized": "table"},
+        query_sql="SELECT * FROM @@schema_name.t",
         custom_materialization_names=frozenset(),
     ),
 ]
@@ -561,11 +567,11 @@ def test_given_valid_placeholder_config_when_validating_then_passes(
 
 PLACEHOLDER_ERROR_TEST_CASES: list[PlaceholderConfigErrorTestCase] = [
     PlaceholderConfigErrorTestCase(
-        description="@@placeholder on built-in materialization",
+        description="@@@placeholder on built-in materialization",
         config_values={"materialized": "table"},
-        query_sql="SELECT * FROM t WHERE d >= @@partition_start",
+        query_sql="SELECT * FROM t WHERE d >= @@@partition_start",
         custom_materialization_names=frozenset(),
-        expected_error_fragment="@@placeholders are only allowed on custom materializations",
+        expected_error_fragment="@@@placeholders are only allowed on custom materializations",
     ),
     PlaceholderConfigErrorTestCase(
         description="placeholders config on built-in materialization",
@@ -575,11 +581,11 @@ PLACEHOLDER_ERROR_TEST_CASES: list[PlaceholderConfigErrorTestCase] = [
         expected_error_fragment="placeholders config is only allowed on custom materializations",
     ),
     PlaceholderConfigErrorTestCase(
-        description="@@placeholder without default in config",
+        description="@@@placeholder without default in config",
         config_values={"materialized": "partition_tracked"},
-        query_sql="SELECT * FROM t WHERE d >= @@partition_start",
+        query_sql="SELECT * FROM t WHERE d >= @@@partition_start",
         custom_materialization_names=frozenset({"partition_tracked"}),
-        expected_error_fragment="@@placeholders without default values",
+        expected_error_fragment="@@@placeholders without default values",
     ),
     PlaceholderConfigErrorTestCase(
         description="placeholder default not used in SQL",
@@ -587,7 +593,7 @@ PLACEHOLDER_ERROR_TEST_CASES: list[PlaceholderConfigErrorTestCase] = [
             "materialized": "partition_tracked",
             "placeholders": {"partition_start": "'2020-01-01'", "unused_var": "'x'"},
         },
-        query_sql="SELECT * FROM t WHERE d >= @@partition_start",
+        query_sql="SELECT * FROM t WHERE d >= @@@partition_start",
         custom_materialization_names=frozenset({"partition_tracked"}),
         expected_error_fragment="placeholders config entries not used in SQL",
     ),
@@ -597,9 +603,9 @@ PLACEHOLDER_ERROR_TEST_CASES: list[PlaceholderConfigErrorTestCase] = [
             "materialized": "partition_tracked",
             "placeholders": {"partition_start": "'2020-01-01'"},
         },
-        query_sql="SELECT * FROM t WHERE d >= @@partition_start AND d < @@partition_end",
+        query_sql="SELECT * FROM t WHERE d >= @@@partition_start AND d < @@@partition_end",
         custom_materialization_names=frozenset({"partition_tracked"}),
-        expected_error_fragment="@@placeholders without default values.*partition_end",
+        expected_error_fragment="@@@placeholders without default values.*partition_end",
     ),
 ]
 

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_sql_vars.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_sql_vars.py
@@ -1,4 +1,4 @@
-"""Tests for SQL project variable substitution."""
+"""Tests for SQL project variable interpolation."""
 
 from __future__ import annotations
 
@@ -9,29 +9,33 @@ import pytest
 from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.helpers.sql_vars import (
     substitute_sql_vars,
-    validate_var_macro_collision,
 )
-from sqlbuild.compiler.compile.models import LoadedMacro
 from tests.unit.src.sqlbuild.compiler.compile.helpers._test_types import (
     SubstituteSqlVarsErrorTestCase,
     SubstituteSqlVarsTestCase,
-    VarMacroCollisionTestCase,
 )
 
 _FILE_PATH: Path = Path("models/test_model.sql")
 
 SUBSTITUTION_TEST_CASES: list[SubstituteSqlVarsTestCase] = [
     SubstituteSqlVarsTestCase(
-        description="replaces bare var in SQL expression",
-        sql="SELECT * FROM orders WHERE region = @target_region",
+        description="replaces project var in SQL expression",
+        sql="SELECT * FROM orders WHERE region = @@target_region",
         effective_vars={"target_region": "us-east-1"},
         expected_sql="SELECT * FROM orders WHERE region = us-east-1",
     ),
     SubstituteSqlVarsTestCase(
         description="replaces multiple vars",
-        sql="SELECT * FROM @schema.@table",
+        sql="SELECT * FROM @@schema.@@table",
         effective_vars={"schema": "staging", "table": "orders"},
         expected_sql="SELECT * FROM staging.orders",
+    ),
+    SubstituteSqlVarsTestCase(
+        description="replaces env var in quoted SQL string",
+        sql="SELECT '@@ENV:USER_NAME' AS loaded_by",
+        effective_vars={},
+        environment_variables={"USER_NAME": "runner"},
+        expected_sql="SELECT 'runner' AS loaded_by",
     ),
     SubstituteSqlVarsTestCase(
         description="does not replace macro call with parens",
@@ -40,34 +44,61 @@ SUBSTITUTION_TEST_CASES: list[SubstituteSqlVarsTestCase] = [
         expected_sql="SELECT @my_macro('arg') FROM orders",
     ),
     SubstituteSqlVarsTestCase(
-        description="returns sql unchanged when no vars defined",
+        description="does not replace single at placeholder syntax",
         sql="SELECT @name FROM orders",
-        effective_vars={},
+        effective_vars={"name": "value"},
         expected_sql="SELECT @name FROM orders",
     ),
     SubstituteSqlVarsTestCase(
-        description="returns sql unchanged when no at signs present",
+        description="returns sql unchanged when no interpolation tokens present",
         sql="SELECT 1 FROM orders",
         effective_vars={"name": "value"},
         expected_sql="SELECT 1 FROM orders",
     ),
     SubstituteSqlVarsTestCase(
-        description="skips var inside single-quoted string",
-        sql="SELECT '@name' FROM orders",
+        description="replaces var inside single-quoted string",
+        sql="SELECT '@@name' FROM orders",
         effective_vars={"name": "value"},
-        expected_sql="SELECT '@name' FROM orders",
+        expected_sql="SELECT 'value' FROM orders",
     ),
     SubstituteSqlVarsTestCase(
-        description="skips var inside line comment",
-        sql="-- @name\nSELECT 1",
+        description="skips interpolation inside line comment",
+        sql="-- @@name\nSELECT 1",
         effective_vars={"name": "value"},
-        expected_sql="-- @name\nSELECT 1",
+        expected_sql="-- @@name\nSELECT 1",
     ),
     SubstituteSqlVarsTestCase(
-        description="skips var inside block comment",
-        sql="/* @name */ SELECT 1",
+        description="skips interpolation inside block comment",
+        sql="/* @@name */ SELECT 1",
         effective_vars={"name": "value"},
-        expected_sql="/* @name */ SELECT 1",
+        expected_sql="/* @@name */ SELECT 1",
+    ),
+    SubstituteSqlVarsTestCase(
+        description="preserves deferred engine placeholder",
+        sql="SELECT * FROM orders WHERE ds >= @@@partition_start",
+        effective_vars={"partition_start": "should_not_appear"},
+        expected_sql="SELECT * FROM orders WHERE ds >= @@@partition_start",
+    ),
+]
+
+SUBSTITUTE_SQL_VARS_ERROR_TEST_CASES: list[SubstituteSqlVarsErrorTestCase] = [
+    SubstituteSqlVarsErrorTestCase(
+        description="raises on unknown var",
+        sql="SELECT @@unknown_var FROM orders",
+        effective_vars={"other": "value"},
+        expected_error_fragment="unknown project variable '@@unknown_var'",
+    ),
+    SubstituteSqlVarsErrorTestCase(
+        description="raises on CTX token",
+        sql="SELECT @@CTX:model.name FROM orders",
+        effective_vars={},
+        expected_error_fragment="does not allow @@CTX templates",
+    ),
+    SubstituteSqlVarsErrorTestCase(
+        description="raises on unknown env var",
+        sql="SELECT '@@ENV:SQLBUILD_MISSING_ENV'",
+        effective_vars={},
+        expected_error_fragment="unknown environment variable '@@ENV:SQLBUILD_MISSING_ENV'",
     ),
 ]
 
@@ -79,7 +110,13 @@ SUBSTITUTION_TEST_CASES: list[SubstituteSqlVarsTestCase] = [
 )
 def test_given_sql_and_vars_when_substituting_then_returns_expected(
     test_case: SubstituteSqlVarsTestCase,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    environment_name: str
+    environment_value: str
+    for environment_name, environment_value in test_case.environment_variables.items():
+        monkeypatch.setenv(environment_name, environment_value)
+
     result: str = substitute_sql_vars(
         sql=test_case.sql,
         file_path=_FILE_PATH,
@@ -91,15 +128,8 @@ def test_given_sql_and_vars_when_substituting_then_returns_expected(
 
 @pytest.mark.parametrize(
     "test_case",
-    [
-        SubstituteSqlVarsErrorTestCase(
-            description="raises on unknown var",
-            sql="SELECT @unknown_var FROM orders",
-            effective_vars={"other": "value"},
-            expected_error_fragment="unknown project variable '@unknown_var'",
-        ),
-    ],
-    ids=["raises on unknown var"],
+    SUBSTITUTE_SQL_VARS_ERROR_TEST_CASES,
+    ids=[case.description for case in SUBSTITUTE_SQL_VARS_ERROR_TEST_CASES],
 )
 def test_given_missing_var_when_substituting_then_raises(
     test_case: SubstituteSqlVarsErrorTestCase,
@@ -110,76 +140,3 @@ def test_given_missing_var_when_substituting_then_raises(
             file_path=_FILE_PATH,
             effective_vars=test_case.effective_vars,
         )
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        VarMacroCollisionTestCase(
-            description="raises when var and macro names collide",
-            var_names=("my_func",),
-            macro_names=("my_func",),
-            expected_valid=False,
-            expected_error_fragment="collide with macro names",
-        ),
-    ],
-    ids=["raises when var and macro names collide"],
-)
-def test_given_colliding_names_when_checking_collision_then_raises(
-    test_case: VarMacroCollisionTestCase,
-) -> None:
-    effective_vars: dict[str, str] = {name: "value" for name in test_case.var_names}
-    loaded_macros: dict[str, LoadedMacro] = {
-        name: LoadedMacro(
-            name=name,
-            function=lambda: "",
-            file_path=Path(f"macros/{name}.py"),
-            relative_path=Path(f"macros/{name}.py"),
-            raw_source="",
-        )
-        for name in test_case.macro_names
-    }
-
-    with pytest.raises(
-        CompileInputError,
-        match=test_case.expected_error_fragment or "",
-    ):
-        validate_var_macro_collision(
-            effective_vars=effective_vars,
-            loaded_macros=loaded_macros,
-        )
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        VarMacroCollisionTestCase(
-            description="passes when no collision exists",
-            var_names=("region",),
-            macro_names=("my_func",),
-            expected_valid=True,
-        ),
-    ],
-    ids=["passes when no collision exists"],
-)
-def test_given_non_colliding_names_when_checking_collision_then_passes(
-    test_case: VarMacroCollisionTestCase,
-) -> None:
-    effective_vars: dict[str, str] = {name: "value" for name in test_case.var_names}
-    loaded_macros: dict[str, LoadedMacro] = {
-        name: LoadedMacro(
-            name=name,
-            function=lambda: "",
-            file_path=Path(f"macros/{name}.py"),
-            relative_path=Path(f"macros/{name}.py"),
-            raw_source="",
-        )
-        for name in test_case.macro_names
-    }
-
-    validate_var_macro_collision(
-        effective_vars=effective_vars,
-        loaded_macros=loaded_macros,
-    )
-
-    assert test_case.expected_valid

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_sqlglot_columns.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_sqlglot_columns.py
@@ -272,21 +272,21 @@ def test_given_query_sql_when_inferring_columns_then_returns_expected(
 SUBSTITUTE_PLACEHOLDER_TEST_CASES: list[SubstitutePlaceholderDefaultsTestCase] = [
     SubstitutePlaceholderDefaultsTestCase(
         description="substitutes single placeholder",
-        query_sql="SELECT * FROM t WHERE d >= @@partition_start",
+        query_sql="SELECT * FROM t WHERE d >= @@@partition_start",
         placeholders={"partition_start": "'2020-01-01'"},
         expected_sql="SELECT * FROM t WHERE d >= '2020-01-01'",
     ),
     SubstitutePlaceholderDefaultsTestCase(
         description="substitutes multiple placeholders",
-        query_sql="SELECT * FROM t WHERE d >= @@start AND d < @@end",
+        query_sql="SELECT * FROM t WHERE d >= @@@start AND d < @@@end",
         placeholders={"start": "'2020-01-01'", "end": "'2099-12-31'"},
         expected_sql="SELECT * FROM t WHERE d >= '2020-01-01' AND d < '2099-12-31'",
     ),
     SubstitutePlaceholderDefaultsTestCase(
         description="returns sql unchanged when no placeholders defined",
-        query_sql="SELECT * FROM t WHERE d >= @@start",
+        query_sql="SELECT * FROM t WHERE d >= @@@start",
         placeholders={},
-        expected_sql="SELECT * FROM t WHERE d >= @@start",
+        expected_sql="SELECT * FROM t WHERE d >= @@@start",
     ),
     SubstitutePlaceholderDefaultsTestCase(
         description="returns sql unchanged when no placeholders in sql",

--- a/tests/unit/src/sqlbuild/compiler/compile/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_main.py
@@ -913,6 +913,87 @@ select 1
         expected_audit_references=(),
     ),
     BuildCompileInputsTestCase(
+        description="expands config templates in model header metadata fields",
+        repo_files=base_repo_files()
+        | {
+            "sqlbuild_project.toml": """
+name = "demo"
+adapter = "duckdb"
+
+[settings]
+default_audit_severity = "warn"
+sql_validation = false
+
+[vars]
+model_schema = "marts"
+tag_name = "finance"
+id_type = "INTEGER"
+source_name = "orders_api"
+valid_order_id = "1"
+""".strip()
+            + "\n",
+            "models/marts/orders.sql": """
+MODEL (
+  schema "${model_schema}",
+  alias "orders_${ENV:ENV_NAME}",
+  description "Orders for ${ENV:ENV_NAME}",
+  tags ["orders", "${tag_name}"],
+  columns (
+    order_id (
+      type ${id_type},
+      description "Order id from ${source_name}",
+      audits [accepted_values (values ["${valid_order_id}"])],
+    ),
+  ),
+);
+
+select 1 as order_id
+""".strip()
+            + "\n",
+        },
+        selected_environment=None,
+        cli_vars=None,
+        run_id=None,
+        expected_model_schema_names=("orders",),
+        expected_model_schema_descriptions=("Orders for dev",),
+        expected_model_column_metadata=(
+            (
+                (
+                    "order_id",
+                    "INTEGER",
+                    "Order id from orders_api",
+                    (("accepted_values", {"values": ["1"]}),),
+                ),
+            ),
+        ),
+        expected_model_config_values=(
+            {"schema": "marts", "alias": "orders_dev", "tags": ["orders", "finance"]},
+        ),
+        expected_model_query_sqls=("select 1 as order_id",),
+        expected_model_path_defaults=(None,),
+        expected_seed_names=(),
+        expected_source_names=(),
+        expected_audit_sql_bodies=(
+            "SELECT order_id\n"
+            'FROM __ref("orders")\n'
+            "WHERE order_id IS NOT NULL\n"
+            "  AND order_id NOT IN ('1')",
+        ),
+        expected_effective_environment_name=None,
+        expected_effective_connection={},
+        expected_effective_vars={
+            "model_schema": "marts",
+            "tag_name": "finance",
+            "id_type": "INTEGER",
+            "source_name": "orders_api",
+            "valid_order_id": "1",
+        },
+        environment_variables={"ENV_NAME": "dev"},
+        expected_effective_sql_validation=False,
+        expected_model_references=((),),
+        expected_audit_references=((("ref", "orders"),),),
+    ),
+    BuildCompileInputsTestCase(
         description="supports multi hop var expansion and preserve environment overrides",
         repo_files=base_repo_files()
         | {
@@ -1074,6 +1155,166 @@ SELECT 1
         expected_audit_references=((("source", "raw_orders"),),),
     ),
     BuildCompileInputsTestCase(
+        description="applies sql interpolation across all authored sql text fields",
+        repo_files=base_repo_files()
+        | {
+            "macros/common.py": """
+def source_columns() -> str:
+    return "1 AS id"
+""".strip()
+            + "\n",
+            "sqlbuild_project.toml": """
+name = "demo"
+adapter = "duckdb"
+
+[settings]
+sql_validation = false
+default_audit_severity = "warn"
+
+[vars]
+raw_database = "raw_db"
+raw_schema = "analytics_raw"
+domain = "example.com"
+audit_schema = "audit"
+min_amount = "100"
+""".strip()
+            + "\n",
+            "models/orders.sql": """
+MODEL (
+  pre_hook "insert into @@audit_schema.load_log select '@@ENV:USER_NAME'",
+  columns (order_id (audits [source_filter])),
+);
+
+SELECT *
+FROM @@raw_schema.orders
+WHERE email LIKE '%@@domain'
+  AND event_date >= CURRENT_DATE
+""".strip()
+            + "\n",
+            "functions/sql/is_large_order.sql": """
+FUNCTION (
+  arguments (amount INTEGER),
+  returns BOOLEAN,
+);
+
+amount > @@min_amount AND '@@ENV:USER_NAME' = 'runner'
+""".strip()
+            + "\n",
+            "tests/unit/orders.sql": """
+TEST ();
+
+WITH
+__ref__orders AS (
+  SELECT * FROM @@raw_schema.orders WHERE loaded_by = '@@ENV:USER_NAME'
+),
+__expected__orders AS (
+  SELECT 1 AS id
+)
+SELECT 1
+""".strip()
+            + "\n",
+            "audits/orders.sql": """
+AUDIT ();
+
+SELECT * FROM @@raw_schema.orders WHERE loaded_by = '@@ENV:USER_NAME'
+""".strip()
+            + "\n",
+            "audits/generic/source_filter.sql": """
+AUDIT ();
+
+SELECT @column
+FROM @relation
+WHERE @column IS NOT NULL
+  AND source_system = '@@ENV:SOURCE_SYSTEM'
+""".strip()
+            + "\n",
+            "sources/raw.yml": """
+sources:
+  - name: raw_orders
+    expression: |
+      SELECT @source_columns(), '@@ENV:USER_NAME' AS loaded_by
+      FROM @@raw_schema.raw_orders
+  - name: raw_table
+    database: ${raw_database}
+    schema: ${raw_schema}
+    table: orders_${ENV:USER_NAME}
+""".strip()
+            + "\n",
+        },
+        selected_environment=None,
+        cli_vars=None,
+        run_id=None,
+        expected_model_schema_names=("orders",),
+        expected_model_config_values=({"pre_hook": "insert into audit.load_log select 'runner'"},),
+        expected_model_query_sqls=(
+            "SELECT *\n"
+            "FROM analytics_raw.orders\n"
+            "WHERE email LIKE '%example.com'\n"
+            "  AND event_date >= CURRENT_DATE",
+        ),
+        expected_model_path_defaults=(None,),
+        expected_seed_names=(),
+        expected_source_names=("raw_orders", "raw_table"),
+        expected_source_expressions=(
+            "SELECT 1 AS id, 'runner' AS loaded_by\nFROM analytics_raw.raw_orders\n",
+            None,
+        ),
+        expected_source_relations=(
+            (None, None, None),
+            ("raw_db", "analytics_raw", "orders_runner"),
+        ),
+        expected_test_sql_bodies=(
+            "WITH\n"
+            "__ref__orders AS (\n"
+            "  SELECT * FROM analytics_raw.orders WHERE loaded_by = 'runner'\n"
+            "),\n"
+            "__expected__orders AS (\n"
+            "  SELECT 1 AS id\n"
+            ")\n"
+            "SELECT 1",
+        ),
+        expected_test_authored_cte_names=(("__ref__orders",),),
+        expected_test_mock_model_names=(("orders",),),
+        expected_test_mock_source_names=((),),
+        expected_test_mock_seed_names=((),),
+        expected_test_expected_model_names=(("orders",),),
+        expected_audit_sql_bodies=(
+            "SELECT * FROM analytics_raw.orders WHERE loaded_by = 'runner'",
+            "SELECT order_id\n"
+            'FROM __ref("orders")\n'
+            "WHERE order_id IS NOT NULL\n"
+            "  AND source_system = 'crm'",
+        ),
+        expected_sql_function_names=("is_large_order",),
+        expected_sql_function_arguments=((("amount", "INTEGER"),),),
+        expected_sql_function_returns=("BOOLEAN",),
+        expected_sql_function_return_columns=((),),
+        expected_sql_function_body_sqls=("amount > 100 AND 'runner' = 'runner'",),
+        expected_sql_function_databases=(None,),
+        expected_sql_function_schemas=(None,),
+        expected_sql_function_languages=("sql",),
+        expected_sql_function_runtime_versions=(None,),
+        expected_sql_function_entry_points=(None,),
+        expected_sql_function_packages=((),),
+        expected_sql_function_query_change_backfills=(None,),
+        expected_effective_environment_name=None,
+        expected_effective_connection={},
+        expected_effective_vars={
+            "raw_database": "raw_db",
+            "raw_schema": "analytics_raw",
+            "domain": "example.com",
+            "audit_schema": "audit",
+            "min_amount": "100",
+        },
+        expected_effective_sql_validation=False,
+        expected_model_references=((),),
+        expected_audit_references=((), (("ref", "orders"),)),
+        environment_variables={
+            "USER_NAME": "runner",
+            "SOURCE_SYSTEM": "crm",
+        },
+    ),
+    BuildCompileInputsTestCase(
         description="expands vars and macros in sql function bodies and headers",
         repo_files=base_repo_files()
         | {
@@ -1111,7 +1352,7 @@ FUNCTION (
   query_change_backfill bounded-${backfill_days}d
 );
 
-@status_match("order_status", "completed") AND order_status <> @cancelled_status
+@status_match("order_status", "completed") AND order_status <> @@cancelled_status
 """.strip()
             + "\n",
         },
@@ -1737,6 +1978,43 @@ def test_given_discovered_inputs_when_building_compile_inputs_then_it_attaches_m
     assert actual_model_column_nullables == expected_or_actual(
         test_case.expected_model_column_nullables, actual_model_column_nullables
     )
+    actual_model_schema_descriptions: tuple[str | None, ...] = tuple(
+        None if model_input.schema_entry is None else model_input.schema_entry.description
+        for model_input in compile_inputs.model_inputs
+    )
+    assert actual_model_schema_descriptions == expected_or_actual(
+        test_case.expected_model_schema_descriptions,
+        actual_model_schema_descriptions,
+    )
+    actual_model_column_metadata: tuple[
+        tuple[
+            tuple[
+                str,
+                str | None,
+                str | None,
+                tuple[tuple[str, dict[str, object]], ...],
+            ],
+            ...,
+        ],
+        ...,
+    ] = tuple(
+        tuple(
+            (
+                column.name,
+                column.type,
+                column.description,
+                tuple((audit.definition_name, audit.arguments) for audit in column.audits),
+            )
+            for column in model_input.schema_entry.columns
+        )
+        if model_input.schema_entry is not None
+        else ()
+        for model_input in compile_inputs.model_inputs
+    )
+    assert actual_model_column_metadata == expected_or_actual(
+        test_case.expected_model_column_metadata,
+        actual_model_column_metadata,
+    )
     assert (
         tuple(
             model_input.config.matched_path_default for model_input in compile_inputs.model_inputs
@@ -1750,6 +2028,25 @@ def test_given_discovered_inputs_when_building_compile_inputs_then_it_attaches_m
     assert (
         tuple(source_input.source_entry.name for source_input in compile_inputs.source_inputs)
         == test_case.expected_source_names
+    )
+    actual_source_expressions: tuple[str | None, ...] = tuple(
+        source_input.source_entry.expression for source_input in compile_inputs.source_inputs
+    )
+    assert actual_source_expressions == expected_or_actual(
+        test_case.expected_source_expressions,
+        actual_source_expressions,
+    )
+    actual_source_relations: tuple[tuple[str | None, str | None, str | None], ...] = tuple(
+        (
+            source_input.source_entry.database,
+            source_input.source_entry.schema,
+            source_input.source_entry.table,
+        )
+        for source_input in compile_inputs.source_inputs
+    )
+    assert actual_source_relations == expected_or_actual(
+        test_case.expected_source_relations,
+        actual_source_relations,
     )
     assert (
         tuple(test_input.sql_body for test_input in compile_inputs.test_inputs)


### PR DESCRIPTION
The syntax for using @ as vars was too vague and ended up causing an issue when I tried to use an email in a model header audit.  This PR unifies the syntax to @@ for vars and envs instead (in areas using SQL e.g. body of model, pre and post hook macros, sources that are inline expressions etc...), among some other adjustments, but ultimately it is just ensuring that our templating will be reliable and hopefully easy to understand (whilst still keeping good aesthetics)