### PR TITLE
fix: narrow function change fingerprints

### DIFF
--- a/src/sqlbuild/compiler/planner/helpers/function_fingerprints.py
+++ b/src/sqlbuild/compiler/planner/helpers/function_fingerprints.py
@@ -18,10 +18,6 @@ def build_compiled_function_fingerprint_sql(function: CompiledFunction) -> str:
     """Build stable function definition text used for change fingerprints."""
 
     return build_function_fingerprint_sql(
-        name=function.name,
-        target_database=function.target.database,
-        target_schema=function.target.schema,
-        target_name=function.target.name,
         arguments=function.arguments,
         returns=function.returns,
         return_columns=function.return_columns,
@@ -81,10 +77,6 @@ def detect_function_change(
 
 def build_function_fingerprint_sql(
     *,
-    name: str,
-    target_database: str | None,
-    target_schema: str | None,
-    target_name: str,
     arguments: tuple[FunctionArgument | object, ...],
     returns: str,
     body_sql: str,
@@ -103,10 +95,6 @@ def build_function_fingerprint_sql(
     rendered_packages: str = ",".join(packages)
     return "\n".join(
         (
-            f"name={name}",
-            f"target_database={target_database or ''}",
-            f"target_schema={target_schema or ''}",
-            f"target_name={target_name}",
             f"language={language}",
             f"arguments={rendered_arguments}",
             f"returns={returns}",

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/_test_types.py
@@ -341,6 +341,7 @@ class DetectFunctionChangeTestCase:
     expected_action: BackfillAction
     expected_duration: str | None = None
     existing_fingerprint: bool = True
+    target_schema: str = "main"
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/helpers.py
@@ -548,7 +548,7 @@ def build_cascade_upstream_state(
 
 
 def build_compiled_function(
-    *, body_sql: str, query_change_backfill: str | None = None
+    *, body_sql: str, query_change_backfill: str | None = None, target_schema: str = "main"
 ) -> CompiledFunction:
     """Build a minimal compiled function for planner tests."""
 
@@ -565,15 +565,15 @@ def build_compiled_function(
         body_sql=body_sql,
         target=CompiledRelationTarget(
             database=None,
-            schema="main",
+            schema=target_schema,
             name="is_completed_order",
-            qualified_name="main.is_completed_order",
+            qualified_name=f"{target_schema}.is_completed_order",
         ),
         fingerprint_target=CompiledRelationTarget(
             database=None,
-            schema="main",
+            schema=target_schema,
             name="is_completed_order",
-            qualified_name="main.is_completed_order",
+            qualified_name=f"{target_schema}.is_completed_order",
         ),
         query_change_backfill=query_change_backfill,
     )

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_function_fingerprints.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_function_fingerprints.py
@@ -56,6 +56,25 @@ DETECT_FUNCTION_CHANGE_TEST_CASES: list[DetectFunctionChangeTestCase] = [
         expected_reason=PlanReason.QUERY_CHANGED,
         expected_action=BackfillAction.WARN_ONLY,
     ),
+    DetectFunctionChangeTestCase(
+        description="target schema case change does not cause function query change",
+        body_sql="order_status = 'completed'",
+        previous_query_sql=(
+            "language=sql\n"
+            "arguments=order_status:STRING\n"
+            "returns=BOOLEAN\n"
+            "return_columns=\n"
+            "runtime_version=\n"
+            "entry_point=\n"
+            "packages=\n"
+            "body=\n"
+            "order_status = 'completed'"
+        ),
+        query_change_backfill=None,
+        expected_reason=PlanReason.NO_CHANGE,
+        expected_action=BackfillAction.WARN_ONLY,
+        target_schema="DEV",
+    ),
 ]
 
 
@@ -70,6 +89,7 @@ def test_given_function_fingerprint_when_detecting_change_then_returns_reason_an
     function: CompiledFunction = build_compiled_function(
         body_sql=test_case.body_sql,
         query_change_backfill=test_case.query_change_backfill,
+        target_schema=test_case.target_schema,
     )
     snapshot: WarehouseSnapshot = WarehouseSnapshot(
         fingerprints=(


### PR DESCRIPTION
Put this fix on the wrong branch. Oh well (it's basically to stop tracking unnecessary fields when making function fingerprints, otherwise it could lead to a lot of false flags). 