### PR TITLE
fix: recognize dbt scenario artifacts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
 
       - id: pytest
         name: pytest
-        entry: bash -c 'uv run pytest tests/unit tests/integration -m "not real_warehouse" -vv'
+        entry: bash -c 'uv run pytest tests/unit tests/integration -m "not real_warehouse and not dbt" -vv'
         language: system
         pass_filenames: false
 

--- a/src/sqlbuild/cli/commands/main/audit.py
+++ b/src/sqlbuild/cli/commands/main/audit.py
@@ -11,6 +11,9 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
 from sqlbuild.cli.commands.main.shared.helpers.connection_progress import ConnectionProgressReporter
+from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
+    resolve_external_reference_resolver,
+)
 from sqlbuild.cli.commands.main.shared.helpers.nested_progress import NestedCommandProgressCallbacks
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.progress import format_build_header
@@ -82,6 +85,9 @@ def run_audit(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
+        external_reference_resolver=resolve_external_reference_resolver(
+            discovered_inputs=discovered_inputs
+        ),
     )
 
     audit_count: int = len(pipeline_result.plan_output.audit_entries)

--- a/src/sqlbuild/cli/commands/main/audit.py
+++ b/src/sqlbuild/cli/commands/main/audit.py
@@ -12,7 +12,7 @@ from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
 from sqlbuild.cli.commands.main.shared.helpers.connection_progress import ConnectionProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
-    resolve_external_reference_resolver,
+    resolve_external_sql_reference_resolver,
 )
 from sqlbuild.cli.commands.main.shared.helpers.nested_progress import NestedCommandProgressCallbacks
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
@@ -85,7 +85,7 @@ def run_audit(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
-        external_reference_resolver=resolve_external_reference_resolver(
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
             project_dir=effective_project_dir,
             discovered_inputs=discovered_inputs,
         ),

--- a/src/sqlbuild/cli/commands/main/audit.py
+++ b/src/sqlbuild/cli/commands/main/audit.py
@@ -86,7 +86,8 @@ def run_audit(
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
         external_reference_resolver=resolve_external_reference_resolver(
-            discovered_inputs=discovered_inputs
+            project_dir=effective_project_dir,
+            discovered_inputs=discovered_inputs,
         ),
     )
 

--- a/src/sqlbuild/cli/commands/main/build.py
+++ b/src/sqlbuild/cli/commands/main/build.py
@@ -102,7 +102,8 @@ def run_build(
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
         external_reference_resolver=resolve_external_reference_resolver(
-            discovered_inputs=discovered_inputs
+            project_dir=effective_project_dir,
+            discovered_inputs=discovered_inputs,
         ),
     )
 

--- a/src/sqlbuild/cli/commands/main/build.py
+++ b/src/sqlbuild/cli/commands/main/build.py
@@ -14,7 +14,7 @@ from sqlbuild.cli.commands.main.shared.helpers.connection_progress import (
     ConnectionProgressReporter,
 )
 from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
-    resolve_external_reference_resolver,
+    resolve_external_sql_reference_resolver,
 )
 from sqlbuild.cli.commands.main.shared.helpers.plan_format import format_plan
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
@@ -101,7 +101,7 @@ def run_build(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
-        external_reference_resolver=resolve_external_reference_resolver(
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
             project_dir=effective_project_dir,
             discovered_inputs=discovered_inputs,
         ),

--- a/src/sqlbuild/cli/commands/main/build.py
+++ b/src/sqlbuild/cli/commands/main/build.py
@@ -13,6 +13,9 @@ from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project
 from sqlbuild.cli.commands.main.shared.helpers.connection_progress import (
     ConnectionProgressReporter,
 )
+from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
+    resolve_external_reference_resolver,
+)
 from sqlbuild.cli.commands.main.shared.helpers.plan_format import format_plan
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.progress import (
@@ -98,6 +101,9 @@ def run_build(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
+        external_reference_resolver=resolve_external_reference_resolver(
+            discovered_inputs=discovered_inputs
+        ),
     )
 
     plan_output: PlanOutput = pipeline_result.plan_output

--- a/src/sqlbuild/cli/commands/main/clone.py
+++ b/src/sqlbuild/cli/commands/main/clone.py
@@ -17,7 +17,7 @@ from sqlbuild.cli.commands.main.shared.helpers.connection import (
     resolve_environment_connection_config,
 )
 from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
-    resolve_external_reference_resolver,
+    resolve_external_sql_reference_resolver,
 )
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
@@ -79,7 +79,7 @@ def run_clone(
             select=select,
             exclude=exclude,
             target_connection=target_connection,
-            external_reference_resolver=resolve_external_reference_resolver(
+            external_sql_reference_resolver=resolve_external_sql_reference_resolver(
                 project_dir=effective_project_dir,
                 discovered_inputs=discovered_inputs,
             ),

--- a/src/sqlbuild/cli/commands/main/clone.py
+++ b/src/sqlbuild/cli/commands/main/clone.py
@@ -80,7 +80,8 @@ def run_clone(
             exclude=exclude,
             target_connection=target_connection,
             external_reference_resolver=resolve_external_reference_resolver(
-                discovered_inputs=discovered_inputs
+                project_dir=effective_project_dir,
+                discovered_inputs=discovered_inputs,
             ),
         )
         target_model_entries: tuple[ModelPlanEntry, ...] = clone_pipeline.target_model_entries

--- a/src/sqlbuild/cli/commands/main/clone.py
+++ b/src/sqlbuild/cli/commands/main/clone.py
@@ -16,6 +16,9 @@ from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import (
     resolve_environment_connection_config,
 )
+from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
+    resolve_external_reference_resolver,
+)
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.clone import run_clone_pipeline
@@ -76,6 +79,9 @@ def run_clone(
             select=select,
             exclude=exclude,
             target_connection=target_connection,
+            external_reference_resolver=resolve_external_reference_resolver(
+                discovered_inputs=discovered_inputs
+            ),
         )
         target_model_entries: tuple[ModelPlanEntry, ...] = clone_pipeline.target_model_entries
         target_seed_entries: tuple[SeedPlanEntry, ...] = clone_pipeline.target_seed_entries

--- a/src/sqlbuild/cli/commands/main/diff.py
+++ b/src/sqlbuild/cli/commands/main/diff.py
@@ -15,6 +15,9 @@ from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import (
     resolve_environment_connection_config,
 )
+from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
+    resolve_external_reference_resolver,
+)
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.diff import run_diff_pipeline
@@ -82,6 +85,9 @@ def run_diff(
         no_sql_validation=no_sql_validation,
         select=select,
         exclude=exclude,
+        external_reference_resolver=resolve_external_reference_resolver(
+            discovered_inputs=discovered_inputs
+        ),
     )
     if not selected_names:
         raise CliUserError("no diffable models found in the selected scope", code="C207")

--- a/src/sqlbuild/cli/commands/main/diff.py
+++ b/src/sqlbuild/cli/commands/main/diff.py
@@ -86,7 +86,8 @@ def run_diff(
         select=select,
         exclude=exclude,
         external_reference_resolver=resolve_external_reference_resolver(
-            discovered_inputs=discovered_inputs
+            project_dir=effective_project_dir,
+            discovered_inputs=discovered_inputs,
         ),
     )
     if not selected_names:

--- a/src/sqlbuild/cli/commands/main/diff.py
+++ b/src/sqlbuild/cli/commands/main/diff.py
@@ -16,7 +16,7 @@ from sqlbuild.cli.commands.main.shared.helpers.connection import (
     resolve_environment_connection_config,
 )
 from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
-    resolve_external_reference_resolver,
+    resolve_external_sql_reference_resolver,
 )
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
@@ -85,7 +85,7 @@ def run_diff(
         no_sql_validation=no_sql_validation,
         select=select,
         exclude=exclude,
-        external_reference_resolver=resolve_external_reference_resolver(
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
             project_dir=effective_project_dir,
             discovered_inputs=discovered_inputs,
         ),

--- a/src/sqlbuild/cli/commands/main/helpers/scenario/capture.py
+++ b/src/sqlbuild/cli/commands/main/helpers/scenario/capture.py
@@ -128,7 +128,8 @@ def run_scenario_capture(
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
         external_reference_resolver=resolve_external_reference_resolver(
-            discovered_inputs=discovered_inputs
+            project_dir=effective_project_dir,
+            discovered_inputs=discovered_inputs,
         ),
     )
     scenarios: tuple[CompiledSqlScenario, ...] = select_scenarios(

--- a/src/sqlbuild/cli/commands/main/helpers/scenario/capture.py
+++ b/src/sqlbuild/cli/commands/main/helpers/scenario/capture.py
@@ -20,7 +20,7 @@ from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
 from sqlbuild.cli.commands.main.shared.helpers.connection_progress import ConnectionProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
-    resolve_external_reference_resolver,
+    resolve_external_sql_reference_resolver,
 )
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.progress import format_build_header
@@ -127,7 +127,7 @@ def run_scenario_capture(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
-        external_reference_resolver=resolve_external_reference_resolver(
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
             project_dir=effective_project_dir,
             discovered_inputs=discovered_inputs,
         ),

--- a/src/sqlbuild/cli/commands/main/helpers/scenario/capture.py
+++ b/src/sqlbuild/cli/commands/main/helpers/scenario/capture.py
@@ -19,6 +19,9 @@ from sqlbuild.cli.commands.main.shared.exceptions import CliUserError
 from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
 from sqlbuild.cli.commands.main.shared.helpers.connection_progress import ConnectionProgressReporter
+from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
+    resolve_external_reference_resolver,
+)
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.progress import format_build_header
 from sqlbuild.cli.commands.main.shared.helpers.status import TransientStatusReporter
@@ -124,6 +127,9 @@ def run_scenario_capture(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
+        external_reference_resolver=resolve_external_reference_resolver(
+            discovered_inputs=discovered_inputs
+        ),
     )
     scenarios: tuple[CompiledSqlScenario, ...] = select_scenarios(
         project=pipeline_result.project,

--- a/src/sqlbuild/cli/commands/main/helpers/scenario/runner.py
+++ b/src/sqlbuild/cli/commands/main/helpers/scenario/runner.py
@@ -19,6 +19,9 @@ from sqlbuild.cli.commands.main.shared.exceptions import CliUserError
 from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
 from sqlbuild.cli.commands.main.shared.helpers.connection_progress import ConnectionProgressReporter
+from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
+    resolve_external_reference_resolver,
+)
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.progress import format_build_header
 from sqlbuild.cli.commands.main.shared.helpers.scenario_runtime_target_writer import (
@@ -164,6 +167,9 @@ def run_scenario(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
+        external_reference_resolver=resolve_external_reference_resolver(
+            discovered_inputs=discovered_inputs
+        ),
     )
     scenarios: tuple[CompiledSqlScenario, ...] = select_scenarios(
         project=pipeline_result.project,
@@ -358,6 +364,9 @@ def _sync_local_snapshots(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
+        external_reference_resolver=resolve_external_reference_resolver(
+            discovered_inputs=discovered_inputs
+        ),
     )
     capture_scenarios: tuple[CompiledSqlScenario, ...] = select_scenarios(
         project=project_pipeline_result.project,

--- a/src/sqlbuild/cli/commands/main/helpers/scenario/runner.py
+++ b/src/sqlbuild/cli/commands/main/helpers/scenario/runner.py
@@ -168,7 +168,8 @@ def run_scenario(
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
         external_reference_resolver=resolve_external_reference_resolver(
-            discovered_inputs=discovered_inputs
+            project_dir=effective_project_dir,
+            discovered_inputs=discovered_inputs,
         ),
     )
     scenarios: tuple[CompiledSqlScenario, ...] = select_scenarios(
@@ -365,7 +366,8 @@ def _sync_local_snapshots(
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
         external_reference_resolver=resolve_external_reference_resolver(
-            discovered_inputs=discovered_inputs
+            project_dir=project_dir,
+            discovered_inputs=discovered_inputs,
         ),
     )
     capture_scenarios: tuple[CompiledSqlScenario, ...] = select_scenarios(

--- a/src/sqlbuild/cli/commands/main/helpers/scenario/runner.py
+++ b/src/sqlbuild/cli/commands/main/helpers/scenario/runner.py
@@ -20,7 +20,7 @@ from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
 from sqlbuild.cli.commands.main.shared.helpers.connection_progress import ConnectionProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
-    resolve_external_reference_resolver,
+    resolve_external_sql_reference_resolver,
 )
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.progress import format_build_header
@@ -167,7 +167,7 @@ def run_scenario(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
-        external_reference_resolver=resolve_external_reference_resolver(
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
             project_dir=effective_project_dir,
             discovered_inputs=discovered_inputs,
         ),
@@ -365,7 +365,7 @@ def _sync_local_snapshots(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
-        external_reference_resolver=resolve_external_reference_resolver(
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
             project_dir=project_dir,
             discovered_inputs=discovered_inputs,
         ),

--- a/src/sqlbuild/cli/commands/main/plan.py
+++ b/src/sqlbuild/cli/commands/main/plan.py
@@ -13,6 +13,9 @@ from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project
 from sqlbuild.cli.commands.main.shared.helpers.connection_progress import (
     ConnectionProgressReporter,
 )
+from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
+    resolve_external_reference_resolver,
+)
 from sqlbuild.cli.commands.main.shared.helpers.json_output import format_plan_json
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
@@ -82,6 +85,9 @@ def run_plan(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
+        external_reference_resolver=resolve_external_reference_resolver(
+            discovered_inputs=discovered_inputs
+        ),
     )
 
     plan_output: PlanOutput = pipeline_result.plan_output

--- a/src/sqlbuild/cli/commands/main/plan.py
+++ b/src/sqlbuild/cli/commands/main/plan.py
@@ -86,7 +86,8 @@ def run_plan(
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
         external_reference_resolver=resolve_external_reference_resolver(
-            discovered_inputs=discovered_inputs
+            project_dir=effective_project_dir,
+            discovered_inputs=discovered_inputs,
         ),
     )
 

--- a/src/sqlbuild/cli/commands/main/plan.py
+++ b/src/sqlbuild/cli/commands/main/plan.py
@@ -14,7 +14,7 @@ from sqlbuild.cli.commands.main.shared.helpers.connection_progress import (
     ConnectionProgressReporter,
 )
 from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
-    resolve_external_reference_resolver,
+    resolve_external_sql_reference_resolver,
 )
 from sqlbuild.cli.commands.main.shared.helpers.json_output import format_plan_json
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
@@ -85,7 +85,7 @@ def run_plan(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
-        external_reference_resolver=resolve_external_reference_resolver(
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
             project_dir=effective_project_dir,
             discovered_inputs=discovered_inputs,
         ),

--- a/src/sqlbuild/cli/commands/main/run.py
+++ b/src/sqlbuild/cli/commands/main/run.py
@@ -102,7 +102,8 @@ def run_run(
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
         external_reference_resolver=resolve_external_reference_resolver(
-            discovered_inputs=discovered_inputs
+            project_dir=effective_project_dir,
+            discovered_inputs=discovered_inputs,
         ),
     )
 

--- a/src/sqlbuild/cli/commands/main/run.py
+++ b/src/sqlbuild/cli/commands/main/run.py
@@ -13,6 +13,9 @@ from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project
 from sqlbuild.cli.commands.main.shared.helpers.connection_progress import (
     ConnectionProgressReporter,
 )
+from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
+    resolve_external_reference_resolver,
+)
 from sqlbuild.cli.commands.main.shared.helpers.plan_format import format_plan
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.progress import (
@@ -98,6 +101,9 @@ def run_run(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
+        external_reference_resolver=resolve_external_reference_resolver(
+            discovered_inputs=discovered_inputs
+        ),
     )
 
     plan_output: PlanOutput = pipeline_result.plan_output

--- a/src/sqlbuild/cli/commands/main/run.py
+++ b/src/sqlbuild/cli/commands/main/run.py
@@ -14,7 +14,7 @@ from sqlbuild.cli.commands.main.shared.helpers.connection_progress import (
     ConnectionProgressReporter,
 )
 from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
-    resolve_external_reference_resolver,
+    resolve_external_sql_reference_resolver,
 )
 from sqlbuild.cli.commands.main.shared.helpers.plan_format import format_plan
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
@@ -101,7 +101,7 @@ def run_run(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
-        external_reference_resolver=resolve_external_reference_resolver(
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
             project_dir=effective_project_dir,
             discovered_inputs=discovered_inputs,
         ),

--- a/src/sqlbuild/cli/commands/main/seed.py
+++ b/src/sqlbuild/cli/commands/main/seed.py
@@ -10,6 +10,9 @@ from pathlib import Path
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
+from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
+    resolve_external_reference_resolver,
+)
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compile import run_compile_pipeline
@@ -50,6 +53,9 @@ def run_seed(
         select=select,
         exclude=exclude,
         connection_config=connection_config,
+        external_reference_resolver=resolve_external_reference_resolver(
+            discovered_inputs=discovered_inputs
+        ),
     )
 
     use_color: bool = not no_color and supports_color()

--- a/src/sqlbuild/cli/commands/main/seed.py
+++ b/src/sqlbuild/cli/commands/main/seed.py
@@ -54,7 +54,8 @@ def run_seed(
         exclude=exclude,
         connection_config=connection_config,
         external_reference_resolver=resolve_external_reference_resolver(
-            discovered_inputs=discovered_inputs
+            project_dir=effective_project_dir,
+            discovered_inputs=discovered_inputs,
         ),
     )
 

--- a/src/sqlbuild/cli/commands/main/seed.py
+++ b/src/sqlbuild/cli/commands/main/seed.py
@@ -11,7 +11,7 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
 from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
-    resolve_external_reference_resolver,
+    resolve_external_sql_reference_resolver,
 )
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
@@ -53,7 +53,7 @@ def run_seed(
         select=select,
         exclude=exclude,
         connection_config=connection_config,
-        external_reference_resolver=resolve_external_reference_resolver(
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
             project_dir=effective_project_dir,
             discovered_inputs=discovered_inputs,
         ),

--- a/src/sqlbuild/cli/commands/main/shared/helpers/external_refs.py
+++ b/src/sqlbuild/cli/commands/main/shared/helpers/external_refs.py
@@ -1,0 +1,23 @@
+"""CLI helpers for optional external SQL reference integrations."""
+
+from __future__ import annotations
+
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.integrations.dbt.main.build_compile_reference_resolver import (
+    build_compile_reference_resolver,
+)
+from sqlbuild.shared.types import ExternalReferenceResolver
+
+
+def resolve_external_reference_resolver(
+    *, discovered_inputs: DiscoveredProjectInputs
+) -> ExternalReferenceResolver | None:
+    """Build the external reference resolver configured for a discovered project."""
+
+    return build_compile_reference_resolver(
+        manifest_contents=(
+            None
+            if discovered_inputs.dbt_manifest_file is None
+            else discovered_inputs.dbt_manifest_file.contents
+        )
+    )

--- a/src/sqlbuild/cli/commands/main/shared/helpers/external_refs.py
+++ b/src/sqlbuild/cli/commands/main/shared/helpers/external_refs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.integrations.dbt.main.build_compile_reference_resolver import (
     build_compile_reference_resolver,
@@ -10,14 +12,27 @@ from sqlbuild.shared.types import ExternalReferenceResolver
 
 
 def resolve_external_reference_resolver(
-    *, discovered_inputs: DiscoveredProjectInputs
+    *, project_dir: Path, discovered_inputs: DiscoveredProjectInputs
 ) -> ExternalReferenceResolver | None:
     """Build the external reference resolver configured for a discovered project."""
 
-    return build_compile_reference_resolver(
-        manifest_contents=(
-            None
-            if discovered_inputs.dbt_manifest_file is None
-            else discovered_inputs.dbt_manifest_file.contents
-        )
+    manifest_contents: str | None = _read_dbt_manifest_contents(
+        project_dir=project_dir,
+        target_path=discovered_inputs.project_config.dbt.target_path,
     )
+    return build_compile_reference_resolver(
+        manifest_contents=manifest_contents,
+    )
+
+
+def _read_dbt_manifest_contents(*, project_dir: Path, target_path: str | None) -> str | None:
+    if target_path is None:
+        return None
+    raw_target_path: Path = Path(target_path)
+    resolved_target_path: Path = (
+        raw_target_path if raw_target_path.is_absolute() else project_dir / raw_target_path
+    )
+    manifest_path: Path = resolved_target_path / "manifest.json"
+    if not manifest_path.is_file():
+        return None
+    return manifest_path.read_text(encoding="utf-8")

--- a/src/sqlbuild/cli/commands/main/shared/helpers/external_refs.py
+++ b/src/sqlbuild/cli/commands/main/shared/helpers/external_refs.py
@@ -8,12 +8,12 @@ from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.integrations.dbt.main.build_compile_reference_resolver import (
     build_compile_reference_resolver,
 )
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 
-def resolve_external_reference_resolver(
+def resolve_external_sql_reference_resolver(
     *, project_dir: Path, discovered_inputs: DiscoveredProjectInputs
-) -> ExternalReferenceResolver | None:
+) -> ExternalSqlReferenceResolver | None:
     """Build the external reference resolver configured for a discovered project."""
 
     manifest_contents: str | None = _read_dbt_manifest_contents(

--- a/src/sqlbuild/cli/commands/main/test.py
+++ b/src/sqlbuild/cli/commands/main/test.py
@@ -92,7 +92,8 @@ def run_test(
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
         external_reference_resolver=resolve_external_reference_resolver(
-            discovered_inputs=discovered_inputs
+            project_dir=effective_project_dir,
+            discovered_inputs=discovered_inputs,
         ),
     )
 

--- a/src/sqlbuild/cli/commands/main/test.py
+++ b/src/sqlbuild/cli/commands/main/test.py
@@ -16,7 +16,7 @@ from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
 from sqlbuild.cli.commands.main.shared.helpers.connection_progress import ConnectionProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
-    resolve_external_reference_resolver,
+    resolve_external_sql_reference_resolver,
 )
 from sqlbuild.cli.commands.main.shared.helpers.nested_progress import NestedCommandProgressCallbacks
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
@@ -91,7 +91,7 @@ def run_test(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
-        external_reference_resolver=resolve_external_reference_resolver(
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
             project_dir=effective_project_dir,
             discovered_inputs=discovered_inputs,
         ),

--- a/src/sqlbuild/cli/commands/main/test.py
+++ b/src/sqlbuild/cli/commands/main/test.py
@@ -15,6 +15,9 @@ from sqlbuild.cli.commands.main.helpers.sql_test_progress import (
 from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_project_connection_config
 from sqlbuild.cli.commands.main.shared.helpers.connection_progress import ConnectionProgressReporter
+from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
+    resolve_external_reference_resolver,
+)
 from sqlbuild.cli.commands.main.shared.helpers.nested_progress import NestedCommandProgressCallbacks
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.progress import format_build_header
@@ -88,6 +91,9 @@ def run_test(
         on_connection_complete=connection_progress.on_connection_complete,
         on_connection_error=connection_progress.on_connection_error,
         on_progress=planning_progress.on_progress,
+        external_reference_resolver=resolve_external_reference_resolver(
+            discovered_inputs=discovered_inputs
+        ),
     )
 
     test_count: int = len(pipeline_result.plan_output.test_entries)

--- a/src/sqlbuild/compiler/compile/helpers/assembly.py
+++ b/src/sqlbuild/compiler/compile/helpers/assembly.py
@@ -109,7 +109,7 @@ def assemble_compiled_project(
             for scenario_input in inputs.scenario_inputs
         ),
         diagnostics=inputs.diagnostics,
-        external_reference_resolver=inputs.external_reference_resolver,
+        external_sql_reference_resolver=inputs.external_sql_reference_resolver,
     )
 
 

--- a/src/sqlbuild/compiler/compile/helpers/assembly.py
+++ b/src/sqlbuild/compiler/compile/helpers/assembly.py
@@ -109,7 +109,7 @@ def assemble_compiled_project(
             for scenario_input in inputs.scenario_inputs
         ),
         diagnostics=inputs.diagnostics,
-        dbt_manifest=inputs.dbt_manifest,
+        external_reference_resolver=inputs.external_reference_resolver,
     )
 
 

--- a/src/sqlbuild/compiler/compile/helpers/attachment.py
+++ b/src/sqlbuild/compiler/compile/helpers/attachment.py
@@ -84,17 +84,8 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlTestFile,
 )
 from sqlbuild.compiler.shared.helpers.schema_audits import parse_audit_instance
-from sqlbuild.integrations.dbt.main.build_compile_manifest_index import (
-    build_compile_manifest_index,
-)
-from sqlbuild.integrations.dbt.main.validate_compile_model_names import (
-    validate_compile_model_names,
-)
-from sqlbuild.integrations.dbt.main.validate_compile_model_reference import (
-    validate_compile_model_reference,
-)
-from sqlbuild.integrations.dbt.manifest.models import DbtManifestIndex
 from sqlbuild.shared.helpers.sqlglot import import_sqlglot
+from sqlbuild.shared.types import ExternalReferenceResolver
 from sqlbuild.spec.models.project import (
     ClonePolicy,
     DefaultsConfig,
@@ -125,7 +116,7 @@ def build_model_inputs(
     run_id: str,
     macro_context: MacroContext,
     no_sql_validation: bool = False,
-    dbt_manifest: DbtManifestIndex | None = None,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> tuple[CompileModelInput, ...]:
     """Attach schema metadata to discovered model files."""
 
@@ -135,18 +126,8 @@ def build_model_inputs(
     known_source_names: set[str] = build_known_source_names(discovered_inputs)
     known_function_names: set[str] = build_known_function_names(discovered_inputs)
     known_table_function_names: set[str] = build_known_table_function_names(discovered_inputs)
-    if dbt_manifest is None:
-        dbt_manifest = build_compile_manifest_index(
-            manifest_contents=(
-                None
-                if discovered_inputs.dbt_manifest_file is None
-                else discovered_inputs.dbt_manifest_file.contents
-            )
-        )
-    validate_compile_model_names(
-        known_model_names=known_model_names,
-        dbt_manifest=dbt_manifest,
-    )
+    if external_reference_resolver is not None:
+        external_reference_resolver.validate_model_names(known_model_names=known_model_names)
     custom_materialization_names: frozenset[str] = frozenset(
         mf.name for mf in discovered_inputs.materialization_files
     )
@@ -209,7 +190,7 @@ def build_model_inputs(
             known_source_names=known_source_names,
             known_function_names=known_function_names,
             known_table_function_names=known_table_function_names,
-            dbt_manifest=dbt_manifest,
+            external_reference_resolver=external_reference_resolver,
         )
         validate_incremental_config(
             config=effective_config,
@@ -1704,7 +1685,7 @@ def validate_model_references(
     known_source_names: set[str],
     known_function_names: set[str],
     known_table_function_names: set[str],
-    dbt_manifest: DbtManifestIndex | None,
+    external_reference_resolver: ExternalReferenceResolver | None,
 ) -> None:
     """Validate extracted model refs against discovered project inputs."""
 
@@ -1747,10 +1728,21 @@ def validate_model_references(
                 f"'{reference.ref_name}'"
             )
         if reference.ref_kind == SqlReferenceKind.DBT_REF:
-            validate_compile_model_reference(
-                reference=reference,
-                model_relative_path=model_file.relative_path,
-                dbt_manifest=dbt_manifest,
+            if external_reference_resolver is None:
+                raise CompileInputError(
+                    f"Model file {model_file.relative_path} uses "
+                    f"__dbt_ref('{reference.ref_name}') but no dbt manifest was found",
+                    code="C214",
+                    help=(
+                        "Run dbt compile or configure dbt target_path so SQLBuild can read "
+                        "manifest.json."
+                    ),
+                )
+            external_reference_resolver.validate_reference(
+                ref_kind=reference.ref_kind,
+                ref_name=reference.ref_name,
+                ref_package=reference.ref_package,
+                owner_relative_path=model_file.relative_path,
             )
         if (
             reference.ref_kind == SqlReferenceKind.UDF

--- a/src/sqlbuild/compiler/compile/helpers/attachment.py
+++ b/src/sqlbuild/compiler/compile/helpers/attachment.py
@@ -450,7 +450,6 @@ def build_sql_function_inputs(
             known_source_names=known_source_names,
             known_function_names=known_function_names,
             known_table_function_names=known_table_function_names,
-            has_dbt_manifest=discovered_inputs.dbt_manifest_file is not None,
         )
         function_inputs.append(
             CompileSqlFunctionInput(
@@ -1778,7 +1777,6 @@ def validate_function_references(
     known_source_names: set[str],
     known_function_names: set[str],
     known_table_function_names: set[str],
-    has_dbt_manifest: bool,
 ) -> None:
     """Validate extracted SQL function refs against discovered project inputs."""
 

--- a/src/sqlbuild/compiler/compile/helpers/attachment.py
+++ b/src/sqlbuild/compiler/compile/helpers/attachment.py
@@ -85,7 +85,7 @@ from sqlbuild.compiler.discovery.models import (
 )
 from sqlbuild.compiler.shared.helpers.schema_audits import parse_audit_instance
 from sqlbuild.shared.helpers.sqlglot import import_sqlglot
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.models.project import (
     ClonePolicy,
     DefaultsConfig,
@@ -116,7 +116,7 @@ def build_model_inputs(
     run_id: str,
     macro_context: MacroContext,
     no_sql_validation: bool = False,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> tuple[CompileModelInput, ...]:
     """Attach schema metadata to discovered model files."""
 
@@ -126,8 +126,8 @@ def build_model_inputs(
     known_source_names: set[str] = build_known_source_names(discovered_inputs)
     known_function_names: set[str] = build_known_function_names(discovered_inputs)
     known_table_function_names: set[str] = build_known_table_function_names(discovered_inputs)
-    if external_reference_resolver is not None:
-        external_reference_resolver.validate_model_names(known_model_names=known_model_names)
+    if external_sql_reference_resolver is not None:
+        external_sql_reference_resolver.validate_model_names(known_model_names=known_model_names)
     custom_materialization_names: frozenset[str] = frozenset(
         mf.name for mf in discovered_inputs.materialization_files
     )
@@ -190,7 +190,7 @@ def build_model_inputs(
             known_source_names=known_source_names,
             known_function_names=known_function_names,
             known_table_function_names=known_table_function_names,
-            external_reference_resolver=external_reference_resolver,
+            external_sql_reference_resolver=external_sql_reference_resolver,
         )
         validate_incremental_config(
             config=effective_config,
@@ -1684,7 +1684,7 @@ def validate_model_references(
     known_source_names: set[str],
     known_function_names: set[str],
     known_table_function_names: set[str],
-    external_reference_resolver: ExternalReferenceResolver | None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None,
 ) -> None:
     """Validate extracted model refs against discovered project inputs."""
 
@@ -1727,7 +1727,7 @@ def validate_model_references(
                 f"'{reference.ref_name}'"
             )
         if reference.ref_kind == SqlReferenceKind.DBT_REF:
-            if external_reference_resolver is None:
+            if external_sql_reference_resolver is None:
                 raise CompileInputError(
                     f"Model file {model_file.relative_path} uses "
                     f"__dbt_ref('{reference.ref_name}') but no dbt manifest was found",
@@ -1737,11 +1737,11 @@ def validate_model_references(
                         "manifest.json."
                     ),
                 )
-            external_reference_resolver.validate_reference(
+            external_sql_reference_resolver.validate_reference(
                 ref_kind=reference.ref_kind,
                 ref_name=reference.ref_name,
                 ref_package=reference.ref_package,
-                owner_relative_path=model_file.relative_path,
+                owner_relative_sql_path=model_file.relative_path,
             )
         if (
             reference.ref_kind == SqlReferenceKind.UDF

--- a/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
+++ b/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
@@ -38,8 +38,10 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredAuditFile,
     DiscoveredProjectInputs,
 )
-from sqlbuild.integrations.dbt.main.build_compile_manifest_index import build_compile_manifest_index
-from sqlbuild.integrations.dbt.manifest.models import DbtManifestIndex
+from sqlbuild.integrations.dbt.main.build_compile_reference_resolver import (
+    build_compile_reference_resolver,
+)
+from sqlbuild.shared.types import ExternalReferenceResolver
 from sqlbuild.spec.models.project import (
     EnvironmentConfig,
     SettingsConfig,
@@ -92,11 +94,13 @@ def build_compile_inputs(
     )
     resolved_run_id: str = resolve_run_id(selected_run_id=run_id)
     loaded_macros: dict[str, LoadedMacro] = load_project_macros(discovered_inputs.macro_files)
-    dbt_manifest: DbtManifestIndex | None = build_compile_manifest_index(
-        manifest_contents=(
-            None
-            if discovered_inputs.dbt_manifest_file is None
-            else discovered_inputs.dbt_manifest_file.contents
+    external_reference_resolver: ExternalReferenceResolver | None = (
+        build_compile_reference_resolver(
+            manifest_contents=(
+                None
+                if discovered_inputs.dbt_manifest_file is None
+                else discovered_inputs.dbt_manifest_file.contents
+            )
         )
     )
 
@@ -109,7 +113,7 @@ def build_compile_inputs(
         run_id=resolved_run_id,
         macro_context=macro_context,
         no_sql_validation=no_sql_validation,
-        dbt_manifest=dbt_manifest,
+        external_reference_resolver=external_reference_resolver,
     )
     seed_inputs: tuple[CompileSeedInput, ...] = build_seed_inputs(discovered_inputs)
     sql_function_inputs: tuple[CompileSqlFunctionInput, ...] = build_sql_function_inputs(
@@ -180,5 +184,5 @@ def build_compile_inputs(
         scenario_inputs=scenario_inputs,
         audit_inputs=audit_inputs,
         diagnostics=diagnostics,
-        dbt_manifest=dbt_manifest,
+        external_reference_resolver=external_reference_resolver,
     )

--- a/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
+++ b/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
@@ -38,9 +38,6 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredAuditFile,
     DiscoveredProjectInputs,
 )
-from sqlbuild.integrations.dbt.main.build_compile_reference_resolver import (
-    build_compile_reference_resolver,
-)
 from sqlbuild.shared.types import ExternalReferenceResolver
 from sqlbuild.spec.models.project import (
     EnvironmentConfig,
@@ -57,6 +54,7 @@ def build_compile_inputs(
     run_id: str | None = None,
     no_sql_validation: bool = False,
     python_functions_inherit_default_namespace: bool = True,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> CompileProjectInputs:
     """Attach discovered metadata into the first compile input snapshot."""
 
@@ -94,16 +92,6 @@ def build_compile_inputs(
     )
     resolved_run_id: str = resolve_run_id(selected_run_id=run_id)
     loaded_macros: dict[str, LoadedMacro] = load_project_macros(discovered_inputs.macro_files)
-    external_reference_resolver: ExternalReferenceResolver | None = (
-        build_compile_reference_resolver(
-            manifest_contents=(
-                None
-                if discovered_inputs.dbt_manifest_file is None
-                else discovered_inputs.dbt_manifest_file.contents
-            )
-        )
-    )
-
     model_inputs: tuple[CompileModelInput, ...] = build_model_inputs(
         discovered_inputs,
         effective_vars=effective_vars,

--- a/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
+++ b/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
@@ -38,7 +38,7 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredAuditFile,
     DiscoveredProjectInputs,
 )
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.models.project import (
     EnvironmentConfig,
     SettingsConfig,
@@ -54,7 +54,7 @@ def build_compile_inputs(
     run_id: str | None = None,
     no_sql_validation: bool = False,
     python_functions_inherit_default_namespace: bool = True,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> CompileProjectInputs:
     """Attach discovered metadata into the first compile input snapshot."""
 
@@ -101,7 +101,7 @@ def build_compile_inputs(
         run_id=resolved_run_id,
         macro_context=macro_context,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )
     seed_inputs: tuple[CompileSeedInput, ...] = build_seed_inputs(discovered_inputs)
     sql_function_inputs: tuple[CompileSqlFunctionInput, ...] = build_sql_function_inputs(
@@ -172,5 +172,5 @@ def build_compile_inputs(
         scenario_inputs=scenario_inputs,
         audit_inputs=audit_inputs,
         diagnostics=diagnostics,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -28,7 +28,7 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlTestFile,
 )
 from sqlbuild.compiler.lineage.types import InferredNullability
-from sqlbuild.integrations.dbt.manifest.models import DbtManifestIndex
+from sqlbuild.shared.types import ExternalReferenceResolver
 from sqlbuild.spec.models.project import (
     EnvironmentConfig,
     LocalConfig,
@@ -297,7 +297,7 @@ class CompileProjectInputs:
     scenario_inputs: tuple[CompileSqlScenarioInput, ...] = field(default_factory=tuple)
     audit_inputs: tuple[CompileAuditInput, ...] = field(default_factory=tuple)
     diagnostics: tuple[CompilerDiagnostic, ...] = field(default_factory=tuple)
-    dbt_manifest: DbtManifestIndex | None = None
+    external_reference_resolver: ExternalReferenceResolver | None = None
 
 
 @dataclass(frozen=True)
@@ -454,4 +454,4 @@ class CompiledProject:
     sql_tests: tuple[CompiledSqlTest, ...] = field(default_factory=tuple)
     sql_scenarios: tuple[CompiledSqlScenario, ...] = field(default_factory=tuple)
     diagnostics: tuple[CompilerDiagnostic, ...] = field(default_factory=tuple)
-    dbt_manifest: DbtManifestIndex | None = None
+    external_reference_resolver: ExternalReferenceResolver | None = None

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -28,7 +28,7 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlTestFile,
 )
 from sqlbuild.compiler.lineage.types import InferredNullability
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.models.project import (
     EnvironmentConfig,
     LocalConfig,
@@ -297,7 +297,7 @@ class CompileProjectInputs:
     scenario_inputs: tuple[CompileSqlScenarioInput, ...] = field(default_factory=tuple)
     audit_inputs: tuple[CompileAuditInput, ...] = field(default_factory=tuple)
     diagnostics: tuple[CompilerDiagnostic, ...] = field(default_factory=tuple)
-    external_reference_resolver: ExternalReferenceResolver | None = None
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None
 
 
 @dataclass(frozen=True)
@@ -454,4 +454,4 @@ class CompiledProject:
     sql_tests: tuple[CompiledSqlTest, ...] = field(default_factory=tuple)
     sql_scenarios: tuple[CompiledSqlScenario, ...] = field(default_factory=tuple)
     diagnostics: tuple[CompilerDiagnostic, ...] = field(default_factory=tuple)
-    external_reference_resolver: ExternalReferenceResolver | None = None
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None

--- a/src/sqlbuild/compiler/discovery/helpers/filesystem.py
+++ b/src/sqlbuild/compiler/discovery/helpers/filesystem.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 from sqlbuild.compiler.discovery.exceptions import SchemaParseError
@@ -21,7 +20,6 @@ from sqlbuild.compiler.discovery.helpers.yml_sources import parse_sources_yml
 from sqlbuild.compiler.discovery.models import (
     DiscoveredAdapterFile,
     DiscoveredAuditFile,
-    DiscoveredDbtManifestFile,
     DiscoveredMacroFile,
     DiscoveredMaterializationFile,
     DiscoveredPythonFunctionFile,
@@ -316,30 +314,6 @@ def discover_materialization_files(
         for file_path in sorted(materializations_root.rglob("*.py"))
         if file_path.stem != "__init__"
     )
-
-
-def discover_dbt_manifest_file(
-    *, project_dir: Path, target_path: str | None = None
-) -> DiscoveredDbtManifestFile | None:
-    """Discover an optional dbt manifest.json in common locations."""
-
-    candidate_paths: list[Path] = []
-    if target_path is not None:
-        raw_target_path: Path = Path(target_path)
-        resolved_target_path: Path = (
-            raw_target_path if raw_target_path.is_absolute() else project_dir / raw_target_path
-        )
-        candidate_paths.append(resolved_target_path / "manifest.json")
-
-    for file_path in candidate_paths:
-        if file_path.is_file():
-            relative_path: Path = Path(os.path.relpath(file_path, project_dir))
-            return DiscoveredDbtManifestFile(
-                file_path=file_path,
-                relative_path=relative_path,
-                contents=file_path.read_text(encoding="utf-8"),
-            )
-    return None
 
 
 def discover_adapter_file(*, project_dir: Path) -> DiscoveredAdapterFile | None:

--- a/src/sqlbuild/compiler/discovery/main/discover.py
+++ b/src/sqlbuild/compiler/discovery/main/discover.py
@@ -8,7 +8,6 @@ from sqlbuild.compiler.discovery.helpers.discovery_validation import validate_di
 from sqlbuild.compiler.discovery.helpers.filesystem import (
     discover_adapter_file,
     discover_audit_files,
-    discover_dbt_manifest_file,
     discover_macro_files,
     discover_materialization_files,
     discover_model_files,
@@ -56,10 +55,6 @@ def discover_project_inputs(*, project_dir: Path) -> DiscoveredProjectInputs:
         audit_files=discover_audit_files(project_dir=project_dir),
         macro_files=discover_macro_files(project_dir=project_dir),
         materialization_files=discover_materialization_files(project_dir=project_dir),
-        dbt_manifest_file=discover_dbt_manifest_file(
-            project_dir=project_dir,
-            target_path=project_config.dbt.target_path,
-        ),
         adapter_file=discover_adapter_file(project_dir=project_dir),
     )
     validate_discovered_inputs(discovered_inputs)

--- a/src/sqlbuild/compiler/discovery/models.py
+++ b/src/sqlbuild/compiler/discovery/models.py
@@ -137,15 +137,6 @@ class DiscoveredMacroFile:
 
 
 @dataclass(frozen=True)
-class DiscoveredDbtManifestFile:
-    """A discovered dbt manifest file and its raw JSON contents."""
-
-    file_path: Path
-    relative_path: Path
-    contents: str
-
-
-@dataclass(frozen=True)
 class DiscoveredAdapterFile:
     """A detected project adapter Python file."""
 
@@ -179,5 +170,4 @@ class DiscoveredProjectInputs:
     audit_files: tuple[DiscoveredAuditFile, ...] = field(default_factory=tuple)
     macro_files: tuple[DiscoveredMacroFile, ...] = field(default_factory=tuple)
     materialization_files: tuple[DiscoveredMaterializationFile, ...] = field(default_factory=tuple)
-    dbt_manifest_file: DiscoveredDbtManifestFile | None = None
     adapter_file: DiscoveredAdapterFile | None = None

--- a/src/sqlbuild/compiler/pipeline/helpers/clone.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/clone.py
@@ -10,6 +10,7 @@ from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 from sqlbuild.compiler.pipeline.models import ClonePipelineResult
 from sqlbuild.compiler.planner.main.clone import run_clone_planning
+from sqlbuild.shared.types import ExternalReferenceResolver
 
 
 def prepare_clone_pipeline(
@@ -22,18 +23,21 @@ def prepare_clone_pipeline(
     select: tuple[str, ...],
     exclude: tuple[str, ...],
     target_connection: Any,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> ClonePipelineResult:
     source_project: CompiledProject = _compile_project_for_environment(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         environment_name=from_environment,
         no_sql_validation=no_sql_validation,
+        external_reference_resolver=external_reference_resolver,
     )
     target_project: CompiledProject = _compile_project_for_environment(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         environment_name=to_environment,
         no_sql_validation=no_sql_validation,
+        external_reference_resolver=external_reference_resolver,
     )
     (
         clone_plan,
@@ -66,10 +70,12 @@ def _compile_project_for_environment(
     adapter: BaseAdapter,
     environment_name: str,
     no_sql_validation: bool,
+    external_reference_resolver: ExternalReferenceResolver | None,
 ) -> CompiledProject:
     return build_compiled_project(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         selected_environment=environment_name,
         no_sql_validation=no_sql_validation,
+        external_reference_resolver=external_reference_resolver,
     )

--- a/src/sqlbuild/compiler/pipeline/helpers/clone.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/clone.py
@@ -10,7 +10,7 @@ from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 from sqlbuild.compiler.pipeline.models import ClonePipelineResult
 from sqlbuild.compiler.planner.main.clone import run_clone_planning
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 
 def prepare_clone_pipeline(
@@ -23,21 +23,21 @@ def prepare_clone_pipeline(
     select: tuple[str, ...],
     exclude: tuple[str, ...],
     target_connection: Any,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> ClonePipelineResult:
     source_project: CompiledProject = _compile_project_for_environment(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         environment_name=from_environment,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )
     target_project: CompiledProject = _compile_project_for_environment(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         environment_name=to_environment,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )
     (
         clone_plan,
@@ -70,12 +70,12 @@ def _compile_project_for_environment(
     adapter: BaseAdapter,
     environment_name: str,
     no_sql_validation: bool,
-    external_reference_resolver: ExternalReferenceResolver | None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None,
 ) -> CompiledProject:
     return build_compiled_project(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         selected_environment=environment_name,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )

--- a/src/sqlbuild/compiler/pipeline/helpers/diff.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/diff.py
@@ -11,6 +11,7 @@ from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
+from sqlbuild.shared.types import ExternalReferenceResolver
 
 
 def compile_project_for_diff_environment(
@@ -19,6 +20,7 @@ def compile_project_for_diff_environment(
     adapter: BaseAdapter,
     environment_name: str,
     no_sql_validation: bool,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> CompiledProject:
     """Compile a project for one diff environment."""
 
@@ -27,6 +29,7 @@ def compile_project_for_diff_environment(
         adapter=adapter,
         selected_environment=environment_name,
         no_sql_validation=no_sql_validation,
+        external_reference_resolver=external_reference_resolver,
     )
 
 

--- a/src/sqlbuild/compiler/pipeline/helpers/diff.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/diff.py
@@ -11,7 +11,7 @@ from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 
 def compile_project_for_diff_environment(
@@ -20,7 +20,7 @@ def compile_project_for_diff_environment(
     adapter: BaseAdapter,
     environment_name: str,
     no_sql_validation: bool,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> CompiledProject:
     """Compile a project for one diff environment."""
 
@@ -29,7 +29,7 @@ def compile_project_for_diff_environment(
         adapter=adapter,
         selected_environment=environment_name,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )
 
 

--- a/src/sqlbuild/compiler/pipeline/main/clone.py
+++ b/src/sqlbuild/compiler/pipeline/main/clone.py
@@ -8,6 +8,7 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.helpers.clone import prepare_clone_pipeline
 from sqlbuild.compiler.pipeline.models import ClonePipelineResult
+from sqlbuild.shared.types import ExternalReferenceResolver
 
 
 def run_clone_pipeline(
@@ -20,6 +21,7 @@ def run_clone_pipeline(
     select: tuple[str, ...] = (),
     exclude: tuple[str, ...] = (),
     target_connection: Any,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> ClonePipelineResult:
     return prepare_clone_pipeline(
         discovered_inputs=discovered_inputs,
@@ -30,4 +32,5 @@ def run_clone_pipeline(
         select=select,
         exclude=exclude,
         target_connection=target_connection,
+        external_reference_resolver=external_reference_resolver,
     )

--- a/src/sqlbuild/compiler/pipeline/main/clone.py
+++ b/src/sqlbuild/compiler/pipeline/main/clone.py
@@ -8,7 +8,7 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.helpers.clone import prepare_clone_pipeline
 from sqlbuild.compiler.pipeline.models import ClonePipelineResult
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 
 def run_clone_pipeline(
@@ -21,7 +21,7 @@ def run_clone_pipeline(
     select: tuple[str, ...] = (),
     exclude: tuple[str, ...] = (),
     target_connection: Any,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> ClonePipelineResult:
     return prepare_clone_pipeline(
         discovered_inputs=discovered_inputs,
@@ -32,5 +32,5 @@ def run_clone_pipeline(
         select=select,
         exclude=exclude,
         target_connection=target_connection,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )

--- a/src/sqlbuild/compiler/pipeline/main/compile.py
+++ b/src/sqlbuild/compiler/pipeline/main/compile.py
@@ -27,7 +27,7 @@ from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_proj
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.main.execution import build_execution_plan
 from sqlbuild.compiler.planner.models import CursorOverrides, PlanOutput
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.models.project import EnvironmentConfig, resolve_effective_adapter_name
 
 
@@ -46,7 +46,7 @@ def run_compile_pipeline(
     on_connection_complete: Callable[[int, float], None] | None = None,
     on_connection_error: Callable[[int, float], None] | None = None,
     on_progress: Callable[[str], None] | None = None,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> CompilePipelineResult:
     """Run compile inputs, assembly, planning, and manifest generation."""
 
@@ -78,7 +78,7 @@ def run_compile_pipeline(
             cursor_overrides=cursor_overrides,
             full_refresh=full_refresh,
             on_progress=on_progress,
-            external_reference_resolver=external_reference_resolver,
+            external_sql_reference_resolver=external_sql_reference_resolver,
         )
     finally:
         adapter.close(connection)
@@ -96,13 +96,13 @@ def _build_result(
     cursor_overrides: CursorOverrides | None = None,
     full_refresh: bool = False,
     on_progress: Callable[[str], None] | None = None,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> CompilePipelineResult:
     project: CompiledProject = build_compiled_project(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )
 
     deferred_targets: dict[str, CompiledRelationTarget] | None = None

--- a/src/sqlbuild/compiler/pipeline/main/compile.py
+++ b/src/sqlbuild/compiler/pipeline/main/compile.py
@@ -27,6 +27,7 @@ from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_proj
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.main.execution import build_execution_plan
 from sqlbuild.compiler.planner.models import CursorOverrides, PlanOutput
+from sqlbuild.shared.types import ExternalReferenceResolver
 from sqlbuild.spec.models.project import EnvironmentConfig, resolve_effective_adapter_name
 
 
@@ -45,6 +46,7 @@ def run_compile_pipeline(
     on_connection_complete: Callable[[int, float], None] | None = None,
     on_connection_error: Callable[[int, float], None] | None = None,
     on_progress: Callable[[str], None] | None = None,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> CompilePipelineResult:
     """Run compile inputs, assembly, planning, and manifest generation."""
 
@@ -76,6 +78,7 @@ def run_compile_pipeline(
             cursor_overrides=cursor_overrides,
             full_refresh=full_refresh,
             on_progress=on_progress,
+            external_reference_resolver=external_reference_resolver,
         )
     finally:
         adapter.close(connection)
@@ -93,11 +96,13 @@ def _build_result(
     cursor_overrides: CursorOverrides | None = None,
     full_refresh: bool = False,
     on_progress: Callable[[str], None] | None = None,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> CompilePipelineResult:
     project: CompiledProject = build_compiled_project(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
+        external_reference_resolver=external_reference_resolver,
     )
 
     deferred_targets: dict[str, CompiledRelationTarget] | None = None

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -9,6 +9,7 @@ from sqlbuild.compiler.compile.models import CompiledProject, CompileProjectInpu
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.helpers.target_defaults import apply_target_defaults
 from sqlbuild.compiler.pipeline.helpers.target_validation import validate_project_targets
+from sqlbuild.shared.types import ExternalReferenceResolver
 from sqlbuild.spec.models.project import resolve_effective_adapter_name
 
 
@@ -18,6 +19,7 @@ def build_compiled_project(
     adapter: BaseAdapter,
     selected_environment: str | None = None,
     no_sql_validation: bool = False,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> CompiledProject:
     """Build one compiled project with adapter defaults and target validation applied."""
 
@@ -28,6 +30,7 @@ def build_compiled_project(
         python_functions_inherit_default_namespace=(
             adapter.python_functions_inherit_default_namespace()
         ),
+        external_reference_resolver=external_reference_resolver,
     )
     project: CompiledProject = apply_target_defaults(
         assemble_project(

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -9,7 +9,7 @@ from sqlbuild.compiler.compile.models import CompiledProject, CompileProjectInpu
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.helpers.target_defaults import apply_target_defaults
 from sqlbuild.compiler.pipeline.helpers.target_validation import validate_project_targets
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.models.project import resolve_effective_adapter_name
 
 
@@ -19,7 +19,7 @@ def build_compiled_project(
     adapter: BaseAdapter,
     selected_environment: str | None = None,
     no_sql_validation: bool = False,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> CompiledProject:
     """Build one compiled project with adapter defaults and target validation applied."""
 
@@ -30,7 +30,7 @@ def build_compiled_project(
         python_functions_inherit_default_namespace=(
             adapter.python_functions_inherit_default_namespace()
         ),
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )
     project: CompiledProject = apply_target_defaults(
         assemble_project(

--- a/src/sqlbuild/compiler/pipeline/main/diff.py
+++ b/src/sqlbuild/compiler/pipeline/main/diff.py
@@ -9,7 +9,7 @@ from sqlbuild.compiler.pipeline.helpers.diff import (
     compile_project_for_diff_environment,
     resolve_diff_model_names,
 )
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 
 def run_diff_pipeline(
@@ -21,7 +21,7 @@ def run_diff_pipeline(
     no_sql_validation: bool,
     select: tuple[str, ...],
     exclude: tuple[str, ...],
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> tuple[CompiledProject, CompiledProject, tuple[str, ...]]:
     """Compile both environments and resolve selected diffable model names."""
 
@@ -30,14 +30,14 @@ def run_diff_pipeline(
         adapter=adapter,
         environment_name=from_environment,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )
     right_project: CompiledProject = compile_project_for_diff_environment(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         environment_name=to_environment,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )
     selected_names: tuple[str, ...] = resolve_diff_model_names(
         project=right_project,

--- a/src/sqlbuild/compiler/pipeline/main/diff.py
+++ b/src/sqlbuild/compiler/pipeline/main/diff.py
@@ -9,6 +9,7 @@ from sqlbuild.compiler.pipeline.helpers.diff import (
     compile_project_for_diff_environment,
     resolve_diff_model_names,
 )
+from sqlbuild.shared.types import ExternalReferenceResolver
 
 
 def run_diff_pipeline(
@@ -20,6 +21,7 @@ def run_diff_pipeline(
     no_sql_validation: bool,
     select: tuple[str, ...],
     exclude: tuple[str, ...],
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> tuple[CompiledProject, CompiledProject, tuple[str, ...]]:
     """Compile both environments and resolve selected diffable model names."""
 
@@ -28,12 +30,14 @@ def run_diff_pipeline(
         adapter=adapter,
         environment_name=from_environment,
         no_sql_validation=no_sql_validation,
+        external_reference_resolver=external_reference_resolver,
     )
     right_project: CompiledProject = compile_project_for_diff_environment(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         environment_name=to_environment,
         no_sql_validation=no_sql_validation,
+        external_reference_resolver=external_reference_resolver,
     )
     selected_names: tuple[str, ...] = resolve_diff_model_names(
         project=right_project,

--- a/src/sqlbuild/compiler/pipeline/main/graph.py
+++ b/src/sqlbuild/compiler/pipeline/main/graph.py
@@ -14,6 +14,7 @@ from sqlbuild.compiler.pipeline.helpers.graph import (
 )
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 from sqlbuild.compiler.pipeline.models import ProjectGraph
+from sqlbuild.shared.types import ExternalReferenceResolver
 
 
 def build_project_graph(
@@ -21,6 +22,7 @@ def build_project_graph(
     discovered_inputs: DiscoveredProjectInputs,
     adapter: BaseAdapter,
     no_sql_validation: bool = False,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> ProjectGraph:
     """Build the static dependency graph for a compiled project."""
 
@@ -28,6 +30,7 @@ def build_project_graph(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
+        external_reference_resolver=external_reference_resolver,
     )
     upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] = (
         build_static_upstream_deps(project)

--- a/src/sqlbuild/compiler/pipeline/main/graph.py
+++ b/src/sqlbuild/compiler/pipeline/main/graph.py
@@ -14,7 +14,7 @@ from sqlbuild.compiler.pipeline.helpers.graph import (
 )
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 from sqlbuild.compiler.pipeline.models import ProjectGraph
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 
 def build_project_graph(
@@ -22,7 +22,7 @@ def build_project_graph(
     discovered_inputs: DiscoveredProjectInputs,
     adapter: BaseAdapter,
     no_sql_validation: bool = False,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> ProjectGraph:
     """Build the static dependency graph for a compiled project."""
 
@@ -30,7 +30,7 @@ def build_project_graph(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )
     upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] = (
         build_static_upstream_deps(project)

--- a/src/sqlbuild/compiler/pipeline/main/project.py
+++ b/src/sqlbuild/compiler/pipeline/main/project.py
@@ -6,7 +6,7 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.compiler.compile.models import CompiledProject
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 
 def compile_project(
@@ -14,7 +14,7 @@ def compile_project(
     discovered_inputs: DiscoveredProjectInputs,
     adapter: BaseAdapter,
     no_sql_validation: bool = False,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> CompiledProject:
     """Compile discovered inputs into a target-defaulted project view."""
 
@@ -22,5 +22,5 @@ def compile_project(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )

--- a/src/sqlbuild/compiler/pipeline/main/project.py
+++ b/src/sqlbuild/compiler/pipeline/main/project.py
@@ -6,6 +6,7 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.compiler.compile.models import CompiledProject
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
+from sqlbuild.shared.types import ExternalReferenceResolver
 
 
 def compile_project(
@@ -13,6 +14,7 @@ def compile_project(
     discovered_inputs: DiscoveredProjectInputs,
     adapter: BaseAdapter,
     no_sql_validation: bool = False,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> CompiledProject:
     """Compile discovered inputs into a target-defaulted project view."""
 
@@ -20,4 +22,5 @@ def compile_project(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
+        external_reference_resolver=external_reference_resolver,
     )

--- a/src/sqlbuild/compiler/planner/helpers/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/helpers/plan_entry.py
@@ -61,7 +61,7 @@ from sqlbuild.compiler.planner.types import (
     PlanReason,
 )
 from sqlbuild.compiler.shared.helpers.sources import render_source_relation
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.models.schema import SchemaColumn
 from sqlbuild.spec.models.source import SourceEntry
 
@@ -89,7 +89,7 @@ def plan_model(
     start_cursor_override: str | None,
     end_cursor_override: str | None,
     backfill_override: BackfillResult | None = None,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> tuple[ModelPlanEntry, tuple[PlanWarning, ...]]:
     """Build a plan entry and warnings for a single model."""
 
@@ -124,7 +124,7 @@ def plan_model(
         start_cursor_override=start_cursor_override,
         end_cursor_override=end_cursor_override,
         suppress_runtime_cursor_bounds=suppress_runtime_cursor_bounds,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )
 
     action: PlanAction

--- a/src/sqlbuild/compiler/planner/helpers/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/helpers/plan_entry.py
@@ -61,7 +61,7 @@ from sqlbuild.compiler.planner.types import (
     PlanReason,
 )
 from sqlbuild.compiler.shared.helpers.sources import render_source_relation
-from sqlbuild.integrations.dbt.manifest.models import DbtManifestIndex
+from sqlbuild.shared.types import ExternalReferenceResolver
 from sqlbuild.spec.models.schema import SchemaColumn
 from sqlbuild.spec.models.source import SourceEntry
 
@@ -89,7 +89,7 @@ def plan_model(
     start_cursor_override: str | None,
     end_cursor_override: str | None,
     backfill_override: BackfillResult | None = None,
-    dbt_manifest: DbtManifestIndex | None = None,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> tuple[ModelPlanEntry, tuple[PlanWarning, ...]]:
     """Build a plan entry and warnings for a single model."""
 
@@ -124,7 +124,7 @@ def plan_model(
         start_cursor_override=start_cursor_override,
         end_cursor_override=end_cursor_override,
         suppress_runtime_cursor_bounds=suppress_runtime_cursor_bounds,
-        dbt_manifest=dbt_manifest,
+        external_reference_resolver=external_reference_resolver,
     )
 
     action: PlanAction

--- a/src/sqlbuild/compiler/planner/helpers/resolve/refs.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/refs.py
@@ -14,7 +14,7 @@ from sqlbuild.compiler.compile.models import (
 )
 from sqlbuild.compiler.planner.models import CursorBounds
 from sqlbuild.shared.helpers.naming import resolve_target_qualified_name
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 _REF_PATTERN: re.Pattern[str] = re.compile(r'__ref\("([^"]+)"\)')
 _SEED_PATTERN: re.Pattern[str] = re.compile(r'__seed\("([^"]+)"\)')
@@ -72,16 +72,16 @@ def resolve_ref_references(
 
 
 def resolve_dbt_ref_references(
-    *, query_sql: str, external_reference_resolver: ExternalReferenceResolver | None = None
+    *, query_sql: str, external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None
 ) -> str:
     """Replace all __dbt_ref() calls with external relation names."""
 
     def _replace_dbt_ref(match: re.Match[str]) -> str:
-        if external_reference_resolver is None:
+        if external_sql_reference_resolver is None:
             return match.group(0)
         first_arg: str = match.group(1)
         second_arg: str | None = match.group(2)
-        relation_name: str | None = external_reference_resolver.resolve_reference(
+        relation_name: str | None = external_sql_reference_resolver.resolve_reference(
             ref_kind="dbt_ref",
             ref_package=first_arg if second_arg is not None else None,
             ref_name=second_arg if second_arg is not None else first_arg,

--- a/src/sqlbuild/compiler/planner/helpers/resolve/refs.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/refs.py
@@ -13,9 +13,8 @@ from sqlbuild.compiler.compile.models import (
     CompiledSeed,
 )
 from sqlbuild.compiler.planner.models import CursorBounds
-from sqlbuild.integrations.dbt.main.resolve_manifest_model import resolve_manifest_model
-from sqlbuild.integrations.dbt.manifest.models import DbtManifestIndex, DbtManifestModel
 from sqlbuild.shared.helpers.naming import resolve_target_qualified_name
+from sqlbuild.shared.types import ExternalReferenceResolver
 
 _REF_PATTERN: re.Pattern[str] = re.compile(r'__ref\("([^"]+)"\)')
 _SEED_PATTERN: re.Pattern[str] = re.compile(r'__seed\("([^"]+)"\)')
@@ -73,21 +72,21 @@ def resolve_ref_references(
 
 
 def resolve_dbt_ref_references(
-    *, query_sql: str, dbt_manifest: DbtManifestIndex | None = None
+    *, query_sql: str, external_reference_resolver: ExternalReferenceResolver | None = None
 ) -> str:
-    """Replace all __dbt_ref() calls with dbt manifest relation names."""
+    """Replace all __dbt_ref() calls with external relation names."""
 
     def _replace_dbt_ref(match: re.Match[str]) -> str:
-        if dbt_manifest is None:
+        if external_reference_resolver is None:
             return match.group(0)
         first_arg: str = match.group(1)
         second_arg: str | None = match.group(2)
-        model: DbtManifestModel = resolve_manifest_model(
-            manifest=dbt_manifest,
-            package_name=first_arg if second_arg is not None else None,
-            name=second_arg if second_arg is not None else first_arg,
+        relation_name: str | None = external_reference_resolver.resolve_reference(
+            ref_kind="dbt_ref",
+            ref_package=first_arg if second_arg is not None else None,
+            ref_name=second_arg if second_arg is not None else first_arg,
         )
-        return model.relation_name
+        return match.group(0) if relation_name is None else relation_name
 
     return _DBT_REF_PATTERN.sub(_replace_dbt_ref, query_sql)
 

--- a/src/sqlbuild/compiler/planner/helpers/resolve/resolve.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/resolve.py
@@ -35,7 +35,7 @@ from sqlbuild.compiler.planner.models import (
     WarehouseSnapshot,
 )
 from sqlbuild.compiler.planner.types import BackfillAction, IncrementalMode, MaterializationType
-from sqlbuild.integrations.dbt.manifest.models import DbtManifestIndex
+from sqlbuild.shared.types import ExternalReferenceResolver
 from sqlbuild.spec.models.source import SourceEntry
 
 
@@ -55,7 +55,7 @@ def resolve_model_sql(
     start_cursor_override: str | None,
     end_cursor_override: str | None,
     suppress_runtime_cursor_bounds: bool = False,
-    dbt_manifest: DbtManifestIndex | None = None,
+    external_reference_resolver: ExternalReferenceResolver | None = None,
 ) -> str:
     """Resolve all references in a model's query SQL to produce executable SQL."""
 
@@ -100,7 +100,10 @@ def resolve_model_sql(
         lower_bound_inclusive=lower_bound_inclusive,
     )
 
-    query_sql = resolve_dbt_ref_references(query_sql=query_sql, dbt_manifest=dbt_manifest)
+    query_sql = resolve_dbt_ref_references(
+        query_sql=query_sql,
+        external_reference_resolver=external_reference_resolver,
+    )
     query_sql = resolve_udf_references(query_sql=query_sql, function_targets=function_targets or {})
     query_sql = resolve_table_function_references(
         query_sql=query_sql,

--- a/src/sqlbuild/compiler/planner/helpers/resolve/resolve.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/resolve.py
@@ -35,7 +35,7 @@ from sqlbuild.compiler.planner.models import (
     WarehouseSnapshot,
 )
 from sqlbuild.compiler.planner.types import BackfillAction, IncrementalMode, MaterializationType
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.models.source import SourceEntry
 
 
@@ -55,7 +55,7 @@ def resolve_model_sql(
     start_cursor_override: str | None,
     end_cursor_override: str | None,
     suppress_runtime_cursor_bounds: bool = False,
-    external_reference_resolver: ExternalReferenceResolver | None = None,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> str:
     """Resolve all references in a model's query SQL to produce executable SQL."""
 
@@ -102,7 +102,7 @@ def resolve_model_sql(
 
     query_sql = resolve_dbt_ref_references(
         query_sql=query_sql,
-        external_reference_resolver=external_reference_resolver,
+        external_sql_reference_resolver=external_sql_reference_resolver,
     )
     query_sql = resolve_udf_references(query_sql=query_sql, function_targets=function_targets or {})
     query_sql = resolve_table_function_references(

--- a/src/sqlbuild/compiler/planner/main/execution.py
+++ b/src/sqlbuild/compiler/planner/main/execution.py
@@ -69,7 +69,7 @@ from sqlbuild.compiler.planner.models import (
     WarehouseSnapshot,
 )
 from sqlbuild.compiler.planner.types import BackfillAction, PlanReason
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.models.source import SourceEntry
 
 
@@ -110,8 +110,8 @@ def build_execution_plan(
     )
 
     execution_order: tuple[CompiledObjectKey, ...] = topologically_order_keys(upstream_deps)
-    external_reference_resolver: ExternalReferenceResolver | None = (
-        project.external_reference_resolver
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None = (
+        project.external_sql_reference_resolver
     )
 
     execute: Any = adapter.execute
@@ -237,7 +237,7 @@ def build_execution_plan(
             full_refresh=full_refresh,
             start_cursor_override=resolved_start,
             end_cursor_override=resolved_end,
-            external_reference_resolver=external_reference_resolver,
+            external_sql_reference_resolver=external_sql_reference_resolver,
         )
 
         model_cursor_types[entry.name] = entry.cursor_type
@@ -270,7 +270,7 @@ def build_execution_plan(
                     action=cascade.effective_action,
                     duration=cascade.effective_duration,
                 ),
-                external_reference_resolver=external_reference_resolver,
+                external_sql_reference_resolver=external_sql_reference_resolver,
             )
             entry = replace(entry, cascade=cascade)
             effective_cascades[entry.name] = cascade

--- a/src/sqlbuild/compiler/planner/main/execution.py
+++ b/src/sqlbuild/compiler/planner/main/execution.py
@@ -69,7 +69,7 @@ from sqlbuild.compiler.planner.models import (
     WarehouseSnapshot,
 )
 from sqlbuild.compiler.planner.types import BackfillAction, PlanReason
-from sqlbuild.integrations.dbt.manifest.models import DbtManifestIndex
+from sqlbuild.shared.types import ExternalReferenceResolver
 from sqlbuild.spec.models.source import SourceEntry
 
 
@@ -110,7 +110,9 @@ def build_execution_plan(
     )
 
     execution_order: tuple[CompiledObjectKey, ...] = topologically_order_keys(upstream_deps)
-    dbt_manifest: DbtManifestIndex | None = project.dbt_manifest
+    external_reference_resolver: ExternalReferenceResolver | None = (
+        project.external_reference_resolver
+    )
 
     execute: Any = adapter.execute
     warehouse_start: float = time.monotonic()
@@ -235,7 +237,7 @@ def build_execution_plan(
             full_refresh=full_refresh,
             start_cursor_override=resolved_start,
             end_cursor_override=resolved_end,
-            dbt_manifest=dbt_manifest,
+            external_reference_resolver=external_reference_resolver,
         )
 
         model_cursor_types[entry.name] = entry.cursor_type
@@ -268,7 +270,7 @@ def build_execution_plan(
                     action=cascade.effective_action,
                     duration=cascade.effective_duration,
                 ),
-                dbt_manifest=dbt_manifest,
+                external_reference_resolver=external_reference_resolver,
             )
             entry = replace(entry, cascade=cascade)
             effective_cascades[entry.name] = cascade

--- a/src/sqlbuild/integrations/dbt/helpers/compile_refs.py
+++ b/src/sqlbuild/integrations/dbt/helpers/compile_refs.py
@@ -14,8 +14,69 @@ from sqlbuild.integrations.dbt.helpers.manifest import (
     resolve_dbt_manifest_model,
 )
 from sqlbuild.integrations.dbt.manifest.models import DbtManifestIndex
+from sqlbuild.shared.types import ExternalReferenceResolver
 
 _DBT_REF_PATTERN: re.Pattern[str] = re.compile(r'__dbt_ref\(\s*"([^"]+)"\s*(?:,\s*"([^"]+)"\s*)?\)')
+
+
+class DbtCompileReferenceResolver:
+    """External reference resolver backed by a dbt manifest index."""
+
+    def __init__(self, *, dbt_manifest: DbtManifestIndex | None) -> None:
+        self._dbt_manifest = dbt_manifest
+
+    def validate_model_names(self, *, known_model_names: set[str]) -> None:
+        validate_compile_dbt_model_names(
+            known_model_names=known_model_names,
+            dbt_manifest=self._dbt_manifest,
+        )
+
+    def validate_reference(
+        self,
+        *,
+        ref_kind: str,
+        ref_name: str,
+        ref_package: str | None,
+        owner_relative_path: Path,
+    ) -> None:
+        validate_compile_dbt_model_reference(
+            reference=CompileSqlReference(
+                ref_kind=ref_kind,
+                ref_name=ref_name,
+                ref_package=ref_package,
+            ),
+            model_relative_path=owner_relative_path,
+            dbt_manifest=self._dbt_manifest,
+        )
+
+    def resolve_reference(
+        self,
+        *,
+        ref_kind: str,
+        ref_name: str,
+        ref_package: str | None,
+    ) -> str | None:
+        if ref_kind != SqlReferenceKind.DBT_REF:
+            return None
+        if self._dbt_manifest is None:
+            return None
+        return resolve_dbt_manifest_model(
+            manifest=self._dbt_manifest,
+            package_name=ref_package,
+            name=ref_name,
+        ).relation_name
+
+
+def build_compile_external_reference_resolver(
+    *, manifest_contents: str | None
+) -> ExternalReferenceResolver | None:
+    """Build a compile-time external reference resolver from dbt manifest contents."""
+
+    if manifest_contents is None:
+        return None
+    return DbtCompileReferenceResolver(
+        dbt_manifest=build_compile_dbt_manifest_index(manifest_contents=manifest_contents)
+    )
 
 
 def build_compile_dbt_manifest_index(*, manifest_contents: str | None) -> DbtManifestIndex | None:

--- a/src/sqlbuild/integrations/dbt/helpers/compile_refs.py
+++ b/src/sqlbuild/integrations/dbt/helpers/compile_refs.py
@@ -14,7 +14,7 @@ from sqlbuild.integrations.dbt.helpers.manifest import (
     resolve_dbt_manifest_model,
 )
 from sqlbuild.integrations.dbt.manifest.models import DbtManifestIndex
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 _DBT_REF_PATTERN: re.Pattern[str] = re.compile(r'__dbt_ref\(\s*"([^"]+)"\s*(?:,\s*"([^"]+)"\s*)?\)')
 
@@ -37,7 +37,7 @@ class DbtCompileReferenceResolver:
         ref_kind: str,
         ref_name: str,
         ref_package: str | None,
-        owner_relative_path: Path,
+        owner_relative_sql_path: Path,
     ) -> None:
         validate_compile_dbt_model_reference(
             reference=CompileSqlReference(
@@ -45,7 +45,7 @@ class DbtCompileReferenceResolver:
                 ref_name=ref_name,
                 ref_package=ref_package,
             ),
-            model_relative_path=owner_relative_path,
+            model_relative_path=owner_relative_sql_path,
             dbt_manifest=self._dbt_manifest,
         )
 
@@ -67,9 +67,9 @@ class DbtCompileReferenceResolver:
         ).relation_name
 
 
-def build_compile_external_reference_resolver(
+def build_compile_external_sql_reference_resolver(
     *, manifest_contents: str | None
-) -> ExternalReferenceResolver | None:
+) -> ExternalSqlReferenceResolver | None:
     """Build a compile-time external reference resolver from dbt manifest contents."""
 
     if manifest_contents is None:

--- a/src/sqlbuild/integrations/dbt/main/build_compile_reference_resolver.py
+++ b/src/sqlbuild/integrations/dbt/main/build_compile_reference_resolver.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from sqlbuild.integrations.dbt.helpers.compile_refs import (
-    build_compile_external_reference_resolver,
+    build_compile_external_sql_reference_resolver,
 )
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 
 def build_compile_reference_resolver(
     *, manifest_contents: str | None
-) -> ExternalReferenceResolver | None:
+) -> ExternalSqlReferenceResolver | None:
     """Build a dbt-backed external reference resolver from manifest contents."""
 
-    return build_compile_external_reference_resolver(manifest_contents=manifest_contents)
+    return build_compile_external_sql_reference_resolver(manifest_contents=manifest_contents)

--- a/src/sqlbuild/integrations/dbt/main/build_compile_reference_resolver.py
+++ b/src/sqlbuild/integrations/dbt/main/build_compile_reference_resolver.py
@@ -1,0 +1,16 @@
+"""Build dbt-backed compile-time external reference resolvers."""
+
+from __future__ import annotations
+
+from sqlbuild.integrations.dbt.helpers.compile_refs import (
+    build_compile_external_reference_resolver,
+)
+from sqlbuild.shared.types import ExternalReferenceResolver
+
+
+def build_compile_reference_resolver(
+    *, manifest_contents: str | None
+) -> ExternalReferenceResolver | None:
+    """Build a dbt-backed external reference resolver from manifest contents."""
+
+    return build_compile_external_reference_resolver(manifest_contents=manifest_contents)

--- a/src/sqlbuild/integrations/dbt/pipeline/main/execute.py
+++ b/src/sqlbuild/integrations/dbt/pipeline/main/execute.py
@@ -15,7 +15,7 @@ from sqlbuild.cli.commands.main.dbt_sqlbuild_work import execute_dbt_sqlbuild_wo
 from sqlbuild.compiler.compile.main.effective_config import build_effective_connection_config
 from sqlbuild.compiler.compile.models import CompiledProject
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
-from sqlbuild.compiler.discovery.models import DiscoveredDbtManifestFile, DiscoveredProjectInputs
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 from sqlbuild.compiler.planner.models import PlanOutput
 from sqlbuild.integrations.dbt.exceptions import DbtInteropRuntimeError
@@ -109,21 +109,13 @@ def execute_dbt_interop_from_project(
 
     sqlbuild_compile_start: float = time.monotonic()
     _report_progress(on_progress, "Compiling SQLBuild project...")
-    discovered_with_manifest: DiscoveredProjectInputs = replace(
-        discovered_inputs,
-        dbt_manifest_file=DiscoveredDbtManifestFile(
-            file_path=manifest_path,
-            relative_path=Path("manifest.json"),
-            contents=manifest_path.read_text(encoding="utf-8"),
-        ),
-    )
     adapter_name: str = resolve_effective_adapter_name(
         project_config=discovered_inputs.project_config,
         local_config=discovered_inputs.local_config,
     )
     adapter: BaseAdapter = resolve_dbt_interop_adapter(adapter_name, project_dir=project_dir)
     project: CompiledProject = build_compiled_project(
-        discovered_inputs=discovered_with_manifest,
+        discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
         external_reference_resolver=DbtCompileReferenceResolver(dbt_manifest=manifest),
@@ -213,7 +205,7 @@ def execute_dbt_interop_from_project(
     )
     plan_output: PlanOutput | None = build_sqlbuild_plan_output(
         project_dir=project_dir,
-        discovered_inputs=discovered_with_manifest,
+        discovered_inputs=discovered_inputs,
         project=project,
         adapter=adapter,
         adapter_name=adapter_name,

--- a/src/sqlbuild/integrations/dbt/pipeline/main/execute.py
+++ b/src/sqlbuild/integrations/dbt/pipeline/main/execute.py
@@ -118,7 +118,7 @@ def execute_dbt_interop_from_project(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=DbtCompileReferenceResolver(dbt_manifest=manifest),
+        external_sql_reference_resolver=DbtCompileReferenceResolver(dbt_manifest=manifest),
     )
     _report_progress(
         on_progress,

--- a/src/sqlbuild/integrations/dbt/pipeline/main/execute.py
+++ b/src/sqlbuild/integrations/dbt/pipeline/main/execute.py
@@ -20,6 +20,7 @@ from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_proj
 from sqlbuild.compiler.planner.models import PlanOutput
 from sqlbuild.integrations.dbt.exceptions import DbtInteropRuntimeError
 from sqlbuild.integrations.dbt.helpers.args import route_dbt_interop_args
+from sqlbuild.integrations.dbt.helpers.compile_refs import DbtCompileReferenceResolver
 from sqlbuild.integrations.dbt.helpers.graph import build_dbt_combined_graph
 from sqlbuild.integrations.dbt.helpers.manifest import load_dbt_manifest_index
 from sqlbuild.integrations.dbt.helpers.plan_orchestration import (
@@ -125,6 +126,7 @@ def execute_dbt_interop_from_project(
         discovered_inputs=discovered_with_manifest,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
+        external_reference_resolver=DbtCompileReferenceResolver(dbt_manifest=manifest),
     )
     _report_progress(
         on_progress,

--- a/src/sqlbuild/integrations/dbt/pipeline/main/plan.py
+++ b/src/sqlbuild/integrations/dbt/pipeline/main/plan.py
@@ -17,6 +17,7 @@ from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_proj
 from sqlbuild.compiler.planner.models import PlanOutput
 from sqlbuild.integrations.dbt.exceptions import DbtInteropRuntimeError
 from sqlbuild.integrations.dbt.helpers.args import route_dbt_interop_args
+from sqlbuild.integrations.dbt.helpers.compile_refs import DbtCompileReferenceResolver
 from sqlbuild.integrations.dbt.helpers.graph import build_dbt_combined_graph
 from sqlbuild.integrations.dbt.helpers.manifest import load_dbt_manifest_index
 from sqlbuild.integrations.dbt.helpers.plan_orchestration import plan_dbt_interop_command
@@ -113,6 +114,7 @@ def plan_dbt_interop_from_project(
         discovered_inputs=discovered_with_manifest,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
+        external_reference_resolver=DbtCompileReferenceResolver(dbt_manifest=manifest),
     )
     _report_progress(
         on_progress,

--- a/src/sqlbuild/integrations/dbt/pipeline/main/plan.py
+++ b/src/sqlbuild/integrations/dbt/pipeline/main/plan.py
@@ -106,7 +106,7 @@ def plan_dbt_interop_from_project(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
-        external_reference_resolver=DbtCompileReferenceResolver(dbt_manifest=manifest),
+        external_sql_reference_resolver=DbtCompileReferenceResolver(dbt_manifest=manifest),
     )
     _report_progress(
         on_progress,

--- a/src/sqlbuild/integrations/dbt/pipeline/main/plan.py
+++ b/src/sqlbuild/integrations/dbt/pipeline/main/plan.py
@@ -12,7 +12,7 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.cli.commands.main.connection_progress import build_connection_progress_reporter
 from sqlbuild.compiler.compile.models import CompiledProject
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
-from sqlbuild.compiler.discovery.models import DiscoveredDbtManifestFile, DiscoveredProjectInputs
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 from sqlbuild.compiler.planner.models import PlanOutput
 from sqlbuild.integrations.dbt.exceptions import DbtInteropRuntimeError
@@ -88,14 +88,6 @@ def plan_dbt_interop_from_project(
     )
     sqlbuild_compile_start: float = time.monotonic()
     _report_progress(on_progress, "Compiling SQLBuild project...")
-    discovered_with_manifest: DiscoveredProjectInputs = replace(
-        discovered_inputs,
-        dbt_manifest_file=DiscoveredDbtManifestFile(
-            file_path=manifest_path,
-            relative_path=Path("manifest.json"),
-            contents=manifest_path.read_text(encoding="utf-8"),
-        ),
-    )
     adapter_name: str = resolve_effective_adapter_name(
         project_config=discovered_inputs.project_config,
         local_config=discovered_inputs.local_config,
@@ -111,7 +103,7 @@ def plan_dbt_interop_from_project(
         else None
     )
     project: CompiledProject = build_compiled_project(
-        discovered_inputs=discovered_with_manifest,
+        discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
         external_reference_resolver=DbtCompileReferenceResolver(dbt_manifest=manifest),
@@ -144,7 +136,7 @@ def plan_dbt_interop_from_project(
     )
     sqlbuild_plan_output: PlanOutput | None = build_sqlbuild_plan_output(
         project_dir=project_dir,
-        discovered_inputs=discovered_with_manifest,
+        discovered_inputs=discovered_inputs,
         project=project,
         adapter=adapter,
         adapter_name=adapter_name,

--- a/src/sqlbuild/shared/constants.py
+++ b/src/sqlbuild/shared/constants.py
@@ -7,7 +7,7 @@ DEFAULT_MAX_DISPLAY_ENTRIES: int = 50
 SCENARIO_ARTIFACT_PREFIX: str = "__sqb_"
 SCENARIO_HASH_PREFIX_LENGTH: int = 12
 SCENARIO_SHORTENED_LOGICAL_HASH_LENGTH: int = 8
-SCENARIO_ARTIFACT_KINDS: tuple[str, ...] = ("source", "ref", "seed", "model")
+SCENARIO_ARTIFACT_KINDS: tuple[str, ...] = ("source", "ref", "seed", "dbt_ref", "model")
 
 # Scenario CLI codes use the existing C45x range.
 SCENARIO_CLI_MISSING_SUBCOMMAND: str = "C450"

--- a/src/sqlbuild/shared/types.py
+++ b/src/sqlbuild/shared/types.py
@@ -1,0 +1,32 @@
+"""Shared type-layer declarations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+
+class ExternalReferenceResolver(Protocol):
+    """Resolve and validate references owned by optional external integrations."""
+
+    def validate_model_names(self, *, known_model_names: set[str]) -> None:
+        """Validate SQLBuild model names against external integration resources."""
+
+    def validate_reference(
+        self,
+        *,
+        ref_kind: str,
+        ref_name: str,
+        ref_package: str | None,
+        owner_relative_path: Path,
+    ) -> None:
+        """Validate one external SQL reference from a SQLBuild-owned file."""
+
+    def resolve_reference(
+        self,
+        *,
+        ref_kind: str,
+        ref_name: str,
+        ref_package: str | None,
+    ) -> str | None:
+        """Return the physical relation for an external reference, if resolvable."""

--- a/src/sqlbuild/shared/types.py
+++ b/src/sqlbuild/shared/types.py
@@ -6,8 +6,14 @@ from pathlib import Path
 from typing import Protocol
 
 
-class ExternalReferenceResolver(Protocol):
-    """Resolve and validate references owned by optional external integrations."""
+class ExternalSqlReferenceResolver(Protocol):
+    """Resolve first-class SQLBuild references backed by external metadata.
+
+    Core compiler and planner code owns parsing and dependency semantics for
+    supported syntax such as ``__dbt_ref(...)``. Provider integrations own the
+    metadata needed to resolve those references, such as DBT manifest loading and
+    model lookup, and expose that behavior through this protocol.
+    """
 
     def validate_model_names(self, *, known_model_names: set[str]) -> None:
         """Validate SQLBuild model names against external integration resources."""
@@ -18,7 +24,7 @@ class ExternalReferenceResolver(Protocol):
         ref_kind: str,
         ref_name: str,
         ref_package: str | None,
-        owner_relative_path: Path,
+        owner_relative_sql_path: Path,
     ) -> None:
         """Validate one external SQL reference from a SQLBuild-owned file."""
 

--- a/tests/integration/src/sqlbuild/integrations/dbt/helpers.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/helpers.py
@@ -4,6 +4,10 @@ from dataclasses import replace
 from pathlib import Path
 
 from sqlbuild.compiler.discovery.models import DiscoveredDbtManifestFile, DiscoveredProjectInputs
+from sqlbuild.integrations.dbt.main.build_compile_reference_resolver import (
+    build_compile_reference_resolver,
+)
+from sqlbuild.shared.types import ExternalReferenceResolver
 
 
 def build_sqlbuild_project_with_manifest(
@@ -42,6 +46,20 @@ def attach_dbt_manifest_file(
             relative_path=Path("manifest.json"),
             contents=manifest_source.read_text(encoding="utf-8"),
         ),
+    )
+
+
+def build_external_reference_resolver(
+    discovered_inputs: DiscoveredProjectInputs,
+) -> ExternalReferenceResolver | None:
+    """Build a dbt-backed resolver for attached manifest integration tests."""
+
+    return build_compile_reference_resolver(
+        manifest_contents=(
+            None
+            if discovered_inputs.dbt_manifest_file is None
+            else discovered_inputs.dbt_manifest_file.contents
+        )
     )
 
 

--- a/tests/integration/src/sqlbuild/integrations/dbt/helpers.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/helpers.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import replace
 from pathlib import Path
 
-from sqlbuild.compiler.discovery.models import DiscoveredDbtManifestFile, DiscoveredProjectInputs
 from sqlbuild.integrations.dbt.main.build_compile_reference_resolver import (
     build_compile_reference_resolver,
 )
@@ -34,32 +32,11 @@ def build_sqlbuild_project_with_manifest(
     return project_dir
 
 
-def attach_dbt_manifest_file(
-    *, discovered_inputs: DiscoveredProjectInputs, manifest_source: Path
-) -> DiscoveredProjectInputs:
-    """Attach a dbt manifest explicitly for dbt interop integration tests."""
-
-    return replace(
-        discovered_inputs,
-        dbt_manifest_file=DiscoveredDbtManifestFile(
-            file_path=manifest_source,
-            relative_path=Path("manifest.json"),
-            contents=manifest_source.read_text(encoding="utf-8"),
-        ),
-    )
-
-
-def build_external_reference_resolver(
-    discovered_inputs: DiscoveredProjectInputs,
-) -> ExternalReferenceResolver | None:
+def build_external_reference_resolver(*, manifest_source: Path) -> ExternalReferenceResolver | None:
     """Build a dbt-backed resolver for attached manifest integration tests."""
 
     return build_compile_reference_resolver(
-        manifest_contents=(
-            None
-            if discovered_inputs.dbt_manifest_file is None
-            else discovered_inputs.dbt_manifest_file.contents
-        )
+        manifest_contents=manifest_source.read_text(encoding="utf-8")
     )
 
 

--- a/tests/integration/src/sqlbuild/integrations/dbt/helpers.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/helpers.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from sqlbuild.integrations.dbt.main.build_compile_reference_resolver import (
     build_compile_reference_resolver,
 )
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 
 def build_sqlbuild_project_with_manifest(
@@ -32,7 +32,9 @@ def build_sqlbuild_project_with_manifest(
     return project_dir
 
 
-def build_external_reference_resolver(*, manifest_source: Path) -> ExternalReferenceResolver | None:
+def build_external_sql_reference_resolver(
+    *, manifest_source: Path
+) -> ExternalSqlReferenceResolver | None:
     """Build a dbt-backed resolver for attached manifest integration tests."""
 
     return build_compile_reference_resolver(

--- a/tests/integration/src/sqlbuild/integrations/dbt/test_graph.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/test_graph.py
@@ -28,6 +28,7 @@ from tests.integration.src.sqlbuild.integrations.dbt._test_types import (
 )
 from tests.integration.src.sqlbuild.integrations.dbt.helpers import (
     attach_dbt_manifest_file,
+    build_external_reference_resolver,
     build_sqlbuild_project_with_manifest,
 )
 from tests.unit.src.sqlbuild.integrations.dbt.helpers import graph_key_stable_ids
@@ -77,7 +78,10 @@ def test_given_real_dbt_manifest_and_sqlbuild_project_when_building_graph_then_e
         discovered_inputs=discover_project_inputs(project_dir=sqlbuild_project_dir),
         manifest_source=manifest_source,
     )
-    compile_inputs: CompileProjectInputs = build_compile_inputs(discovered_inputs)
+    compile_inputs: CompileProjectInputs = build_compile_inputs(
+        discovered_inputs,
+        external_reference_resolver=build_external_reference_resolver(discovered_inputs),
+    )
     project: CompiledProject = assemble_compiled_project(compile_inputs)
     manifest: DbtManifestIndex = build_dbt_manifest_index(
         raw_data=json.loads(manifest_source.read_text(encoding="utf-8"))

--- a/tests/integration/src/sqlbuild/integrations/dbt/test_graph.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/test_graph.py
@@ -27,7 +27,6 @@ from tests.integration.src.sqlbuild.integrations.dbt._test_types import (
     RealDbtCombinedGraphTestCase,
 )
 from tests.integration.src.sqlbuild.integrations.dbt.helpers import (
-    attach_dbt_manifest_file,
     build_external_reference_resolver,
     build_sqlbuild_project_with_manifest,
 )
@@ -74,13 +73,14 @@ def test_given_real_dbt_manifest_and_sqlbuild_project_when_building_graph_then_e
         model_sql_by_name=test_case.sqlbuild_model_sql_by_name,
     )
     manifest_source: Path = dbt_project_dir / "target/manifest.json"
-    discovered_inputs: DiscoveredProjectInputs = attach_dbt_manifest_file(
-        discovered_inputs=discover_project_inputs(project_dir=sqlbuild_project_dir),
-        manifest_source=manifest_source,
+    discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(
+        project_dir=sqlbuild_project_dir
     )
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs,
-        external_reference_resolver=build_external_reference_resolver(discovered_inputs),
+        external_reference_resolver=build_external_reference_resolver(
+            manifest_source=manifest_source
+        ),
     )
     project: CompiledProject = assemble_compiled_project(compile_inputs)
     manifest: DbtManifestIndex = build_dbt_manifest_index(

--- a/tests/integration/src/sqlbuild/integrations/dbt/test_graph.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/test_graph.py
@@ -27,7 +27,7 @@ from tests.integration.src.sqlbuild.integrations.dbt._test_types import (
     RealDbtCombinedGraphTestCase,
 )
 from tests.integration.src.sqlbuild.integrations.dbt.helpers import (
-    build_external_reference_resolver,
+    build_external_sql_reference_resolver,
     build_sqlbuild_project_with_manifest,
 )
 from tests.unit.src.sqlbuild.integrations.dbt.helpers import graph_key_stable_ids
@@ -78,7 +78,7 @@ def test_given_real_dbt_manifest_and_sqlbuild_project_when_building_graph_then_e
     )
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs,
-        external_reference_resolver=build_external_reference_resolver(
+        external_sql_reference_resolver=build_external_sql_reference_resolver(
             manifest_source=manifest_source
         ),
     )

--- a/tests/integration/src/sqlbuild/integrations/dbt/test_manifest.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/test_manifest.py
@@ -14,7 +14,6 @@ from tests.integration.src.sqlbuild.integrations.dbt._test_types import (
     RealDbtManifestCompileTestCase,
 )
 from tests.integration.src.sqlbuild.integrations.dbt.helpers import (
-    attach_dbt_manifest_file,
     build_external_reference_resolver,
 )
 
@@ -63,13 +62,15 @@ def test_given_real_dbt_manifest_when_compiling_sqlbuild_then_preserves_dbt_ref(
         encoding="utf-8",
     )
 
-    discovered_inputs: DiscoveredProjectInputs = attach_dbt_manifest_file(
-        discovered_inputs=discover_project_inputs(project_dir=sqlbuild_project_dir),
-        manifest_source=dbt_project_dir / "target/manifest.json",
+    manifest_source: Path = dbt_project_dir / "target/manifest.json"
+    discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(
+        project_dir=sqlbuild_project_dir
     )
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs,
-        external_reference_resolver=build_external_reference_resolver(discovered_inputs),
+        external_reference_resolver=build_external_reference_resolver(
+            manifest_source=manifest_source
+        ),
     )
 
     assert compile_inputs.model_inputs[0].query_sql == test_case.expected_compiled_sql

--- a/tests/integration/src/sqlbuild/integrations/dbt/test_manifest.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/test_manifest.py
@@ -14,7 +14,7 @@ from tests.integration.src.sqlbuild.integrations.dbt._test_types import (
     RealDbtManifestCompileTestCase,
 )
 from tests.integration.src.sqlbuild.integrations.dbt.helpers import (
-    build_external_reference_resolver,
+    build_external_sql_reference_resolver,
 )
 
 pytestmark: pytest.MarkDecorator = pytest.mark.dbt
@@ -68,7 +68,7 @@ def test_given_real_dbt_manifest_when_compiling_sqlbuild_then_preserves_dbt_ref(
     )
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs,
-        external_reference_resolver=build_external_reference_resolver(
+        external_sql_reference_resolver=build_external_sql_reference_resolver(
             manifest_source=manifest_source
         ),
     )

--- a/tests/integration/src/sqlbuild/integrations/dbt/test_manifest.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/test_manifest.py
@@ -13,7 +13,10 @@ from sqlbuild.integrations.dbt.models import DbtCliOptions, DbtCommandResult
 from tests.integration.src.sqlbuild.integrations.dbt._test_types import (
     RealDbtManifestCompileTestCase,
 )
-from tests.integration.src.sqlbuild.integrations.dbt.helpers import attach_dbt_manifest_file
+from tests.integration.src.sqlbuild.integrations.dbt.helpers import (
+    attach_dbt_manifest_file,
+    build_external_reference_resolver,
+)
 
 pytestmark: pytest.MarkDecorator = pytest.mark.dbt
 
@@ -64,6 +67,9 @@ def test_given_real_dbt_manifest_when_compiling_sqlbuild_then_preserves_dbt_ref(
         discovered_inputs=discover_project_inputs(project_dir=sqlbuild_project_dir),
         manifest_source=dbt_project_dir / "target/manifest.json",
     )
-    compile_inputs: CompileProjectInputs = build_compile_inputs(discovered_inputs)
+    compile_inputs: CompileProjectInputs = build_compile_inputs(
+        discovered_inputs,
+        external_reference_resolver=build_external_reference_resolver(discovered_inputs),
+    )
 
     assert compile_inputs.model_inputs[0].query_sql == test_case.expected_compiled_sql

--- a/tests/unit/src/sqlbuild/compiler/compile/_test_helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_test_helpers.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from sqlbuild.integrations.dbt.main.build_compile_reference_resolver import (
     build_compile_reference_resolver,
 )
-from sqlbuild.shared.types import ExternalReferenceResolver
+from sqlbuild.shared.types import ExternalSqlReferenceResolver
 
 
 def base_repo_files() -> dict[str, str]:
@@ -14,7 +14,9 @@ def base_repo_files() -> dict[str, str]:
     }
 
 
-def build_external_reference_resolver(*, project_dir: Path) -> ExternalReferenceResolver | None:
+def build_external_sql_reference_resolver(
+    *, project_dir: Path
+) -> ExternalSqlReferenceResolver | None:
     manifest_path: Path = project_dir / "dbt" / "target" / "manifest.json"
     if not manifest_path.is_file():
         return None

--- a/tests/unit/src/sqlbuild/compiler/compile/_test_helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_test_helpers.py
@@ -1,7 +1,5 @@
-from dataclasses import replace
 from pathlib import Path
 
-from sqlbuild.compiler.discovery.models import DiscoveredDbtManifestFile, DiscoveredProjectInputs
 from sqlbuild.integrations.dbt.main.build_compile_reference_resolver import (
     build_compile_reference_resolver,
 )
@@ -16,31 +14,12 @@ def base_repo_files() -> dict[str, str]:
     }
 
 
-def attach_dbt_manifest_file(
-    *, discovered_inputs: DiscoveredProjectInputs, project_dir: Path
-) -> DiscoveredProjectInputs:
+def build_external_reference_resolver(*, project_dir: Path) -> ExternalReferenceResolver | None:
     manifest_path: Path = project_dir / "dbt" / "target" / "manifest.json"
     if not manifest_path.is_file():
-        return discovered_inputs
-    return replace(
-        discovered_inputs,
-        dbt_manifest_file=DiscoveredDbtManifestFile(
-            file_path=manifest_path,
-            relative_path=manifest_path.relative_to(project_dir),
-            contents=manifest_path.read_text(encoding="utf-8"),
-        ),
-    )
-
-
-def build_external_reference_resolver(
-    discovered_inputs: DiscoveredProjectInputs,
-) -> ExternalReferenceResolver | None:
+        return None
     return build_compile_reference_resolver(
-        manifest_contents=(
-            None
-            if discovered_inputs.dbt_manifest_file is None
-            else discovered_inputs.dbt_manifest_file.contents
-        )
+        manifest_contents=manifest_path.read_text(encoding="utf-8")
     )
 
 

--- a/tests/unit/src/sqlbuild/compiler/compile/_test_helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_test_helpers.py
@@ -2,6 +2,10 @@ from dataclasses import replace
 from pathlib import Path
 
 from sqlbuild.compiler.discovery.models import DiscoveredDbtManifestFile, DiscoveredProjectInputs
+from sqlbuild.integrations.dbt.main.build_compile_reference_resolver import (
+    build_compile_reference_resolver,
+)
+from sqlbuild.shared.types import ExternalReferenceResolver
 
 
 def base_repo_files() -> dict[str, str]:
@@ -25,6 +29,18 @@ def attach_dbt_manifest_file(
             relative_path=manifest_path.relative_to(project_dir),
             contents=manifest_path.read_text(encoding="utf-8"),
         ),
+    )
+
+
+def build_external_reference_resolver(
+    discovered_inputs: DiscoveredProjectInputs,
+) -> ExternalReferenceResolver | None:
+    return build_compile_reference_resolver(
+        manifest_contents=(
+            None
+            if discovered_inputs.dbt_manifest_file is None
+            else discovered_inputs.dbt_manifest_file.contents
+        )
     )
 
 

--- a/tests/unit/src/sqlbuild/compiler/compile/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_main.py
@@ -2401,7 +2401,8 @@ SELECT * FROM __dbt_ref("stg_orders")
         selected_environment=None,
         run_id=None,
         expected_error_fragment=(
-            r"Audit file audits/orders\.sql may not use __dbt_ref\('stg_orders'\) right now"
+            r"Audit file audits/orders\.sql may not use __dbt_ref\('stg_orders'\); "
+            "audit dbt model checks belong in dbt"
         ),
     ),
     BuildCompileInputsErrorTestCase(

--- a/tests/unit/src/sqlbuild/compiler/compile/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_main.py
@@ -23,7 +23,7 @@ from sqlbuild.spec.models.project import (
 )
 from tests.unit.src.sqlbuild.compiler.compile._test_helpers import (
     base_repo_files,
-    build_external_reference_resolver,
+    build_external_sql_reference_resolver,
     expected_or_actual,
 )
 from tests.unit.src.sqlbuild.compiler.compile._test_types import (
@@ -2001,7 +2001,7 @@ def test_given_discovered_inputs_when_building_compile_inputs_then_it_attaches_m
         cli_vars=test_case.cli_vars,
         run_id=test_case.run_id,
         no_sql_validation=test_case.no_sql_validation,
-        external_reference_resolver=build_external_reference_resolver(project_dir=tmp_path),
+        external_sql_reference_resolver=build_external_sql_reference_resolver(project_dir=tmp_path),
     )
 
     assert (
@@ -3053,7 +3053,9 @@ def test_given_attachment_conflicts_when_building_compile_inputs_then_it_raises_
             discovered_inputs,
             selected_environment=test_case.selected_environment,
             run_id=test_case.run_id,
-            external_reference_resolver=build_external_reference_resolver(project_dir=tmp_path),
+            external_sql_reference_resolver=build_external_sql_reference_resolver(
+                project_dir=tmp_path
+            ),
         )
 
 

--- a/tests/unit/src/sqlbuild/compiler/compile/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_main.py
@@ -24,6 +24,7 @@ from sqlbuild.spec.models.project import (
 from tests.unit.src.sqlbuild.compiler.compile._test_helpers import (
     attach_dbt_manifest_file,
     base_repo_files,
+    build_external_reference_resolver,
     expected_or_actual,
 )
 from tests.unit.src.sqlbuild.compiler.compile._test_types import (
@@ -2004,6 +2005,7 @@ def test_given_discovered_inputs_when_building_compile_inputs_then_it_attaches_m
         cli_vars=test_case.cli_vars,
         run_id=test_case.run_id,
         no_sql_validation=test_case.no_sql_validation,
+        external_reference_resolver=build_external_reference_resolver(discovered_inputs),
     )
 
     assert (
@@ -3058,6 +3060,7 @@ def test_given_attachment_conflicts_when_building_compile_inputs_then_it_raises_
             discovered_inputs,
             selected_environment=test_case.selected_environment,
             run_id=test_case.run_id,
+            external_reference_resolver=build_external_reference_resolver(discovered_inputs),
         )
 
 

--- a/tests/unit/src/sqlbuild/compiler/compile/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_main.py
@@ -22,7 +22,6 @@ from sqlbuild.spec.models.project import (
     ProjectConfig,
 )
 from tests.unit.src.sqlbuild.compiler.compile._test_helpers import (
-    attach_dbt_manifest_file,
     base_repo_files,
     build_external_reference_resolver,
     expected_or_actual,
@@ -1995,17 +1994,14 @@ def test_given_discovered_inputs_when_building_compile_inputs_then_it_attaches_m
 
     write_repo_files(tmp_path, test_case.repo_files)
 
-    discovered_inputs: DiscoveredProjectInputs = attach_dbt_manifest_file(
-        discovered_inputs=discover_project_inputs(project_dir=tmp_path),
-        project_dir=tmp_path,
-    )
+    discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs,
         selected_environment=test_case.selected_environment,
         cli_vars=test_case.cli_vars,
         run_id=test_case.run_id,
         no_sql_validation=test_case.no_sql_validation,
-        external_reference_resolver=build_external_reference_resolver(discovered_inputs),
+        external_reference_resolver=build_external_reference_resolver(project_dir=tmp_path),
     )
 
     assert (
@@ -3050,17 +3046,14 @@ def test_given_attachment_conflicts_when_building_compile_inputs_then_it_raises_
 
     write_repo_files(tmp_path, test_case.repo_files)
 
-    discovered_inputs: DiscoveredProjectInputs = attach_dbt_manifest_file(
-        discovered_inputs=discover_project_inputs(project_dir=tmp_path),
-        project_dir=tmp_path,
-    )
+    discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
 
     with pytest.raises(ValueError, match=test_case.expected_error_fragment):
         build_compile_inputs(
             discovered_inputs,
             selected_environment=test_case.selected_environment,
             run_id=test_case.run_id,
-            external_reference_resolver=build_external_reference_resolver(discovered_inputs),
+            external_reference_resolver=build_external_reference_resolver(project_dir=tmp_path),
         )
 
 

--- a/tests/unit/src/sqlbuild/compiler/discovery/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_test_types.py
@@ -27,7 +27,6 @@ class DiscoverProjectInputsTestCase:
     expected_audit_block_names: tuple[str | None, ...]
     expected_audit_block_sql_bodies: tuple[str, ...]
     expected_macro_paths: tuple[str, ...]
-    expected_manifest_path: str | None
     expected_adapter_path: str | None
 
 
@@ -36,10 +35,3 @@ class DiscoverProjectInputsErrorTestCase:
     description: str
     repo_files: dict[str, str]
     expected_error_fragment: str
-
-
-@dataclass(frozen=True)
-class DiscoverDbtManifestTargetPathTestCase:
-    description: str
-    repo_files: dict[str, str]
-    expected_manifest_path: str

--- a/tests/unit/src/sqlbuild/compiler/discovery/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/test_main.py
@@ -10,7 +10,6 @@ from tests.unit.src.sqlbuild.compiler.discovery._test_helpers import (
     base_repo_files,
 )
 from tests.unit.src.sqlbuild.compiler.discovery._test_types import (
-    DiscoverDbtManifestTargetPathTestCase,
     DiscoverProjectInputsErrorTestCase,
     DiscoverProjectInputsTestCase,
 )
@@ -86,7 +85,6 @@ SELECT 1
             expected_audit_block_names=(None,),
             expected_audit_block_sql_bodies=("SELECT 1",),
             expected_macro_paths=("macros/name_helpers.py",),
-            expected_manifest_path=None,
             expected_adapter_path="adapter.py",
         )
     ],
@@ -202,59 +200,12 @@ def test_given_project_repo_slice_when_discovering_inputs_then_it_returns_expect
     )
     assert (
         None
-        if discovered_inputs.dbt_manifest_file is None
-        else str(discovered_inputs.dbt_manifest_file.relative_path)
-    ) == test_case.expected_manifest_path
-    assert (
-        None
         if discovered_inputs.adapter_file is None
         else str(discovered_inputs.adapter_file.relative_path)
     ) == test_case.expected_adapter_path
     assert discovered_inputs.project_config.name == "demo"
     assert discovered_inputs.project_config.adapter == "duckdb"
     assert discovered_inputs.local_config.environment == "dev"
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        DiscoverDbtManifestTargetPathTestCase(
-            description="discovers dbt manifest from configured target path outside project",
-            repo_files=base_repo_files()
-            | {
-                "sqlbuild_project.toml": """
-name = "demo"
-adapter = "duckdb"
-
-[dbt]
-target_path = "../dbt_project/target"
-""".strip()
-                + "\n",
-                "../dbt_project/target/manifest.json": (
-                    '{"metadata": {"dbt_schema_version": "v12"}}\n'
-                ),
-            },
-            expected_manifest_path="../dbt_project/target/manifest.json",
-        )
-    ],
-    ids=["discovers dbt manifest from configured target path outside project"],
-)
-def test_given_dbt_target_path_when_discovering_inputs_then_loads_configured_manifest(
-    test_case: DiscoverDbtManifestTargetPathTestCase,
-    tmp_path: Path,
-    write_repo_files: Callable[[Path, dict[str, str]], None],
-) -> None:
-    write_repo_files(
-        tmp_path,
-        test_case.repo_files,
-    )
-
-    discovered_inputs: object = discover_project_inputs(project_dir=tmp_path)
-
-    assert discovered_inputs.dbt_manifest_file is not None
-    assert (
-        str(discovered_inputs.dbt_manifest_file.relative_path) == test_case.expected_manifest_path
-    )
 
 
 DISCOVERY_ERROR_TEST_CASES: list[DiscoverProjectInputsErrorTestCase] = [

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_refs.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_refs.py
@@ -263,7 +263,7 @@ def test_given_dbt_ref_when_resolving_then_returns_expected_sql(
 ) -> None:
     result: str = resolve_dbt_ref_references(
         query_sql=test_case.query_sql,
-        external_reference_resolver=_DBT_RESOLVER,
+        external_sql_reference_resolver=_DBT_RESOLVER,
     )
 
     assert result == test_case.expected_sql

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_refs.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_refs.py
@@ -14,6 +14,7 @@ from sqlbuild.compiler.planner.helpers.resolve.refs import (
     resolve_table_function_references,
 )
 from sqlbuild.compiler.planner.models import CursorBounds
+from sqlbuild.integrations.dbt.helpers.compile_refs import DbtCompileReferenceResolver
 from sqlbuild.integrations.dbt.helpers.manifest import build_dbt_manifest_index
 from sqlbuild.integrations.dbt.manifest.models import DbtManifestIndex
 from sqlbuild.integrations.duckdb.client import DuckDbAdapter
@@ -168,6 +169,7 @@ _DBT_MANIFEST: DbtManifestIndex = build_dbt_manifest_index(
         )
     )
 )
+_DBT_RESOLVER: DbtCompileReferenceResolver = DbtCompileReferenceResolver(dbt_manifest=_DBT_MANIFEST)
 
 
 @pytest.mark.parametrize(
@@ -261,7 +263,7 @@ def test_given_dbt_ref_when_resolving_then_returns_expected_sql(
 ) -> None:
     result: str = resolve_dbt_ref_references(
         query_sql=test_case.query_sql,
-        dbt_manifest=_DBT_MANIFEST,
+        external_reference_resolver=_DBT_RESOLVER,
     )
 
     assert result == test_case.expected_sql

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_scenario_artifacts.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_scenario_artifacts.py
@@ -158,6 +158,18 @@ VALID_ARTIFACT_NAME_RECOGNITION_TEST_CASES: list[ScenarioArtifactNameRecognition
         expected_kind="model",
         expected_logical_name="very_long_customer_revenue__f3f1eed0",
     ),
+    ScenarioArtifactNameRecognitionTestCase(
+        description="recognizes generated dbt ref artifact name",
+        physical_name=build_scenario_artifact_name(
+            hash_prefix="51b385aebe20",
+            kind="dbt_ref",
+            logical_name="stripe__payments",
+        ),
+        expected_is_scenario_artifact=True,
+        expected_hash_prefix="51b385aebe20",
+        expected_kind="dbt_ref",
+        expected_logical_name="stripe__payments",
+    ),
 ]
 
 INVALID_ARTIFACT_NAME_RECOGNITION_TEST_CASES: list[ScenarioArtifactNameRecognitionTestCase] = [

--- a/tests/unit/src/sqlbuild/executor/janitor/main/test_plan.py
+++ b/tests/unit/src/sqlbuild/executor/janitor/main/test_plan.py
@@ -108,6 +108,14 @@ PLAN_TEST_CASES: list[JanitorPlanTestCase] = [
         expected_candidate_names=("__sqb_a13f09c2e7b8__model__daily_revenue",),
     ),
     JanitorPlanTestCase(
+        description="dbt scenario artifact is eligible when tracked-only is enabled",
+        relation_infos=(
+            relation_info("__sqb_a13f09c2e7b8__dbt_ref__stripe__payments", created_at=OLD_TIME),
+        ),
+        delete_tracked_only=True,
+        expected_candidate_names=("__sqb_a13f09c2e7b8__dbt_ref__stripe__payments",),
+    ),
+    JanitorPlanTestCase(
         description="scenario-like relation is not eligible when tracked-only is enabled",
         relation_infos=(
             relation_info("__sqb_a13f09c2e7b__model__daily_revenue", created_at=OLD_TIME),


### PR DESCRIPTION
Yeah that last PR was a bit shit and defo had too much DBT code interweaving. This refactor is to move all that shit out of the way, otherwise we will be stuck with that crap forever.

EDIT - The syntax resolution is mostly fine to stay in compiler, but stuff to do with knowledge of manifest etc... shouldn't really be in the main code.