### PR TITLE
refactor: split compile models package

### DIFF
--- a/scripts/structure/structure_conventions/rules.py
+++ b/scripts/structure/structure_conventions/rules.py
@@ -531,7 +531,11 @@ def check_type_declarations_outside_types(file_path: Path, module: ast.Module) -
             )
             continue
 
-        if isinstance(node, ast.TypeAlias):
+        if isinstance(node, ast.TypeAlias) and not _is_local_model_union_alias(
+            file_path=file_path,
+            module=module,
+            node=node,
+        ):
             violations.append(
                 Violation(
                     code="SC015",
@@ -1172,6 +1176,40 @@ def _inherits_from_base_names(node: ast.ClassDef, base_names: frozenset[str]) ->
     return any(_base_name(base) in base_names for base in node.bases)
 
 
+def _is_local_model_union_alias(
+    *, file_path: Path, module: ast.Module, node: ast.TypeAlias
+) -> bool:
+    if not _is_within_role_package(file_path, "models"):
+        return False
+
+    model_class_names: frozenset[str] = frozenset(
+        child.name
+        for child in _non_docstring_body(module)
+        if isinstance(child, ast.ClassDef) and _is_allowed_model_class(child)
+    )
+    if not model_class_names:
+        return False
+
+    union_member_names: tuple[str, ...] | None = _local_union_member_names(node.value)
+    if union_member_names is None:
+        return False
+    if len(union_member_names) < 2:
+        return False
+    return all(name in model_class_names for name in union_member_names)
+
+
+def _local_union_member_names(node: ast.expr) -> tuple[str, ...] | None:
+    if isinstance(node, ast.Name):
+        return (node.id,)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left_names: tuple[str, ...] | None = _local_union_member_names(node.left)
+        right_names: tuple[str, ...] | None = _local_union_member_names(node.right)
+        if left_names is None or right_names is None:
+            return None
+        return (*left_names, *right_names)
+    return None
+
+
 def _base_name(node: ast.expr) -> str | None:
     if isinstance(node, ast.Name):
         return node.id
@@ -1259,17 +1297,28 @@ def _is_allowed_sibling_public_surface(
     parent_package_parts: tuple[str, ...],
     imported_parts: tuple[str, ...],
 ) -> bool:
+    public_surface_names: frozenset[str] = frozenset({"models", "types", "constants", "exceptions"})
     if (
         len(imported_parts) == len(parent_package_parts) + 2
         and imported_parts[len(parent_package_parts)] == "main"
         and imported_parts[-1] != "main"
     ):
         return True
+    if (
+        len(imported_parts) == len(parent_package_parts) + 2
+        and imported_parts[len(parent_package_parts)] in public_surface_names
+    ):
+        return True
+    if (
+        len(imported_parts) == len(parent_package_parts) + 3
+        and imported_parts[len(parent_package_parts) + 1] in public_surface_names
+    ):
+        return True
     if len(imported_parts) != len(parent_package_parts) + 2:
         return False
 
     public_module_name: str = imported_parts[-1]
-    if public_module_name in {"models", "types", "constants", "exceptions"}:
+    if public_module_name in public_surface_names:
         return True
     if "adapter" in parent_package_parts:
         return True

--- a/src/sqlbuild/cli/commands/main/compile.py
+++ b/src/sqlbuild/cli/commands/main/compile.py
@@ -19,7 +19,7 @@ from sqlbuild.cli.commands.main.helpers.compile.types import CompileLineageMode
 from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.status import maybe_status
 from sqlbuild.compiler.compile.main.load_macros import load_macros
-from sqlbuild.compiler.compile.models import LoadedMacro
+from sqlbuild.compiler.compile.models.core import LoadedMacro
 from sqlbuild.compiler.contracts.main.validate import validate_model_contracts
 from sqlbuild.compiler.contracts.models import ContractValidationResult
 from sqlbuild.compiler.diagnostics.models import CompilerDiagnostic

--- a/src/sqlbuild/cli/commands/main/dbt_sqlbuild_work.py
+++ b/src/sqlbuild/cli/commands/main/dbt_sqlbuild_work.py
@@ -10,7 +10,7 @@ from sqlbuild.cli.commands.main.helpers.dbt_sqlbuild_work import (
     execute_sqlbuild_build_work,
     execute_sqlbuild_test_work,
 )
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.planner.models import PlanOutput
 from sqlbuild.integrations.dbt.types import DbtInteropCommand, DbtInteropSqlbuildTestAction
 

--- a/src/sqlbuild/cli/commands/main/helpers/compile/output.py
+++ b/src/sqlbuild/cli/commands/main/helpers/compile/output.py
@@ -9,15 +9,17 @@ from pathlib import Path
 
 from sqlbuild.cli.commands.main.helpers.compile.models import WrittenTarget
 from sqlbuild.cli.commands.main.helpers.compile.types import CompileLineageMode
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledAudit,
     CompiledFunction,
     CompiledModel,
-    CompiledModelSqlTestPayload,
     CompiledObjectKey,
     CompiledProject,
     CompiledSeed,
     CompiledSource,
+)
+from sqlbuild.compiler.compile.models.sql_tests import (
+    CompiledModelSqlTestPayload,
     CompiledSqlTest,
 )
 from sqlbuild.compiler.diagnostics.models import CompilerDiagnostic, RelatedLocation

--- a/src/sqlbuild/cli/commands/main/helpers/compile/target_writer.py
+++ b/src/sqlbuild/cli/commands/main/helpers/compile/target_writer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.cli.commands.main.helpers.compile.models import WrittenTarget
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.planner.main.sql_test_assembly import build_sql_test_plan_entry
 from sqlbuild.compiler.planner.models import AuditPlanEntry, PlanOutput, SqlTestPlanEntry

--- a/src/sqlbuild/cli/commands/main/helpers/dbt_sqlbuild_work.py
+++ b/src/sqlbuild/cli/commands/main/helpers/dbt_sqlbuild_work.py
@@ -21,7 +21,7 @@ from sqlbuild.cli.commands.main.shared.helpers.progress import (
 from sqlbuild.cli.commands.main.shared.helpers.runtime_target_writer import write_runtime_target
 from sqlbuild.cli.commands.main.shared.helpers.status import TransientStatusReporter
 from sqlbuild.compiler.auditing.types import AuditOutcome
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.planner.models import AuditPlanEntry, PlanOutput, SqlTestPlanEntry
 from sqlbuild.executor.auditing.models import AuditExecutionResult
 from sqlbuild.executor.build.models import BuildExecutionResult

--- a/src/sqlbuild/cli/commands/main/helpers/lineage/models.py
+++ b/src/sqlbuild/cli/commands/main/helpers/lineage/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.lineage.models import ColumnLineageEdge, QualifiedLineageColumn
 from sqlbuild.compiler.lineage.types import ColumnLineageMode
 

--- a/src/sqlbuild/cli/commands/main/helpers/lineage/output.py
+++ b/src/sqlbuild/cli/commands/main/helpers/lineage/output.py
@@ -10,7 +10,7 @@ from sqlbuild.cli.commands.main.helpers.lineage.models import (
     LineageGraph,
     LineageNode,
 )
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.lineage.models import ColumnLineageEdge, QualifiedLineageColumn
 from sqlbuild.shared.helpers.colors import blue_bold, bold, dim

--- a/src/sqlbuild/cli/commands/main/helpers/lineage/selection.py
+++ b/src/sqlbuild/cli/commands/main/helpers/lineage/selection.py
@@ -16,7 +16,10 @@ from sqlbuild.cli.commands.main.helpers.lineage.models import (
 )
 from sqlbuild.cli.commands.main.shared.exceptions import CliUserError
 from sqlbuild.cli.commands.main.shared.helpers.status import maybe_status
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledProject,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.lineage.main.columns import build_project_column_lineage
 from sqlbuild.compiler.lineage.models import (

--- a/src/sqlbuild/cli/commands/main/helpers/scenario/capture.py
+++ b/src/sqlbuild/cli/commands/main/helpers/scenario/capture.py
@@ -25,7 +25,7 @@ from sqlbuild.cli.commands.main.shared.helpers.external_refs import (
 from sqlbuild.cli.commands.main.shared.helpers.planning_progress import PlanningProgressReporter
 from sqlbuild.cli.commands.main.shared.helpers.progress import format_build_header
 from sqlbuild.cli.commands.main.shared.helpers.status import TransientStatusReporter
-from sqlbuild.compiler.compile.models import CompiledSqlScenario
+from sqlbuild.compiler.compile.models.core import CompiledSqlScenario
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compile import run_compile_pipeline

--- a/src/sqlbuild/cli/commands/main/helpers/scenario/runner.py
+++ b/src/sqlbuild/cli/commands/main/helpers/scenario/runner.py
@@ -29,7 +29,7 @@ from sqlbuild.cli.commands.main.shared.helpers.scenario_runtime_target_writer im
     write_scenario_runtime_target,
 )
 from sqlbuild.cli.commands.main.shared.helpers.status import TransientStatusReporter
-from sqlbuild.compiler.compile.models import CompiledSqlScenario
+from sqlbuild.compiler.compile.models.core import CompiledSqlScenario
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compile import run_compile_pipeline

--- a/src/sqlbuild/cli/commands/main/helpers/scenario/selection.py
+++ b/src/sqlbuild/cli/commands/main/helpers/scenario/selection.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from sqlbuild.cli.commands.main.shared.exceptions import CliUserError
-from sqlbuild.compiler.compile.models import CompiledProject, CompiledSqlScenario
+from sqlbuild.compiler.compile.models.core import (
+    CompiledProject,
+    CompiledSqlScenario,
+)
 from sqlbuild.shared.constants import (
     SCENARIO_CLI_NONE_DISCOVERED,
     SCENARIO_CLI_UNKNOWN_SELECTOR,

--- a/src/sqlbuild/cli/commands/main/janitor.py
+++ b/src/sqlbuild/cli/commands/main/janitor.py
@@ -15,7 +15,7 @@ from sqlbuild.cli.commands.main.helpers.janitor.output import (
 from sqlbuild.cli.commands.main.shared.exceptions import CliUserError
 from sqlbuild.cli.commands.main.shared.helpers.adapters import resolve_adapter
 from sqlbuild.cli.commands.main.shared.helpers.connection import resolve_connection_config
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.project import compile_project

--- a/src/sqlbuild/compiler/auditing/main/render.py
+++ b/src/sqlbuild/compiler/auditing/main/render.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 
 from sqlbuild.compiler.auditing.constants import REF_PATTERN, SEED_PATTERN, SOURCE_PATTERN
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.shared.helpers.sources import render_source_relation
 from sqlbuild.spec.models.source import SourceEntry
 

--- a/src/sqlbuild/compiler/compile/helpers/assembly.py
+++ b/src/sqlbuild/compiler/compile/helpers/assembly.py
@@ -14,32 +14,34 @@ from sqlbuild.compiler.compile.helpers.deps import (
 from sqlbuild.compiler.compile.helpers.macros import expand_sql_macros, find_macro_call_names
 from sqlbuild.compiler.compile.helpers.sqlglot_columns import infer_columns_with_sqlglot
 from sqlbuild.compiler.compile.helpers.templating import expand_template_data
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompileAuditInput,
     CompiledAudit,
-    CompiledDirectLogicSqlTestPayload,
     CompiledFunction,
-    CompileDirectLogicSqlTestInputPayload,
     CompiledModel,
-    CompiledModelSqlTestPayload,
     CompiledObjectKey,
     CompiledProject,
     CompiledRelationTarget,
     CompiledSeed,
     CompiledSource,
     CompiledSqlScenario,
-    CompiledSqlTest,
     CompileModelInput,
-    CompileModelSqlTestInputPayload,
     CompileProjectInputs,
     CompileSeedInput,
     CompileSourceInput,
     CompileSqlFunctionInput,
     CompileSqlScenarioInput,
-    CompileSqlTestCte,
-    CompileSqlTestInput,
     InferredColumn,
     MacroContext,
+)
+from sqlbuild.compiler.compile.models.sql_tests import (
+    CompiledDirectLogicSqlTestPayload,
+    CompileDirectLogicSqlTestInputPayload,
+    CompiledModelSqlTestPayload,
+    CompiledSqlTest,
+    CompileModelSqlTestInputPayload,
+    CompileSqlTestCte,
+    CompileSqlTestInput,
 )
 from sqlbuild.compiler.compile.types import (
     AttachedAuditTargetKind,

--- a/src/sqlbuild/compiler/compile/helpers/attachment.py
+++ b/src/sqlbuild/compiler/compile/helpers/attachment.py
@@ -46,27 +46,29 @@ from sqlbuild.compiler.compile.helpers.templating import (
     expand_template_data,
 )
 from sqlbuild.compiler.compile.helpers.tests import extract_sql_test_ctes
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompileAuditInput,
-    CompileDirectLogicSqlTestCtes,
-    CompileDirectLogicSqlTestInputPayload,
     CompileModelConfig,
     CompileModelInput,
-    CompileModelSqlTestCtes,
-    CompileModelSqlTestInputPayload,
     CompileSeedInput,
     CompileSourceInput,
     CompileSqlFunctionInput,
     CompileSqlReference,
     CompileSqlScenarioCtes,
     CompileSqlScenarioInput,
-    CompileSqlTestCte,
-    CompileSqlTestCtes,
-    CompileSqlTestInput,
     FunctionArgument,
     FunctionReturnColumn,
     LoadedMacro,
     MacroContext,
+)
+from sqlbuild.compiler.compile.models.sql_tests import (
+    CompileDirectLogicSqlTestCtes,
+    CompileDirectLogicSqlTestInputPayload,
+    CompileModelSqlTestCtes,
+    CompileModelSqlTestInputPayload,
+    CompileSqlTestCte,
+    CompileSqlTestCtes,
+    CompileSqlTestInput,
 )
 from sqlbuild.compiler.compile.types import (
     AttachedAuditTargetKind,

--- a/src/sqlbuild/compiler/compile/helpers/deps.py
+++ b/src/sqlbuild/compiler/compile/helpers/deps.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompileSqlReference
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompileSqlReference,
+)
 from sqlbuild.compiler.compile.types import (
     AttachedAuditTargetKind,
     CompiledResourceType,

--- a/src/sqlbuild/compiler/compile/helpers/macros.py
+++ b/src/sqlbuild/compiler/compile/helpers/macros.py
@@ -24,7 +24,10 @@ from sqlbuild.compiler.compile.helpers.sql_scanning import (
 from sqlbuild.compiler.compile.helpers.sql_scanning import (
     is_identifier_start as _is_identifier_start,
 )
-from sqlbuild.compiler.compile.models import LoadedMacro, MacroContext
+from sqlbuild.compiler.compile.models.core import (
+    LoadedMacro,
+    MacroContext,
+)
 from sqlbuild.compiler.discovery.models import DiscoveredMacroFile
 
 _CONTEXT: str = "Macro expansion"

--- a/src/sqlbuild/compiler/compile/helpers/model_config_validation.py
+++ b/src/sqlbuild/compiler/compile/helpers/model_config_validation.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 
 from sqlbuild.compiler.compile.exceptions import CompileInputError
-from sqlbuild.compiler.compile.models import CompileModelConfig
+from sqlbuild.compiler.compile.models.core import CompileModelConfig
 from sqlbuild.compiler.planner.types import (
     CursorGrain,
     CursorType,

--- a/src/sqlbuild/compiler/compile/helpers/refs.py
+++ b/src/sqlbuild/compiler/compile/helpers/refs.py
@@ -9,7 +9,7 @@ from sqlbuild.compiler.compile.helpers.sql_scanning import (
     skip_line_comment,
     skip_quoted_text,
 )
-from sqlbuild.compiler.compile.models import CompileSqlReference
+from sqlbuild.compiler.compile.models.core import CompileSqlReference
 from sqlbuild.shared.types import SqlReferenceKind
 
 _CONTEXT: str = "SQL reference"

--- a/src/sqlbuild/compiler/compile/helpers/scenarios.py
+++ b/src/sqlbuild/compiler/compile/helpers/scenarios.py
@@ -21,7 +21,10 @@ from sqlbuild.compiler.compile.helpers.tests import (
     _try_consume_keyword,
     _validate_ceremonial_select,
 )
-from sqlbuild.compiler.compile.models import CompileSqlScenarioCte, CompileSqlScenarioCtes
+from sqlbuild.compiler.compile.models.core import (
+    CompileSqlScenarioCte,
+    CompileSqlScenarioCtes,
+)
 
 _CONTEXT: str = "SQL scenario"
 

--- a/src/sqlbuild/compiler/compile/helpers/sql_vars.py
+++ b/src/sqlbuild/compiler/compile/helpers/sql_vars.py
@@ -19,7 +19,10 @@ from sqlbuild.compiler.compile.helpers.sql_scanning import (
     skip_line_comment,
     skip_quoted_text,
 )
-from sqlbuild.compiler.compile.models import LoadedMacro, MacroContext
+from sqlbuild.compiler.compile.models.core import (
+    LoadedMacro,
+    MacroContext,
+)
 from sqlbuild.shared.helpers.project_var_values import render_project_var_text
 
 _CONTEXT: str = "SQL interpolation"

--- a/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
+++ b/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from sqlbuild.adapter.shared.models import ExpressionInferenceProfile
 from sqlbuild.adapter.shared.types import FunctionNullabilityRule
-from sqlbuild.compiler.compile.models import InferredColumn
+from sqlbuild.compiler.compile.models.core import InferredColumn
 from sqlbuild.compiler.lineage.types import InferredNullability
 from sqlbuild.shared.helpers.sql_reference_patterns import (
     quoted_reference_call_pattern,

--- a/src/sqlbuild/compiler/compile/helpers/tests.py
+++ b/src/sqlbuild/compiler/compile/helpers/tests.py
@@ -28,7 +28,7 @@ from sqlbuild.compiler.compile.helpers.sql_scanning import (
 from sqlbuild.compiler.compile.helpers.sqlglot_tests import (
     extract_expected_branch_column_names_with_sqlglot,
 )
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.sql_tests import (
     CompileDirectLogicSqlTestCtes,
     CompileModelSqlTestCtes,
     CompileSqlTestCte,

--- a/src/sqlbuild/compiler/compile/main/assemble_project.py
+++ b/src/sqlbuild/compiler/compile/main/assemble_project.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from sqlbuild.adapter.shared.models import ExpressionInferenceProfile
 from sqlbuild.compiler.compile.helpers.assembly import assemble_compiled_project
-from sqlbuild.compiler.compile.models import CompiledProject, CompileProjectInputs
+from sqlbuild.compiler.compile.models.core import (
+    CompiledProject,
+    CompileProjectInputs,
+)
 
 
 def assemble_project(

--- a/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
+++ b/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
@@ -20,7 +20,7 @@ from sqlbuild.compiler.compile.helpers.attachment import (
     resolve_run_id,
 )
 from sqlbuild.compiler.compile.helpers.macros import load_project_macros
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompileAuditInput,
     CompileModelInput,
     CompileProjectInputs,
@@ -28,10 +28,10 @@ from sqlbuild.compiler.compile.models import (
     CompileSourceInput,
     CompileSqlFunctionInput,
     CompileSqlScenarioInput,
-    CompileSqlTestInput,
     LoadedMacro,
     MacroContext,
 )
+from sqlbuild.compiler.compile.models.sql_tests import CompileSqlTestInput
 from sqlbuild.compiler.diagnostics.models import CompilerDiagnostic
 from sqlbuild.compiler.discovery.models import (
     DiscoveredAuditBlock,

--- a/src/sqlbuild/compiler/compile/main/load_macros.py
+++ b/src/sqlbuild/compiler/compile/main/load_macros.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sqlbuild.compiler.compile.helpers.macros import load_project_macros
-from sqlbuild.compiler.compile.models import LoadedMacro
+from sqlbuild.compiler.compile.models.core import LoadedMacro
 from sqlbuild.compiler.discovery.models import DiscoveredMacroFile
 
 

--- a/src/sqlbuild/compiler/compile/models/__init__.py
+++ b/src/sqlbuild/compiler/compile/models/__init__.py
@@ -1,0 +1,1 @@
+"""Compile model modules."""

--- a/src/sqlbuild/compiler/compile/models/core.py
+++ b/src/sqlbuild/compiler/compile/models/core.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from sqlbuild.compiler.compile.constants import DEFAULT_SQL_TEST_MODE
 from sqlbuild.compiler.compile.types import (
     AttachedAuditTargetKind,
     CompiledResourceType,
     FunctionLanguage,
-    SqlTestMode,
 )
 from sqlbuild.compiler.diagnostics.models import CompilerDiagnostic
 from sqlbuild.compiler.discovery.models import (
@@ -25,8 +24,6 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlFunctionFile,
     DiscoveredSqlModelFile,
     DiscoveredSqlScenarioFile,
-    DiscoveredSqlTestBlock,
-    DiscoveredSqlTestFile,
 )
 from sqlbuild.compiler.lineage.types import InferredNullability
 from sqlbuild.shared.types import ExternalSqlReferenceResolver, SqlReferenceKind
@@ -39,6 +36,9 @@ from sqlbuild.spec.models.project import (
 )
 from sqlbuild.spec.models.schema import SchemaModelEntry, SchemaSeedEntry, SourceLocation
 from sqlbuild.spec.models.source import SourceEntry
+
+if TYPE_CHECKING:
+    from sqlbuild.compiler.compile.models.sql_tests import CompiledSqlTest, CompileSqlTestInput
 
 
 @dataclass(frozen=True)
@@ -102,47 +102,6 @@ class CompiledObjectKey:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "resource_type", CompiledResourceType(self.resource_type))
-
-
-@dataclass(frozen=True)
-class CompileSqlTestCte:
-    """One top-level SQL-native test CTE extracted after macro expansion."""
-
-    name: str
-    sql_body: str
-
-
-@dataclass(frozen=True)
-class CompileModelSqlTestCtes:
-    """Extracted model-mode SQL-native test CTE semantics."""
-
-    authored_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
-    macro_mocks: dict[str, str] = field(default_factory=dict)
-    mock_model_names: tuple[str, ...] = field(default_factory=tuple)
-    mock_source_names: tuple[str, ...] = field(default_factory=tuple)
-    mock_seed_names: tuple[str, ...] = field(default_factory=tuple)
-    mock_dbt_ref_names: tuple[str, ...] = field(default_factory=tuple)
-    expected_model_names: tuple[str, ...] = field(default_factory=tuple)
-    assertion_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
-    assertion_names: tuple[str, ...] = field(default_factory=tuple)
-
-
-@dataclass(frozen=True)
-class CompileDirectLogicSqlTestCtes:
-    """Extracted direct-logic SQL-native test CTE semantics."""
-
-    mode: SqlTestMode
-    helper_ctes: tuple[CompileSqlTestCte, ...]
-    actual_cte: CompileSqlTestCte
-    expected_cte: CompileSqlTestCte
-
-
-@dataclass(frozen=True)
-class CompileSqlTestCtes:
-    """Extracted top-level SQL-native test CTE semantics."""
-
-    mode: SqlTestMode
-    payload: CompileModelSqlTestCtes | CompileDirectLogicSqlTestCtes
 
 
 @dataclass(frozen=True)
@@ -234,45 +193,6 @@ class CompileSourceInput:
 
     source_entry: SourceEntry
     source_file: DiscoveredSourceFile
-
-
-@dataclass(frozen=True)
-class CompileModelSqlTestInputPayload:
-    """Model-mode SQL test compile payload."""
-
-    authored_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
-    macro_mocks: dict[str, str] = field(default_factory=dict)
-    mock_model_names: tuple[str, ...] = field(default_factory=tuple)
-    mock_source_names: tuple[str, ...] = field(default_factory=tuple)
-    mock_seed_names: tuple[str, ...] = field(default_factory=tuple)
-    mock_dbt_ref_names: tuple[str, ...] = field(default_factory=tuple)
-    expected_model_names: tuple[str, ...] = field(default_factory=tuple)
-    assertion_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
-    assertion_names: tuple[str, ...] = field(default_factory=tuple)
-
-
-@dataclass(frozen=True)
-class CompileDirectLogicSqlTestInputPayload:
-    """Direct-logic SQL test compile payload."""
-
-    actual_cte: CompileSqlTestCte
-    expected_cte: CompileSqlTestCte
-    mode: SqlTestMode
-    helper_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
-    tested_resource_names: tuple[str, ...] = field(default_factory=tuple)
-
-
-@dataclass(frozen=True)
-class CompileSqlTestInput:
-    """One discovered SQL-native test block with compile-time SQL expansion applied."""
-
-    test_file: DiscoveredSqlTestFile
-    test_block: DiscoveredSqlTestBlock
-    sql_body: str
-    mode: SqlTestMode = DEFAULT_SQL_TEST_MODE
-    payload: CompileModelSqlTestInputPayload | CompileDirectLogicSqlTestInputPayload = field(
-        default_factory=CompileModelSqlTestInputPayload
-    )
 
 
 @dataclass(frozen=True)
@@ -434,49 +354,6 @@ class CompiledAudit:
     attached_column_name: str | None = None
     severity: str | None = None
     run_scope: str | None = None
-
-
-@dataclass(frozen=True)
-class CompiledModelSqlTestPayload:
-    """Compiled model-mode SQL test payload."""
-
-    authored_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
-    macro_mocks: dict[str, str] = field(default_factory=dict)
-    model_query_overrides: dict[str, str] = field(default_factory=dict)
-    mock_model_names: tuple[str, ...] = field(default_factory=tuple)
-    mock_source_names: tuple[str, ...] = field(default_factory=tuple)
-    mock_seed_names: tuple[str, ...] = field(default_factory=tuple)
-    mock_dbt_ref_names: tuple[str, ...] = field(default_factory=tuple)
-    expected_model_names: tuple[str, ...] = field(default_factory=tuple)
-    assertion_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
-    assertion_names: tuple[str, ...] = field(default_factory=tuple)
-
-
-@dataclass(frozen=True)
-class CompiledDirectLogicSqlTestPayload:
-    """Compiled direct-logic SQL test payload."""
-
-    actual_cte: CompileSqlTestCte
-    expected_cte: CompileSqlTestCte
-    mode: SqlTestMode = DEFAULT_SQL_TEST_MODE
-    helper_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
-    tested_resource_names: tuple[str, ...] = field(default_factory=tuple)
-
-
-@dataclass(frozen=True)
-class CompiledSqlTest:
-    """Compiled SQL-native unit test metadata selected by expected targets."""
-
-    key: CompiledObjectKey
-    scope_deps: tuple[CompiledObjectKey, ...]
-    name: str
-    test_file: DiscoveredSqlTestFile
-    test_block: DiscoveredSqlTestBlock
-    sql_body: str
-    mode: SqlTestMode = DEFAULT_SQL_TEST_MODE
-    payload: CompiledModelSqlTestPayload | CompiledDirectLogicSqlTestPayload = field(
-        default_factory=CompiledModelSqlTestPayload
-    )
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/compile/models/sql_tests.py
+++ b/src/sqlbuild/compiler/compile/models/sql_tests.py
@@ -1,0 +1,140 @@
+"""SQL-native test compile and compiled models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sqlbuild.compiler.compile.constants import DEFAULT_SQL_TEST_MODE
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
+from sqlbuild.compiler.compile.types import SqlTestMode
+from sqlbuild.compiler.discovery.models import DiscoveredSqlTestBlock, DiscoveredSqlTestFile
+
+
+@dataclass(frozen=True)
+class CompileSqlTestCte:
+    """One top-level SQL-native test CTE extracted after macro expansion."""
+
+    name: str
+    sql_body: str
+
+
+@dataclass(frozen=True)
+class CompileModelSqlTestCtes:
+    """Extracted model-mode SQL-native test CTE semantics."""
+
+    authored_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
+    macro_mocks: dict[str, str] = field(default_factory=dict)
+    mock_model_names: tuple[str, ...] = field(default_factory=tuple)
+    mock_source_names: tuple[str, ...] = field(default_factory=tuple)
+    mock_seed_names: tuple[str, ...] = field(default_factory=tuple)
+    mock_dbt_ref_names: tuple[str, ...] = field(default_factory=tuple)
+    expected_model_names: tuple[str, ...] = field(default_factory=tuple)
+    assertion_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
+    assertion_names: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class CompileDirectLogicSqlTestCtes:
+    """Extracted direct-logic SQL-native test CTE semantics."""
+
+    mode: SqlTestMode
+    helper_ctes: tuple[CompileSqlTestCte, ...]
+    actual_cte: CompileSqlTestCte
+    expected_cte: CompileSqlTestCte
+
+
+type CompileSqlTestCtesPayload = CompileModelSqlTestCtes | CompileDirectLogicSqlTestCtes
+
+
+@dataclass(frozen=True)
+class CompileSqlTestCtes:
+    """Extracted top-level SQL-native test CTE semantics."""
+
+    mode: SqlTestMode
+    payload: CompileSqlTestCtesPayload
+
+
+@dataclass(frozen=True)
+class CompileModelSqlTestInputPayload:
+    """Model-mode SQL test compile payload."""
+
+    authored_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
+    macro_mocks: dict[str, str] = field(default_factory=dict)
+    mock_model_names: tuple[str, ...] = field(default_factory=tuple)
+    mock_source_names: tuple[str, ...] = field(default_factory=tuple)
+    mock_seed_names: tuple[str, ...] = field(default_factory=tuple)
+    mock_dbt_ref_names: tuple[str, ...] = field(default_factory=tuple)
+    expected_model_names: tuple[str, ...] = field(default_factory=tuple)
+    assertion_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
+    assertion_names: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class CompileDirectLogicSqlTestInputPayload:
+    """Direct-logic SQL test compile payload."""
+
+    actual_cte: CompileSqlTestCte
+    expected_cte: CompileSqlTestCte
+    mode: SqlTestMode
+    helper_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
+    tested_resource_names: tuple[str, ...] = field(default_factory=tuple)
+
+
+type CompileSqlTestInputPayload = (
+    CompileModelSqlTestInputPayload | CompileDirectLogicSqlTestInputPayload
+)
+
+
+@dataclass(frozen=True)
+class CompileSqlTestInput:
+    """One discovered SQL-native test block with compile-time SQL expansion applied."""
+
+    test_file: DiscoveredSqlTestFile
+    test_block: DiscoveredSqlTestBlock
+    sql_body: str
+    mode: SqlTestMode = DEFAULT_SQL_TEST_MODE
+    payload: CompileSqlTestInputPayload = field(default_factory=CompileModelSqlTestInputPayload)
+
+
+@dataclass(frozen=True)
+class CompiledModelSqlTestPayload:
+    """Compiled model-mode SQL test payload."""
+
+    authored_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
+    macro_mocks: dict[str, str] = field(default_factory=dict)
+    model_query_overrides: dict[str, str] = field(default_factory=dict)
+    mock_model_names: tuple[str, ...] = field(default_factory=tuple)
+    mock_source_names: tuple[str, ...] = field(default_factory=tuple)
+    mock_seed_names: tuple[str, ...] = field(default_factory=tuple)
+    mock_dbt_ref_names: tuple[str, ...] = field(default_factory=tuple)
+    expected_model_names: tuple[str, ...] = field(default_factory=tuple)
+    assertion_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
+    assertion_names: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class CompiledDirectLogicSqlTestPayload:
+    """Compiled direct-logic SQL test payload."""
+
+    actual_cte: CompileSqlTestCte
+    expected_cte: CompileSqlTestCte
+    mode: SqlTestMode = DEFAULT_SQL_TEST_MODE
+    helper_ctes: tuple[CompileSqlTestCte, ...] = field(default_factory=tuple)
+    tested_resource_names: tuple[str, ...] = field(default_factory=tuple)
+
+
+type CompiledSqlTestPayload = CompiledModelSqlTestPayload | CompiledDirectLogicSqlTestPayload
+
+
+@dataclass(frozen=True)
+class CompiledSqlTest:
+    """Compiled SQL-native unit test metadata selected by expected targets."""
+
+    key: CompiledObjectKey
+    scope_deps: tuple[CompiledObjectKey, ...]
+    name: str
+    test_file: DiscoveredSqlTestFile
+    test_block: DiscoveredSqlTestBlock
+    sql_body: str
+    mode: SqlTestMode = DEFAULT_SQL_TEST_MODE
+    payload: CompiledSqlTestPayload = field(default_factory=CompiledModelSqlTestPayload)

--- a/src/sqlbuild/compiler/contracts/helpers/columns.py
+++ b/src/sqlbuild/compiler/contracts/helpers/columns.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from sqlbuild.adapter.shared.type_normalization import types_equal
 from sqlbuild.adapter.shared.types import TypeDialect
-from sqlbuild.compiler.compile.models import CompiledModel, InferredColumn
+from sqlbuild.compiler.compile.models.core import (
+    CompiledModel,
+    InferredColumn,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.diagnostics.models import CompilerDiagnostic, RelatedLocation
 from sqlbuild.compiler.diagnostics.types import DiagnosticPhase, DiagnosticSeverity

--- a/src/sqlbuild/compiler/contracts/main/validate.py
+++ b/src/sqlbuild/compiler/contracts/main/validate.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.shared.types import TypeDialect
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.contracts.helpers.columns import validate_model_column_contracts
 from sqlbuild.compiler.contracts.models import ContractValidationResult
 from sqlbuild.compiler.diagnostics.models import CompilerDiagnostic

--- a/src/sqlbuild/compiler/lineage/helpers/columns.py
+++ b/src/sqlbuild/compiler/lineage/helpers/columns.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledProject,
 )

--- a/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
+++ b/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject
+from sqlbuild.compiler.compile.models.core import (
+    CompiledModel,
+    CompiledProject,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.lineage.helpers.columns import (
     _build_schema_mapping,

--- a/src/sqlbuild/compiler/lineage/main/columns.py
+++ b/src/sqlbuild/compiler/lineage/main/columns.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.lineage.helpers.columns import (
     build_project_column_lineage as _build_project_column_lineage,
 )

--- a/src/sqlbuild/compiler/manifest/helpers/graph_maps.py
+++ b/src/sqlbuild/compiler/manifest/helpers/graph_maps.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledProject,
+)
 
 
 def build_unique_id(key: CompiledObjectKey, project_name: str, project: CompiledProject) -> str:

--- a/src/sqlbuild/compiler/manifest/helpers/macros.py
+++ b/src/sqlbuild/compiler/manifest/helpers/macros.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import LoadedMacro
+from sqlbuild.compiler.compile.models.core import LoadedMacro
 from sqlbuild.compiler.manifest.constants import RESOURCE_TYPE_MACRO
 
 

--- a/src/sqlbuild/compiler/manifest/helpers/model_nodes.py
+++ b/src/sqlbuild/compiler/manifest/helpers/model_nodes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sqlbuild.compiler.compile.models import CompiledModel
+from sqlbuild.compiler.compile.models.core import CompiledModel
 from sqlbuild.compiler.manifest.constants import CHECKSUM_HASH_NAME, RESOURCE_TYPE_MODEL
 from sqlbuild.compiler.manifest.helpers.shared import (
     build_columns_dict,

--- a/src/sqlbuild/compiler/manifest/helpers/seeds.py
+++ b/src/sqlbuild/compiler/manifest/helpers/seeds.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import CompiledSeed
+from sqlbuild.compiler.compile.models.core import CompiledSeed
 from sqlbuild.compiler.manifest.constants import CHECKSUM_HASH_NAME, RESOURCE_TYPE_SEED
 from sqlbuild.compiler.manifest.helpers.shared import build_columns_dict, build_fqn
 

--- a/src/sqlbuild/compiler/manifest/helpers/shared.py
+++ b/src/sqlbuild/compiler/manifest/helpers/shared.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.spec.models.schema import SchemaColumn, SchemaModelEntry, SchemaSeedEntry
 from sqlbuild.spec.models.source import SourceColumnEntry

--- a/src/sqlbuild/compiler/manifest/helpers/sources.py
+++ b/src/sqlbuild/compiler/manifest/helpers/sources.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import CompiledSource
+from sqlbuild.compiler.compile.models.core import CompiledSource
 from sqlbuild.compiler.manifest.constants import RESOURCE_TYPE_SOURCE
 from sqlbuild.compiler.manifest.helpers.shared import build_source_columns_dict
 from sqlbuild.spec.models.source import SourceEntry

--- a/src/sqlbuild/compiler/manifest/main/build.py
+++ b/src/sqlbuild/compiler/manifest/main/build.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/src/sqlbuild/compiler/pipeline/helpers/clone.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/clone.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 from sqlbuild.compiler.pipeline.models import ClonePipelineResult

--- a/src/sqlbuild/compiler/pipeline/helpers/deferred_targets.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/deferred_targets.py
@@ -9,7 +9,7 @@ from typing import Any
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import RelationInfo
 from sqlbuild.compiler.compile.constants import PRESERVE_ENVIRONMENT_VALUE
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledProject,
     CompiledRelationTarget,

--- a/src/sqlbuild/compiler/pipeline/helpers/diff.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/diff.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledObjectKey,
     CompiledProject,
 )

--- a/src/sqlbuild/compiler/pipeline/helpers/graph.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/graph.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledFunction,
     CompiledModel,
     CompiledObjectKey,

--- a/src/sqlbuild/compiler/pipeline/helpers/target_defaults.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/target_defaults.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import replace
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledFunction,
     CompiledModel,
     CompiledProject,

--- a/src/sqlbuild/compiler/pipeline/helpers/target_validation.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/target_validation.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.shared.types import BuiltinAdapter
-from sqlbuild.compiler.compile.models import CompiledProject, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledProject,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 
 

--- a/src/sqlbuild/compiler/pipeline/main/compile.py
+++ b/src/sqlbuild/compiler/pipeline/main/compile.py
@@ -10,7 +10,7 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import RelationInfo
 from sqlbuild.compiler.compile.main.effective_config import build_effective_connection_config
 from sqlbuild.compiler.compile.main.load_macros import load_macros
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledProject,
     CompiledRelationTarget,
     LoadedMacro,

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.compiler.compile.main.assemble_project import assemble_project
 from sqlbuild.compiler.compile.main.build_compile_inputs import build_compile_inputs
-from sqlbuild.compiler.compile.models import CompiledProject, CompileProjectInputs
+from sqlbuild.compiler.compile.models.core import (
+    CompiledProject,
+    CompileProjectInputs,
+)
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.helpers.target_defaults import apply_target_defaults
 from sqlbuild.compiler.pipeline.helpers.target_validation import validate_project_targets

--- a/src/sqlbuild/compiler/pipeline/main/diff.py
+++ b/src/sqlbuild/compiler/pipeline/main/diff.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.helpers.diff import (
     compile_project_for_diff_environment,

--- a/src/sqlbuild/compiler/pipeline/main/graph.py
+++ b/src/sqlbuild/compiler/pipeline/main/graph.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledProject,
+)
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.helpers.graph import (
     build_static_all_keys,

--- a/src/sqlbuild/compiler/pipeline/main/project.py
+++ b/src/sqlbuild/compiler/pipeline/main/project.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 from sqlbuild.shared.types import ExternalSqlReferenceResolver

--- a/src/sqlbuild/compiler/pipeline/models.py
+++ b/src/sqlbuild/compiler/pipeline/models.py
@@ -6,7 +6,10 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledProject,
+)
 from sqlbuild.compiler.planner.models import ModelPlanEntry, PlanOutput, SeedPlanEntry
 
 

--- a/src/sqlbuild/compiler/planner/helpers/audit_entry.py
+++ b/src/sqlbuild/compiler/planner/helpers/audit_entry.py
@@ -8,7 +8,7 @@ from sqlbuild.compiler.auditing.types import (
     AuditRunScope,
     AuditSeverity,
 )
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledAudit,
     CompiledObjectKey,
     CompiledRelationTarget,

--- a/src/sqlbuild/compiler/planner/helpers/audit_scheduling.py
+++ b/src/sqlbuild/compiler/planner/helpers/audit_scheduling.py
@@ -6,7 +6,7 @@ from sqlbuild.compiler.auditing.types import (
     AuditAttachmentKind,
     AuditRunScope,
 )
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledAudit,
     CompiledObjectKey,
     CompileSqlReference,

--- a/src/sqlbuild/compiler/planner/helpers/buildability.py
+++ b/src/sqlbuild/compiler/planner/helpers/buildability.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.shared.models import RelationInfo
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import MissingUpstream, WarehouseSnapshot
 

--- a/src/sqlbuild/compiler/planner/helpers/cascade.py
+++ b/src/sqlbuild/compiler/planner/helpers/cascade.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from datetime import timedelta
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import (
     BackfillResult,

--- a/src/sqlbuild/compiler/planner/helpers/changes/config.py
+++ b/src/sqlbuild/compiler/planner/helpers/changes/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import CompiledModel
+from sqlbuild.compiler.compile.models.core import CompiledModel
 
 
 def get_config_str(model: CompiledModel, key: str) -> str | None:

--- a/src/sqlbuild/compiler/planner/helpers/changes/detect.py
+++ b/src/sqlbuild/compiler/planner/helpers/changes/detect.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import logging
 
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import CompiledModel, InferredColumn
+from sqlbuild.compiler.compile.models.core import (
+    CompiledModel,
+    InferredColumn,
+)
 from sqlbuild.compiler.fingerprints.models import Fingerprint
 from sqlbuild.compiler.planner.helpers.changes.config import (
     get_config_dict,

--- a/src/sqlbuild/compiler/planner/helpers/changes/schema.py
+++ b/src/sqlbuild/compiler/planner/helpers/changes/schema.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import InferredColumn
+from sqlbuild.compiler.compile.models.core import InferredColumn
 from sqlbuild.compiler.planner.models import SchemaFinding
 from sqlbuild.compiler.planner.types import SchemaChangeKind, SchemaColumnSource
 

--- a/src/sqlbuild/compiler/planner/helpers/clone.py
+++ b/src/sqlbuild/compiler/planner/helpers/clone.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/src/sqlbuild/compiler/planner/helpers/function_fingerprints.py
+++ b/src/sqlbuild/compiler/planner/helpers/function_fingerprints.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledFunction,
     FunctionArgument,
     FunctionReturnColumn,

--- a/src/sqlbuild/compiler/planner/helpers/graph.py
+++ b/src/sqlbuild/compiler/planner/helpers/graph.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledObjectKey,
     CompiledProject,
-    CompiledSqlTest,
 )
+from sqlbuild.compiler.compile.models.sql_tests import CompiledSqlTest
 from sqlbuild.compiler.compile.types import CompiledResourceType
 
 

--- a/src/sqlbuild/compiler/planner/helpers/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/helpers/plan_entry.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/src/sqlbuild/compiler/planner/helpers/resolve/config.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
-from sqlbuild.compiler.compile.models import CompiledModel
+from sqlbuild.compiler.compile.models.core import CompiledModel
 from sqlbuild.compiler.planner.types import IncrementalStrategy
 
 

--- a/src/sqlbuild/compiler/planner/helpers/resolve/cursor_inputs.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/cursor_inputs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledRelationTarget,
     CompileSqlReference,

--- a/src/sqlbuild/compiler/planner/helpers/resolve/refs.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/refs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledFunction,
     CompiledModel,
     CompiledObjectKey,

--- a/src/sqlbuild/compiler/planner/helpers/resolve/resolve.py
+++ b/src/sqlbuild/compiler/planner/helpers/resolve/resolve.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledFunction,
     CompiledModel,
     CompiledRelationTarget,

--- a/src/sqlbuild/compiler/planner/helpers/scenario_artifacts.py
+++ b/src/sqlbuild/compiler/planner/helpers/scenario_artifacts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Callable
 
-from sqlbuild.compiler.compile.models import CompiledSqlScenario
+from sqlbuild.compiler.compile.models.core import CompiledSqlScenario
 from sqlbuild.compiler.planner.constants import (
     SCENARIO_DEFAULT_IDENTIFIER_LIMIT,
     SCENARIO_HASH_PREFIX_LENGTH,

--- a/src/sqlbuild/compiler/planner/helpers/scenario_cli.py
+++ b/src/sqlbuild/compiler/planner/helpers/scenario_cli.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject, CompiledSqlScenario
+from sqlbuild.compiler.compile.models.core import (
+    CompiledModel,
+    CompiledProject,
+    CompiledSqlScenario,
+)
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.helpers.scenario_artifacts import (

--- a/src/sqlbuild/compiler/planner/helpers/scenario_graph.py
+++ b/src/sqlbuild/compiler/planner/helpers/scenario_graph.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/src/sqlbuild/compiler/planner/helpers/scenario_relations.py
+++ b/src/sqlbuild/compiler/planner/helpers/scenario_relations.py
@@ -14,7 +14,7 @@ from sqlbuild.compiler.compile.constants import (
     SEED_TEST_CTE_PREFIX,
     SOURCE_TEST_CTE_PREFIX,
 )
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledFunction,
     CompiledModel,
     CompiledObjectKey,

--- a/src/sqlbuild/compiler/planner/helpers/selectors.py
+++ b/src/sqlbuild/compiler/planner/helpers/selectors.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.helpers.graph import (

--- a/src/sqlbuild/compiler/planner/helpers/sql_test_assembly.py
+++ b/src/sqlbuild/compiler/planner/helpers/sql_test_assembly.py
@@ -12,13 +12,15 @@ from sqlbuild.compiler.compile.constants import (
     SEED_TEST_CTE_PREFIX,
     SOURCE_TEST_CTE_PREFIX,
 )
-from sqlbuild.compiler.compile.models import (
-    CompiledDirectLogicSqlTestPayload,
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
-    CompiledModelSqlTestPayload,
     CompiledObjectKey,
     CompiledProject,
     CompiledRelationTarget,
+)
+from sqlbuild.compiler.compile.models.sql_tests import (
+    CompiledDirectLogicSqlTestPayload,
+    CompiledModelSqlTestPayload,
     CompiledSqlTest,
     CompileSqlTestCte,
 )

--- a/src/sqlbuild/compiler/planner/helpers/sqlglot_sql_test_assembly.py
+++ b/src/sqlbuild/compiler/planner/helpers/sqlglot_sql_test_assembly.py
@@ -12,7 +12,7 @@ from sqlbuild.compiler.compile.constants import (
     SOURCE_TEST_CTE_PREFIX,
 )
 from sqlbuild.compiler.compile.exceptions import CompileInputError
-from sqlbuild.compiler.compile.models import CompileSqlTestCte
+from sqlbuild.compiler.compile.models.sql_tests import CompileSqlTestCte
 from sqlbuild.compiler.planner.models import SqlglotResolvedTestSql
 from sqlbuild.shared.helpers.sqlglot import import_sqlglot, import_sqlglot_expressions
 from sqlbuild.shared.types import SqlReferenceKind

--- a/src/sqlbuild/compiler/planner/helpers/strategy.py
+++ b/src/sqlbuild/compiler/planner/helpers/strategy.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import CompiledModel, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledModel,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.models import (
     ChangeDetectionResult,

--- a/src/sqlbuild/compiler/planner/helpers/warehouse_snapshot.py
+++ b/src/sqlbuild/compiler/planner/helpers/warehouse_snapshot.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import ColumnInfo, RelationInfo
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledFunction,
     CompiledModel,
     CompiledObjectKey,

--- a/src/sqlbuild/compiler/planner/main/clone.py
+++ b/src/sqlbuild/compiler/planner/main/clone.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.planner.helpers.clone import (
     build_clone_model_entries,
     build_clone_plan_output,

--- a/src/sqlbuild/compiler/planner/main/display_plan.py
+++ b/src/sqlbuild/compiler/planner/main/display_plan.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledProject,
+)
 from sqlbuild.compiler.planner.helpers.graph import build_downstream_deps, build_upstream_deps
 from sqlbuild.compiler.planner.helpers.strategy import get_materialization_type
 from sqlbuild.compiler.planner.models import BackfillResult, ModelPlanEntry, PlanOutput

--- a/src/sqlbuild/compiler/planner/main/execution.py
+++ b/src/sqlbuild/compiler/planner/main/execution.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import ColumnInfo, RelationInfo
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledAudit,
     CompiledFunction,
     CompiledModel,
@@ -18,8 +18,8 @@ from sqlbuild.compiler.compile.models import (
     CompiledRelationTarget,
     CompiledSeed,
     CompiledSource,
-    CompiledSqlTest,
 )
+from sqlbuild.compiler.compile.models.sql_tests import CompiledSqlTest
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.helpers.audit_entry import plan_audit

--- a/src/sqlbuild/compiler/planner/main/scenario.py
+++ b/src/sqlbuild/compiler/planner/main/scenario.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledSqlScenario
+from sqlbuild.compiler.compile.models.core import CompiledSqlScenario
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.helpers.scenario_cli import build_cli_scenario_plan
 from sqlbuild.compiler.planner.models import ScenarioExecutionPlan

--- a/src/sqlbuild/compiler/planner/main/sql_test_assembly.py
+++ b/src/sqlbuild/compiler/planner/main/sql_test_assembly.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import CompiledProject, CompiledSqlTest
+from sqlbuild.compiler.compile.models.core import CompiledProject
+from sqlbuild.compiler.compile.models.sql_tests import CompiledSqlTest
 from sqlbuild.compiler.planner.helpers.sql_test_assembly import plan_test
 from sqlbuild.compiler.planner.models import PlanWarning, SqlTestPlanEntry
 

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -14,7 +14,7 @@ from sqlbuild.compiler.auditing.types import (
     AuditRunScope,
     AuditSeverity,
 )
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledObjectKey,
     CompiledRelationTarget,
     FunctionReturnColumn,

--- a/src/sqlbuild/executor/auditing/main/execute.py
+++ b/src/sqlbuild/executor/auditing/main/execute.py
@@ -11,7 +11,7 @@ from sqlbuild.compiler.auditing.types import (
     AuditRunScope,
     AuditSeverity,
 )
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.models import AuditPlanEntry
 from sqlbuild.executor.auditing.models import AuditExecutionResult
 from sqlbuild.shared.helpers.diagnostics_logging import diagnostics_context

--- a/src/sqlbuild/executor/build/helpers/blocking.py
+++ b/src/sqlbuild/executor/build/helpers/blocking.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 
 
 def block_downstream(

--- a/src/sqlbuild/executor/build/helpers/end_audits.py
+++ b/src/sqlbuild/executor/build/helpers/end_audits.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.compiler.auditing.types import AuditRunScope
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.models import AuditPlanEntry
 from sqlbuild.executor.auditing.main.execute import execute_audit
 from sqlbuild.executor.auditing.models import AuditExecutionResult

--- a/src/sqlbuild/executor/build/helpers/scheduler.py
+++ b/src/sqlbuild/executor/build/helpers/scheduler.py
@@ -14,7 +14,7 @@ from typing import Any
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import RelationInfo, StatementRecorder
 from sqlbuild.adapter.shared.types import TablePromotionMode
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import (
     AuditPlanEntry,

--- a/src/sqlbuild/executor/build/helpers/source_audits.py
+++ b/src/sqlbuild/executor/build/helpers/source_audits.py
@@ -6,7 +6,10 @@ from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.compiler.auditing.types import AuditOutcome, AuditRunScope
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import AuditPlanEntry
 from sqlbuild.executor.auditing.main.execute import execute_audit

--- a/src/sqlbuild/executor/build/models.py
+++ b/src/sqlbuild/executor/build/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from sqlbuild.adapter.shared.models import LifeCycleEvent
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.planner.models import (
     AuditPlanEntry,
     FunctionPlanEntry,

--- a/src/sqlbuild/executor/janitor/helpers/plan.py
+++ b/src/sqlbuild/executor/janitor/helpers/plan.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import RelationInfo
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledProject,
     CompiledSeed,

--- a/src/sqlbuild/executor/janitor/main/plan.py
+++ b/src/sqlbuild/executor/janitor/main/plan.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import RelationInfo
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.executor.janitor.constants import BUILT_IN_EXCLUDE_PATTERNS
 from sqlbuild.executor.janitor.helpers.plan import (
     collect_desired_keys,

--- a/src/sqlbuild/executor/pipeline/helpers/scenario.py
+++ b/src/sqlbuild/executor/pipeline/helpers/scenario.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledSqlScenario
+from sqlbuild.compiler.compile.models.core import CompiledSqlScenario
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.main.scenario import build_scenario_plan
 from sqlbuild.compiler.planner.models import ScenarioExecutionPlan

--- a/src/sqlbuild/executor/pipeline/helpers/testing.py
+++ b/src/sqlbuild/executor/pipeline/helpers/testing.py
@@ -8,7 +8,10 @@ from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import FunctionInfo, StatementRecorder
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.planner.models import FunctionPlanEntry, PlanOutput, SqlTestPlanEntry
 from sqlbuild.executor.build.models import FunctionExecutionResult

--- a/src/sqlbuild/executor/run/helpers/custom.py
+++ b/src/sqlbuild/executor/run/helpers/custom.py
@@ -9,7 +9,7 @@ from typing import Any
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import ColumnInfo, RelationInfo, StatementRecorder
 from sqlbuild.compiler.auditing.types import AuditOutcome, AuditRunScope
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.models import AuditPlanEntry, ModelPlanEntry, SchemaFinding
 from sqlbuild.compiler.planner.types import PlanReason
 from sqlbuild.executor.auditing.main.execute import execute_audit

--- a/src/sqlbuild/executor/run/helpers/incremental.py
+++ b/src/sqlbuild/executor/run/helpers/incremental.py
@@ -7,7 +7,7 @@ from typing import Any
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import ColumnInfo, StatementRecorder
 from sqlbuild.compiler.auditing.types import AuditOutcome, AuditRunScope
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.models import AuditPlanEntry, CursorBounds, ModelPlanEntry
 from sqlbuild.compiler.planner.types import IncrementalStrategy, OnSchemaChange
 from sqlbuild.executor.auditing.main.execute import execute_audit

--- a/src/sqlbuild/executor/run/helpers/microbatch.py
+++ b/src/sqlbuild/executor/run/helpers/microbatch.py
@@ -10,7 +10,7 @@ from typing import Any
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import ColumnInfo, StatementRecorder
 from sqlbuild.compiler.auditing.types import AuditOutcome, AuditRunScope
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.constants import (
     MICROBATCH_END_SENTINEL,
     MICROBATCH_START_SENTINEL,

--- a/src/sqlbuild/executor/run/helpers/view.py
+++ b/src/sqlbuild/executor/run/helpers/view.py
@@ -7,7 +7,7 @@ from typing import Any
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import StatementRecorder
 from sqlbuild.compiler.auditing.types import AuditOutcome, AuditRunScope
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.models import AuditPlanEntry, ModelPlanEntry
 from sqlbuild.executor.auditing.main.execute import execute_audit
 from sqlbuild.executor.auditing.models import AuditExecutionResult

--- a/src/sqlbuild/executor/run/main/execute.py
+++ b/src/sqlbuild/executor/run/main/execute.py
@@ -8,7 +8,7 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import ColumnInfo, StatementRecorder
 from sqlbuild.adapter.shared.types import PromotionStrategy, TablePromotionMode
 from sqlbuild.compiler.auditing.types import AuditOutcome, AuditRunScope
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.models import AuditPlanEntry, CursorBounds, ModelPlanEntry
 from sqlbuild.executor.auditing.main.execute import execute_audit
 from sqlbuild.executor.auditing.models import AuditExecutionResult

--- a/src/sqlbuild/executor/scenario/helpers/cleanup.py
+++ b/src/sqlbuild/executor/scenario/helpers/cleanup.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.models import (
     ModelPlanEntry,
     ScenarioExecutionPlan,

--- a/src/sqlbuild/executor/scenario/helpers/local_execution.py
+++ b/src/sqlbuild/executor/scenario/helpers/local_execution.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import StatementRecorder
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.planner.models import (
     FunctionPlanEntry,

--- a/src/sqlbuild/integrations/dbt/helpers/compile_refs.py
+++ b/src/sqlbuild/integrations/dbt/helpers/compile_refs.py
@@ -7,7 +7,7 @@ import re
 from pathlib import Path
 
 from sqlbuild.compiler.compile.exceptions import CompileInputError
-from sqlbuild.compiler.compile.models import CompileSqlReference
+from sqlbuild.compiler.compile.models.core import CompileSqlReference
 from sqlbuild.integrations.dbt.helpers.manifest import (
     build_dbt_manifest_index,
     resolve_dbt_manifest_model,

--- a/src/sqlbuild/integrations/dbt/helpers/graph.py
+++ b/src/sqlbuild/integrations/dbt/helpers/graph.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/src/sqlbuild/integrations/dbt/helpers/plan_orchestration.py
+++ b/src/sqlbuild/integrations/dbt/helpers/plan_orchestration.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject, CompileSqlReference
+from sqlbuild.compiler.compile.models.core import (
+    CompiledModel,
+    CompiledProject,
+    CompileSqlReference,
+)
 from sqlbuild.integrations.dbt.exceptions import DbtInteropRuntimeError
 from sqlbuild.integrations.dbt.helpers.manifest import resolve_dbt_manifest_model
 from sqlbuild.integrations.dbt.helpers.plan import build_dbt_interop_plan

--- a/src/sqlbuild/integrations/dbt/helpers/selection.py
+++ b/src/sqlbuild/integrations/dbt/helpers/selection.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
-from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject
+from sqlbuild.compiler.compile.models.core import (
+    CompiledModel,
+    CompiledProject,
+)
 from sqlbuild.integrations.dbt.helpers.graph import (
     dbt_model_graph_key,
     expand_combined_downstream,

--- a/src/sqlbuild/integrations/dbt/main/validate_compile_model_reference.py
+++ b/src/sqlbuild/integrations/dbt/main/validate_compile_model_reference.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sqlbuild.compiler.compile.models import CompileSqlReference
+from sqlbuild.compiler.compile.models.core import CompileSqlReference
 from sqlbuild.integrations.dbt.helpers.compile_refs import validate_compile_dbt_model_reference
 from sqlbuild.integrations.dbt.manifest.models import DbtManifestIndex
 

--- a/src/sqlbuild/integrations/dbt/pipeline/helpers/plan_output.py
+++ b/src/sqlbuild/integrations/dbt/pipeline/helpers/plan_output.py
@@ -11,7 +11,7 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import RelationInfo
 from sqlbuild.adapter.shared.types import BuiltinAdapter
 from sqlbuild.compiler.compile.main.effective_config import build_effective_connection_config
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.main.display_plan import build_display_only_sqlbuild_plan

--- a/src/sqlbuild/integrations/dbt/pipeline/main/execute.py
+++ b/src/sqlbuild/integrations/dbt/pipeline/main/execute.py
@@ -13,7 +13,7 @@ from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.cli.commands.main.connection_progress import build_connection_progress_reporter
 from sqlbuild.cli.commands.main.dbt_sqlbuild_work import execute_dbt_sqlbuild_work
 from sqlbuild.compiler.compile.main.effective_config import build_effective_connection_config
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project

--- a/src/sqlbuild/integrations/dbt/pipeline/main/plan.py
+++ b/src/sqlbuild/integrations/dbt/pipeline/main/plan.py
@@ -10,7 +10,7 @@ from typing import Any, TextIO
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.cli.commands.main.connection_progress import build_connection_progress_reporter
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project

--- a/src/sqlbuild/shared/helpers/naming.py
+++ b/src/sqlbuild/shared/helpers/naming.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 
 
 def resolve_qualified_name_parts(

--- a/tests/integration/src/sqlbuild/compiler/auditing/main/test_rendering.py
+++ b/tests/integration/src/sqlbuild/compiler/auditing/main/test_rendering.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from sqlbuild.compiler.auditing.main.render import render_audit_sql
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.spec.models.source import SourceEntry
 from tests.integration.src.sqlbuild.compiler.auditing.main._test_types import (
     ExecuteRenderedAuditTestCase,

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_diff_selectors.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_diff_selectors.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.helpers.diff import (

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
@@ -7,7 +7,7 @@ from typing import cast
 import pytest
 
 from sqlbuild.cli.commands.main.helpers.compile.target_writer import write_compile_target
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.project import compile_project

--- a/tests/integration/src/sqlbuild/compiler/planner/helpers/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/helpers/_test_types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.fingerprints.models import Fingerprint
 from sqlbuild.compiler.planner.models import ModelCursorSnapshot
 from sqlbuild.spec.models.source import SourceEntry

--- a/tests/integration/src/sqlbuild/compiler/planner/helpers/helpers.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/helpers/helpers.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/tests/integration/src/sqlbuild/compiler/planner/helpers/resolve/helpers.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/helpers/resolve/helpers.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledRelationTarget,

--- a/tests/integration/src/sqlbuild/compiler/planner/helpers/resolve/test_resolve.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/helpers/resolve/test_resolve.py
@@ -7,7 +7,10 @@ from typing import Any
 import pytest
 
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import CompiledModel, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledModel,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.planner.models import ModelCursorSnapshot, WarehouseSnapshot
 from sqlbuild.spec.models.source import SourceColumnEntry, SourceEntry
 from tests.integration.src.sqlbuild.compiler.planner.helpers.resolve._test_types import (

--- a/tests/integration/src/sqlbuild/compiler/planner/helpers/sql_test_assembly/helpers.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/helpers/sql_test_assembly/helpers.py
@@ -9,14 +9,16 @@ from sqlbuild.compiler.compile.constants import (
     REF_TEST_CTE_PREFIX,
     SOURCE_TEST_CTE_PREFIX,
 )
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
-    CompiledModelSqlTestPayload,
     CompiledObjectKey,
     CompiledProject,
     CompiledRelationTarget,
-    CompiledSqlTest,
     CompileModelConfig,
+)
+from sqlbuild.compiler.compile.models.sql_tests import (
+    CompiledModelSqlTestPayload,
+    CompiledSqlTest,
     CompileSqlTestCte,
 )
 from sqlbuild.compiler.compile.types import CompiledResourceType

--- a/tests/integration/src/sqlbuild/compiler/planner/helpers/sql_test_assembly/test_execute_chain.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/helpers/sql_test_assembly/test_execute_chain.py
@@ -5,10 +5,12 @@ from typing import Any
 
 import pytest
 
-from sqlbuild.compiler.compile.models import (
-    CompiledDirectLogicSqlTestPayload,
+from sqlbuild.compiler.compile.models.core import (
     CompiledObjectKey,
     CompiledProject,
+)
+from sqlbuild.compiler.compile.models.sql_tests import (
+    CompiledDirectLogicSqlTestPayload,
     CompiledSqlTest,
     CompileSqlTestCte,
 )

--- a/tests/integration/src/sqlbuild/compiler/planner/helpers/test_audit_entry.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/helpers/test_audit_entry.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledAudit,
     CompiledObjectKey,
     CompiledRelationTarget,

--- a/tests/integration/src/sqlbuild/compiler/planner/helpers/test_warehouse_snapshot.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/helpers/test_warehouse_snapshot.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledObjectKey,
     CompiledProject,
     CompiledRelationTarget,

--- a/tests/integration/src/sqlbuild/compiler/planner/main/helpers.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/helpers.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledFunction,
     CompiledModel,
     CompiledObjectKey,

--- a/tests/integration/src/sqlbuild/executor/build/concurrent/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/build/concurrent/helpers.py
@@ -110,7 +110,7 @@ def extract_upstream_model_deps(
 ) -> dict[str, frozenset[str]]:
     """Extract upstream model dependency names for each model in the plan."""
 
-    from sqlbuild.compiler.compile.models import CompiledObjectKey
+    from sqlbuild.compiler.compile.models.core import CompiledObjectKey
     from sqlbuild.compiler.compile.types import CompiledResourceType
 
     result: dict[str, frozenset[str]] = {}

--- a/tests/integration/src/sqlbuild/executor/build/custom/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/build/custom/helpers.py
@@ -13,7 +13,10 @@ from sqlbuild.compiler.auditing.types import (
     AuditRunScope,
     AuditSeverity,
 )
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import AuditPlanEntry, ModelPlanEntry
 from sqlbuild.compiler.planner.types import MaterializationType, PlanAction, PlanReason

--- a/tests/integration/src/sqlbuild/executor/build/custom/test_advanced_custom_materialization.py
+++ b/tests/integration/src/sqlbuild/executor/build/custom/test_advanced_custom_materialization.py
@@ -11,7 +11,7 @@ import pytest
 
 from sqlbuild.adapter.shared.models import RelationInfo
 from sqlbuild.adapter.shared.types import LifeCycleEventKind
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.models import AuditPlanEntry, ModelPlanEntry
 from sqlbuild.compiler.planner.types import PlanReason
 from sqlbuild.diagnostics.main.configure import configure_diagnostics

--- a/tests/integration/src/sqlbuild/executor/build/custom/test_custom_materialization.py
+++ b/tests/integration/src/sqlbuild/executor/build/custom/test_custom_materialization.py
@@ -8,7 +8,7 @@ import duckdb
 import pytest
 
 from sqlbuild.compiler.auditing.types import AuditOutcome
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.models import AuditPlanEntry, ModelPlanEntry
 from sqlbuild.compiler.planner.types import PlanReason
 from sqlbuild.executor.custom.models import MaterializationContext, MaterializationResult

--- a/tests/integration/src/sqlbuild/executor/run/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/run/helpers.py
@@ -11,7 +11,10 @@ from sqlbuild.compiler.auditing.types import (
     AuditRunScope,
     AuditSeverity,
 )
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import AuditPlanEntry, ModelPlanEntry
 from sqlbuild.compiler.planner.types import (

--- a/tests/integration/src/sqlbuild/executor/run/incremental/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/run/incremental/helpers.py
@@ -11,7 +11,10 @@ from sqlbuild.compiler.auditing.types import (
     AuditRunScope,
     AuditSeverity,
 )
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import (
     AuditPlanEntry,

--- a/tests/integration/src/sqlbuild/executor/run/microbatch/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/run/microbatch/helpers.py
@@ -9,7 +9,10 @@ from sqlbuild.compiler.auditing.types import (
     AuditAttachmentKind,
     AuditSeverity,
 )
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.constants import (
     MICROBATCH_END_SENTINEL,

--- a/tests/integration/src/sqlbuild/executor/run/view/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/run/view/helpers.py
@@ -10,7 +10,10 @@ from sqlbuild.compiler.auditing.types import (
     AuditRunScope,
     AuditSeverity,
 )
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import AuditPlanEntry, ModelPlanEntry
 from sqlbuild.compiler.planner.types import (

--- a/tests/integration/src/sqlbuild/executor/scenario/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/scenario/helpers.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import (
     ModelPlanEntry,

--- a/tests/integration/src/sqlbuild/executor/scenario/test_capture_types.py
+++ b/tests/integration/src/sqlbuild/executor/scenario/test_capture_types.py
@@ -9,7 +9,7 @@ from uuid import UUID
 import duckdb
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.types import ScenarioArtifactKind
 from sqlbuild.executor.scenario.helpers.snapshots import read_scenario_snapshot_manifest
 from sqlbuild.executor.scenario.main.capture import execute_scenario_snapshot_capture

--- a/tests/integration/src/sqlbuild/executor/scenario/test_fixture_lifecycle.py
+++ b/tests/integration/src/sqlbuild/executor/scenario/test_fixture_lifecycle.py
@@ -6,7 +6,10 @@ from typing import Any
 import pytest
 
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import (
     ScenarioExecutionPlan,

--- a/tests/integration/src/sqlbuild/executor/testing/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/testing/helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import ChainStep, SqlTestPlanEntry
 from sqlbuild.executor.testing.main.execute import execute_sql_test

--- a/tests/integration/src/sqlbuild/integrations/dbt/test_graph.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/test_graph.py
@@ -7,7 +7,10 @@ import pytest
 
 from sqlbuild.compiler.compile.helpers.assembly import assemble_compiled_project
 from sqlbuild.compiler.compile.main.build_compile_inputs import build_compile_inputs
-from sqlbuild.compiler.compile.models import CompiledProject, CompileProjectInputs
+from sqlbuild.compiler.compile.models.core import (
+    CompiledProject,
+    CompileProjectInputs,
+)
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.integrations.dbt.helpers.graph import (

--- a/tests/integration/src/sqlbuild/integrations/dbt/test_manifest.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/test_manifest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from sqlbuild.compiler.compile.main.build_compile_inputs import build_compile_inputs
-from sqlbuild.compiler.compile.models import CompileProjectInputs
+from sqlbuild.compiler.compile.models.core import CompileProjectInputs
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.integrations.dbt.helpers.runner import DbtRunner

--- a/tests/unit/src/sqlbuild/adapter/base/test_base_adapter.py
+++ b/tests/unit/src/sqlbuild/adapter/base/test_base_adapter.py
@@ -6,7 +6,7 @@ import pytest
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import ExpressionInferenceProfile
-from sqlbuild.compiler.compile.models import FunctionArgument
+from sqlbuild.compiler.compile.models.core import FunctionArgument
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from tests.unit.src.sqlbuild.adapter.base._test_types import (
     BaseAdapterExpressionInferenceProfileTestCase,

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/helpers.py
@@ -10,7 +10,7 @@ from sqlbuild.compiler.auditing.types import (
     AuditRunScope,
     AuditSeverity,
 )
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledFunction,
     CompiledModel,
     CompiledObjectKey,

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
@@ -10,7 +10,7 @@ from sqlbuild.cli.commands.main.helpers.compile.target_writer import (
     write_compile_target,
     write_static_compile_target,
 )
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.planner.models import PlanOutput
 from sqlbuild.executor.testing.main.comparison_sql import build_sql_test_comparison_sql
 from sqlbuild.integrations.duckdb.client import DuckDbAdapter

--- a/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/helpers/lineage/helpers.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from sqlbuild.cli.commands.main.helpers.lineage.models import ColumnLineageTrace, LineageNode
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/tests/unit/src/sqlbuild/cli/commands/main/plan/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/plan/helpers/helpers.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType, FunctionLanguage
 from sqlbuild.compiler.planner.models import (
     BackfillResult,

--- a/tests/unit/src/sqlbuild/compiler/auditing/main/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/auditing/main/helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.spec.models.source import SourceEntry
 
 

--- a/tests/unit/src/sqlbuild/compiler/auditing/main/test_rendering.py
+++ b/tests/unit/src/sqlbuild/compiler/auditing/main/test_rendering.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from sqlbuild.compiler.auditing.main.render import render_audit_sql
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.spec.models.source import SourceEntry
 from tests.unit.src.sqlbuild.compiler.auditing.main._test_types import (
     RenderAuditSqlTestCase,

--- a/tests/unit/src/sqlbuild/compiler/compile/_test_helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_test_helpers.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.sql_tests import (
     CompileModelSqlTestInputPayload,
     CompileSqlTestInput,
 )

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/_test_types.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 
 from sqlbuild.adapter.shared.models import ExpressionInferenceProfile
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledObjectKey,
     CompileSqlReference,
     InferredColumn,

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/helpers.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
 from sqlbuild.compiler.compile.helpers.macros import load_project_macros
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import LoadedMacro
+from sqlbuild.compiler.compile.models.sql_tests import (
     CompiledDirectLogicSqlTestPayload,
     CompiledModelSqlTestPayload,
     CompiledSqlTest,
-    LoadedMacro,
 )
 from sqlbuild.compiler.discovery.models import DiscoveredMacroFile
 

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_assembly.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_assembly.py
@@ -7,7 +7,7 @@ import pytest
 
 from sqlbuild.compiler.compile.helpers.assembly import assemble_compiled_project
 from sqlbuild.compiler.compile.main.build_compile_inputs import build_compile_inputs
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledObjectKey,
     CompiledProject,
     CompileProjectInputs,

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_audit_validation.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_audit_validation.py
@@ -14,7 +14,7 @@ from sqlbuild.compiler.compile.helpers.attachment import (
     validate_audit_references,
     validate_model_attached_audit_references,
 )
-from sqlbuild.compiler.compile.models import CompileSqlReference
+from sqlbuild.compiler.compile.models.core import CompileSqlReference
 from sqlbuild.compiler.compile.types import AttachedAuditTargetKind
 from sqlbuild.compiler.discovery.models import DiscoveredAuditFile
 from sqlbuild.shared.types import SqlReferenceKind

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_deps.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_deps.py
@@ -7,7 +7,10 @@ from sqlbuild.compiler.compile.helpers.deps import (
     model_build_deps,
     sql_test_scope_deps,
 )
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompileSqlReference
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompileSqlReference,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.shared.types import SqlReferenceKind
 from tests.unit.src.sqlbuild.compiler.compile.helpers._test_types import (

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_macros.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_macros.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import pytest
 
 from sqlbuild.compiler.compile.helpers.macros import expand_sql_macros
-from sqlbuild.compiler.compile.models import LoadedMacro, MacroContext
+from sqlbuild.compiler.compile.models.core import (
+    LoadedMacro,
+    MacroContext,
+)
 from tests.unit.src.sqlbuild.compiler.compile.helpers._test_types import (
     ExpandSqlMacrosErrorTestCase,
     ExpandSqlMacrosTestCase,

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_model_config_validation.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_model_config_validation.py
@@ -11,7 +11,7 @@ from sqlbuild.compiler.compile.helpers.model_config_validation import (
     validate_non_incremental_config,
     validate_placeholder_config,
 )
-from sqlbuild.compiler.compile.models import CompileModelConfig
+from sqlbuild.compiler.compile.models.core import CompileModelConfig
 from tests.unit.src.sqlbuild.compiler.compile.helpers._test_types import (
     CustomMaterializationConfigErrorTestCase,
     CustomMaterializationConfigValidTestCase,

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_scenarios.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_scenarios.py
@@ -6,7 +6,7 @@ import pytest
 
 from sqlbuild.compiler.compile.helpers.attachment import build_scenario_inputs
 from sqlbuild.compiler.compile.helpers.scenarios import extract_sql_scenario_ctes
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompileSqlScenarioCtes,
     CompileSqlScenarioInput,
     MacroContext,

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_sqlglot_columns.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_sqlglot_columns.py
@@ -7,7 +7,7 @@ from sqlbuild.compiler.compile.helpers.sqlglot_columns import (
     infer_columns_with_sqlglot,
     substitute_placeholder_defaults,
 )
-from sqlbuild.compiler.compile.models import InferredColumn
+from sqlbuild.compiler.compile.models.core import InferredColumn
 from sqlbuild.compiler.lineage.types import InferredNullability
 from tests.unit.src.sqlbuild.compiler.compile.helpers._test_types import (
     InferColumnsTestCase,

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_tests.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_tests.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from sqlbuild.compiler.compile.helpers.tests import CompileSqlTestCtes, extract_sql_test_ctes
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.sql_tests import (
     CompileDirectLogicSqlTestCtes,
     CompileModelSqlTestCtes,
 )

--- a/tests/unit/src/sqlbuild/compiler/compile/test_cursor_start.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_cursor_start.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from sqlbuild.compiler.compile.main.build_compile_inputs import build_compile_inputs
-from sqlbuild.compiler.compile.models import CompileProjectInputs
+from sqlbuild.compiler.compile.models.core import CompileProjectInputs
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from tests.unit.src.sqlbuild.compiler.compile._test_types import (

--- a/tests/unit/src/sqlbuild/compiler/compile/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_main.py
@@ -10,7 +10,7 @@ from sqlbuild.compiler.compile.helpers.attachment import (
     resolve_environment_config,
 )
 from sqlbuild.compiler.compile.main.build_compile_inputs import build_compile_inputs
-from sqlbuild.compiler.compile.models import CompileProjectInputs
+from sqlbuild.compiler.compile.models.core import CompileProjectInputs
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.spec.models.project import (

--- a/tests/unit/src/sqlbuild/compiler/contracts/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/contracts/helpers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/tests/unit/src/sqlbuild/compiler/discovery/helpers/test_sql_tests.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/helpers/test_sql_tests.py
@@ -116,7 +116,7 @@ ERROR_TEST_CASES: list[ParseSqlTestFileErrorTestCase] = [
 
         SELECT 1
         """,
-        expected_error_fragment="only supports `name` right now; unsupported keys: chain",
+        expected_error_fragment="only supports `name` and `mode`; unsupported keys: chain",
     ),
     ParseSqlTestFileErrorTestCase(
         description="raises when the test name is blank",

--- a/tests/unit/src/sqlbuild/compiler/lineage/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/lineage/helpers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/tests/unit/src/sqlbuild/compiler/lineage/test_columns.py
+++ b/tests/unit/src/sqlbuild/compiler/lineage/test_columns.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject
+from sqlbuild.compiler.compile.models.core import (
+    CompiledModel,
+    CompiledProject,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.lineage.main.columns import build_project_column_lineage
 from sqlbuild.compiler.lineage.models import ColumnLineage, ModelColumnLineage, ProjectColumnLineage

--- a/tests/unit/src/sqlbuild/compiler/manifest/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/manifest/_test_types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/tests/unit/src/sqlbuild/compiler/manifest/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/manifest/helpers.py
@@ -10,7 +10,7 @@ from sqlbuild.compiler.auditing.types import (
     AuditRunScope,
     AuditSeverity,
 )
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/tests/unit/src/sqlbuild/compiler/manifest/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/manifest/test_main.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/tests/unit/src/sqlbuild/compiler/pipeline/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/helpers/helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/tests/unit/src/sqlbuild/compiler/pipeline/helpers/target_validation/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/helpers/target_validation/_test_types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/pipeline/helpers/target_validation/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/helpers/target_validation/helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/tests/unit/src/sqlbuild/compiler/pipeline/helpers/target_validation/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/helpers/target_validation/test_main.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import pytest
 
 from sqlbuild.adapter.shared.types import BuiltinAdapter
-from sqlbuild.compiler.compile.models import CompiledProject, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledProject,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.pipeline.helpers.target_validation import validate_project_targets
 from tests.unit.src.sqlbuild.compiler.pipeline.helpers.target_validation._test_types import (
     ValidateProjectTargetsTestCase,

--- a/tests/unit/src/sqlbuild/compiler/pipeline/helpers/test_deferred_targets.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/helpers/test_deferred_targets.py
@@ -6,7 +6,10 @@ from collections.abc import Callable
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledProject, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledProject,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.pipeline.helpers.deferred_targets import build_deferred_targets
 from sqlbuild.integrations.bigquery.client import BigQueryAdapter
 from sqlbuild.integrations.duckdb.client import DuckDbAdapter

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/_test_types.py
@@ -5,7 +5,10 @@ from sqlbuild.compiler.auditing.types import (
     AuditAttachmentKind,
     AuditRunScope,
 )
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompileSqlReference
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompileSqlReference,
+)
 from sqlbuild.compiler.compile.types import AttachedAuditTargetKind
 from sqlbuild.compiler.planner.models import (
     MissingUpstream,

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/changes/_test_helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/changes/_test_helpers.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 
 from sqlbuild.adapter.shared.models import ColumnInfo, RelationInfo
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledRelationTarget,

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/changes/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/changes/_test_types.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import InferredColumn
+from sqlbuild.compiler.compile.models.core import InferredColumn
 from sqlbuild.compiler.planner.models import BackfillResult, SchemaFinding
 from sqlbuild.compiler.planner.types import BackfillAction, ChangeKind
 

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/changes/test_detect.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/changes/test_detect.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledModel
+from sqlbuild.compiler.compile.models.core import CompiledModel
 from sqlbuild.compiler.planner.helpers.changes.detect import detect_model_changes
 from sqlbuild.compiler.planner.models import ChangeDetectionResult, WarehouseSnapshot
 from sqlbuild.compiler.planner.types import BackfillAction, ChangeKind

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/changes/test_schema.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/changes/test_schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import InferredColumn
+from sqlbuild.compiler.compile.models.core import InferredColumn
 from sqlbuild.compiler.planner.helpers.changes.schema import detect_schema_changes
 from sqlbuild.compiler.planner.models import SchemaFinding
 from sqlbuild.compiler.planner.types import SchemaChangeKind, SchemaColumnSource

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/conftest.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/conftest.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledProject,
+)
 from sqlbuild.compiler.planner.helpers.graph import (
     build_downstream_deps,
     build_upstream_deps,

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/helpers.py
@@ -8,22 +8,24 @@ from pathlib import Path
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import RelationInfo
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledAudit,
     CompiledFunction,
     CompiledModel,
-    CompiledModelSqlTestPayload,
     CompiledObjectKey,
     CompiledProject,
     CompiledRelationTarget,
     CompiledSeed,
     CompiledSource,
     CompiledSqlScenario,
-    CompiledSqlTest,
     CompileModelConfig,
     CompileSqlReference,
     CompileSqlScenarioCte,
     FunctionArgument,
+)
+from sqlbuild.compiler.compile.models.sql_tests import (
+    CompiledModelSqlTestPayload,
+    CompiledSqlTest,
 )
 from sqlbuild.compiler.compile.types import (
     AttachedAuditTargetKind,

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 
 
 def build_target(qualified: str | None, name: str) -> CompiledRelationTarget:

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_refs.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/resolve/test_refs.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import pytest
 
 from sqlbuild.adapter.shared.types import CursorKind
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.helpers.resolve.refs import (
     apply_deferred_targets,

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/sql_test_assembly/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/sql_test_assembly/helpers.py
@@ -13,18 +13,20 @@ from sqlbuild.compiler.compile.constants import (
     SOURCE_TEST_CTE_PREFIX,
 )
 from sqlbuild.compiler.compile.helpers.macros import expand_sql_macros
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledFunction,
     CompiledModel,
-    CompiledModelSqlTestPayload,
     CompiledObjectKey,
     CompiledProject,
     CompiledRelationTarget,
-    CompiledSqlTest,
     CompileModelConfig,
-    CompileSqlTestCte,
     LoadedMacro,
     MacroContext,
+)
+from sqlbuild.compiler.compile.models.sql_tests import (
+    CompiledModelSqlTestPayload,
+    CompiledSqlTest,
+    CompileSqlTestCte,
 )
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.discovery.models import (

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/sql_test_assembly/test_plan_test.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/sql_test_assembly/test_plan_test.py
@@ -4,10 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from sqlbuild.compiler.compile.models import (
-    CompiledDirectLogicSqlTestPayload,
+from sqlbuild.compiler.compile.models.core import (
     CompiledObjectKey,
     CompiledProject,
+)
+from sqlbuild.compiler.compile.models.sql_tests import (
+    CompiledDirectLogicSqlTestPayload,
     CompiledSqlTest,
     CompileSqlTestCte,
 )

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_audit_entry.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_audit_entry.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledAudit, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledAudit,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.planner.helpers.audit_entry import plan_audit
 from sqlbuild.compiler.planner.models import AuditPlanEntry
 from sqlbuild.spec.models.source import SourceEntry

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_audit_scheduling.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_audit_scheduling.py
@@ -8,7 +8,7 @@ from sqlbuild.compiler.auditing.types import (
     AuditAttachmentKind,
     AuditRunScope,
 )
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledAudit,
     CompiledObjectKey,
     CompileSqlReference,

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_cascade.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_cascade.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.helpers.cascade import (
     build_self_cascade,

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_cursor_override_resolution.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_cursor_override_resolution.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import (
-    CompiledModel,
-)
+from sqlbuild.compiler.compile.models.core import CompiledModel
 from sqlbuild.compiler.planner.helpers.plan_entry import resolve_cursor_overrides
 from sqlbuild.compiler.planner.models import CursorOverrides
 from tests.unit.src.sqlbuild.compiler.planner.helpers._test_types import (

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_function_fingerprints.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_function_fingerprints.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledFunction
+from sqlbuild.compiler.compile.models.core import CompiledFunction
 from sqlbuild.compiler.planner.helpers.function_fingerprints import (
     build_compiled_function_fingerprint_sql,
     detect_function_change,

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_graph.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.planner.helpers.graph import (
     build_downstream_deps,
     build_upstream_deps,

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_microbatch_lookback.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_microbatch_lookback.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledModel
+from sqlbuild.compiler.compile.models.core import CompiledModel
 from sqlbuild.compiler.planner.helpers.plan_entry import resolve_microbatch_lookback
 from sqlbuild.compiler.planner.types import IncrementalStrategy
 from tests.unit.src.sqlbuild.compiler.planner.helpers._test_types import (

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_scenario_cli.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_scenario_cli.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledSqlScenario
+from sqlbuild.compiler.compile.models.core import CompiledSqlScenario
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.helpers.scenario_cli import build_cli_scenario_plan
 from sqlbuild.compiler.planner.models import ScenarioArtifactName, ScenarioExecutionPlan

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_scenario_graph.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_scenario_graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledObjectKey,
     CompiledSqlScenario,
 )

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_scenario_relations.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_scenario_relations.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.planner.helpers.scenario_relations import (
     build_scenario_execution_plan,
     build_scenario_fixture_plans,

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_selectors.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_selectors.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledProject,
+)
 from sqlbuild.compiler.planner.helpers.selectors import (
     parse_selector,
     resolve_selectors,

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_source_columns.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_source_columns.py
@@ -8,7 +8,7 @@ import pytest
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.compiler.planner.helpers.plan_entry import gather_source_columns
 from sqlbuild.spec.models.source import SourceEntry
 from tests.unit.src.sqlbuild.compiler.planner.helpers._test_types import SourceColumnsTestCase

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_strategy_action.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_strategy_action.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledModel
+from sqlbuild.compiler.compile.models.core import CompiledModel
 from sqlbuild.compiler.planner.helpers.strategy import resolve_model_plan_action
 from sqlbuild.compiler.planner.models import ChangeDetectionResult, SchemaFinding
 from sqlbuild.compiler.planner.types import (

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_strategy_ddl.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_strategy_ddl.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from sqlbuild.adapter.shared.models import ColumnInfo
-from sqlbuild.compiler.compile.models import CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import CompiledRelationTarget
 from sqlbuild.compiler.planner.helpers.strategy import build_logical_ddl
 from sqlbuild.compiler.planner.types import PlanAction
 from tests.unit.src.sqlbuild.compiler.planner.helpers._test_types import (

--- a/tests/unit/src/sqlbuild/compiler/planner/helpers/test_warehouse_cursor_resolution.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/helpers/test_warehouse_cursor_resolution.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledRelationTarget,
     CompileSqlReference,

--- a/tests/unit/src/sqlbuild/executor/build/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/executor/build/helpers/helpers.py
@@ -11,7 +11,10 @@ from sqlbuild.compiler.auditing.types import (
     AuditRunScope,
     AuditSeverity,
 )
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import ModelPlanEntry, PlanOutput, SeedPlanEntry
 from sqlbuild.compiler.planner.types import (

--- a/tests/unit/src/sqlbuild/executor/clone/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/executor/clone/helpers/helpers.py
@@ -4,7 +4,10 @@ from pathlib import Path
 from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import ModelPlanEntry
 from sqlbuild.compiler.planner.types import MaterializationType, PlanAction, PlanReason

--- a/tests/unit/src/sqlbuild/executor/janitor/main/helpers.py
+++ b/tests/unit/src/sqlbuild/executor/janitor/main/helpers.py
@@ -17,7 +17,7 @@ from sqlbuild.adapter.shared.models import (
     StatementRecorder,
 )
 from sqlbuild.adapter.shared.types import TablePromotionMode
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,

--- a/tests/unit/src/sqlbuild/executor/pipeline/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/helpers/helpers.py
@@ -6,7 +6,11 @@ from collections.abc import Callable
 from pathlib import Path
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject, CompiledSqlScenario
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledProject,
+    CompiledSqlScenario,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.discovery.models import DiscoveredSqlScenarioFile
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult

--- a/tests/unit/src/sqlbuild/executor/pipeline/helpers/test_scenario.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/helpers/test_scenario.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledSqlScenario
+from sqlbuild.compiler.compile.models.core import CompiledSqlScenario
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.models import ScenarioExecutionPlan
 from sqlbuild.executor.pipeline.helpers import scenario as scenario_pipeline

--- a/tests/unit/src/sqlbuild/executor/pipeline/helpers/test_testing.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/helpers/test_testing.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import ChainStep, PlanOutput, SqlTestPlanEntry
 from sqlbuild.executor.pipeline.helpers.testing import run_test_pipeline

--- a/tests/unit/src/sqlbuild/executor/run/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/executor/run/helpers/helpers.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 from typing import Any
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import ModelPlanEntry
 from sqlbuild.compiler.planner.types import MaterializationType, PlanAction, PlanReason

--- a/tests/unit/src/sqlbuild/executor/scenario/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/executor/scenario/helpers/helpers.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import (
     ModelPlanEntry,

--- a/tests/unit/src/sqlbuild/executor/scenario/main/helpers.py
+++ b/tests/unit/src/sqlbuild/executor/scenario/main/helpers.py
@@ -5,7 +5,10 @@ from typing import Any
 
 from sqlbuild.adapter.base.base_adapter import BaseAdapter
 from sqlbuild.adapter.shared.models import ColumnInfo, QueryResult, StatementRecorder
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationTarget
+from sqlbuild.compiler.compile.models.core import (
+    CompiledObjectKey,
+    CompiledRelationTarget,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import (
     ModelPlanEntry,

--- a/tests/unit/src/sqlbuild/executor/testing/main/helpers.py
+++ b/tests/unit/src/sqlbuild/executor/testing/main/helpers.py
@@ -1,4 +1,4 @@
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models.core import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import ChainStep, SqlTestAssertionStep, SqlTestPlanEntry
 from sqlbuild.integrations.bigquery.client import BigQueryAdapter

--- a/tests/unit/src/sqlbuild/integrations/bigquery/test_client.py
+++ b/tests/unit/src/sqlbuild/integrations/bigquery/test_client.py
@@ -16,7 +16,10 @@ from sqlbuild.adapter.shared.models import (
     SchemaDiffResult,
 )
 from sqlbuild.adapter.shared.types import CursorKind, FunctionNullabilityRule
-from sqlbuild.compiler.compile.models import FunctionArgument, FunctionReturnColumn
+from sqlbuild.compiler.compile.models.core import (
+    FunctionArgument,
+    FunctionReturnColumn,
+)
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.lineage.types import InferredNullability
 from sqlbuild.integrations.bigquery.client import BigQueryAdapter, _BigQueryConnection

--- a/tests/unit/src/sqlbuild/integrations/databricks/test_client.py
+++ b/tests/unit/src/sqlbuild/integrations/databricks/test_client.py
@@ -4,7 +4,10 @@ import pytest
 
 from sqlbuild.adapter.shared.models import ExpressionInferenceProfile
 from sqlbuild.adapter.shared.types import FunctionNullabilityRule
-from sqlbuild.compiler.compile.models import FunctionArgument, FunctionReturnColumn
+from sqlbuild.compiler.compile.models.core import (
+    FunctionArgument,
+    FunctionReturnColumn,
+)
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.lineage.types import InferredNullability
 from sqlbuild.integrations.databricks.client import DatabricksAdapter

--- a/tests/unit/src/sqlbuild/integrations/dbt/helpers.py
+++ b/tests/unit/src/sqlbuild/integrations/dbt/helpers.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from sqlbuild.compiler.compile.helpers.assembly import assemble_compiled_project
 from sqlbuild.compiler.compile.helpers.refs import extract_sql_references
-from sqlbuild.compiler.compile.models import (
+from sqlbuild.compiler.compile.models.core import (
     CompiledObjectKey,
     CompiledProject,
     CompiledRelationTarget,

--- a/tests/unit/src/sqlbuild/integrations/dbt/test_graph.py
+++ b/tests/unit/src/sqlbuild/integrations/dbt/test_graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.integrations.dbt.helpers.graph import (
     build_dbt_combined_graph,
     expand_combined_downstream,

--- a/tests/unit/src/sqlbuild/integrations/dbt/test_plan_orchestration.py
+++ b/tests/unit/src/sqlbuild/integrations/dbt/test_plan_orchestration.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.integrations.dbt.exceptions import DbtInteropRuntimeError
 from sqlbuild.integrations.dbt.helpers.graph import build_dbt_combined_graph
 from sqlbuild.integrations.dbt.helpers.manifest import build_dbt_manifest_index

--- a/tests/unit/src/sqlbuild/integrations/dbt/test_selection.py
+++ b/tests/unit/src/sqlbuild/integrations/dbt/test_selection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models.core import CompiledProject
 from sqlbuild.integrations.dbt.helpers.graph import build_dbt_combined_graph
 from sqlbuild.integrations.dbt.helpers.manifest import build_dbt_manifest_index
 from sqlbuild.integrations.dbt.helpers.selection import resolve_dbt_interop_sqlbuild_selection

--- a/tests/unit/src/sqlbuild/integrations/duckdb/test_client.py
+++ b/tests/unit/src/sqlbuild/integrations/duckdb/test_client.py
@@ -4,7 +4,10 @@ import pytest
 
 from sqlbuild.adapter.shared.models import ExpressionInferenceProfile
 from sqlbuild.adapter.shared.types import CursorKind, FunctionNullabilityRule
-from sqlbuild.compiler.compile.models import FunctionArgument, FunctionReturnColumn
+from sqlbuild.compiler.compile.models.core import (
+    FunctionArgument,
+    FunctionReturnColumn,
+)
 from sqlbuild.compiler.lineage.types import InferredNullability
 from sqlbuild.integrations.duckdb.client import DuckDbAdapter
 from tests.unit.src.sqlbuild.integrations.duckdb._test_types import (

--- a/tests/unit/src/sqlbuild/integrations/snowflake/test_client.py
+++ b/tests/unit/src/sqlbuild/integrations/snowflake/test_client.py
@@ -11,7 +11,10 @@ from sqlbuild.adapter.shared.models import (
     StatementRecorder,
 )
 from sqlbuild.adapter.shared.types import CursorKind, FunctionNullabilityRule
-from sqlbuild.compiler.compile.models import FunctionArgument, FunctionReturnColumn
+from sqlbuild.compiler.compile.models.core import (
+    FunctionArgument,
+    FunctionReturnColumn,
+)
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.lineage.types import InferredNullability
 from sqlbuild.integrations.snowflake.client import SnowflakeAdapter


### PR DESCRIPTION
Small refactor turned massive, but mostly mechanical and it exposed a few issues with the structure checker.