### PR TITLE
fix: normalize path separators for Windows compatibility + init command

### DIFF
--- a/src/sqlbuild/cli/commands/main/entry.py
+++ b/src/sqlbuild/cli/commands/main/entry.py
@@ -302,6 +302,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     from sqlbuild.cli.commands.main.lineage import run_lineage
     from sqlbuild.cli.commands.main.load import run_load
     from sqlbuild.cli.commands.main.plan import run_plan
+    from sqlbuild.cli.commands.main.init import run_init
     from sqlbuild.cli.commands.main.playground import run_playground
     from sqlbuild.cli.commands.main.query import run_query
     from sqlbuild.cli.commands.main.run import run_run
@@ -356,6 +357,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         run_debug=run_debug,
         run_lineage=run_lineage,
         run_janitor=run_janitor,
+        run_init=run_init,
         run_playground=run_playground,
         run_skills_update=run_skills_update,
         run_scenario=run_scenario,
@@ -638,6 +640,8 @@ def _main_with_dependencies(
                 args.auto_approve,
                 args.retention_days,
             )
+        if args.command == CliCommand.INIT:
+            return handlers.run_init(project_dir)
         if args.command == CliCommand.PLAYGROUND:
             return handlers.run_playground(
                 project_dir, args.playground_path, args.playground_template

--- a/src/sqlbuild/cli/commands/main/helpers/entry/models.py
+++ b/src/sqlbuild/cli/commands/main/helpers/entry/models.py
@@ -288,6 +288,7 @@ class CliEntrypointHandlers:
         int,
     ]
     run_janitor: Callable[[Path | None, bool, bool, int | None], int]
+    run_init: Callable[[Path | None], int]
     run_playground: Callable[[Path | None, str, str], int]
     run_skills_update: Callable[[Path | None, bool, tuple[str, ...], bool], int]
     run_scenario: Callable[

--- a/src/sqlbuild/cli/commands/main/init.py
+++ b/src/sqlbuild/cli/commands/main/init.py
@@ -1,0 +1,94 @@
+"""Scaffold a new blank SQLBuild project."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlbuild.cli.commands.main.helpers.skills.update import update_sqlbuild_skills
+from sqlbuild.shared.helpers.colors import green_bold, supports_color
+
+
+_PROJECT_TOML_TEMPLATE: str = """\
+name = "{name}"
+adapter = "duckdb"
+default_environment = "dev"
+
+[connection]
+database = "{name}.duckdb"
+
+[settings]
+default_audit_severity = "warn"
+
+[defaults]
+materialized = "table"
+
+[environments.prod]
+schema = "prod"
+
+[environments.dev]
+schema = "dev"
+"""
+
+_DIRECTORIES: tuple[str, ...] = (
+    "models/staging",
+    "models/marts",
+    "sources",
+    "seeds",
+    "tests/unit",
+    "macros",
+    "audits",
+)
+
+
+def run_init(project_dir: Path | None) -> int:
+    """Create a minimal SQLBuild project in the current directory."""
+
+    base_dir: Path = project_dir if project_dir is not None else Path.cwd()
+    project_file: Path = base_dir / "sqlbuild_project.toml"
+
+    if project_file.exists():
+        from sqlbuild.cli.commands.main.shared.exceptions import CliUserError
+
+        raise CliUserError(
+            "sqlbuild_project.toml already exists in this directory",
+            code="C900",
+        )
+
+    project_name: str = base_dir.name.replace("-", "_").replace(" ", "_").lower()
+
+    for directory in _DIRECTORIES:
+        (base_dir / directory).mkdir(parents=True, exist_ok=True)
+
+    project_file.write_text(_PROJECT_TOML_TEMPLATE.format(name=project_name))
+
+    gitkeep_dirs: tuple[str, ...] = (
+        "models/staging",
+        "models/marts",
+        "sources",
+        "seeds",
+        "tests/unit",
+        "macros",
+        "audits",
+    )
+    for directory in gitkeep_dirs:
+        gitkeep: Path = base_dir / directory / ".gitkeep"
+        if not any((base_dir / directory).iterdir()):
+            gitkeep.touch()
+
+    update_sqlbuild_skills(project_dir=base_dir)
+
+    use_color: bool = supports_color()
+    heading: str = (
+        green_bold("SQLBuild project created") if use_color else "SQLBuild project created"
+    )
+    print(heading)
+    print()
+    print(f"  Project: {project_name}")
+    print(f"  Config:  sqlbuild_project.toml")
+    print()
+    print("Next steps:")
+    print("  1. Add sources to sources/")
+    print("  2. Add models to models/staging/ and models/marts/")
+    print("  3. sqb compile")
+    print("  4. sqb build")
+    return 0

--- a/src/sqlbuild/compiler/compile/helpers/attachment.py
+++ b/src/sqlbuild/compiler/compile/helpers/attachment.py
@@ -3070,7 +3070,7 @@ def find_matching_path_default(
 ) -> str | None:
     """Return the nearest matching path_defaults key for a model file."""
 
-    relative_path: Path = Path(str(model_file.relative_path).removeprefix("models/"))
+    relative_path: Path = Path(str(model_file.relative_path).replace("\\", "/").removeprefix("models/"))
     best_match: str | None = None
     best_length: int = -1
 

--- a/src/sqlbuild/compiler/discovery/helpers/discovery_validation.py
+++ b/src/sqlbuild/compiler/discovery/helpers/discovery_validation.py
@@ -444,7 +444,7 @@ def _validate_path_defaults_match_models(
     if not path_defaults:
         return
     model_paths: tuple[str, ...] = tuple(
-        str(model_file.relative_path).removeprefix("models/") for model_file in model_files
+        str(model_file.relative_path).replace("\\", "/").removeprefix("models/") for model_file in model_files
     )
     model_folders: tuple[str, ...] = tuple(
         sorted(

--- a/src/sqlbuild/compiler/pipeline/helpers/diff.py
+++ b/src/sqlbuild/compiler/pipeline/helpers/diff.py
@@ -112,7 +112,7 @@ def _build_tag_index(project: CompiledProject) -> dict[str, frozenset[CompiledOb
 
 def _build_path_index(project: CompiledProject) -> dict[CompiledObjectKey, str]:
     return {
-        model.key: str(model.relative_path.parent).removeprefix("models/")
+        model.key: str(model.relative_path.parent).replace("\\", "/").removeprefix("models/")
         for model in project.models
     }
 
@@ -200,8 +200,8 @@ def _resolve_selector_token(
                 code="S008",
             )
         return _expand_keys(keys, upstream_requested, downstream_requested, upstream, downstream)
-    if core.startswith("path:") or "/" in core:
-        path_value: str = core.removeprefix("path:").strip("/")
+    if core.startswith("path:") or "/" in core or "\\" in core:
+        path_value: str = core.removeprefix("path:").replace("\\", "/").strip("/")
         keys = frozenset(
             key
             for key, folder in path_index.items()

--- a/src/sqlbuild/integrations/dbt/helpers/plan_orchestration.py
+++ b/src/sqlbuild/integrations/dbt/helpers/plan_orchestration.py
@@ -249,11 +249,12 @@ def resolve_sqlbuild_test_actions(
 
 
 def _translate_dbt_path_selector(raw_path: str) -> str:
-    if raw_path == "models":
+    normalised: str = raw_path.replace("\\", "/")
+    if normalised == "models":
         return ""
-    if raw_path.startswith("models/"):
-        return raw_path.removeprefix("models/")
-    return raw_path
+    if normalised.startswith("models/"):
+        return normalised.removeprefix("models/")
+    return normalised
 
 
 def _model_path_selector(model: CompiledModel) -> str:

--- a/src/sqlbuild/integrations/dbt/helpers/selection.py
+++ b/src/sqlbuild/integrations/dbt/helpers/selection.py
@@ -204,11 +204,12 @@ def _resolve_excluded_sqlbuild_names(
 
 
 def _translate_dbt_path_selector(raw_path: str) -> str:
-    if raw_path == "models":
+    normalised: str = raw_path.replace("\\", "/")
+    if normalised == "models":
         return ""
-    if raw_path.startswith("models/"):
-        return raw_path.removeprefix("models/")
-    return raw_path
+    if normalised.startswith("models/"):
+        return normalised.removeprefix("models/")
+    return normalised
 
 
 def _model_path_selector(model: CompiledModel) -> str:


### PR DESCRIPTION
- Fix removeprefix('models/') failing on Windows backslash paths in 5 files
- Add sqb init to scaffold a blank project in the current directory