### PR TITLE
fix: make sqlglot a core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,10 @@ dependencies = [
   "duckdb>=1.3.2",
   "PyYAML>=6.0.2",
   "rich>=15.0.0",
+  "sqlglot>=27.13.2",
 ]
 
 [project.optional-dependencies]
-sqlglot = [
-  "sqlglot>=27.13.2",
-]
 performance = [
   "sqlglot[c]>=30.7.0",
 ]


### PR DESCRIPTION
sqlglot is required for SQL validation, column lineage, scenario assertion parsing, and compile-time contracts. Fresh installs without it fail on sqb scenario test in the playground.