### PR TITLE
perf: speed up compile analysis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
   "duckdb>=1.3.2",
+  "polyglot-sql>=0.3.12",
   "pydantic-settings>=2,<3",
   "PyYAML>=6.0.2",
   "rich>=15.0.0",

--- a/src/sqlbuild/cli/commands/main/compile.py
+++ b/src/sqlbuild/cli/commands/main/compile.py
@@ -49,6 +49,10 @@ def run_compile(
     no_color: bool = False,
     lineage_mode: CompileLineageMode = CompileLineageMode.FAST,
     cli_vars: dict[str, object] | None = None,
+    profile_skip_discovery_sqlglot: bool = False,
+    profile_skip_column_inference: bool = False,
+    profile_skip_contracts: bool = False,
+    profile_skip_write: bool = False,
 ) -> int:
     """Execute the compile command."""
 
@@ -57,7 +61,8 @@ def run_compile(
     effective_project_dir: Path = project_dir if project_dir is not None else Path.cwd()
     discover_start: float = time.monotonic()
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(
-        project_dir=effective_project_dir
+        project_dir=effective_project_dir,
+        sqlglot_enabled_override=False if profile_skip_discovery_sqlglot else None,
     )
     discover_ms: int = _elapsed_ms(discover_start)
     adapter: BaseAdapter = resolve_adapter(
@@ -72,6 +77,7 @@ def run_compile(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
+        skip_column_inference=profile_skip_column_inference,
         cli_vars=cli_vars,
     )
     graph_ms: int = _elapsed_ms(graph_start)
@@ -83,10 +89,13 @@ def run_compile(
     )
     lineage_ms: int = _elapsed_ms(lineage_start)
     contracts_start: float = time.monotonic()
-    contract_result: ContractValidationResult = validate_model_contracts(
-        graph.project,
-        dialect=adapter.sqlglot_dialect(),
-    )
+    if profile_skip_contracts:
+        contract_result = ContractValidationResult(diagnostics=())
+    else:
+        contract_result = validate_model_contracts(
+            graph.project,
+            dialect=adapter.sqlglot_dialect(),
+        )
     contract_ms: int = _elapsed_ms(contracts_start)
     diagnostics: tuple[CompilerDiagnostic, ...] = (
         *graph.project.diagnostics,
@@ -125,12 +134,23 @@ def run_compile(
         )
 
     write_start: float = time.monotonic()
-    written: WrittenTarget = write_static_compile_target(
-        target_dir=effective_project_dir / "target",
-        adapter=adapter,
-        project=graph.project,
-        manifest=manifest_payload,
-    )
+    target_dir: Path = effective_project_dir / "target"
+    if profile_skip_write:
+        written = WrittenTarget(
+            model_count=0,
+            seed_count=0,
+            function_count=0,
+            audit_count=0,
+            test_count=0,
+            target_dir=target_dir,
+        )
+    else:
+        written = write_static_compile_target(
+            target_dir=target_dir,
+            adapter=adapter,
+            project=graph.project,
+            manifest=manifest_payload,
+        )
     write_ms: int = _elapsed_ms(write_start)
     timings_ms: dict[str, int] = {
         "discover_ms": discover_ms,

--- a/src/sqlbuild/cli/commands/main/compile.py
+++ b/src/sqlbuild/cli/commands/main/compile.py
@@ -89,6 +89,7 @@ def run_compile(
     )
     lineage_ms: int = _elapsed_ms(lineage_start)
     contracts_start: float = time.monotonic()
+    contract_result: ContractValidationResult
     if profile_skip_contracts:
         contract_result = ContractValidationResult(diagnostics=())
     else:
@@ -135,6 +136,7 @@ def run_compile(
 
     write_start: float = time.monotonic()
     target_dir: Path = effective_project_dir / "target"
+    written: WrittenTarget
     if profile_skip_write:
         written = WrittenTarget(
             model_count=0,

--- a/src/sqlbuild/cli/commands/main/entry.py
+++ b/src/sqlbuild/cli/commands/main/entry.py
@@ -73,6 +73,30 @@ def _build_parser(*, use_color: bool = False) -> argparse.ArgumentParser:
         default=CompileLineageMode.FAST.value,
         help="Column lineage mode: fast (default), rich (slower), or none",
     )
+    compile_parser.add_argument(
+        "--profile-skip-discovery-sqlglot",
+        action="store_true",
+        default=False,
+        help="Diagnostic: skip SQLGlot-assisted discovery parsing",
+    )
+    compile_parser.add_argument(
+        "--profile-skip-column-inference",
+        action="store_true",
+        default=False,
+        help="Diagnostic: skip compile-time column inference",
+    )
+    compile_parser.add_argument(
+        "--profile-skip-contracts",
+        action="store_true",
+        default=False,
+        help="Diagnostic: skip offline contract validation",
+    )
+    compile_parser.add_argument(
+        "--profile-skip-write",
+        action="store_true",
+        default=False,
+        help="Diagnostic: skip writing target/compiled artifacts",
+    )
     add_vars_args(compile_parser)
     add_dbt_config_args(compile_parser)
 
@@ -547,6 +571,10 @@ def _main_with_dependencies(
                 args.no_color,
                 CompileLineageMode(args.compile_lineage_mode),
                 args.vars,
+                args.profile_skip_discovery_sqlglot,
+                args.profile_skip_column_inference,
+                args.profile_skip_contracts,
+                args.profile_skip_write,
             )
         if args.command == CliCommand.DAG:
             return handlers.run_dag(

--- a/src/sqlbuild/cli/commands/main/helpers/compile/output.py
+++ b/src/sqlbuild/cli/commands/main/helpers/compile/output.py
@@ -487,22 +487,34 @@ def _execution_layer_count(graph: ProjectGraph) -> int:
     model_keys: set[CompiledObjectKey] = {model.key for model in graph.project.models}
     if not model_keys:
         return 0
-    cache: dict[CompiledObjectKey, int] = {}
-
-    def layer_for(key: CompiledObjectKey, visiting: frozenset[CompiledObjectKey]) -> int:
-        if key in cache:
-            return cache[key]
-        if key in visiting:
-            return 1
-        dep_layers: list[int] = []
-        for dep in graph.upstream_deps.get(key, ()):
-            if dep in model_keys:
-                dep_layers.append(layer_for(dep, visiting | {key}))
-        layer: int = 1 + max(dep_layers, default=0)
-        cache[key] = layer
-        return layer
-
-    return max(layer_for(key, frozenset()) for key in model_keys)
+    remaining_model_deps: dict[CompiledObjectKey, set[CompiledObjectKey]] = {
+        key: {dep for dep in graph.upstream_deps.get(key, ()) if dep in model_keys}
+        for key in model_keys
+    }
+    downstream_model_deps: dict[CompiledObjectKey, set[CompiledObjectKey]] = {
+        key: {dep for dep in graph.downstream_deps.get(key, ()) if dep in model_keys}
+        for key in model_keys
+    }
+    current_layer: set[CompiledObjectKey] = {
+        key for key, deps in remaining_model_deps.items() if not deps
+    }
+    visited: set[CompiledObjectKey] = set()
+    layer_count: int = 0
+    while current_layer:
+        layer_count += 1
+        next_layer: set[CompiledObjectKey] = set()
+        for key in current_layer:
+            visited.add(key)
+            for downstream_key in downstream_model_deps.get(key, set()):
+                if downstream_key in visited:
+                    continue
+                remaining_model_deps[downstream_key].discard(key)
+                if not remaining_model_deps[downstream_key]:
+                    next_layer.add(downstream_key)
+        current_layer = next_layer
+    if len(visited) != len(model_keys):
+        return max(layer_count, 1)
+    return layer_count
 
 
 def _relative_target_path(path: Path) -> str:

--- a/src/sqlbuild/cli/commands/main/helpers/entry/models.py
+++ b/src/sqlbuild/cli/commands/main/helpers/entry/models.py
@@ -35,6 +35,10 @@ class CliNamespace:
     manifest: bool = False
     dag: str | None = None
     compile_lineage_mode: CompileLineageMode = CompileLineageMode.FAST
+    profile_skip_discovery_sqlglot: bool = False
+    profile_skip_column_inference: bool = False
+    profile_skip_contracts: bool = False
+    profile_skip_write: bool = False
     start_cursor_ts: str | None = None
     end_cursor_ts: str | None = None
     start_cursor_int: str | None = None
@@ -126,6 +130,10 @@ class CliEntrypointHandlers:
             bool,
             CompileLineageMode,
             dict[str, object],
+            bool,
+            bool,
+            bool,
+            bool,
         ],
         int,
     ]

--- a/src/sqlbuild/compiler/compile/helpers/assembly.py
+++ b/src/sqlbuild/compiler/compile/helpers/assembly.py
@@ -13,10 +13,15 @@ from sqlbuild.compiler.compile.helpers.deps import (
     sql_test_scope_deps,
 )
 from sqlbuild.compiler.compile.helpers.macros import expand_sql_macros, find_macro_call_names
-from sqlbuild.compiler.compile.helpers.sqlglot_columns import infer_columns_with_sqlglot
+from sqlbuild.compiler.compile.helpers.sqlglot_columns import (
+    analyze_columns_and_lineage_with_polyglot,
+    infer_columns_with_sqlglot,
+)
+from sqlbuild.compiler.compile.helpers.sqlglot_validation import validate_sql_syntax
 from sqlbuild.compiler.compile.helpers.templating import expand_template_data
 from sqlbuild.compiler.compile.models.core import (
     CompileAuditInput,
+    CompiledLineageColumnFact,
     CompiledAudit,
     CompiledFunction,
     CompiledModel,
@@ -65,10 +70,11 @@ def assemble_compiled_project(
     inputs: CompileProjectInputs,
     *,
     inference_profile: ExpressionInferenceProfile | None = None,
+    skip_column_inference: bool = False,
 ) -> CompiledProject:
     """Convert attached compile inputs into the planner-ready project view."""
 
-    sqlglot_enabled: bool = inputs.effective_settings.sqlglot
+    sqlglot_enabled: bool = inputs.effective_settings.sqlglot and not skip_column_inference
     seed_names: frozenset[str] = frozenset(
         seed_input.schema_entry.name for seed_input in inputs.seed_inputs
     )
@@ -148,6 +154,8 @@ def _assemble_compiled_model(
 ) -> CompiledModel:
     model_name: str = model_input.model_file.file_path.stem
     inferred_columns: tuple[InferredColumn, ...] | None = None
+    fast_lineage_columns: tuple[CompiledLineageColumnFact, ...] | None = None
+    fast_lineage_has_star: bool = False
     raw_placeholders: object | None = model_input.config.values.get("placeholders")
     placeholders: dict[str, str] | None = (
         {str(k): str(v) for k, v in raw_placeholders.items()}
@@ -155,11 +163,41 @@ def _assemble_compiled_model(
         else None
     )
     if sqlglot_enabled:
-        inferred_columns = infer_columns_with_sqlglot(
+        profile: ExpressionInferenceProfile = inference_profile or ExpressionInferenceProfile()
+        polyglot_analysis = analyze_columns_and_lineage_with_polyglot(
             query_sql=model_input.query_sql,
+            references=model_input.references,
             placeholders=placeholders,
             column_nullability_by_table=column_nullability_by_table,
-            inference_profile=inference_profile,
+            inference_profile=profile,
+        )
+        if isinstance(polyglot_analysis, tuple):
+            inferred_columns = polyglot_analysis[0]
+            fast_lineage_columns = polyglot_analysis[1]
+            fast_lineage_has_star = polyglot_analysis[2]
+        else:
+            if model_input.sql_validation_enabled:
+                validate_sql_syntax(
+                    query_sql=model_input.query_sql,
+                    model_name=model_name,
+                    file_path=model_input.model_file.file_path,
+                    placeholders=placeholders,
+                    dialect=profile.sqlglot_dialect,
+                )
+            inferred_columns = infer_columns_with_sqlglot(
+                query_sql=model_input.query_sql,
+                placeholders=placeholders,
+                column_nullability_by_table=column_nullability_by_table,
+                inference_profile=profile,
+            )
+    elif model_input.sql_validation_enabled:
+        profile = inference_profile or ExpressionInferenceProfile()
+        validate_sql_syntax(
+            query_sql=model_input.query_sql,
+            model_name=model_name,
+            file_path=model_input.model_file.file_path,
+            placeholders=placeholders,
+            dialect=profile.sqlglot_dialect,
         )
     return CompiledModel(
         key=CompiledObjectKey(resource_type=CompiledResourceType.MODEL, name=model_name),
@@ -172,6 +210,8 @@ def _assemble_compiled_model(
         references=model_input.references,
         schema_entry=model_input.schema_entry,
         inferred_columns=inferred_columns,
+        fast_lineage_columns=fast_lineage_columns,
+        fast_lineage_has_star=fast_lineage_has_star,
         authored_sql=model_input.model_file.contents,
         output_column_locations=model_input.model_file.output_column_locations,
         macro_deps=find_macro_call_names(model_input.macro_source_sql),

--- a/src/sqlbuild/compiler/compile/helpers/assembly.py
+++ b/src/sqlbuild/compiler/compile/helpers/assembly.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from dataclasses import replace
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, replace
 
 from sqlbuild.adapter.shared.models import ExpressionInferenceProfile
 from sqlbuild.compiler.compile.helpers.deps import (
@@ -65,6 +66,17 @@ from sqlbuild.spec.models.project import (
 from sqlbuild.spec.models.schema import SchemaAuditInstance, SchemaColumn, SchemaSeedEntry
 from sqlbuild.spec.models.source import SourceColumnEntry, SourceEntry
 
+_POLYGLOT_ANALYSIS_WORKERS: int = 2
+_POLYGLOT_PARALLEL_ANALYSIS_MIN_MODELS: int = 32
+
+
+@dataclass(frozen=True)
+class _ModelSqlAnalysis:
+    polyglot_analysis: (
+        tuple[tuple[InferredColumn, ...] | None, tuple[CompiledLineageColumnFact, ...], bool] | bool
+    )
+    placeholders: dict[str, str] | None
+
 
 def assemble_compiled_project(
     inputs: CompileProjectInputs,
@@ -81,6 +93,14 @@ def assemble_compiled_project(
     column_nullability_by_table: dict[str, dict[str, InferredNullability]] = (
         _build_column_nullability_by_table(inputs)
     )
+    profile: ExpressionInferenceProfile = inference_profile or ExpressionInferenceProfile()
+    model_sql_analysis_by_name: dict[str, _ModelSqlAnalysis] = {}
+    if sqlglot_enabled:
+        model_sql_analysis_by_name = _analyze_model_sql_in_parallel(
+            model_inputs=inputs.model_inputs,
+            column_nullability_by_table=column_nullability_by_table,
+            inference_profile=profile,
+        )
     return CompiledProject(
         run_id=inputs.run_id,
         effective_target_name=inputs.effective_target_name,
@@ -103,7 +123,8 @@ def assemble_compiled_project(
                 sqlglot_enabled=sqlglot_enabled,
                 seed_names=seed_names,
                 column_nullability_by_table=column_nullability_by_table,
-                inference_profile=inference_profile,
+                inference_profile=profile,
+                sql_analysis=model_sql_analysis_by_name.get(model_input.model_file.file_path.stem),
             )
             for model_input in inputs.model_inputs
         ),
@@ -151,28 +172,30 @@ def _assemble_compiled_model(
     seed_names: frozenset[str] = frozenset(),
     column_nullability_by_table: dict[str, dict[str, InferredNullability]] | None = None,
     inference_profile: ExpressionInferenceProfile | None = None,
+    sql_analysis: _ModelSqlAnalysis | None = None,
 ) -> CompiledModel:
     model_name: str = model_input.model_file.file_path.stem
     inferred_columns: tuple[InferredColumn, ...] | None = None
     fast_lineage_columns: tuple[CompiledLineageColumnFact, ...] | None = None
     fast_lineage_has_star: bool = False
-    raw_placeholders: object | None = model_input.config.values.get("placeholders")
     placeholders: dict[str, str] | None = (
-        {str(k): str(v) for k, v in raw_placeholders.items()}
-        if isinstance(raw_placeholders, dict)
-        else None
+        sql_analysis.placeholders if sql_analysis is not None else _model_placeholders(model_input)
     )
     if sqlglot_enabled:
         profile: ExpressionInferenceProfile = inference_profile or ExpressionInferenceProfile()
         polyglot_analysis: (
             tuple[tuple[InferredColumn, ...] | None, tuple[CompiledLineageColumnFact, ...], bool]
             | bool
-        ) = analyze_columns_and_lineage_with_polyglot(
-            query_sql=model_input.query_sql,
-            references=model_input.references,
-            placeholders=placeholders,
-            column_nullability_by_table=column_nullability_by_table,
-            inference_profile=profile,
+        ) = (
+            sql_analysis.polyglot_analysis
+            if sql_analysis is not None
+            else analyze_columns_and_lineage_with_polyglot(
+                query_sql=model_input.query_sql,
+                references=model_input.references,
+                placeholders=placeholders,
+                column_nullability_by_table=column_nullability_by_table,
+                inference_profile=profile,
+            )
         )
         if isinstance(polyglot_analysis, tuple):
             inferred_columns = polyglot_analysis[0]
@@ -219,6 +242,72 @@ def _assemble_compiled_model(
         output_column_locations=model_input.model_file.output_column_locations,
         macro_deps=find_macro_call_names(model_input.macro_source_sql),
     )
+
+
+def _analyze_model_sql_in_parallel(
+    *,
+    model_inputs: tuple[CompileModelInput, ...],
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+    inference_profile: ExpressionInferenceProfile,
+) -> dict[str, _ModelSqlAnalysis]:
+    if not model_inputs:
+        return {}
+    if len(model_inputs) < _POLYGLOT_PARALLEL_ANALYSIS_MIN_MODELS:
+        return {
+            _model_name(model_input): _analyze_model_sql(
+                model_input,
+                column_nullability_by_table,
+                inference_profile,
+            )
+            for model_input in model_inputs
+        }
+    workers: int = min(_POLYGLOT_ANALYSIS_WORKERS, len(model_inputs))
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        analyses: tuple[_ModelSqlAnalysis, ...] = tuple(
+            executor.map(
+                lambda model_input: _analyze_model_sql(
+                    model_input,
+                    column_nullability_by_table,
+                    inference_profile,
+                ),
+                model_inputs,
+            )
+        )
+    return {
+        _model_name(model_input): analysis
+        for model_input, analysis in zip(model_inputs, analyses, strict=True)
+    }
+
+
+def _analyze_model_sql(
+    model_input: CompileModelInput,
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+    inference_profile: ExpressionInferenceProfile,
+) -> _ModelSqlAnalysis:
+    placeholders: dict[str, str] | None = _model_placeholders(model_input)
+    return _ModelSqlAnalysis(
+        polyglot_analysis=analyze_columns_and_lineage_with_polyglot(
+            query_sql=model_input.query_sql,
+            references=model_input.references,
+            placeholders=placeholders,
+            column_nullability_by_table=column_nullability_by_table,
+            inference_profile=inference_profile,
+        ),
+        placeholders=placeholders,
+    )
+
+
+def _model_placeholders(model_input: CompileModelInput) -> dict[str, str] | None:
+    raw_placeholders: object | None = model_input.config.values.get("placeholders")
+    return (
+        {str(k): str(v) for k, v in raw_placeholders.items()}
+        if isinstance(raw_placeholders, dict)
+        else None
+    )
+
+
+def _model_name(model_input: CompileModelInput) -> str:
+    return model_input.model_file.file_path.stem
 
 
 def _build_column_nullability_by_table(

--- a/src/sqlbuild/compiler/compile/helpers/assembly.py
+++ b/src/sqlbuild/compiler/compile/helpers/assembly.py
@@ -21,9 +21,9 @@ from sqlbuild.compiler.compile.helpers.sqlglot_validation import validate_sql_sy
 from sqlbuild.compiler.compile.helpers.templating import expand_template_data
 from sqlbuild.compiler.compile.models.core import (
     CompileAuditInput,
-    CompiledLineageColumnFact,
     CompiledAudit,
     CompiledFunction,
+    CompiledLineageColumnFact,
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,
@@ -164,7 +164,10 @@ def _assemble_compiled_model(
     )
     if sqlglot_enabled:
         profile: ExpressionInferenceProfile = inference_profile or ExpressionInferenceProfile()
-        polyglot_analysis = analyze_columns_and_lineage_with_polyglot(
+        polyglot_analysis: (
+            tuple[tuple[InferredColumn, ...] | None, tuple[CompiledLineageColumnFact, ...], bool]
+            | bool
+        ) = analyze_columns_and_lineage_with_polyglot(
             query_sql=model_input.query_sql,
             references=model_input.references,
             placeholders=placeholders,

--- a/src/sqlbuild/compiler/compile/helpers/attachment.py
+++ b/src/sqlbuild/compiler/compile/helpers/attachment.py
@@ -134,6 +134,7 @@ def build_model_inputs(
     run_id: str,
     macro_context: MacroContext,
     no_sql_validation: bool = False,
+    defer_model_sql_validation: bool = False,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> tuple[CompileModelInput, ...]:
     """Attach schema metadata to discovered model files."""
@@ -191,14 +192,15 @@ def build_model_inputs(
             if isinstance(raw_placeholders, dict)
             else None
         )
-        if (
+        sql_validation_enabled: bool = (
             effective_settings.sqlglot
             and not no_sql_validation
             and _is_sql_validation_enabled(
                 project_setting=effective_settings.sql_validation,
                 model_config=effective_config,
             )
-        ):
+        )
+        if sql_validation_enabled and not defer_model_sql_validation:
             validate_sql_syntax(
                 query_sql=expanded_query_sql,
                 model_name=model_file.file_path.stem,
@@ -310,6 +312,7 @@ def build_model_inputs(
                     query_sql=expanded_query_sql,
                     macro_source_sql=var_substituted_sql,
                     references=references,
+                    sql_validation_enabled=sql_validation_enabled,
                 )
             )
             continue
@@ -322,6 +325,7 @@ def build_model_inputs(
                 macro_source_sql=var_substituted_sql,
                 references=references,
                 schema_entry=header_schema_entry,
+                sql_validation_enabled=sql_validation_enabled,
             )
         )
 

--- a/src/sqlbuild/compiler/compile/helpers/deps.py
+++ b/src/sqlbuild/compiler/compile/helpers/deps.py
@@ -22,6 +22,10 @@ def model_build_deps(
 ) -> tuple[CompiledObjectKey, ...]:
     """Return build graph dependencies implied by model SQL references."""
 
+    if not references:
+        return ()
+    if len(references) == 1:
+        return (_reference_dep(reference=references[0], seed_names=seed_names),)
     return _dedupe_object_keys(
         _reference_dep(reference=reference, seed_names=seed_names) for reference in references
     )
@@ -34,6 +38,10 @@ def function_build_deps(
 ) -> tuple[CompiledObjectKey, ...]:
     """Return build graph dependencies implied by function SQL references."""
 
+    if not references:
+        return ()
+    if len(references) == 1:
+        return (_reference_dep(reference=references[0], seed_names=seed_names),)
     return _dedupe_object_keys(
         _reference_dep(reference=reference, seed_names=seed_names) for reference in references
     )
@@ -72,6 +80,14 @@ def audit_scope_deps(
 def sql_test_scope_deps(*, expected_model_names: tuple[str, ...]) -> tuple[CompiledObjectKey, ...]:
     """Return model targets that select a SQL-native unit test."""
 
+    if not expected_model_names:
+        return ()
+    if len(expected_model_names) == 1:
+        return (
+            CompiledObjectKey(
+                resource_type=CompiledResourceType.MODEL, name=expected_model_names[0]
+            ),
+        )
     return _dedupe_object_keys(
         CompiledObjectKey(resource_type=CompiledResourceType.MODEL, name=model_name)
         for model_name in expected_model_names

--- a/src/sqlbuild/compiler/compile/helpers/macros.py
+++ b/src/sqlbuild/compiler/compile/helpers/macros.py
@@ -114,6 +114,9 @@ def expand_sql_macros(
 def find_macro_call_names(sql: str) -> tuple[str, ...]:
     """Return unique authored macro call names in encounter order."""
 
+    if "@" not in sql:
+        return ()
+
     names: list[str] = []
     seen: set[str] = set()
     cursor: int = 0

--- a/src/sqlbuild/compiler/compile/helpers/refs.py
+++ b/src/sqlbuild/compiler/compile/helpers/refs.py
@@ -33,6 +33,9 @@ def extract_sql_references(sql: str) -> tuple[CompileSqlReference, ...]:
     index: int = 0
     length: int = len(sql)
     while index < length:
+        index = _next_reference_scan_position(sql=sql, start=index)
+        if index >= length:
+            break
         if sql.startswith("--", index):
             index = skip_line_comment(sql=sql, start=index)
             continue
@@ -41,10 +44,6 @@ def extract_sql_references(sql: str) -> tuple[CompileSqlReference, ...]:
             continue
         if sql[index] in {"'", '"', "`"}:
             index = skip_quoted_text(sql=sql, start=index, context=_CONTEXT)
-            continue
-
-        if sql[index] != "_" or index + 1 >= length or sql[index + 1] != "_":
-            index += 1
             continue
 
         parsed_reference: tuple[CompileSqlReference, int] | None = _parse_reference_at(
@@ -57,6 +56,16 @@ def extract_sql_references(sql: str) -> tuple[CompileSqlReference, ...]:
         references.append(parsed_reference[0])
         index = parsed_reference[1]
     return tuple(references)
+
+
+def _next_reference_scan_position(*, sql: str, start: int) -> int:
+    positions: list[int] = []
+    token: str
+    for token in ("__", "--", "/*", "'", '"', "`"):
+        position: int = sql.find(token, start)
+        if position >= 0:
+            positions.append(position)
+    return min(positions, default=len(sql))
 
 
 def _parse_reference_at(*, sql: str, start: int) -> tuple[CompileSqlReference, int] | None:

--- a/src/sqlbuild/compiler/compile/helpers/refs.py
+++ b/src/sqlbuild/compiler/compile/helpers/refs.py
@@ -13,6 +13,17 @@ from sqlbuild.compiler.shared.helpers.sql_scanning import (
 from sqlbuild.shared.types import SqlReferenceKind
 
 _CONTEXT: str = "SQL reference"
+_REFERENCE_PREFIXES: tuple[tuple[str, SqlReferenceKind], ...] = (
+    ("__dbt_ref(", SqlReferenceKind.DBT_REF),
+    ("__table_fn(", SqlReferenceKind.TABLE_FUNCTION),
+    ("__source(", SqlReferenceKind.SOURCE),
+    ("__seed(", SqlReferenceKind.SEED),
+    ("__udf(", SqlReferenceKind.UDF),
+    ("__ref(", SqlReferenceKind.REF),
+)
+_REFERENCE_PREFIX_BY_KIND: dict[SqlReferenceKind, str] = {
+    ref_kind: prefix[:-1] for prefix, ref_kind in _REFERENCE_PREFIXES
+}
 
 
 def extract_sql_references(sql: str) -> tuple[CompileSqlReference, ...]:
@@ -32,6 +43,10 @@ def extract_sql_references(sql: str) -> tuple[CompileSqlReference, ...]:
             index = skip_quoted_text(sql=sql, start=index, context=_CONTEXT)
             continue
 
+        if sql[index] != "_" or index + 1 >= length or sql[index + 1] != "_":
+            index += 1
+            continue
+
         parsed_reference: tuple[CompileSqlReference, int] | None = _parse_reference_at(
             sql=sql,
             start=index,
@@ -46,22 +61,15 @@ def extract_sql_references(sql: str) -> tuple[CompileSqlReference, ...]:
 
 def _parse_reference_at(*, sql: str, start: int) -> tuple[CompileSqlReference, int] | None:
     ref_kind: SqlReferenceKind | None = None
-    if sql.startswith(f"{SqlReferenceKind.DBT_REF.function_name}(", start):
-        ref_kind = SqlReferenceKind.DBT_REF
-    elif sql.startswith(f"{SqlReferenceKind.SEED.function_name}(", start):
-        ref_kind = SqlReferenceKind.SEED
-    elif sql.startswith(f"{SqlReferenceKind.SOURCE.function_name}(", start):
-        ref_kind = SqlReferenceKind.SOURCE
-    elif sql.startswith(f"{SqlReferenceKind.UDF.function_name}(", start):
-        ref_kind = SqlReferenceKind.UDF
-    elif sql.startswith(f"{SqlReferenceKind.TABLE_FUNCTION.function_name}(", start):
-        ref_kind = SqlReferenceKind.TABLE_FUNCTION
-    elif sql.startswith(f"{SqlReferenceKind.REF.function_name}(", start):
-        ref_kind = SqlReferenceKind.REF
+    prefix: str
+    for prefix, candidate_kind in _REFERENCE_PREFIXES:
+        if sql.startswith(prefix, start):
+            ref_kind = candidate_kind
+            break
     if ref_kind is None:
         return None
 
-    open_paren_index: int = start + len(ref_prefix(ref_kind))
+    open_paren_index: int = start + len(_REFERENCE_PREFIX_BY_KIND[ref_kind])
     closing_paren_index: int = find_matching_paren(
         sql=sql, open_paren_index=open_paren_index, context=_CONTEXT
     )
@@ -96,7 +104,7 @@ def _parse_reference_at(*, sql: str, start: int) -> tuple[CompileSqlReference, i
 
 def ref_prefix(ref_kind: SqlReferenceKind | str) -> str:
     normalized_ref_kind: SqlReferenceKind = SqlReferenceKind(ref_kind)
-    return normalized_ref_kind.function_name
+    return _REFERENCE_PREFIX_BY_KIND[normalized_ref_kind]
 
 
 def _split_top_level_arguments(raw_arguments: str) -> tuple[str, ...]:

--- a/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
+++ b/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
@@ -7,8 +7,16 @@ from typing import Any
 
 from sqlbuild.adapter.shared.models import ExpressionInferenceProfile
 from sqlbuild.adapter.shared.types import FunctionNullabilityRule
-from sqlbuild.compiler.compile.models.core import InferredColumn
+from sqlbuild.compiler.compile.models.core import (
+    CompiledLineageColumnFact,
+    CompiledLineageSourceFact,
+    CompileSqlReference,
+    InferredColumn,
+)
+from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.lineage.types import InferredNullability
+from sqlbuild.compiler.lineage.types import ColumnLineageConfidence, ColumnTransformKind
+from sqlbuild.shared.helpers.polyglot import import_polyglot_sql
 from sqlbuild.shared.helpers.sql_reference_patterns import (
     quoted_reference_call_pattern,
     reference_call_prefix_pattern_text,
@@ -45,15 +53,25 @@ def infer_columns_with_sqlglot(
     extractable column names.
     """
 
-    sqlglot_module: Any | None = import_sqlglot()
-    expressions_module: Any | None = import_sqlglot_expressions()
-    if sqlglot_module is None or expressions_module is None:
-        return None
     profile: ExpressionInferenceProfile = inference_profile or ExpressionInferenceProfile()
 
     cleaned_sql: str = _replace_refs_with_stubs(query_sql)
     if placeholders:
         cleaned_sql = substitute_placeholder_defaults(cleaned_sql, placeholders)
+
+    polyglot_columns: tuple[InferredColumn, ...] | None | bool = _infer_columns_with_polyglot(
+        cleaned_sql=cleaned_sql,
+        dialect=profile.sqlglot_dialect,
+        column_nullability_by_table=column_nullability_by_table or {},
+        inference_profile=profile,
+    )
+    if isinstance(polyglot_columns, tuple):
+        return polyglot_columns
+
+    sqlglot_module: Any | None = import_sqlglot()
+    expressions_module: Any | None = import_sqlglot_expressions()
+    if sqlglot_module is None or expressions_module is None:
+        return None
 
     try:
         parsed: Any = sqlglot_module.parse_one(cleaned_sql, dialect=profile.sqlglot_dialect)
@@ -76,6 +94,412 @@ def infer_columns_with_sqlglot(
         infer_nullability=infer_nullability,
         inference_profile=profile,
     )
+
+
+def analyze_columns_with_polyglot(
+    *,
+    query_sql: str,
+    placeholders: dict[str, str] | None = None,
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]] | None = None,
+    inference_profile: ExpressionInferenceProfile | None = None,
+) -> tuple[InferredColumn, ...] | None | bool:
+    """Infer columns with one Polyglot parse, returning False when unavailable."""
+
+    profile: ExpressionInferenceProfile = inference_profile or ExpressionInferenceProfile()
+    cleaned_sql: str = _replace_refs_with_stubs(query_sql)
+    if placeholders:
+        cleaned_sql = substitute_placeholder_defaults(cleaned_sql, placeholders)
+    return _infer_columns_with_polyglot(
+        cleaned_sql=cleaned_sql,
+        dialect=profile.sqlglot_dialect,
+        column_nullability_by_table=column_nullability_by_table or {},
+        inference_profile=profile,
+    )
+
+
+def analyze_columns_and_lineage_with_polyglot(
+    *,
+    query_sql: str,
+    references: tuple[CompileSqlReference, ...] = (),
+    placeholders: dict[str, str] | None = None,
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]] | None = None,
+    inference_profile: ExpressionInferenceProfile | None = None,
+) -> tuple[tuple[InferredColumn, ...] | None, tuple[CompiledLineageColumnFact, ...], bool] | bool:
+    """Infer columns and compact lineage facts from one Polyglot parse."""
+
+    polyglot_module: Any | None = import_polyglot_sql()
+    if polyglot_module is None:
+        return False
+    profile: ExpressionInferenceProfile = inference_profile or ExpressionInferenceProfile()
+    cleaned_sql: str = _replace_refs_with_stubs(query_sql)
+    if placeholders:
+        cleaned_sql = substitute_placeholder_defaults(cleaned_sql, placeholders)
+    try:
+        parsed: Any = polyglot_module.parse_one(
+            cleaned_sql,
+            dialect=profile.sqlglot_dialect or "generic",
+        )
+    except Exception:
+        return False
+    columns: tuple[InferredColumn, ...] | None | bool = _infer_columns_from_polyglot_ast(
+        parsed=parsed,
+        column_nullability_by_table=column_nullability_by_table or {},
+        inference_profile=profile,
+    )
+    if columns is False:
+        return False
+    lineage_columns, has_star = _extract_polyglot_lineage_facts(
+        parsed=parsed,
+        references=references,
+    )
+    return columns, lineage_columns, has_star
+
+
+def _infer_columns_with_polyglot(
+    *,
+    cleaned_sql: str,
+    dialect: str | None,
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+    inference_profile: ExpressionInferenceProfile,
+) -> tuple[InferredColumn, ...] | None | bool:
+    polyglot_module: Any | None = import_polyglot_sql()
+    if polyglot_module is None:
+        return False
+    try:
+        parsed: Any = polyglot_module.parse_one(cleaned_sql, dialect=dialect or "generic")
+    except Exception:
+        return False
+    return _infer_columns_from_polyglot_ast(
+        parsed=parsed,
+        column_nullability_by_table=column_nullability_by_table,
+        inference_profile=inference_profile,
+    )
+
+
+def _infer_columns_from_polyglot_ast(
+    *,
+    parsed: Any,
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+    inference_profile: ExpressionInferenceProfile,
+) -> tuple[InferredColumn, ...] | None | bool:
+    infer_nullability: bool = str(getattr(parsed, "kind", "")) not in {
+        "union",
+        "intersect",
+        "except",
+    }
+    select: Any | None = parsed
+    if str(getattr(select, "kind", "")) != "select":
+        try:
+            select = parsed.find("select")
+        except Exception:
+            return None
+    if select is None or str(getattr(select, "kind", "")) != "select":
+        return None
+
+    columns: list[InferredColumn] = []
+    projection: Any
+    for projection in getattr(select, "expressions", ()):
+        if bool(getattr(projection, "is_star", False)):
+            continue
+        name: str = str(getattr(projection, "output_name", "") or "")
+        if not name or name == "*":
+            continue
+        inner: Any = projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+        col_type: str | None = _polyglot_cast_type(inner)
+        nullability: InferredNullability = InferredNullability.UNKNOWN
+        if infer_nullability:
+            nullability = _infer_polyglot_nullability(
+                expression=inner,
+                column_nullability_by_table=column_nullability_by_table,
+                inference_profile=inference_profile,
+            )
+        columns.append(InferredColumn(name=name, type=col_type, nullability=nullability))
+    return tuple(columns)
+
+
+def _extract_polyglot_lineage_facts(
+    *,
+    parsed: Any,
+    references: tuple[CompileSqlReference, ...],
+) -> tuple[tuple[CompiledLineageColumnFact, ...], bool]:
+    if str(getattr(parsed, "kind", "")) != "select":
+        return (), False
+    alias_map: dict[str, tuple[CompiledResourceType, str]] = _polyglot_reference_alias_map(
+        parsed=parsed,
+        references=references,
+    )
+    lineage_columns: list[CompiledLineageColumnFact] = []
+    has_star: bool = False
+    projection: Any
+    for projection in getattr(parsed, "expressions", ()):
+        if bool(getattr(projection, "is_star", False)):
+            has_star = True
+            continue
+        inner: Any = projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+        if bool(getattr(inner, "is_star", False)):
+            has_star = True
+            continue
+        output_column: str = str(getattr(projection, "output_name", "") or "")
+        if not output_column or output_column == "*":
+            continue
+        upstream_columns, confidence = _polyglot_lineage_upstream_columns(
+            projection=projection,
+            alias_map=alias_map,
+        )
+        transform_kind: ColumnTransformKind = _polyglot_lineage_transform_kind(
+            inner,
+            has_upstream=bool(upstream_columns),
+        )
+        lineage_columns.append(
+            CompiledLineageColumnFact(
+                output_column=output_column,
+                upstream_columns=upstream_columns,
+                transform_kind=transform_kind,
+                confidence=confidence
+                if upstream_columns or transform_kind == ColumnTransformKind.CONSTANT
+                else ColumnLineageConfidence.UNKNOWN,
+            )
+        )
+    return tuple(lineage_columns), has_star
+
+
+def _polyglot_reference_alias_map(
+    *, parsed: Any, references: tuple[CompileSqlReference, ...]
+) -> dict[str, tuple[CompiledResourceType, str]]:
+    resource_by_name: dict[str, tuple[CompiledResourceType, str]] = {}
+    reference: CompileSqlReference
+    for reference in references:
+        resource_type: CompiledResourceType | None = _lineage_resource_type(reference)
+        if resource_type is None:
+            continue
+        resource_by_name[reference.ref_name] = (resource_type, reference.ref_name)
+    alias_map: dict[str, tuple[CompiledResourceType, str]] = {}
+    try:
+        tables: tuple[Any, ...] = tuple(parsed.find_all("table"))
+    except Exception:
+        return alias_map
+    table: Any
+    for table in tables:
+        table_name: str = str(getattr(table, "name", "") or "")
+        resource: tuple[CompiledResourceType, str] | None = resource_by_name.get(table_name)
+        if resource is None:
+            continue
+        alias_map[table_name] = resource
+        alias_or_name: str = str(getattr(table, "alias_or_name", "") or "")
+        if alias_or_name:
+            alias_map[alias_or_name] = resource
+    return alias_map
+
+
+def _lineage_resource_type(reference: CompileSqlReference) -> CompiledResourceType | None:
+    if reference.ref_kind == SqlReferenceKind.REF:
+        return CompiledResourceType.MODEL
+    if reference.ref_kind == SqlReferenceKind.SOURCE:
+        return CompiledResourceType.SOURCE
+    if reference.ref_kind == SqlReferenceKind.SEED:
+        return CompiledResourceType.SEED
+    return None
+
+
+def _polyglot_lineage_upstream_columns(
+    *,
+    projection: Any,
+    alias_map: dict[str, tuple[CompiledResourceType, str]],
+) -> tuple[tuple[CompiledLineageSourceFact, ...], ColumnLineageConfidence]:
+    columns: list[CompiledLineageSourceFact] = []
+    seen: set[tuple[CompiledResourceType, str, str]] = set()
+    confidence: ColumnLineageConfidence = ColumnLineageConfidence.HIGH
+    try:
+        column_nodes: tuple[Any, ...] = tuple(projection.find_all("column"))
+    except Exception:
+        return (), ColumnLineageConfidence.UNKNOWN
+    column: Any
+    for column in column_nodes:
+        if bool(getattr(column, "is_star", False)):
+            continue
+        column_name: str = str(getattr(column, "name", "") or "")
+        if not column_name:
+            continue
+        table_name: str = _polyglot_column_table_name(column)
+        resource: tuple[CompiledResourceType, str] | None = None
+        if table_name:
+            resource = alias_map.get(table_name)
+        elif len({resource_name for _, resource_name in alias_map.values()}) == 1:
+            resource = next(iter(alias_map.values()))
+            confidence = ColumnLineageConfidence.MEDIUM
+        else:
+            confidence = ColumnLineageConfidence.UNKNOWN
+        if resource is None:
+            continue
+        resource_type, resource_name = resource
+        key: tuple[CompiledResourceType, str, str] = (resource_type, resource_name, column_name)
+        if key in seen:
+            continue
+        seen.add(key)
+        columns.append(
+            CompiledLineageSourceFact(
+                resource_type=resource_type,
+                resource_name=resource_name,
+                column_name=column_name,
+            )
+        )
+    return tuple(columns), confidence
+
+
+def _polyglot_lineage_transform_kind(expression: Any, *, has_upstream: bool) -> ColumnTransformKind:
+    kind: str = str(getattr(expression, "kind", ""))
+    if bool(getattr(expression, "is_star", False)):
+        return ColumnTransformKind.STAR
+    if kind in {"cast", "try_cast"}:
+        return ColumnTransformKind.CAST
+    if _polyglot_has_aggregation(expression):
+        return ColumnTransformKind.AGGREGATION
+    if not has_upstream:
+        return ColumnTransformKind.CONSTANT
+    if kind == "column":
+        return ColumnTransformKind.DIRECT
+    return ColumnTransformKind.EXPRESSION
+
+
+def _polyglot_has_aggregation(expression: Any) -> bool:
+    aggregate_kinds: frozenset[str] = frozenset(
+        {"avg", "count", "max", "min", "sum", "array_agg", "string_agg"}
+    )
+    try:
+        nodes: tuple[Any, ...] = tuple(expression.walk())
+    except Exception:
+        return False
+    return any(str(getattr(node, "kind", "")) in aggregate_kinds for node in nodes)
+
+
+def _polyglot_cast_type(expression: Any) -> str | None:
+    kind: str = str(getattr(expression, "kind", ""))
+    if kind not in {"cast", "try_cast"}:
+        return None
+    try:
+        payload: object = expression.to_dict().get(kind, {})
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    target: object = payload.get("to")
+    if not isinstance(target, dict):
+        return None
+    raw_type: object = target.get("data_type")
+    if not isinstance(raw_type, str) or not raw_type:
+        return None
+    return _polyglot_type_name(raw_type)
+
+
+def _polyglot_type_name(raw_type: str) -> str:
+    known_types: dict[str, str] = {
+        "big_int": "BIGINT",
+        "bool": "BOOLEAN",
+        "boolean": "BOOLEAN",
+        "date": "DATE",
+        "decimal": "DECIMAL",
+        "double": "DOUBLE",
+        "float": "FLOAT",
+        "int": "INT",
+        "integer": "INT",
+        "text": "TEXT",
+        "timestamp": "TIMESTAMP",
+        "var_char": "TEXT",
+        "varchar": "TEXT",
+    }
+    return known_types.get(raw_type, raw_type.replace("_", " ").upper())
+
+
+def _infer_polyglot_nullability(
+    *,
+    expression: Any,
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+    inference_profile: ExpressionInferenceProfile,
+) -> InferredNullability:
+    kind: str = str(getattr(expression, "kind", ""))
+    if kind == "null":
+        return InferredNullability.NULLABLE
+    if kind == "literal":
+        return InferredNullability.NON_NULL
+    if kind == "column":
+        return _infer_polyglot_column_nullability(
+            expression=expression,
+            column_nullability_by_table=column_nullability_by_table,
+        )
+    if kind == "cast":
+        inner: Any | None = getattr(expression, "this", None)
+        if inner is None:
+            return InferredNullability.UNKNOWN
+        return _infer_polyglot_nullability(
+            expression=inner,
+            column_nullability_by_table=column_nullability_by_table,
+            inference_profile=inference_profile,
+        )
+    if kind == "try_cast":
+        return InferredNullability.UNKNOWN
+    if kind == "count":
+        return InferredNullability.NON_NULL
+    if kind == "coalesce":
+        child_nullabilities: list[InferredNullability] = [
+            _infer_polyglot_nullability(
+                expression=child,
+                column_nullability_by_table=column_nullability_by_table,
+                inference_profile=inference_profile,
+            )
+            for child in getattr(expression, "expressions", ())
+        ]
+        if any(value == InferredNullability.NON_NULL for value in child_nullabilities):
+            return InferredNullability.NON_NULL
+        if child_nullabilities and all(
+            value == InferredNullability.NULLABLE for value in child_nullabilities
+        ):
+            return InferredNullability.NULLABLE
+        return InferredNullability.UNKNOWN
+    rule: FunctionNullabilityRule | None = inference_profile.function_nullability_rule(kind)
+    if rule is None:
+        return InferredNullability.UNKNOWN
+    child_nullabilities: tuple[InferredNullability, ...] = tuple(
+        _infer_polyglot_nullability(
+            expression=child,
+            column_nullability_by_table=column_nullability_by_table,
+            inference_profile=inference_profile,
+        )
+        for child in getattr(expression, "expressions", ())
+    )
+    return rule(child_nullabilities)
+
+
+def _infer_polyglot_column_nullability(
+    *,
+    expression: Any,
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+) -> InferredNullability:
+    column_name: str = str(getattr(expression, "name", "") or "")
+    if not column_name:
+        return InferredNullability.UNKNOWN
+    try:
+        payload: object = expression.to_dict().get("column", {})
+    except Exception:
+        payload = {}
+    table_name: str = ""
+    if isinstance(payload, dict):
+        table_payload: object = payload.get("table")
+        if isinstance(table_payload, dict):
+            raw_name: object = table_payload.get("name")
+            if isinstance(raw_name, str):
+                table_name = raw_name
+    if table_name:
+        return column_nullability_by_table.get(table_name, {}).get(
+            column_name, InferredNullability.UNKNOWN
+        )
+    matches: list[InferredNullability] = [
+        columns[column_name]
+        for columns in column_nullability_by_table.values()
+        if column_name in columns
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    return InferredNullability.UNKNOWN
 
 
 def substitute_placeholder_defaults(query_sql: str, placeholders: dict[str, str]) -> str:

--- a/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
+++ b/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
@@ -40,6 +40,57 @@ _TABLE_FUNCTION_PATTERN: re.Pattern[str] = re.compile(
     r'"([A-Za-z_][A-Za-z0-9_]*)"\)\s*(?=\()'
 )
 _PLACEHOLDER_PATTERN: re.Pattern[str] = re.compile(r"@@@(\w+)")
+_POLYGLOT_KIND_ALIAS: str = "alias"
+_POLYGLOT_KIND_ARRAY_AGG: str = "array_agg"
+_POLYGLOT_KIND_AVG: str = "avg"
+_POLYGLOT_KIND_CAST: str = "cast"
+_POLYGLOT_KIND_COALESCE: str = "coalesce"
+_POLYGLOT_KIND_COLUMN: str = "column"
+_POLYGLOT_KIND_COUNT: str = "count"
+_POLYGLOT_KIND_EXCEPT: str = "except"
+_POLYGLOT_KIND_INTERSECT: str = "intersect"
+_POLYGLOT_KIND_LITERAL: str = "literal"
+_POLYGLOT_KIND_MAX: str = "max"
+_POLYGLOT_KIND_MIN: str = "min"
+_POLYGLOT_KIND_NULL: str = "null"
+_POLYGLOT_KIND_SELECT: str = "select"
+_POLYGLOT_KIND_STRING_AGG: str = "string_agg"
+_POLYGLOT_KIND_SUM: str = "sum"
+_POLYGLOT_KIND_TABLE: str = "table"
+_POLYGLOT_KIND_TRY_CAST: str = "try_cast"
+_POLYGLOT_KIND_UNION: str = "union"
+_POLYGLOT_SET_OPERATION_KINDS: frozenset[str] = frozenset(
+    {_POLYGLOT_KIND_UNION, _POLYGLOT_KIND_INTERSECT, _POLYGLOT_KIND_EXCEPT}
+)
+_POLYGLOT_CAST_KINDS: frozenset[str] = frozenset({_POLYGLOT_KIND_CAST, _POLYGLOT_KIND_TRY_CAST})
+_POLYGLOT_AGGREGATE_KINDS: frozenset[str] = frozenset(
+    {
+        _POLYGLOT_KIND_AVG,
+        _POLYGLOT_KIND_COUNT,
+        _POLYGLOT_KIND_MAX,
+        _POLYGLOT_KIND_MIN,
+        _POLYGLOT_KIND_SUM,
+        _POLYGLOT_KIND_ARRAY_AGG,
+        _POLYGLOT_KIND_STRING_AGG,
+    }
+)
+_POLYGLOT_PAYLOAD_ALIAS: str = "alias"
+_POLYGLOT_PAYLOAD_COLUMN: str = "column"
+_POLYGLOT_PAYLOAD_DATA_TYPE: str = "data_type"
+_POLYGLOT_PAYLOAD_FROM: str = "from"
+_POLYGLOT_PAYLOAD_EXPRESSIONS: str = "expressions"
+_POLYGLOT_PAYLOAD_JOINS: str = "joins"
+_POLYGLOT_PAYLOAD_KIND: str = "kind"
+_POLYGLOT_PAYLOAD_NAME: str = "name"
+_POLYGLOT_PAYLOAD_PRECISION: str = "precision"
+_POLYGLOT_PAYLOAD_SCALE: str = "scale"
+_POLYGLOT_PAYLOAD_SELECT: str = "select"
+_POLYGLOT_PAYLOAD_TABLE: str = "table"
+_POLYGLOT_PAYLOAD_THIS: str = "this"
+_POLYGLOT_PAYLOAD_TO: str = "to"
+_POLYGLOT_JOIN_FULL: str = "FULL"
+_POLYGLOT_JOIN_LEFT: str = "LEFT"
+_POLYGLOT_JOIN_RIGHT: str = "RIGHT"
 
 
 def infer_columns_with_sqlglot(
@@ -182,18 +233,14 @@ def _infer_columns_from_polyglot_ast(
     column_nullability_by_table: dict[str, dict[str, InferredNullability]],
     inference_profile: ExpressionInferenceProfile,
 ) -> tuple[InferredColumn, ...] | None | bool:
-    infer_nullability: bool = str(getattr(parsed, "kind", "")) not in {
-        "union",
-        "intersect",
-        "except",
-    }
+    infer_nullability: bool = str(getattr(parsed, "kind", "")) not in _POLYGLOT_SET_OPERATION_KINDS
     select: Any | None = parsed
-    if str(getattr(select, "kind", "")) != "select":
+    if str(getattr(select, "kind", "")) != _POLYGLOT_KIND_SELECT:
         try:
-            select = parsed.find("select")
+            select = parsed.find(_POLYGLOT_KIND_SELECT)
         except Exception:
             return None
-    if select is None or str(getattr(select, "kind", "")) != "select":
+    if select is None or str(getattr(select, "kind", "")) != _POLYGLOT_KIND_SELECT:
         return None
 
     column_nullability_by_table = dict(column_nullability_by_table)
@@ -212,7 +259,9 @@ def _infer_columns_from_polyglot_ast(
         if not name or name == "*":
             continue
         inner: Any = (
-            projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+            projection.this
+            if str(getattr(projection, "kind", "")) == _POLYGLOT_KIND_ALIAS
+            else projection
         )
         col_type: str | None = _polyglot_cast_type(inner)
         nullability: InferredNullability = InferredNullability.UNKNOWN
@@ -234,18 +283,14 @@ def _analyze_columns_and_lineage_from_polyglot_ast(
     column_nullability_by_table: dict[str, dict[str, InferredNullability]],
     inference_profile: ExpressionInferenceProfile,
 ) -> tuple[tuple[InferredColumn, ...] | None, tuple[CompiledLineageColumnFact, ...], bool] | bool:
-    infer_nullability: bool = str(getattr(parsed, "kind", "")) not in {
-        "union",
-        "intersect",
-        "except",
-    }
+    infer_nullability: bool = str(getattr(parsed, "kind", "")) not in _POLYGLOT_SET_OPERATION_KINDS
     select: Any | None = parsed
-    if str(getattr(select, "kind", "")) != "select":
+    if str(getattr(select, "kind", "")) != _POLYGLOT_KIND_SELECT:
         try:
-            select = parsed.find("select")
+            select = parsed.find(_POLYGLOT_KIND_SELECT)
         except Exception:
             return None, (), False
-    if select is None or str(getattr(select, "kind", "")) != "select":
+    if select is None or str(getattr(select, "kind", "")) != _POLYGLOT_KIND_SELECT:
         return None, (), False
 
     column_nullability_by_table = dict(column_nullability_by_table)
@@ -260,6 +305,9 @@ def _analyze_columns_and_lineage_from_polyglot_ast(
         parsed=select,
         references=references,
     )
+    unqualified_resource: tuple[CompiledResourceType, str] | None = _single_alias_resource(
+        alias_map
+    )
 
     columns: list[InferredColumn] = []
     lineage_columns: list[CompiledLineageColumnFact] = []
@@ -270,7 +318,9 @@ def _analyze_columns_and_lineage_from_polyglot_ast(
             has_star = True
             continue
         inner: Any = (
-            projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+            projection.this
+            if str(getattr(projection, "kind", "")) == _POLYGLOT_KIND_ALIAS
+            else projection
         )
         if bool(getattr(inner, "is_star", False)):
             has_star = True
@@ -299,6 +349,7 @@ def _analyze_columns_and_lineage_from_polyglot_ast(
         upstream_columns, confidence = _polyglot_lineage_upstream_columns(
             projection=projection,
             alias_map=alias_map,
+            unqualified_resource=unqualified_resource,
         )
         transform_kind: ColumnTransformKind = _polyglot_lineage_transform_kind(
             inner,
@@ -322,11 +373,14 @@ def _extract_polyglot_lineage_facts(
     parsed: Any,
     references: tuple[CompileSqlReference, ...],
 ) -> tuple[tuple[CompiledLineageColumnFact, ...], bool]:
-    if str(getattr(parsed, "kind", "")) != "select":
+    if str(getattr(parsed, "kind", "")) != _POLYGLOT_KIND_SELECT:
         return (), False
     alias_map: dict[str, tuple[CompiledResourceType, str]] = _polyglot_reference_alias_map(
         parsed=parsed,
         references=references,
+    )
+    unqualified_resource: tuple[CompiledResourceType, str] | None = _single_alias_resource(
+        alias_map
     )
     lineage_columns: list[CompiledLineageColumnFact] = []
     has_star: bool = False
@@ -336,7 +390,9 @@ def _extract_polyglot_lineage_facts(
             has_star = True
             continue
         inner: Any = (
-            projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+            projection.this
+            if str(getattr(projection, "kind", "")) == _POLYGLOT_KIND_ALIAS
+            else projection
         )
         if bool(getattr(inner, "is_star", False)):
             has_star = True
@@ -347,6 +403,7 @@ def _extract_polyglot_lineage_facts(
         upstream_columns, confidence = _polyglot_lineage_upstream_columns(
             projection=projection,
             alias_map=alias_map,
+            unqualified_resource=unqualified_resource,
         )
         transform_kind: ColumnTransformKind = _polyglot_lineage_transform_kind(
             inner,
@@ -377,7 +434,7 @@ def _polyglot_reference_alias_map(
         resource_by_name[reference.ref_name] = (resource_type, reference.ref_name)
     alias_map: dict[str, tuple[CompiledResourceType, str]] = {}
     try:
-        tables: tuple[Any, ...] = tuple(parsed.find_all("table"))
+        tables: tuple[Any, ...] = tuple(parsed.find_all(_POLYGLOT_KIND_TABLE))
     except Exception:
         return alias_map
     table: Any
@@ -407,6 +464,7 @@ def _polyglot_lineage_upstream_columns(
     *,
     projection: Any,
     alias_map: dict[str, tuple[CompiledResourceType, str]],
+    unqualified_resource: tuple[CompiledResourceType, str] | None,
 ) -> tuple[tuple[CompiledLineageSourceFact, ...], ColumnLineageConfidence]:
     columns: list[CompiledLineageSourceFact] = []
     seen: set[tuple[CompiledResourceType, str, str]] = set()
@@ -418,8 +476,8 @@ def _polyglot_lineage_upstream_columns(
         resource: tuple[CompiledResourceType, str] | None = None
         if table_name:
             resource = alias_map.get(table_name)
-        elif len({resource_name for _, resource_name in alias_map.values()}) == 1:
-            resource = next(iter(alias_map.values()))
+        elif unqualified_resource is not None:
+            resource = unqualified_resource
             confidence = ColumnLineageConfidence.MEDIUM
         else:
             confidence = ColumnLineageConfidence.UNKNOWN
@@ -440,8 +498,21 @@ def _polyglot_lineage_upstream_columns(
     return tuple(columns), confidence
 
 
+def _single_alias_resource(
+    alias_map: dict[str, tuple[CompiledResourceType, str]],
+) -> tuple[CompiledResourceType, str] | None:
+    resource: tuple[CompiledResourceType, str] | None = None
+    for candidate in alias_map.values():
+        if resource is None:
+            resource = candidate
+            continue
+        if candidate[1] != resource[1]:
+            return None
+    return resource
+
+
 def _polyglot_column_refs_in_expression(expression: Any) -> tuple[tuple[str, str], ...]:
-    if str(getattr(expression, "kind", "")) == "column":
+    if str(getattr(expression, "kind", "")) == _POLYGLOT_KIND_COLUMN:
         return (
             (str(getattr(expression, "name", "") or ""), _polyglot_column_table_name(expression)),
         )
@@ -454,15 +525,19 @@ def _polyglot_column_refs_in_expression(expression: Any) -> tuple[tuple[str, str
     def visit(node: object) -> None:
         if isinstance(node, dict):
             node_dict: dict[str, object] = cast(dict[str, object], node)
-            column_payload: object = node_dict.get("column")
+            column_payload: object = node_dict.get(_POLYGLOT_PAYLOAD_COLUMN)
             if isinstance(column_payload, dict):
                 column_dict: dict[str, object] = cast(dict[str, object], column_payload)
-                column_name: str = _polyglot_name_payload_value(column_dict.get("name"))
-                table_payload: object = column_dict.get("table")
+                column_name: str = _polyglot_name_payload_value(
+                    column_dict.get(_POLYGLOT_PAYLOAD_NAME)
+                )
+                table_payload: object = column_dict.get(_POLYGLOT_PAYLOAD_TABLE)
                 table_name: str = ""
                 if isinstance(table_payload, dict):
                     table_dict: dict[str, object] = cast(dict[str, object], table_payload)
-                    table_name = _polyglot_name_payload_value(table_dict.get("name"))
+                    table_name = _polyglot_name_payload_value(
+                        table_dict.get(_POLYGLOT_PAYLOAD_NAME)
+                    )
                 refs.append((column_name, table_name))
                 return
             for value in node_dict.values():
@@ -489,31 +564,28 @@ def _polyglot_lineage_transform_kind(expression: Any, *, has_upstream: bool) -> 
     kind: str = str(getattr(expression, "kind", ""))
     if bool(getattr(expression, "is_star", False)):
         return ColumnTransformKind.STAR
-    if kind in {"cast", "try_cast"}:
+    if kind in _POLYGLOT_CAST_KINDS:
         return ColumnTransformKind.CAST
     if _polyglot_has_aggregation(expression):
         return ColumnTransformKind.AGGREGATION
     if not has_upstream:
         return ColumnTransformKind.CONSTANT
-    if kind == "column":
+    if kind == _POLYGLOT_KIND_COLUMN:
         return ColumnTransformKind.DIRECT
     return ColumnTransformKind.EXPRESSION
 
 
 def _polyglot_has_aggregation(expression: Any) -> bool:
-    aggregate_kinds: frozenset[str] = frozenset(
-        {"avg", "count", "max", "min", "sum", "array_agg", "string_agg"}
-    )
     try:
         nodes: tuple[Any, ...] = tuple(expression.walk())
     except Exception:
         return False
-    return any(str(getattr(node, "kind", "")) in aggregate_kinds for node in nodes)
+    return any(str(getattr(node, "kind", "")) in _POLYGLOT_AGGREGATE_KINDS for node in nodes)
 
 
 def _polyglot_cast_type(expression: Any) -> str | None:
     kind: str = str(getattr(expression, "kind", ""))
-    if kind not in {"cast", "try_cast"}:
+    if kind not in _POLYGLOT_CAST_KINDS:
         return None
     try:
         payload: object = expression.to_dict().get(kind, {})
@@ -521,15 +593,15 @@ def _polyglot_cast_type(expression: Any) -> str | None:
         return None
     if not isinstance(payload, dict):
         return None
-    target: object = payload.get("to")
+    target: object = payload.get(_POLYGLOT_PAYLOAD_TO)
     if not isinstance(target, dict):
         return None
-    raw_type: object = target.get("data_type")
+    raw_type: object = target.get(_POLYGLOT_PAYLOAD_DATA_TYPE)
     if not isinstance(raw_type, str) or not raw_type:
         return None
     type_name: str = _polyglot_type_name(raw_type)
-    precision: object = target.get("precision")
-    scale: object = target.get("scale")
+    precision: object = target.get(_POLYGLOT_PAYLOAD_PRECISION)
+    scale: object = target.get(_POLYGLOT_PAYLOAD_SCALE)
     if type_name == "DECIMAL" and isinstance(precision, int):
         if isinstance(scale, int):
             return f"DECIMAL({precision}, {scale})"
@@ -564,17 +636,17 @@ def _infer_polyglot_nullability(
     inference_profile: ExpressionInferenceProfile,
 ) -> InferredNullability:
     kind: str = str(getattr(expression, "kind", ""))
-    if kind == "null":
+    if kind == _POLYGLOT_KIND_NULL:
         return InferredNullability.NULLABLE
-    if kind == "literal":
+    if kind == _POLYGLOT_KIND_LITERAL:
         return InferredNullability.NON_NULL
-    if kind == "column":
+    if kind == _POLYGLOT_KIND_COLUMN:
         return _infer_polyglot_column_nullability(
             expression=expression,
             alias_nullability=alias_nullability,
             column_nullability_by_table=column_nullability_by_table,
         )
-    if kind == "cast":
+    if kind == _POLYGLOT_KIND_CAST:
         inner: Any | None = getattr(expression, "this", None)
         if inner is None:
             return InferredNullability.UNKNOWN
@@ -584,11 +656,11 @@ def _infer_polyglot_nullability(
             column_nullability_by_table=column_nullability_by_table,
             inference_profile=inference_profile,
         )
-    if kind == "try_cast":
+    if kind == _POLYGLOT_KIND_TRY_CAST:
         return InferredNullability.UNKNOWN
-    if kind == "count":
+    if kind == _POLYGLOT_KIND_COUNT:
         return InferredNullability.NON_NULL
-    if kind == "coalesce":
+    if kind == _POLYGLOT_KIND_COALESCE:
         child_nullabilities: list[InferredNullability] = [
             _infer_polyglot_nullability(
                 expression=child,
@@ -626,15 +698,15 @@ def _infer_polyglot_shallow_nullability(
     inference_profile: ExpressionInferenceProfile,
 ) -> InferredNullability:
     kind: str = str(getattr(expression, "kind", ""))
-    if kind == "null":
+    if kind == _POLYGLOT_KIND_NULL:
         return InferredNullability.NULLABLE
-    if kind == "literal":
+    if kind == _POLYGLOT_KIND_LITERAL:
         return InferredNullability.NON_NULL
-    if kind == "count":
+    if kind == _POLYGLOT_KIND_COUNT:
         return InferredNullability.NON_NULL
-    if kind == "column":
+    if kind == _POLYGLOT_KIND_COLUMN:
         return InferredNullability.UNKNOWN
-    if kind == "cast":
+    if kind == _POLYGLOT_KIND_CAST:
         inner: Any | None = getattr(expression, "this", None)
         if inner is None:
             return InferredNullability.UNKNOWN
@@ -642,9 +714,9 @@ def _infer_polyglot_shallow_nullability(
             expression=inner,
             inference_profile=inference_profile,
         )
-    if kind == "try_cast":
+    if kind == _POLYGLOT_KIND_TRY_CAST:
         return InferredNullability.UNKNOWN
-    if kind == "coalesce":
+    if kind == _POLYGLOT_KIND_COALESCE:
         child_nullabilities: tuple[InferredNullability, ...] = tuple(
             _infer_polyglot_shallow_nullability(
                 expression=child,
@@ -682,14 +754,14 @@ def _infer_polyglot_column_nullability(
     if not column_name:
         return InferredNullability.UNKNOWN
     try:
-        payload: object = expression.to_dict().get("column", {})
+        payload: object = expression.to_dict().get(_POLYGLOT_PAYLOAD_COLUMN, {})
     except Exception:
         payload = {}
     table_name: str = ""
     if isinstance(payload, dict):
-        table_payload: object = payload.get("table")
+        table_payload: object = payload.get(_POLYGLOT_PAYLOAD_TABLE)
         if isinstance(table_payload, dict):
-            raw_name: object = table_payload.get("name")
+            raw_name: object = table_payload.get(_POLYGLOT_PAYLOAD_NAME)
             if isinstance(raw_name, str):
                 table_name = raw_name
     if table_name:
@@ -712,7 +784,7 @@ def _infer_polyglot_column_nullability(
 
 
 def _polyglot_columns_in_expression(expression: Any) -> tuple[Any, ...]:
-    if str(getattr(expression, "kind", "")) == "column":
+    if str(getattr(expression, "kind", "")) == _POLYGLOT_KIND_COLUMN:
         return (expression,)
     columns: list[Any] = []
     seen: set[int] = set()
@@ -722,7 +794,7 @@ def _polyglot_columns_in_expression(expression: Any) -> tuple[Any, ...]:
         if node_id in seen:
             return
         seen.add(node_id)
-        if str(getattr(node, "kind", "")) == "column":
+        if str(getattr(node, "kind", "")) == _POLYGLOT_KIND_COLUMN:
             columns.append(node)
             return
         for child in _polyglot_child_expressions(node):
@@ -734,15 +806,15 @@ def _polyglot_columns_in_expression(expression: Any) -> tuple[Any, ...]:
 
 def _polyglot_column_table_name(column: Any) -> str:
     try:
-        payload: object = column.to_dict().get("column", {})
+        payload: object = column.to_dict().get(_POLYGLOT_PAYLOAD_COLUMN, {})
     except Exception:
         return ""
     if not isinstance(payload, dict):
         return ""
-    table_payload: object = payload.get("table")
+    table_payload: object = payload.get(_POLYGLOT_PAYLOAD_TABLE)
     if not isinstance(table_payload, dict):
         return ""
-    raw_name: object = table_payload.get("name")
+    raw_name: object = table_payload.get(_POLYGLOT_PAYLOAD_NAME)
     return raw_name if isinstance(raw_name, str) else ""
 
 
@@ -776,19 +848,19 @@ def _polyglot_alias_nullability_from_select(
     current_aliases: set[str] = set()
 
     try:
-        select_payload: object = select.to_dict().get("select", {})
+        select_payload: object = select.to_dict().get(_POLYGLOT_PAYLOAD_SELECT, {})
     except Exception:
         select_payload = {}
     if not isinstance(select_payload, dict):
         return alias_nullability
 
-    from_payload: object = select_payload.get("from")
+    from_payload: object = select_payload.get(_POLYGLOT_PAYLOAD_FROM)
     if isinstance(from_payload, dict):
-        from_expressions: object = from_payload.get("expressions")
+        from_expressions: object = from_payload.get(_POLYGLOT_PAYLOAD_EXPRESSIONS)
         if isinstance(from_expressions, list) and len(from_expressions) == 1:
             from_table_payload: object = from_expressions[0]
             if isinstance(from_table_payload, dict):
-                table_payload: object = from_table_payload.get("table")
+                table_payload: object = from_table_payload.get(_POLYGLOT_PAYLOAD_TABLE)
                 if isinstance(table_payload, dict):
                     alias, table_name = _polyglot_table_payload_alias_and_name(table_payload)
                     current_aliases.add(alias)
@@ -799,29 +871,29 @@ def _polyglot_alias_nullability_from_select(
                         column_nullability_by_table=column_nullability_by_table,
                     )
 
-    joins_payload: object = select_payload.get("joins")
+    joins_payload: object = select_payload.get(_POLYGLOT_PAYLOAD_JOINS)
     if not isinstance(joins_payload, list):
         return alias_nullability
     for join_payload in joins_payload:
         if not isinstance(join_payload, dict):
             continue
-        this_payload: object = join_payload.get("this")
+        this_payload: object = join_payload.get(_POLYGLOT_PAYLOAD_THIS)
         if not isinstance(this_payload, dict):
             continue
-        joined_table_payload: object = this_payload.get("table")
+        joined_table_payload: object = this_payload.get(_POLYGLOT_PAYLOAD_TABLE)
         if not isinstance(joined_table_payload, dict):
             continue
         joined_alias, joined_table_name = _polyglot_table_payload_alias_and_name(
             joined_table_payload
         )
-        side: str = str(join_payload.get("kind") or "").upper()
-        if side == "LEFT":
+        side: str = str(join_payload.get(_POLYGLOT_PAYLOAD_KIND) or "").upper()
+        if side == _POLYGLOT_JOIN_LEFT:
             alias_nullability[joined_alias] = InferredNullability.NULLABLE
-        elif side == "RIGHT":
+        elif side == _POLYGLOT_JOIN_RIGHT:
             for alias in current_aliases:
                 alias_nullability[alias] = InferredNullability.NULLABLE
             alias_nullability[joined_alias] = InferredNullability.UNKNOWN
-        elif side == "FULL":
+        elif side == _POLYGLOT_JOIN_FULL:
             for alias in current_aliases:
                 alias_nullability[alias] = InferredNullability.NULLABLE
             alias_nullability[joined_alias] = InferredNullability.NULLABLE
@@ -844,8 +916,10 @@ def _polyglot_table_alias_or_name(table: Any) -> str:
 
 
 def _polyglot_table_payload_alias_and_name(table_payload: dict[str, object]) -> tuple[str, str]:
-    table_name: str = _polyglot_name_payload_value(table_payload.get("name"))
-    alias: str = _polyglot_name_payload_value(table_payload.get("alias")) or table_name
+    table_name: str = _polyglot_name_payload_value(table_payload.get(_POLYGLOT_PAYLOAD_NAME))
+    alias: str = (
+        _polyglot_name_payload_value(table_payload.get(_POLYGLOT_PAYLOAD_ALIAS)) or table_name
+    )
     return alias, table_name
 
 
@@ -854,7 +928,7 @@ def _polyglot_name_payload_value(payload: object) -> str:
         return payload
     if isinstance(payload, dict):
         payload_dict: dict[str, object] = cast(dict[str, object], payload)
-        name: object = payload_dict.get("name")
+        name: object = payload_dict.get(_POLYGLOT_PAYLOAD_NAME)
         if isinstance(name, str):
             return name
     return ""

--- a/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
+++ b/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
@@ -202,10 +202,12 @@ def _infer_columns_from_polyglot_ast(
         return None
 
     column_nullability_by_table = dict(column_nullability_by_table)
-    alias_nullability: dict[str, InferredNullability] = _polyglot_alias_nullability_from_select(
-        select=select,
-        column_nullability_by_table=column_nullability_by_table,
-    )
+    alias_nullability: dict[str, InferredNullability] = {}
+    if _has_known_nullability(column_nullability_by_table):
+        alias_nullability = _polyglot_alias_nullability_from_select(
+            select=select,
+            column_nullability_by_table=column_nullability_by_table,
+        )
     columns: list[InferredColumn] = []
     projection: Any
     for projection in getattr(select, "expressions", ()):
@@ -354,6 +356,8 @@ def _polyglot_lineage_upstream_columns(
 
 
 def _polyglot_column_refs_in_expression(expression: Any) -> tuple[tuple[str, str], ...]:
+    if str(getattr(expression, "kind", "")) == "column":
+        return ((str(getattr(expression, "name", "") or ""), _polyglot_column_table_name(expression)),)
     try:
         payload: object = expression.to_dict()
     except Exception:
@@ -382,6 +386,16 @@ def _polyglot_column_refs_in_expression(expression: Any) -> tuple[tuple[str, str
 
     visit(payload)
     return tuple(refs)
+
+
+def _has_known_nullability(
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+) -> bool:
+    return any(
+        value != InferredNullability.UNKNOWN
+        for column_facts in column_nullability_by_table.values()
+        for value in column_facts.values()
+    )
 
 
 def _polyglot_lineage_transform_kind(expression: Any, *, has_upstream: bool) -> ColumnTransformKind:

--- a/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
+++ b/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Any, cast
 
 from sqlbuild.adapter.shared.models import ExpressionInferenceProfile
 from sqlbuild.adapter.shared.types import FunctionNullabilityRule
@@ -14,8 +14,11 @@ from sqlbuild.compiler.compile.models.core import (
     InferredColumn,
 )
 from sqlbuild.compiler.compile.types import CompiledResourceType
-from sqlbuild.compiler.lineage.types import InferredNullability
-from sqlbuild.compiler.lineage.types import ColumnLineageConfidence, ColumnTransformKind
+from sqlbuild.compiler.lineage.types import (
+    ColumnLineageConfidence,
+    ColumnTransformKind,
+    InferredNullability,
+)
 from sqlbuild.shared.helpers.polyglot import import_polyglot_sql
 from sqlbuild.shared.helpers.sql_reference_patterns import (
     quoted_reference_call_pattern,
@@ -148,6 +151,8 @@ def analyze_columns_and_lineage_with_polyglot(
     )
     if columns is False:
         return False
+    if columns is True:
+        return False
     lineage_columns, has_star = _extract_polyglot_lineage_facts(
         parsed=parsed,
         references=references,
@@ -196,6 +201,11 @@ def _infer_columns_from_polyglot_ast(
     if select is None or str(getattr(select, "kind", "")) != "select":
         return None
 
+    column_nullability_by_table = dict(column_nullability_by_table)
+    alias_nullability: dict[str, InferredNullability] = _polyglot_alias_nullability_from_select(
+        select=select,
+        column_nullability_by_table=column_nullability_by_table,
+    )
     columns: list[InferredColumn] = []
     projection: Any
     for projection in getattr(select, "expressions", ()):
@@ -204,12 +214,15 @@ def _infer_columns_from_polyglot_ast(
         name: str = str(getattr(projection, "output_name", "") or "")
         if not name or name == "*":
             continue
-        inner: Any = projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+        inner: Any = (
+            projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+        )
         col_type: str | None = _polyglot_cast_type(inner)
         nullability: InferredNullability = InferredNullability.UNKNOWN
         if infer_nullability:
             nullability = _infer_polyglot_nullability(
                 expression=inner,
+                alias_nullability=alias_nullability,
                 column_nullability_by_table=column_nullability_by_table,
                 inference_profile=inference_profile,
             )
@@ -235,7 +248,9 @@ def _extract_polyglot_lineage_facts(
         if bool(getattr(projection, "is_star", False)):
             has_star = True
             continue
-        inner: Any = projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+        inner: Any = (
+            projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+        )
         if bool(getattr(inner, "is_star", False)):
             has_star = True
             continue
@@ -309,18 +324,10 @@ def _polyglot_lineage_upstream_columns(
     columns: list[CompiledLineageSourceFact] = []
     seen: set[tuple[CompiledResourceType, str, str]] = set()
     confidence: ColumnLineageConfidence = ColumnLineageConfidence.HIGH
-    try:
-        column_nodes: tuple[Any, ...] = tuple(projection.find_all("column"))
-    except Exception:
-        return (), ColumnLineageConfidence.UNKNOWN
-    column: Any
-    for column in column_nodes:
-        if bool(getattr(column, "is_star", False)):
-            continue
-        column_name: str = str(getattr(column, "name", "") or "")
+    column_refs: tuple[tuple[str, str], ...] = _polyglot_column_refs_in_expression(projection)
+    for column_name, table_name in column_refs:
         if not column_name:
             continue
-        table_name: str = _polyglot_column_table_name(column)
         resource: tuple[CompiledResourceType, str] | None = None
         if table_name:
             resource = alias_map.get(table_name)
@@ -344,6 +351,37 @@ def _polyglot_lineage_upstream_columns(
             )
         )
     return tuple(columns), confidence
+
+
+def _polyglot_column_refs_in_expression(expression: Any) -> tuple[tuple[str, str], ...]:
+    try:
+        payload: object = expression.to_dict()
+    except Exception:
+        return ()
+    refs: list[tuple[str, str]] = []
+
+    def visit(node: object) -> None:
+        if isinstance(node, dict):
+            node_dict: dict[str, object] = cast(dict[str, object], node)
+            column_payload: object = node_dict.get("column")
+            if isinstance(column_payload, dict):
+                column_dict: dict[str, object] = cast(dict[str, object], column_payload)
+                column_name: str = _polyglot_name_payload_value(column_dict.get("name"))
+                table_payload: object = column_dict.get("table")
+                table_name: str = ""
+                if isinstance(table_payload, dict):
+                    table_dict: dict[str, object] = cast(dict[str, object], table_payload)
+                    table_name = _polyglot_name_payload_value(table_dict.get("name"))
+                refs.append((column_name, table_name))
+                return
+            for value in node_dict.values():
+                visit(value)
+        elif isinstance(node, list):
+            for value in node:
+                visit(value)
+
+    visit(payload)
+    return tuple(refs)
 
 
 def _polyglot_lineage_transform_kind(expression: Any, *, has_upstream: bool) -> ColumnTransformKind:
@@ -388,7 +426,14 @@ def _polyglot_cast_type(expression: Any) -> str | None:
     raw_type: object = target.get("data_type")
     if not isinstance(raw_type, str) or not raw_type:
         return None
-    return _polyglot_type_name(raw_type)
+    type_name: str = _polyglot_type_name(raw_type)
+    precision: object = target.get("precision")
+    scale: object = target.get("scale")
+    if type_name == "DECIMAL" and isinstance(precision, int):
+        if isinstance(scale, int):
+            return f"DECIMAL({precision}, {scale})"
+        return f"DECIMAL({precision})"
+    return type_name
 
 
 def _polyglot_type_name(raw_type: str) -> str:
@@ -413,6 +458,7 @@ def _polyglot_type_name(raw_type: str) -> str:
 def _infer_polyglot_nullability(
     *,
     expression: Any,
+    alias_nullability: dict[str, InferredNullability],
     column_nullability_by_table: dict[str, dict[str, InferredNullability]],
     inference_profile: ExpressionInferenceProfile,
 ) -> InferredNullability:
@@ -424,6 +470,7 @@ def _infer_polyglot_nullability(
     if kind == "column":
         return _infer_polyglot_column_nullability(
             expression=expression,
+            alias_nullability=alias_nullability,
             column_nullability_by_table=column_nullability_by_table,
         )
     if kind == "cast":
@@ -432,6 +479,7 @@ def _infer_polyglot_nullability(
             return InferredNullability.UNKNOWN
         return _infer_polyglot_nullability(
             expression=inner,
+            alias_nullability=alias_nullability,
             column_nullability_by_table=column_nullability_by_table,
             inference_profile=inference_profile,
         )
@@ -443,10 +491,11 @@ def _infer_polyglot_nullability(
         child_nullabilities: list[InferredNullability] = [
             _infer_polyglot_nullability(
                 expression=child,
+                alias_nullability=alias_nullability,
                 column_nullability_by_table=column_nullability_by_table,
                 inference_profile=inference_profile,
             )
-            for child in getattr(expression, "expressions", ())
+            for child in _polyglot_expression_args(expression)
         ]
         if any(value == InferredNullability.NON_NULL for value in child_nullabilities):
             return InferredNullability.NON_NULL
@@ -461,10 +510,11 @@ def _infer_polyglot_nullability(
     child_nullabilities: tuple[InferredNullability, ...] = tuple(
         _infer_polyglot_nullability(
             expression=child,
+            alias_nullability=alias_nullability,
             column_nullability_by_table=column_nullability_by_table,
             inference_profile=inference_profile,
         )
-        for child in getattr(expression, "expressions", ())
+        for child in _polyglot_expression_args(expression)
     )
     return rule(child_nullabilities)
 
@@ -472,6 +522,7 @@ def _infer_polyglot_nullability(
 def _infer_polyglot_column_nullability(
     *,
     expression: Any,
+    alias_nullability: dict[str, InferredNullability],
     column_nullability_by_table: dict[str, dict[str, InferredNullability]],
 ) -> InferredNullability:
     column_name: str = str(getattr(expression, "name", "") or "")
@@ -489,6 +540,11 @@ def _infer_polyglot_column_nullability(
             if isinstance(raw_name, str):
                 table_name = raw_name
     if table_name:
+        table_fact: InferredNullability = alias_nullability.get(
+            table_name, InferredNullability.UNKNOWN
+        )
+        if table_fact == InferredNullability.NULLABLE:
+            return InferredNullability.NULLABLE
         return column_nullability_by_table.get(table_name, {}).get(
             column_name, InferredNullability.UNKNOWN
         )
@@ -500,6 +556,155 @@ def _infer_polyglot_column_nullability(
     if len(matches) == 1:
         return matches[0]
     return InferredNullability.UNKNOWN
+
+
+def _polyglot_columns_in_expression(expression: Any) -> tuple[Any, ...]:
+    if str(getattr(expression, "kind", "")) == "column":
+        return (expression,)
+    columns: list[Any] = []
+    seen: set[int] = set()
+
+    def visit(node: Any) -> None:
+        node_id: int = id(node)
+        if node_id in seen:
+            return
+        seen.add(node_id)
+        if str(getattr(node, "kind", "")) == "column":
+            columns.append(node)
+            return
+        for child in _polyglot_child_expressions(node):
+            visit(child)
+
+    visit(expression)
+    return tuple(columns)
+
+
+def _polyglot_column_table_name(column: Any) -> str:
+    try:
+        payload: object = column.to_dict().get("column", {})
+    except Exception:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    table_payload: object = payload.get("table")
+    if not isinstance(table_payload, dict):
+        return ""
+    raw_name: object = table_payload.get("name")
+    return raw_name if isinstance(raw_name, str) else ""
+
+
+def _polyglot_child_expressions(expression: Any) -> tuple[Any, ...]:
+    children: list[Any] = []
+    for attr_name in ("this", "expression", "left", "right"):
+        child: Any | None = getattr(expression, attr_name, None)
+        if child is not None and str(getattr(child, "kind", "")):
+            children.append(child)
+    for child in getattr(expression, "expressions", ()) or ():
+        if str(getattr(child, "kind", "")):
+            children.append(child)
+    return tuple(children)
+
+
+def _polyglot_expression_args(expression: Any) -> tuple[Any, ...]:
+    args: list[Any] = []
+    primary_arg: Any | None = getattr(expression, "this", None)
+    if primary_arg is not None:
+        args.append(primary_arg)
+    args.extend(getattr(expression, "expressions", ()) or ())
+    return tuple(args)
+
+
+def _polyglot_alias_nullability_from_select(
+    *,
+    select: Any,
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+) -> dict[str, InferredNullability]:
+    alias_nullability: dict[str, InferredNullability] = {}
+    current_aliases: set[str] = set()
+
+    try:
+        select_payload: object = select.to_dict().get("select", {})
+    except Exception:
+        select_payload = {}
+    if not isinstance(select_payload, dict):
+        return alias_nullability
+
+    from_payload: object = select_payload.get("from")
+    if isinstance(from_payload, dict):
+        from_expressions: object = from_payload.get("expressions")
+        if isinstance(from_expressions, list) and len(from_expressions) == 1:
+            from_table_payload: object = from_expressions[0]
+            if isinstance(from_table_payload, dict):
+                table_payload: object = from_table_payload.get("table")
+                if isinstance(table_payload, dict):
+                    alias, table_name = _polyglot_table_payload_alias_and_name(table_payload)
+                    current_aliases.add(alias)
+                    alias_nullability[alias] = InferredNullability.UNKNOWN
+                    _copy_table_facts_to_alias(
+                        alias=alias,
+                        table_name=table_name,
+                        column_nullability_by_table=column_nullability_by_table,
+                    )
+
+    joins_payload: object = select_payload.get("joins")
+    if not isinstance(joins_payload, list):
+        return alias_nullability
+    for join_payload in joins_payload:
+        if not isinstance(join_payload, dict):
+            continue
+        this_payload: object = join_payload.get("this")
+        if not isinstance(this_payload, dict):
+            continue
+        joined_table_payload: object = this_payload.get("table")
+        if not isinstance(joined_table_payload, dict):
+            continue
+        joined_alias, joined_table_name = _polyglot_table_payload_alias_and_name(
+            joined_table_payload
+        )
+        side: str = str(join_payload.get("kind") or "").upper()
+        if side == "LEFT":
+            alias_nullability[joined_alias] = InferredNullability.NULLABLE
+        elif side == "RIGHT":
+            for alias in current_aliases:
+                alias_nullability[alias] = InferredNullability.NULLABLE
+            alias_nullability[joined_alias] = InferredNullability.UNKNOWN
+        elif side == "FULL":
+            for alias in current_aliases:
+                alias_nullability[alias] = InferredNullability.NULLABLE
+            alias_nullability[joined_alias] = InferredNullability.NULLABLE
+        else:
+            alias_nullability[joined_alias] = InferredNullability.UNKNOWN
+        current_aliases.add(joined_alias)
+        _copy_table_facts_to_alias(
+            alias=joined_alias,
+            table_name=joined_table_name,
+            column_nullability_by_table=column_nullability_by_table,
+        )
+    return alias_nullability
+
+
+def _polyglot_table_alias_or_name(table: Any) -> str:
+    alias_or_name: str = str(getattr(table, "alias_or_name", "") or "")
+    if alias_or_name:
+        return alias_or_name
+    return str(getattr(table, "name", "") or "")
+
+
+def _polyglot_table_payload_alias_and_name(table_payload: dict[str, object]) -> tuple[str, str]:
+    table_name: str = _polyglot_name_payload_value(table_payload.get("name"))
+    alias: str = _polyglot_name_payload_value(table_payload.get("alias")) or table_name
+    return alias, table_name
+
+
+def _polyglot_name_payload_value(payload: object) -> str:
+    if isinstance(payload, str):
+        return payload
+    if isinstance(payload, dict):
+        payload_dict: dict[str, object] = cast(dict[str, object], payload)
+        name: object = payload_dict.get("name")
+        if isinstance(name, str):
+            return name
+    return ""
 
 
 def substitute_placeholder_defaults(query_sql: str, placeholders: dict[str, str]) -> str:

--- a/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
+++ b/src/sqlbuild/compiler/compile/helpers/sqlglot_columns.py
@@ -144,20 +144,15 @@ def analyze_columns_and_lineage_with_polyglot(
         )
     except Exception:
         return False
-    columns: tuple[InferredColumn, ...] | None | bool = _infer_columns_from_polyglot_ast(
+    analysis: (
+        tuple[tuple[InferredColumn, ...] | None, tuple[CompiledLineageColumnFact, ...], bool] | bool
+    ) = _analyze_columns_and_lineage_from_polyglot_ast(
         parsed=parsed,
+        references=references,
         column_nullability_by_table=column_nullability_by_table or {},
         inference_profile=profile,
     )
-    if columns is False:
-        return False
-    if columns is True:
-        return False
-    lineage_columns, has_star = _extract_polyglot_lineage_facts(
-        parsed=parsed,
-        references=references,
-    )
-    return columns, lineage_columns, has_star
+    return analysis
 
 
 def _infer_columns_with_polyglot(
@@ -230,6 +225,96 @@ def _infer_columns_from_polyglot_ast(
             )
         columns.append(InferredColumn(name=name, type=col_type, nullability=nullability))
     return tuple(columns)
+
+
+def _analyze_columns_and_lineage_from_polyglot_ast(
+    *,
+    parsed: Any,
+    references: tuple[CompileSqlReference, ...],
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+    inference_profile: ExpressionInferenceProfile,
+) -> tuple[tuple[InferredColumn, ...] | None, tuple[CompiledLineageColumnFact, ...], bool] | bool:
+    infer_nullability: bool = str(getattr(parsed, "kind", "")) not in {
+        "union",
+        "intersect",
+        "except",
+    }
+    select: Any | None = parsed
+    if str(getattr(select, "kind", "")) != "select":
+        try:
+            select = parsed.find("select")
+        except Exception:
+            return None, (), False
+    if select is None or str(getattr(select, "kind", "")) != "select":
+        return None, (), False
+
+    column_nullability_by_table = dict(column_nullability_by_table)
+    has_known_nullability: bool = _has_known_nullability(column_nullability_by_table)
+    alias_nullability: dict[str, InferredNullability] = {}
+    if has_known_nullability:
+        alias_nullability = _polyglot_alias_nullability_from_select(
+            select=select,
+            column_nullability_by_table=column_nullability_by_table,
+        )
+    alias_map: dict[str, tuple[CompiledResourceType, str]] = _polyglot_reference_alias_map(
+        parsed=select,
+        references=references,
+    )
+
+    columns: list[InferredColumn] = []
+    lineage_columns: list[CompiledLineageColumnFact] = []
+    has_star: bool = False
+    projection: Any
+    for projection in getattr(select, "expressions", ()):
+        if bool(getattr(projection, "is_star", False)):
+            has_star = True
+            continue
+        inner: Any = (
+            projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+        )
+        if bool(getattr(inner, "is_star", False)):
+            has_star = True
+            continue
+        output_column: str = str(getattr(projection, "output_name", "") or "")
+        if not output_column or output_column == "*":
+            continue
+        col_type: str | None = _polyglot_cast_type(inner)
+        nullability: InferredNullability = InferredNullability.UNKNOWN
+        if infer_nullability:
+            nullability = (
+                _infer_polyglot_nullability(
+                    expression=inner,
+                    alias_nullability=alias_nullability,
+                    column_nullability_by_table=column_nullability_by_table,
+                    inference_profile=inference_profile,
+                )
+                if has_known_nullability
+                else _infer_polyglot_shallow_nullability(
+                    expression=inner,
+                    inference_profile=inference_profile,
+                )
+            )
+        columns.append(InferredColumn(name=output_column, type=col_type, nullability=nullability))
+
+        upstream_columns, confidence = _polyglot_lineage_upstream_columns(
+            projection=projection,
+            alias_map=alias_map,
+        )
+        transform_kind: ColumnTransformKind = _polyglot_lineage_transform_kind(
+            inner,
+            has_upstream=bool(upstream_columns),
+        )
+        lineage_columns.append(
+            CompiledLineageColumnFact(
+                output_column=output_column,
+                upstream_columns=upstream_columns,
+                transform_kind=transform_kind,
+                confidence=confidence
+                if upstream_columns or transform_kind == ColumnTransformKind.CONSTANT
+                else ColumnLineageConfidence.UNKNOWN,
+            )
+        )
+    return tuple(columns), tuple(lineage_columns), has_star
 
 
 def _extract_polyglot_lineage_facts(
@@ -357,7 +442,9 @@ def _polyglot_lineage_upstream_columns(
 
 def _polyglot_column_refs_in_expression(expression: Any) -> tuple[tuple[str, str], ...]:
     if str(getattr(expression, "kind", "")) == "column":
-        return ((str(getattr(expression, "name", "") or ""), _polyglot_column_table_name(expression)),)
+        return (
+            (str(getattr(expression, "name", "") or ""), _polyglot_column_table_name(expression)),
+        )
     try:
         payload: object = expression.to_dict()
     except Exception:
@@ -526,6 +613,58 @@ def _infer_polyglot_nullability(
             expression=child,
             alias_nullability=alias_nullability,
             column_nullability_by_table=column_nullability_by_table,
+            inference_profile=inference_profile,
+        )
+        for child in _polyglot_expression_args(expression)
+    )
+    return rule(child_nullabilities)
+
+
+def _infer_polyglot_shallow_nullability(
+    *,
+    expression: Any,
+    inference_profile: ExpressionInferenceProfile,
+) -> InferredNullability:
+    kind: str = str(getattr(expression, "kind", ""))
+    if kind == "null":
+        return InferredNullability.NULLABLE
+    if kind == "literal":
+        return InferredNullability.NON_NULL
+    if kind == "count":
+        return InferredNullability.NON_NULL
+    if kind == "column":
+        return InferredNullability.UNKNOWN
+    if kind == "cast":
+        inner: Any | None = getattr(expression, "this", None)
+        if inner is None:
+            return InferredNullability.UNKNOWN
+        return _infer_polyglot_shallow_nullability(
+            expression=inner,
+            inference_profile=inference_profile,
+        )
+    if kind == "try_cast":
+        return InferredNullability.UNKNOWN
+    if kind == "coalesce":
+        child_nullabilities: tuple[InferredNullability, ...] = tuple(
+            _infer_polyglot_shallow_nullability(
+                expression=child,
+                inference_profile=inference_profile,
+            )
+            for child in _polyglot_expression_args(expression)
+        )
+        if any(value == InferredNullability.NON_NULL for value in child_nullabilities):
+            return InferredNullability.NON_NULL
+        if child_nullabilities and all(
+            value == InferredNullability.NULLABLE for value in child_nullabilities
+        ):
+            return InferredNullability.NULLABLE
+        return InferredNullability.UNKNOWN
+    rule: FunctionNullabilityRule | None = inference_profile.function_nullability_rule(kind)
+    if rule is None:
+        return InferredNullability.UNKNOWN
+    child_nullabilities: tuple[InferredNullability, ...] = tuple(
+        _infer_polyglot_shallow_nullability(
+            expression=child,
             inference_profile=inference_profile,
         )
         for child in _polyglot_expression_args(expression)

--- a/src/sqlbuild/compiler/compile/helpers/sqlglot_validation.py
+++ b/src/sqlbuild/compiler/compile/helpers/sqlglot_validation.py
@@ -63,9 +63,7 @@ def validate_sql_syntax(
     if placeholders:
         cleaned_sql = substitute_placeholder_defaults(cleaned_sql, placeholders)
 
-    polyglot_error: str | None | bool = _validate_sql_with_polyglot(
-        cleaned_sql, dialect=dialect
-    )
+    polyglot_error: str | None | bool = _validate_sql_with_polyglot(cleaned_sql, dialect=dialect)
     if polyglot_error is None:
         return
     if isinstance(polyglot_error, str):

--- a/src/sqlbuild/compiler/compile/helpers/sqlglot_validation.py
+++ b/src/sqlbuild/compiler/compile/helpers/sqlglot_validation.py
@@ -10,6 +10,7 @@ from sqlbuild.compiler.compile.helpers.sqlglot_columns import (
     _replace_refs_with_stubs,
     substitute_placeholder_defaults,
 )
+from sqlbuild.shared.helpers.polyglot import import_polyglot_sql
 from sqlbuild.shared.helpers.sqlglot import import_sqlglot
 from sqlbuild.shared.models import PythonHookEntry, SqlHookEntry
 
@@ -50,6 +51,7 @@ def validate_sql_syntax(
     model_name: str,
     file_path: Path,
     placeholders: dict[str, str] | None = None,
+    dialect: str | None = None,
 ) -> None:
     """Validate that the model query SQL is parseable by SQLGlot.
 
@@ -57,13 +59,28 @@ def validate_sql_syntax(
     if SQLGlot is not installed.
     """
 
-    sqlglot_module: Any | None = import_sqlglot()
-    if sqlglot_module is None:
-        return
-
     cleaned_sql: str = _replace_refs_with_stubs(query_sql)
     if placeholders:
         cleaned_sql = substitute_placeholder_defaults(cleaned_sql, placeholders)
+
+    polyglot_error: str | None | bool = _validate_sql_with_polyglot(
+        cleaned_sql, dialect=dialect
+    )
+    if polyglot_error is None:
+        return
+    if isinstance(polyglot_error, str):
+        raise CompileInputError(
+            f"SQL syntax error in model '{model_name}' ({file_path}): {polyglot_error}\n\n"
+            f"To skip SQL validation for this model, add `sql_validation: false` "
+            f"to the MODEL header.\n"
+            f"To disable project-wide, set `settings.sql_validation: false` "
+            f"in sqlbuild_project.toml.\n"
+            f"To skip for this run, use `--no-sql-validation`."
+        ) from None
+
+    sqlglot_module: Any | None = import_sqlglot()
+    if sqlglot_module is None:
+        return
 
     try:
         sqlglot_module.parse_one(cleaned_sql)
@@ -76,6 +93,23 @@ def validate_sql_syntax(
             f"in sqlbuild_project.toml.\n"
             f"To skip for this run, use `--no-sql-validation`."
         ) from None
+
+
+def _validate_sql_with_polyglot(sql: str, *, dialect: str | None) -> str | None | bool:
+    polyglot_module: Any | None = import_polyglot_sql()
+    if polyglot_module is None:
+        return False
+    try:
+        result: Any = polyglot_module.validate(sql, dialect=dialect or "generic")
+    except Exception:
+        return False
+    if result:
+        return None
+    error_message: str = "invalid SQL"
+    errors: object = getattr(result, "errors", ())
+    if isinstance(errors, list) and errors:
+        error_message = str(getattr(errors[0], "message", error_message))
+    return error_message
 
 
 def validate_function_sql_syntax(

--- a/src/sqlbuild/compiler/compile/main/assemble_project.py
+++ b/src/sqlbuild/compiler/compile/main/assemble_project.py
@@ -14,7 +14,12 @@ def assemble_project(
     inputs: CompileProjectInputs,
     *,
     inference_profile: ExpressionInferenceProfile | None = None,
+    skip_column_inference: bool = False,
 ) -> CompiledProject:
     """Convert compile inputs into the planner-ready project view."""
 
-    return assemble_compiled_project(inputs, inference_profile=inference_profile)
+    return assemble_compiled_project(
+        inputs,
+        inference_profile=inference_profile,
+        skip_column_inference=skip_column_inference,
+    )

--- a/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
+++ b/src/sqlbuild/compiler/compile/main/build_compile_inputs.py
@@ -55,6 +55,7 @@ def build_compile_inputs(
     cli_vars: dict[str, object] | None = None,
     run_id: str | None = None,
     no_sql_validation: bool = False,
+    defer_model_sql_validation: bool = False,
     python_functions_inherit_default_namespace: bool = True,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> CompileProjectInputs:
@@ -103,6 +104,7 @@ def build_compile_inputs(
         run_id=resolved_run_id,
         macro_context=macro_context,
         no_sql_validation=no_sql_validation,
+        defer_model_sql_validation=defer_model_sql_validation,
         external_sql_reference_resolver=external_sql_reference_resolver,
     )
     seed_inputs: tuple[CompileSeedInput, ...] = build_seed_inputs(discovered_inputs)

--- a/src/sqlbuild/compiler/compile/models/core.py
+++ b/src/sqlbuild/compiler/compile/models/core.py
@@ -28,8 +28,11 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlModelFile,
     DiscoveredSqlScenarioFile,
 )
-from sqlbuild.compiler.lineage.types import InferredNullability
-from sqlbuild.compiler.lineage.types import ColumnLineageConfidence, ColumnTransformKind
+from sqlbuild.compiler.lineage.types import (
+    ColumnLineageConfidence,
+    ColumnTransformKind,
+    InferredNullability,
+)
 from sqlbuild.shared.types import ExternalSqlReferenceResolver, SqlReferenceKind
 from sqlbuild.spec.models.project import (
     LocalConfig,

--- a/src/sqlbuild/compiler/compile/models/core.py
+++ b/src/sqlbuild/compiler/compile/models/core.py
@@ -29,6 +29,7 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlScenarioFile,
 )
 from sqlbuild.compiler.lineage.types import InferredNullability
+from sqlbuild.compiler.lineage.types import ColumnLineageConfidence, ColumnTransformKind
 from sqlbuild.shared.types import ExternalSqlReferenceResolver, SqlReferenceKind
 from sqlbuild.spec.models.project import (
     LocalConfig,
@@ -94,6 +95,28 @@ class CompileSqlReference:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "ref_kind", SqlReferenceKind(self.ref_kind))
+
+
+@dataclass(frozen=True)
+class CompiledLineageSourceFact:
+    """Compact upstream column fact extracted during SQL analysis."""
+
+    resource_type: CompiledResourceType | str
+    resource_name: str
+    column_name: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "resource_type", CompiledResourceType(self.resource_type))
+
+
+@dataclass(frozen=True)
+class CompiledLineageColumnFact:
+    """Compact output column lineage fact extracted during SQL analysis."""
+
+    output_column: str
+    upstream_columns: tuple[CompiledLineageSourceFact, ...] = field(default_factory=tuple)
+    transform_kind: ColumnTransformKind = ColumnTransformKind.UNKNOWN
+    confidence: ColumnLineageConfidence = ColumnLineageConfidence.UNKNOWN
 
 
 @dataclass(frozen=True)
@@ -179,6 +202,7 @@ class CompileModelInput:
     references: tuple[CompileSqlReference, ...] = field(default_factory=tuple)
     schema_entry: SchemaModelEntry | None = None
     schema_file: DiscoveredSchemaFile | None = None
+    sql_validation_enabled: bool = False
 
 
 @dataclass(frozen=True)
@@ -289,6 +313,8 @@ class CompiledModel:
     references: tuple[CompileSqlReference, ...] = field(default_factory=tuple)
     schema_entry: SchemaModelEntry | None = None
     inferred_columns: tuple[InferredColumn, ...] | None = None
+    fast_lineage_columns: tuple[CompiledLineageColumnFact, ...] | None = None
+    fast_lineage_has_star: bool = False
     authored_sql: str = ""
     output_column_locations: dict[str, SourceLocation] = field(default_factory=dict)
     macro_deps: tuple[str, ...] = field(default_factory=tuple)

--- a/src/sqlbuild/compiler/contracts/main/validate.py
+++ b/src/sqlbuild/compiler/contracts/main/validate.py
@@ -16,6 +16,13 @@ def validate_model_contracts(
 ) -> ContractValidationResult:
     """Validate model header column contracts against inferred output columns."""
 
+    if not any(
+        model.config.values.get("contract") == "enforced"
+        or (model.schema_entry is not None and model.schema_entry.columns)
+        for model in project.models
+    ):
+        return ContractValidationResult(diagnostics=())
+
     diagnostics: list[CompilerDiagnostic] = []
     for model in project.models:
         diagnostics.extend(validate_model_column_contracts(model, dialect=dialect))

--- a/src/sqlbuild/compiler/discovery/helpers/filesystem.py
+++ b/src/sqlbuild/compiler/discovery/helpers/filesystem.py
@@ -108,22 +108,23 @@ def discover_model_files(
     file_path: Path
     for file_path in sorted(model_root.rglob("*.sql")):
         contents: str = file_path.read_text(encoding="utf-8")
+        relative_path: Path = file_path.relative_to(project_dir)
         header_values: dict[str, object]
         query_sql: str
         header_values, query_sql = parse_model_sql(contents, file_path)
         discovered_model_files.append(
             DiscoveredSqlModelFile(
                 file_path=file_path,
-                relative_path=file_path.relative_to(project_dir),
+                relative_path=relative_path,
                 contents=contents,
                 header_values=header_values,
                 header_column_locations=model_header_column_locations(
                     contents=contents,
-                    relative_path=file_path.relative_to(project_dir),
+                    relative_path=relative_path,
                 ),
                 output_column_locations=model_output_column_locations(
                     contents=contents,
-                    relative_path=file_path.relative_to(project_dir),
+                    relative_path=relative_path,
                     sqlglot_enabled=sqlglot_enabled,
                 ),
                 query_sql=query_sql,

--- a/src/sqlbuild/compiler/discovery/helpers/sql_models.py
+++ b/src/sqlbuild/compiler/discovery/helpers/sql_models.py
@@ -107,7 +107,6 @@ def model_output_column_locations(
     header_match: re.Match[str] | None = MODEL_HEADER_PATTERN.match(contents)
     if header_match is None:
         return {}
-    del sqlglot_enabled
     sql_start: int = header_match.start("sql")
     sql: str = header_match.group("sql")
     projection_ranges: tuple[tuple[int, int], ...] | None = _top_level_select_projection_ranges(sql)
@@ -118,19 +117,69 @@ def model_output_column_locations(
         sql_start=sql_start,
         relative_path=relative_path,
         projection_ranges=projection_ranges,
+        sqlglot_enabled=sqlglot_enabled,
     )
 
 
 def _top_level_select_projection_ranges(sql: str) -> tuple[tuple[int, int], ...] | None:
-    select_start: int | None = _find_top_level_keyword(sql, "SELECT", start=0)
-    if select_start is None:
+    bounds: tuple[int, int] | None = _top_level_select_list_bounds(sql)
+    if bounds is None:
         return None
-    select_list_start: int = select_start + len("SELECT")
-    if _find_top_level_keyword(sql, "UNION", start=select_list_start) is not None:
-        return None
-    from_start: int | None = _find_top_level_keyword(sql, "FROM", start=select_list_start)
-    select_list_end: int = from_start if from_start is not None else len(sql)
+    select_list_start, select_list_end = bounds
     return _split_top_level_select_items(sql, start=select_list_start, end=select_list_end)
+
+
+def _top_level_select_list_bounds(sql: str) -> tuple[int, int] | None:
+    depth: int = 0
+    index: int = 0
+    select_list_start: int | None = None
+    select_list_end: int | None = None
+    in_quote: str | None = None
+    length: int = len(sql)
+    while index < length:
+        character: str = sql[index]
+        if in_quote is not None:
+            if character == "\\":
+                index += 2
+                continue
+            if character == in_quote:
+                in_quote = None
+            index += 1
+            continue
+        if character in _QUOTE_NAMES:
+            in_quote = character
+            index += 1
+            continue
+        if character == "(":
+            depth += 1
+            index += 1
+            continue
+        if character == ")":
+            depth = max(0, depth - 1)
+            index += 1
+            continue
+        if depth != 0:
+            index += 1
+            continue
+        upper_character: str = character.upper()
+        if select_list_start is None:
+            if upper_character == "S" and _keyword_at(sql, "SELECT", index):
+                select_list_start = index + len("SELECT")
+                index = select_list_start
+                continue
+        else:
+            if upper_character == "U" and _keyword_at(sql, "UNION", index):
+                return None
+            if (
+                select_list_end is None
+                and upper_character == "F"
+                and _keyword_at(sql, "FROM", index)
+            ):
+                select_list_end = index
+        index += 1
+    if select_list_start is None:
+        return None
+    return select_list_start, select_list_end if select_list_end is not None else length
 
 
 def _scanner_output_column_locations(
@@ -139,13 +188,15 @@ def _scanner_output_column_locations(
     sql_start: int,
     relative_path: Path,
     projection_ranges: tuple[tuple[int, int], ...],
+    sqlglot_enabled: bool,
 ) -> dict[str, SourceLocation]:
     locations: dict[str, SourceLocation] = {}
     item_start: int
     item_end: int
     for item_start, item_end in projection_ranges:
         output_name: str | None = _select_item_output_name(
-            contents[sql_start + item_start : sql_start + item_end]
+            contents[sql_start + item_start : sql_start + item_end],
+            sqlglot_enabled=sqlglot_enabled,
         )
         if output_name is None:
             continue
@@ -274,7 +325,7 @@ def _split_top_level_select_items(sql: str, *, start: int, end: int) -> tuple[tu
     return tuple(items)
 
 
-def _select_item_output_name(item: str) -> str | None:
+def _select_item_output_name(item: str, *, sqlglot_enabled: bool) -> str | None:
     as_match: re.Match[str] | None = re.search(
         r"\s+AS\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*|\"[^\"]+\")\s*\Z",
         item,
@@ -288,7 +339,15 @@ def _select_item_output_name(item: str) -> str | None:
         item,
     )
     if bare_match is None:
-        return None
+        if not sqlglot_enabled:
+            return None
+        implicit_alias_match: re.Match[str] | None = re.search(
+            r"\)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*|\"[^\"]+\")\s*\Z",
+            item,
+        )
+        if implicit_alias_match is None:
+            return None
+        return implicit_alias_match.group("name").strip('"')
     return bare_match.group("name").strip('"')
 
 

--- a/src/sqlbuild/compiler/discovery/helpers/sql_models.py
+++ b/src/sqlbuild/compiler/discovery/helpers/sql_models.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 from sqlbuild.compiler.discovery.exceptions import ModelHeaderSyntaxError, ModelSqlParseError
 from sqlbuild.compiler.discovery.helpers.constants import MODEL_HEADER_PATTERN
-from sqlbuild.shared.helpers.sqlglot import import_sqlglot
 from sqlbuild.shared.models import PythonHookEntry, SqlHookEntry
 from sqlbuild.shared.types import SqlReferenceKind
 from sqlbuild.spec.models.schema import SourceLocation
@@ -109,26 +107,12 @@ def model_output_column_locations(
     header_match: re.Match[str] | None = MODEL_HEADER_PATTERN.match(contents)
     if header_match is None:
         return {}
+    del sqlglot_enabled
     sql_start: int = header_match.start("sql")
     sql: str = header_match.group("sql")
-    sqlglot_output_names: tuple[str | None, ...] | None = (
-        _sqlglot_projection_output_names(sql) if sqlglot_enabled else None
-    )
-    if sqlglot_output_names == ():
-        return {}
     projection_ranges: tuple[tuple[int, int], ...] | None = _top_level_select_projection_ranges(sql)
     if projection_ranges is None:
         return {}
-    if sqlglot_output_names is not None:
-        if len(sqlglot_output_names) != len(projection_ranges):
-            return {}
-        return _locations_from_projection_names(
-            contents=contents,
-            sql_start=sql_start,
-            relative_path=relative_path,
-            projection_ranges=projection_ranges,
-            output_names=sqlglot_output_names,
-        )
     return _scanner_output_column_locations(
         contents=contents,
         sql_start=sql_start,
@@ -176,29 +160,6 @@ def _scanner_output_column_locations(
     return locations
 
 
-def _locations_from_projection_names(
-    *,
-    contents: str,
-    sql_start: int,
-    relative_path: Path,
-    projection_ranges: tuple[tuple[int, int], ...],
-    output_names: tuple[str | None, ...],
-) -> dict[str, SourceLocation]:
-    locations: dict[str, SourceLocation] = {}
-    for output_name, projection_range in zip(output_names, projection_ranges, strict=True):
-        if output_name is None or output_name == "*":
-            continue
-        location: SourceLocation | None = _location_for_projection_range(
-            contents=contents,
-            sql_start=sql_start,
-            relative_path=relative_path,
-            projection_range=projection_range,
-        )
-        if location is not None:
-            locations[output_name] = location
-    return locations
-
-
 def _location_for_projection_range(
     *, contents: str, sql_start: int, relative_path: Path, projection_range: tuple[int, int]
 ) -> SourceLocation | None:
@@ -215,31 +176,6 @@ def _location_for_projection_range(
         end=sql_start + end_offset,
         relative_path=relative_path,
     )
-
-
-def _sqlglot_projection_output_names(sql: str) -> tuple[str | None, ...] | None:
-    sqlglot_module: Any | None = import_sqlglot()
-    if sqlglot_module is None:
-        return None
-    try:
-        parsed: Any = sqlglot_module.parse_one(sql)
-    except Exception:
-        return None
-    if type(parsed).__name__ != "Select":
-        return ()
-    output_names: list[str | None] = []
-    projection: Any
-    for projection in parsed.expressions:
-        if "Star" in type(projection).__name__:
-            output_names.append(None)
-            continue
-        raw_name: object | None = getattr(projection, "alias_or_name", None)
-        if raw_name is None:
-            output_names.append(None)
-            continue
-        output_name: str = str(raw_name)
-        output_names.append(output_name if output_name and output_name != "*" else None)
-    return tuple(output_names)
 
 
 def _location_for_header_token(

--- a/src/sqlbuild/compiler/discovery/helpers/sql_models.py
+++ b/src/sqlbuild/compiler/discovery/helpers/sql_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from bisect import bisect_right
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -70,6 +71,7 @@ def model_header_column_locations(
     header: str = header_match.group("header")
     header_start: int = header_match.start("header")
     tokens: list[_ModelHeaderToken] = _tokenize_model_header(header)
+    line_starts: tuple[int, ...] | None = None
     locations: dict[str, SourceLocation] = {}
     depth: int = 0
     in_columns: bool = False
@@ -83,11 +85,14 @@ def model_header_column_locations(
             if next_token.kind == _SYMBOL_TOKEN and next_token.value == "(":
                 in_columns = True
         elif in_columns and token.kind == _WORD_TOKEN and depth == 1:
+            if line_starts is None:
+                line_starts = _line_starts(contents)
             locations[token.value] = _location_for_header_token(
                 contents=contents,
                 header_start=header_start,
                 token=token,
                 relative_path=relative_path,
+                line_starts=line_starts,
             )
         if token.kind == _SYMBOL_TOKEN and token.value == "(":
             depth += 1
@@ -118,6 +123,7 @@ def model_output_column_locations(
         relative_path=relative_path,
         projection_ranges=projection_ranges,
         sqlglot_enabled=sqlglot_enabled,
+        line_starts=_line_starts(contents),
     )
 
 
@@ -192,6 +198,7 @@ def _scanner_output_column_locations(
     relative_path: Path,
     projection_ranges: tuple[tuple[int, int], ...],
     sqlglot_enabled: bool,
+    line_starts: tuple[int, ...],
 ) -> dict[str, SourceLocation]:
     locations: dict[str, SourceLocation] = {}
     item_start: int
@@ -208,6 +215,7 @@ def _scanner_output_column_locations(
             sql_start=sql_start,
             relative_path=relative_path,
             projection_range=(item_start, item_end),
+            line_starts=line_starts,
         )
         if location is not None:
             locations[output_name] = location
@@ -215,7 +223,12 @@ def _scanner_output_column_locations(
 
 
 def _location_for_projection_range(
-    *, contents: str, sql_start: int, relative_path: Path, projection_range: tuple[int, int]
+    *,
+    contents: str,
+    sql_start: int,
+    relative_path: Path,
+    projection_range: tuple[int, int],
+    line_starts: tuple[int, ...],
 ) -> SourceLocation | None:
     item_start: int = projection_range[0]
     item_end: int = projection_range[1]
@@ -229,11 +242,17 @@ def _location_for_projection_range(
         start=sql_start + start_offset,
         end=sql_start + end_offset,
         relative_path=relative_path,
+        line_starts=line_starts,
     )
 
 
 def _location_for_header_token(
-    *, contents: str, header_start: int, token: _ModelHeaderToken, relative_path: Path
+    *,
+    contents: str,
+    header_start: int,
+    token: _ModelHeaderToken,
+    relative_path: Path,
+    line_starts: tuple[int, ...],
 ) -> SourceLocation:
     absolute_position: int = header_start + token.position
     return _location_for_absolute_span(
@@ -241,19 +260,22 @@ def _location_for_header_token(
         start=absolute_position,
         end=absolute_position + len(token.value),
         relative_path=relative_path,
+        line_starts=line_starts,
     )
 
 
 def _location_for_absolute_span(
-    *, contents: str, start: int, end: int, relative_path: Path
+    *, contents: str, start: int, end: int, relative_path: Path, line_starts: tuple[int, ...]
 ) -> SourceLocation:
     end = max(start, end)
     end_position: int = max(start, end - 1)
-    line: int = contents.count("\n", 0, start) + 1
-    line_start: int = contents.rfind("\n", 0, start) + 1
+    line_index: int = bisect_right(line_starts, start) - 1
+    line: int = line_index + 1
+    line_start: int = line_starts[line_index]
     column: int = start - line_start + 1
-    end_line: int = contents.count("\n", 0, end_position) + 1
-    end_line_start: int = contents.rfind("\n", 0, end_position) + 1
+    end_line_index: int = bisect_right(line_starts, end_position) - 1
+    end_line: int = end_line_index + 1
+    end_line_start: int = line_starts[end_line_index]
     end_column: int = end_position - end_line_start + 2
     return SourceLocation(
         path=relative_path,
@@ -262,6 +284,15 @@ def _location_for_absolute_span(
         end_line=end_line,
         end_column=end_column,
     )
+
+
+def _line_starts(contents: str) -> tuple[int, ...]:
+    starts: list[int] = [0]
+    index: int = contents.find("\n")
+    while index != -1:
+        starts.append(index + 1)
+        index = contents.find("\n", index + 1)
+    return tuple(starts)
 
 
 def _find_top_level_keyword(sql: str, keyword: str, *, start: int) -> int | None:

--- a/src/sqlbuild/compiler/discovery/helpers/sql_models.py
+++ b/src/sqlbuild/compiler/discovery/helpers/sql_models.py
@@ -136,6 +136,7 @@ def _top_level_select_list_bounds(sql: str) -> tuple[int, int] | None:
     select_list_end: int | None = None
     in_quote: str | None = None
     length: int = len(sql)
+    has_union_candidate: bool = "union" in sql.lower()
     while index < length:
         character: str = sql[index]
         if in_quote is not None:
@@ -176,6 +177,8 @@ def _top_level_select_list_bounds(sql: str) -> tuple[int, int] | None:
                 and _keyword_at(sql, "FROM", index)
             ):
                 select_list_end = index
+                if not has_union_candidate:
+                    return select_list_start, select_list_end
         index += 1
     if select_list_start is None:
         return None

--- a/src/sqlbuild/compiler/discovery/main/discover.py
+++ b/src/sqlbuild/compiler/discovery/main/discover.py
@@ -42,15 +42,21 @@ from sqlbuild.compiler.discovery.models import (
 from sqlbuild.spec.models.project import LocalConfig, ProjectConfig
 
 
-def discover_project_inputs(*, project_dir: Path) -> DiscoveredProjectInputs:
+def discover_project_inputs(
+    *, project_dir: Path, sqlglot_enabled_override: bool | None = None
+) -> DiscoveredProjectInputs:
     """Load all raw project inputs from disk before semantic resolution."""
 
     project_config: ProjectConfig = load_project_config(project_dir=project_dir)
     local_config: LocalConfig = load_local_config(project_dir=project_dir)
     sqlglot_enabled: bool = (
-        local_config.settings.sqlglot
-        if "sqlglot" in local_config.setting_overrides
-        else project_config.settings.sqlglot
+        sqlglot_enabled_override
+        if sqlglot_enabled_override is not None
+        else (
+            local_config.settings.sqlglot
+            if "sqlglot" in local_config.setting_overrides
+            else project_config.settings.sqlglot
+        )
     )
 
     source_files: tuple[DiscoveredSourceFile, ...] = discover_source_files(project_dir=project_dir)

--- a/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
+++ b/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
@@ -290,7 +290,9 @@ def _polyglot_projection_upstream_columns(
 
 def _polyglot_column_refs_in_expression(expression: Any) -> tuple[tuple[str, str], ...]:
     if str(getattr(expression, "kind", "")) == "column":
-        return ((str(getattr(expression, "name", "") or ""), _polyglot_column_table_name(expression)),)
+        return (
+            (str(getattr(expression, "name", "") or ""), _polyglot_column_table_name(expression)),
+        )
     try:
         payload: object = expression.to_dict()
     except Exception:

--- a/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
+++ b/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
@@ -29,6 +29,7 @@ from sqlbuild.compiler.lineage.types import (
     ColumnTransformKind,
     InferredNullability,
 )
+from sqlbuild.shared.helpers.polyglot import import_polyglot_sql
 from sqlbuild.shared.helpers.sqlglot import import_sqlglot, import_sqlglot_expressions
 
 
@@ -55,13 +56,19 @@ def build_fast_project_column_lineage(
     for model in project.models:
         if model_names is not None and model.name not in model_names:
             continue
-        result: ModelColumnLineage | None = _build_fast_model_column_lineage(
+        result: ModelColumnLineage | None = _build_polyglot_fast_model_column_lineage(
+            model,
+            schema=schema,
+            dialect=dialect,
+        )
+        if result is None:
+            result = _build_fast_model_column_lineage(
             model,
             schema=schema,
             dialect=dialect,
             sqlglot=sqlglot,
             exp=exp,
-        )
+            )
         if result is None:
             continue
         model_results[model.name] = result
@@ -82,6 +89,253 @@ def build_fast_project_column_lineage(
                 )
 
     return ProjectColumnLineage(models=model_results, edges=tuple(collapsed_edges))
+
+
+def _build_polyglot_fast_model_column_lineage(
+    model: CompiledModel,
+    *,
+    schema: dict[str, dict[str, str]],
+    dialect: str | None,
+) -> ModelColumnLineage | None:
+    if model.fast_lineage_columns is not None:
+        lineages: list[ColumnLineage] = [
+            ColumnLineage(
+                output_column=fact.output_column,
+                transform_kind=fact.transform_kind,
+                expression_sql=None,
+                upstream_columns=tuple(
+                    ColumnLineageSource(
+                        resource_type=source.resource_type,
+                        resource_name=source.resource_name,
+                        column_name=source.column_name,
+                    )
+                    for source in fact.upstream_columns
+                ),
+                nullability=InferredNullability.UNKNOWN,
+                confidence=fact.confidence,
+            )
+            for fact in model.fast_lineage_columns
+        ]
+        if model.fast_lineage_has_star:
+            normalized_sql: str
+            physical_resources: tuple[_PhysicalResource, ...]
+            normalized_sql, physical_resources = _normalize_sqlbuild_refs(model.query_sql)
+            del normalized_sql
+            lineages.extend(
+                _build_star_lineage(
+                    model=model,
+                    schema=schema,
+                    physical_resources=physical_resources,
+                    existing_columns={lineage.output_column for lineage in lineages},
+                )
+            )
+        return ModelColumnLineage(
+            model_name=model.name,
+            columns=tuple(lineages),
+            has_star=model.fast_lineage_has_star,
+        )
+
+    polyglot_module: Any | None = import_polyglot_sql()
+    if polyglot_module is None:
+        return None
+    normalized_sql: str
+    physical_resources: tuple[_PhysicalResource, ...]
+    normalized_sql, physical_resources = _normalize_sqlbuild_refs(model.query_sql)
+    try:
+        parsed: Any = polyglot_module.parse_one(normalized_sql, dialect=dialect or "generic")
+    except Exception:
+        return None
+    if str(getattr(parsed, "kind", "")) != "select":
+        return None
+
+    alias_map: dict[str, _PhysicalResource] = _polyglot_table_alias_map(
+        parsed,
+        physical_resources=physical_resources,
+    )
+    lineages: list[ColumnLineage] = []
+    has_star: bool = False
+    projections: tuple[Any, ...] = tuple(getattr(parsed, "expressions", ()))
+    inferred_names: tuple[str, ...] = tuple(column.name for column in model.inferred_columns or ())
+    for index, projection in enumerate(projections):
+        if bool(getattr(projection, "is_star", False)):
+            has_star = True
+            continue
+        inner: Any = projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+        if bool(getattr(inner, "is_star", False)):
+            has_star = True
+            continue
+        output_column: str | None = _polyglot_projection_output_name(
+            projection,
+            index=index,
+            inferred_names=inferred_names,
+        )
+        if output_column is None:
+            continue
+        upstream_columns, confidence = _polyglot_projection_upstream_columns(
+            projection,
+            alias_map=alias_map,
+        )
+        transform_kind: ColumnTransformKind = _polyglot_classify_transform(
+            inner,
+            upstream_columns=upstream_columns,
+        )
+        lineages.append(
+            ColumnLineage(
+                output_column=output_column,
+                transform_kind=transform_kind,
+                expression_sql=None,
+                upstream_columns=upstream_columns,
+                nullability=InferredNullability.UNKNOWN,
+                confidence=confidence
+                if upstream_columns or transform_kind == ColumnTransformKind.CONSTANT
+                else ColumnLineageConfidence.UNKNOWN,
+            )
+        )
+
+    if has_star:
+        lineages.extend(
+            _build_star_lineage(
+                model=model,
+                schema=schema,
+                physical_resources=physical_resources,
+                existing_columns={lineage.output_column for lineage in lineages},
+            )
+        )
+    return ModelColumnLineage(model_name=model.name, columns=tuple(lineages), has_star=has_star)
+
+
+def _polyglot_table_alias_map(
+    parsed: Any,
+    *,
+    physical_resources: tuple[_PhysicalResource, ...],
+) -> dict[str, _PhysicalResource]:
+    physical_resource_by_name: dict[str, _PhysicalResource] = {
+        resource.physical_name: resource for resource in physical_resources
+    }
+    physical_resource_by_name.update(
+        {resource.resource_name: resource for resource in physical_resources}
+    )
+    alias_map: dict[str, _PhysicalResource] = {}
+    try:
+        tables: tuple[Any, ...] = tuple(parsed.find_all("table"))
+    except Exception:
+        return alias_map
+    for table in tables:
+        table_name: str = str(getattr(table, "name", "") or "")
+        resource: _PhysicalResource | None = physical_resource_by_name.get(table_name)
+        if resource is None:
+            continue
+        alias_map[table_name] = resource
+        alias_or_name: str = str(getattr(table, "alias_or_name", "") or "")
+        if alias_or_name:
+            alias_map[alias_or_name] = resource
+    return alias_map
+
+
+def _polyglot_projection_output_name(
+    projection: Any, *, index: int, inferred_names: tuple[str, ...]
+) -> str | None:
+    raw_name: str = str(getattr(projection, "output_name", "") or "")
+    if raw_name and raw_name != "*":
+        return raw_name
+    raw_name = str(getattr(projection, "alias_or_name", "") or "")
+    if raw_name and raw_name != "*":
+        return raw_name
+    if index < len(inferred_names):
+        return inferred_names[index]
+    return None
+
+
+def _polyglot_projection_upstream_columns(
+    projection: Any,
+    *,
+    alias_map: dict[str, _PhysicalResource],
+) -> tuple[tuple[ColumnLineageSource, ...], ColumnLineageConfidence]:
+    columns: list[ColumnLineageSource] = []
+    seen: set[tuple[CompiledResourceType, str, str]] = set()
+    confidence: ColumnLineageConfidence = ColumnLineageConfidence.HIGH
+    try:
+        column_nodes: tuple[Any, ...] = tuple(projection.find_all("column"))
+    except Exception:
+        return (), ColumnLineageConfidence.UNKNOWN
+    column: Any
+    for column in column_nodes:
+        if bool(getattr(column, "is_star", False)):
+            continue
+        column_name: str = str(getattr(column, "name", "") or "")
+        if not column_name:
+            continue
+        table_name: str = _polyglot_column_table_name(column)
+        resource: _PhysicalResource | None = None
+        if table_name:
+            resource = alias_map.get(table_name)
+        elif len({resource.resource_name for resource in alias_map.values()}) == 1:
+            resource = next(iter(alias_map.values()))
+            confidence = ColumnLineageConfidence.MEDIUM
+        else:
+            confidence = ColumnLineageConfidence.UNKNOWN
+        if resource is None:
+            continue
+        key: tuple[CompiledResourceType, str, str] = (
+            resource.resource_type,
+            resource.resource_name,
+            column_name,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        columns.append(
+            ColumnLineageSource(
+                resource_type=resource.resource_type,
+                resource_name=resource.resource_name,
+                column_name=column_name,
+            )
+        )
+    return tuple(columns), confidence
+
+
+def _polyglot_column_table_name(column: Any) -> str:
+    try:
+        payload: object = column.to_dict().get("column", {})
+    except Exception:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    table_payload: object = payload.get("table")
+    if not isinstance(table_payload, dict):
+        return ""
+    raw_name: object = table_payload.get("name")
+    return raw_name if isinstance(raw_name, str) else ""
+
+
+def _polyglot_classify_transform(
+    expression: Any,
+    *,
+    upstream_columns: tuple[ColumnLineageSource, ...],
+) -> ColumnTransformKind:
+    kind: str = str(getattr(expression, "kind", ""))
+    if bool(getattr(expression, "is_star", False)):
+        return ColumnTransformKind.STAR
+    if kind in {"cast", "try_cast"}:
+        return ColumnTransformKind.CAST
+    if _polyglot_has_aggregation(expression):
+        return ColumnTransformKind.AGGREGATION
+    if not upstream_columns:
+        return ColumnTransformKind.CONSTANT
+    if kind == "column" and len(upstream_columns) == 1:
+        return ColumnTransformKind.DIRECT
+    return ColumnTransformKind.EXPRESSION
+
+
+def _polyglot_has_aggregation(expression: Any) -> bool:
+    aggregate_kinds: frozenset[str] = frozenset(
+        {"avg", "count", "max", "min", "sum", "array_agg", "string_agg"}
+    )
+    try:
+        nodes: tuple[Any, ...] = tuple(expression.walk())
+    except Exception:
+        return False
+    return any(str(getattr(node, "kind", "")) in aggregate_kinds for node in nodes)
 
 
 def _build_fast_model_column_lineage(

--- a/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
+++ b/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
@@ -152,6 +152,7 @@ def _build_polyglot_fast_model_column_lineage(
         parsed,
         physical_resources=physical_resources,
     )
+    unqualified_resource: _PhysicalResource | None = _single_alias_resource(alias_map)
     lineages: list[ColumnLineage] = []
     has_star: bool = False
     projections: tuple[Any, ...] = tuple(getattr(parsed, "expressions", ()))
@@ -176,6 +177,7 @@ def _build_polyglot_fast_model_column_lineage(
         upstream_columns, confidence = _polyglot_projection_upstream_columns(
             projection,
             alias_map=alias_map,
+            unqualified_resource=unqualified_resource,
         )
         transform_kind: ColumnTransformKind = _polyglot_classify_transform(
             inner,
@@ -252,6 +254,7 @@ def _polyglot_projection_upstream_columns(
     projection: Any,
     *,
     alias_map: dict[str, _PhysicalResource],
+    unqualified_resource: _PhysicalResource | None,
 ) -> tuple[tuple[ColumnLineageSource, ...], ColumnLineageConfidence]:
     columns: list[ColumnLineageSource] = []
     seen: set[tuple[CompiledResourceType, str, str]] = set()
@@ -263,8 +266,8 @@ def _polyglot_projection_upstream_columns(
         resource: _PhysicalResource | None = None
         if table_name:
             resource = alias_map.get(table_name)
-        elif len({resource.resource_name for resource in alias_map.values()}) == 1:
-            resource = next(iter(alias_map.values()))
+        elif unqualified_resource is not None:
+            resource = unqualified_resource
             confidence = ColumnLineageConfidence.MEDIUM
         else:
             confidence = ColumnLineageConfidence.UNKNOWN
@@ -286,6 +289,17 @@ def _polyglot_projection_upstream_columns(
             )
         )
     return tuple(columns), confidence
+
+
+def _single_alias_resource(alias_map: dict[str, _PhysicalResource]) -> _PhysicalResource | None:
+    resource: _PhysicalResource | None = None
+    for candidate in alias_map.values():
+        if resource is None:
+            resource = candidate
+            continue
+        if candidate.resource_name != resource.resource_name:
+            return None
+    return resource
 
 
 def _polyglot_column_refs_in_expression(expression: Any) -> tuple[tuple[str, str], ...]:
@@ -435,6 +449,7 @@ def _build_fast_model_column_lineage(
         physical_resources=physical_resources,
         exp=exp,
     )
+    unqualified_resource: _PhysicalResource | None = _single_alias_resource(alias_map)
     lineages: list[ColumnLineage] = []
     has_star: bool = False
     projections: tuple[Any, ...] = tuple(parsed.expressions)
@@ -457,6 +472,7 @@ def _build_fast_model_column_lineage(
         upstream_columns, confidence = _projection_upstream_columns(
             projection,
             alias_map=alias_map,
+            unqualified_resource=unqualified_resource,
             exp=exp,
         )
         transform_kind: ColumnTransformKind = _classify_fast_transform(
@@ -531,6 +547,7 @@ def _projection_upstream_columns(
     projection: Any,
     *,
     alias_map: dict[str, _PhysicalResource],
+    unqualified_resource: _PhysicalResource | None,
     exp: Any,
 ) -> tuple[tuple[ColumnLineageSource, ...], ColumnLineageConfidence]:
     columns: list[ColumnLineageSource] = []
@@ -543,8 +560,8 @@ def _projection_upstream_columns(
         table_name: str = str(column.table or "")
         if table_name:
             resource = alias_map.get(table_name)
-        elif len({resource.resource_name for resource in alias_map.values()}) == 1:
-            resource = next(iter(alias_map.values()))
+        elif unqualified_resource is not None:
+            resource = unqualified_resource
             confidence = ColumnLineageConfidence.MEDIUM
         else:
             confidence = ColumnLineageConfidence.UNKNOWN

--- a/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
+++ b/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from sqlbuild.compiler.compile.models.core import (
     CompiledModel,
@@ -63,11 +63,11 @@ def build_fast_project_column_lineage(
         )
         if result is None:
             result = _build_fast_model_column_lineage(
-            model,
-            schema=schema,
-            dialect=dialect,
-            sqlglot=sqlglot,
-            exp=exp,
+                model,
+                schema=schema,
+                dialect=dialect,
+                sqlglot=sqlglot,
+                exp=exp,
             )
         if result is None:
             continue
@@ -160,7 +160,9 @@ def _build_polyglot_fast_model_column_lineage(
         if bool(getattr(projection, "is_star", False)):
             has_star = True
             continue
-        inner: Any = projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+        inner: Any = (
+            projection.this if str(getattr(projection, "kind", "")) == "alias" else projection
+        )
         if bool(getattr(inner, "is_star", False)):
             has_star = True
             continue
@@ -254,18 +256,10 @@ def _polyglot_projection_upstream_columns(
     columns: list[ColumnLineageSource] = []
     seen: set[tuple[CompiledResourceType, str, str]] = set()
     confidence: ColumnLineageConfidence = ColumnLineageConfidence.HIGH
-    try:
-        column_nodes: tuple[Any, ...] = tuple(projection.find_all("column"))
-    except Exception:
-        return (), ColumnLineageConfidence.UNKNOWN
-    column: Any
-    for column in column_nodes:
-        if bool(getattr(column, "is_star", False)):
-            continue
-        column_name: str = str(getattr(column, "name", "") or "")
+    column_refs: tuple[tuple[str, str], ...] = _polyglot_column_refs_in_expression(projection)
+    for column_name, table_name in column_refs:
         if not column_name:
             continue
-        table_name: str = _polyglot_column_table_name(column)
         resource: _PhysicalResource | None = None
         if table_name:
             resource = alias_map.get(table_name)
@@ -294,6 +288,48 @@ def _polyglot_projection_upstream_columns(
     return tuple(columns), confidence
 
 
+def _polyglot_column_refs_in_expression(expression: Any) -> tuple[tuple[str, str], ...]:
+    try:
+        payload: object = expression.to_dict()
+    except Exception:
+        return ()
+    refs: list[tuple[str, str]] = []
+
+    def visit(node: object) -> None:
+        if isinstance(node, dict):
+            node_dict: dict[str, object] = cast(dict[str, object], node)
+            column_payload: object = node_dict.get("column")
+            if isinstance(column_payload, dict):
+                column_dict: dict[str, object] = cast(dict[str, object], column_payload)
+                column_name: str = _polyglot_name_payload_value(column_dict.get("name"))
+                table_payload: object = column_dict.get("table")
+                table_name: str = ""
+                if isinstance(table_payload, dict):
+                    table_dict: dict[str, object] = cast(dict[str, object], table_payload)
+                    table_name = _polyglot_name_payload_value(table_dict.get("name"))
+                refs.append((column_name, table_name))
+                return
+            for value in node_dict.values():
+                visit(value)
+        elif isinstance(node, list):
+            for value in node:
+                visit(value)
+
+    visit(payload)
+    return tuple(refs)
+
+
+def _polyglot_name_payload_value(payload: object) -> str:
+    if isinstance(payload, str):
+        return payload
+    if isinstance(payload, dict):
+        payload_dict: dict[str, object] = cast(dict[str, object], payload)
+        name: object = payload_dict.get("name")
+        if isinstance(name, str):
+            return name
+    return ""
+
+
 def _polyglot_column_table_name(column: Any) -> str:
     try:
         payload: object = column.to_dict().get("column", {})
@@ -306,6 +342,39 @@ def _polyglot_column_table_name(column: Any) -> str:
         return ""
     raw_name: object = table_payload.get("name")
     return raw_name if isinstance(raw_name, str) else ""
+
+
+def _polyglot_columns_in_expression(expression: Any) -> tuple[Any, ...]:
+    if str(getattr(expression, "kind", "")) == "column":
+        return (expression,)
+    columns: list[Any] = []
+    seen: set[int] = set()
+
+    def visit(node: Any) -> None:
+        node_id: int = id(node)
+        if node_id in seen:
+            return
+        seen.add(node_id)
+        if str(getattr(node, "kind", "")) == "column":
+            columns.append(node)
+            return
+        for child in _polyglot_child_expressions(node):
+            visit(child)
+
+    visit(expression)
+    return tuple(columns)
+
+
+def _polyglot_child_expressions(expression: Any) -> tuple[Any, ...]:
+    children: list[Any] = []
+    for attr_name in ("this", "expression", "left", "right"):
+        child: Any | None = getattr(expression, attr_name, None)
+        if child is not None and str(getattr(child, "kind", "")):
+            children.append(child)
+    for child in getattr(expression, "expressions", ()) or ():
+        if str(getattr(child, "kind", "")):
+            children.append(child)
+    return tuple(children)
 
 
 def _polyglot_classify_transform(

--- a/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
+++ b/src/sqlbuild/compiler/lineage/helpers/fast_columns.py
@@ -289,6 +289,8 @@ def _polyglot_projection_upstream_columns(
 
 
 def _polyglot_column_refs_in_expression(expression: Any) -> tuple[tuple[str, str], ...]:
+    if str(getattr(expression, "kind", "")) == "column":
+        return ((str(getattr(expression, "name", "") or ""), _polyglot_column_table_name(expression)),)
     try:
         payload: object = expression.to_dict()
     except Exception:

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -22,6 +22,7 @@ def build_compiled_project(
     adapter: BaseAdapter,
     selected_target: str | None = None,
     no_sql_validation: bool = False,
+    skip_column_inference: bool = False,
     cli_vars: dict[str, object] | None = None,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> CompiledProject:
@@ -31,6 +32,7 @@ def build_compiled_project(
         discovered_inputs,
         selected_target=selected_target,
         no_sql_validation=no_sql_validation,
+        defer_model_sql_validation=True,
         cli_vars=cli_vars,
         python_functions_inherit_default_namespace=(
             adapter.python_functions_inherit_default_namespace()
@@ -41,6 +43,7 @@ def build_compiled_project(
         assemble_project(
             compile_inputs,
             inference_profile=adapter.expression_inference_profile(),
+            skip_column_inference=skip_column_inference,
         ),
         default_schema=adapter.default_schema(),
         default_database=adapter.default_database(),

--- a/src/sqlbuild/compiler/pipeline/main/graph.py
+++ b/src/sqlbuild/compiler/pipeline/main/graph.py
@@ -28,6 +28,7 @@ def build_project_graph(
     discovered_inputs: DiscoveredProjectInputs,
     adapter: BaseAdapter,
     no_sql_validation: bool = False,
+    skip_column_inference: bool = False,
     cli_vars: dict[str, object] | None = None,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
     on_progress: Callable[[str], None] | None = None,
@@ -41,6 +42,7 @@ def build_project_graph(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         no_sql_validation=no_sql_validation,
+        skip_column_inference=skip_column_inference,
         cli_vars=cli_vars,
         external_sql_reference_resolver=external_sql_reference_resolver,
     )

--- a/src/sqlbuild/shared/helpers/polyglot.py
+++ b/src/sqlbuild/shared/helpers/polyglot.py
@@ -1,0 +1,17 @@
+"""Optional Polyglot SQL import helper."""
+
+from __future__ import annotations
+
+from functools import cache
+from typing import Any
+
+
+@cache
+def import_polyglot_sql() -> Any | None:
+    """Return the polyglot_sql module when installed."""
+
+    try:
+        import polyglot_sql
+    except ImportError:
+        return None
+    return polyglot_sql

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/_test_types.py
@@ -54,6 +54,13 @@ class CompileTextColorTestCase:
 
 
 @dataclass(frozen=True)
+class CompileJsonExecutionLayersTestCase:
+    description: str
+    model_count: int
+    expected_execution_layers: int
+
+
+@dataclass(frozen=True)
 class CompileJsonDiagnosticsTestCase:
     description: str
     model_sql: str

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/helpers.py
@@ -372,6 +372,34 @@ def build_compile_output_graph(*, model_names: tuple[str, ...]) -> ProjectGraph:
     )
 
 
+def build_linear_compile_output_graph(*, model_count: int) -> ProjectGraph:
+    """Build a static project graph with one model depending on the previous model."""
+
+    graph: ProjectGraph = build_compile_output_graph(
+        model_names=tuple(f"model_{index:05d}" for index in range(model_count))
+    )
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] = {}
+    downstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] = {
+        model.key: () for model in graph.project.models
+    }
+    previous_key: CompiledObjectKey | None = None
+    for model in graph.project.models:
+        if previous_key is None:
+            upstream_deps[model.key] = ()
+        else:
+            upstream_deps[model.key] = (previous_key,)
+            downstream_deps[previous_key] = (*downstream_deps[previous_key], model.key)
+        previous_key = model.key
+    return ProjectGraph(
+        project=graph.project,
+        upstream_deps=upstream_deps,
+        downstream_deps=downstream_deps,
+        tag_index=graph.tag_index,
+        path_index=graph.path_index,
+        all_keys=graph.all_keys,
+    )
+
+
 def build_compile_output_model_names(model_count: int) -> tuple[str, ...]:
     """Build model names for compile output formatter cases."""
 

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_output.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_output.py
@@ -1,17 +1,24 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from sqlbuild.cli.commands.main.helpers.compile.models import WrittenTarget
-from sqlbuild.cli.commands.main.helpers.compile.output import format_compile_text
+from sqlbuild.cli.commands.main.helpers.compile.output import (
+    format_compile_json,
+    format_compile_text,
+)
 from sqlbuild.compiler.pipeline.models import ProjectGraph
 from tests.unit.src.sqlbuild.cli.commands.main.compile._test_types import (
+    CompileJsonExecutionLayersTestCase,
     CompileTextColorTestCase,
     CompileTextOutputTestCase,
 )
 from tests.unit.src.sqlbuild.cli.commands.main.compile.helpers import (
     build_compile_output_graph,
     build_compile_output_model_names,
+    build_linear_compile_output_graph,
 )
 
 TEST_CASES: tuple[CompileTextOutputTestCase, ...] = (
@@ -68,6 +75,44 @@ def test_given_compiled_project_when_formatting_compile_text_then_matches_expect
     for fragment in test_case.unexpected_fragments:
         assert fragment not in output
     assert "\033[" not in output
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        CompileJsonExecutionLayersTestCase(
+            description="counts deep linear graph layers without recursion",
+            model_count=1100,
+            expected_execution_layers=1100,
+        )
+    ],
+    ids=["counts deep linear graph layers without recursion"],
+)
+def test_given_deep_linear_project_when_formatting_compile_json_then_counts_execution_layers(
+    test_case: CompileJsonExecutionLayersTestCase,
+) -> None:
+    graph: ProjectGraph = build_linear_compile_output_graph(model_count=test_case.model_count)
+
+    output: str = format_compile_json(
+        graph=graph,
+        written=WrittenTarget(
+            model_count=test_case.model_count,
+            seed_count=0,
+            function_count=0,
+            audit_count=0,
+            test_count=0,
+            target_dir=graph.project.models[0].relative_path.parent.parent / "target",
+        ),
+        manifest=False,
+        timings_ms={},
+        lineage=None,
+        diagnostics=(),
+    )
+    payload: dict[str, object] = json.loads(output)
+    summary: object = payload["summary"]
+
+    assert isinstance(summary, dict)
+    assert summary["execution_layers"] == test_case.expected_execution_layers
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -1895,6 +1895,10 @@ def test_given_compile_no_sql_validation_when_running_then_dispatches_expected_f
             bool,
             CompileLineageMode,
             dict[str, object],
+            bool,
+            bool,
+            bool,
+            bool,
         ]
     ] = []
 
@@ -1908,6 +1912,10 @@ def test_given_compile_no_sql_validation_when_running_then_dispatches_expected_f
         no_color: bool,
         lineage_mode: CompileLineageMode,
         cli_vars: dict[str, object],
+        profile_skip_discovery_sqlglot: bool,
+        profile_skip_column_inference: bool,
+        profile_skip_contracts: bool,
+        profile_skip_write: bool,
     ) -> int:
         received_args.append(
             (
@@ -1920,6 +1928,10 @@ def test_given_compile_no_sql_validation_when_running_then_dispatches_expected_f
                 no_color,
                 lineage_mode,
                 cli_vars,
+                profile_skip_discovery_sqlglot,
+                profile_skip_column_inference,
+                profile_skip_contracts,
+                profile_skip_write,
             )
         )
         return test_case.expected_exit_code
@@ -1941,6 +1953,10 @@ def test_given_compile_no_sql_validation_when_running_then_dispatches_expected_f
             False,
             test_case.expected_compile_lineage_mode,
             {} if test_case.expected_vars is None else test_case.expected_vars,
+            False,
+            False,
+            False,
+            False,
         )
     ]
 
@@ -2598,6 +2614,10 @@ def test_given_expected_cli_errors_when_running_main_then_it_renders_stderr_and_
         no_color: bool,
         lineage_mode: CompileLineageMode,
         cli_vars: dict[str, object],
+        profile_skip_discovery_sqlglot: bool,
+        profile_skip_column_inference: bool,
+        profile_skip_contracts: bool,
+        profile_skip_write: bool,
     ) -> int:
         del no_sql_validation
         del defer_to
@@ -2607,6 +2627,10 @@ def test_given_expected_cli_errors_when_running_main_then_it_renders_stderr_and_
         del no_color
         del lineage_mode
         del cli_vars
+        del profile_skip_discovery_sqlglot
+        del profile_skip_column_inference
+        del profile_skip_contracts
+        del profile_skip_write
         assert project_dir is not None
         raise test_case.error_factory(project_dir)
 

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/_test_types.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 
 from sqlbuild.adapter.shared.models import ExpressionInferenceProfile
 from sqlbuild.compiler.compile.models.core import (
+    CompiledLineageColumnFact,
     CompiledObjectKey,
     CompileSqlReference,
     InferredColumn,
@@ -174,6 +175,16 @@ class InferColumnsTestCase:
         default_factory=dict
     )
     inference_profile: ExpressionInferenceProfile | None = None
+
+
+@dataclass(frozen=True)
+class PolyglotAnalysisTestCase:
+    description: str
+    query_sql: str
+    references: tuple[CompileSqlReference, ...]
+    expected_columns: tuple[InferredColumn, ...] | None
+    expected_lineage_columns: tuple[CompiledLineageColumnFact, ...]
+    expected_has_star: bool
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/compile/helpers/test_sqlglot_columns.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/helpers/test_sqlglot_columns.py
@@ -4,13 +4,26 @@ import pytest
 
 from sqlbuild.adapter.shared.models import ExpressionInferenceProfile
 from sqlbuild.compiler.compile.helpers.sqlglot_columns import (
+    analyze_columns_and_lineage_with_polyglot,
     infer_columns_with_sqlglot,
     substitute_placeholder_defaults,
 )
-from sqlbuild.compiler.compile.models.core import InferredColumn
-from sqlbuild.compiler.lineage.types import InferredNullability
+from sqlbuild.compiler.compile.models.core import (
+    CompiledLineageColumnFact,
+    CompiledLineageSourceFact,
+    CompileSqlReference,
+    InferredColumn,
+)
+from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.lineage.types import (
+    ColumnLineageConfidence,
+    ColumnTransformKind,
+    InferredNullability,
+)
+from sqlbuild.shared.types import SqlReferenceKind
 from tests.unit.src.sqlbuild.compiler.compile.helpers._test_types import (
     InferColumnsTestCase,
+    PolyglotAnalysisTestCase,
     SubstitutePlaceholderDefaultsTestCase,
 )
 
@@ -267,6 +280,50 @@ def test_given_query_sql_when_inferring_columns_then_returns_expected(
     )
 
     assert result == test_case.expected_columns
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        PolyglotAnalysisTestCase(
+            description="extracts compact direct lineage facts from unqualified refs",
+            query_sql='SELECT order_id FROM __ref("orders")',
+            references=(CompileSqlReference(SqlReferenceKind.REF, "orders"),),
+            expected_columns=(InferredColumn(name="order_id"),),
+            expected_lineage_columns=(
+                CompiledLineageColumnFact(
+                    output_column="order_id",
+                    upstream_columns=(
+                        CompiledLineageSourceFact(
+                            resource_type=CompiledResourceType.MODEL,
+                            resource_name="orders",
+                            column_name="order_id",
+                        ),
+                    ),
+                    transform_kind=ColumnTransformKind.DIRECT,
+                    confidence=ColumnLineageConfidence.MEDIUM,
+                ),
+            ),
+            expected_has_star=False,
+        )
+    ],
+    ids=["extracts compact direct lineage facts from unqualified refs"],
+)
+def test_given_ref_query_when_analyzing_columns_and_lineage_then_returns_compact_facts(
+    test_case: PolyglotAnalysisTestCase,
+) -> None:
+    result: (
+        tuple[tuple[InferredColumn, ...] | None, tuple[CompiledLineageColumnFact, ...], bool] | bool
+    ) = analyze_columns_and_lineage_with_polyglot(
+        query_sql=test_case.query_sql,
+        references=test_case.references,
+    )
+
+    assert isinstance(result, tuple)
+    columns, lineage_columns, has_star = result
+    assert columns == test_case.expected_columns
+    assert lineage_columns == test_case.expected_lineage_columns
+    assert has_star is test_case.expected_has_star
 
 
 SUBSTITUTE_PLACEHOLDER_TEST_CASES: list[SubstitutePlaceholderDefaultsTestCase] = [

--- a/uv.lock
+++ b/uv.lock
@@ -1922,6 +1922,32 @@ wheels = [
 ]
 
 [[package]]
+name = "polyglot-sql"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/6c/e903494340effa374a5b29cc82184c960b8039426c122e47c73ddfb0d54f/polyglot_sql-0.5.0.tar.gz", hash = "sha256:8c9f72cc3949e542d36710d794c4385f0f4614935e6353fe923cd95c3c03b320", size = 1578865, upload-time = "2026-06-07T12:55:24.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/8c/8a07c7bc99e06f132cb679ccdd71968b7e493f86cf5583e2ec64dd8ea924/polyglot_sql-0.5.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:21dfe044bc2b67ae48ea7d3544288edc2b173aff06f0553a9ce81623a6420974", size = 6667584, upload-time = "2026-06-07T12:54:35.229Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6d/c85df2c44929bdad0dc749d42daf620c8513784806bec29c46ac9b7a63f6/polyglot_sql-0.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ad28281b830036247ed22443bf126e52f0290a418dca876408bf482160516fe0", size = 6350005, upload-time = "2026-06-07T12:54:37.243Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/2c/feedff9f56ee9e766295ea46a1ed1c0eb7b21b9e97f65723af078a34cb06/polyglot_sql-0.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:610cac44ae882852c623fafd441c9fcdae8bd570c29e61437c4522dde27ae6e8", size = 7395765, upload-time = "2026-06-07T12:54:39.548Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a0/336e4d0f713266ee18f4998b91ce431c4019aa8e73b898f797c3e1089158/polyglot_sql-0.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06f7fa19e6975e9cd969a9d513358c9e099acd50c72376f978801dec86a7df23", size = 7458678, upload-time = "2026-06-07T12:54:41.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/5e/946f8053f351218b3e11a21c3639a89b0d62087a72d4762b940153d68140/polyglot_sql-0.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:b3f7eb5e10c89ac120fb9873c3621ab88a7457491fb9fc301c5d12a330da9c8a", size = 7006261, upload-time = "2026-06-07T12:54:44.073Z" },
+    { url = "https://files.pythonhosted.org/packages/39/69/79131eca41a5ac64a80fbef2fbdbeba5b19d340fb9b7d8045d8f4c4b9f06/polyglot_sql-0.5.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:fc7b8e0e58e6992a2c87c6858f8e297eb7e3103fcab61bf3014dd6f4ebd52dc2", size = 6668209, upload-time = "2026-06-07T12:54:46.081Z" },
+    { url = "https://files.pythonhosted.org/packages/06/47/d6deeed71fb04c23b60cf36be5954110896429effb1cf0619a1bfdd51b69/polyglot_sql-0.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d828ba34f3b2ea10c041e7f670cc975762e8b1075bed14fe6a868436af9ea0c6", size = 6350168, upload-time = "2026-06-07T12:54:48.314Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/54/a7281c18957be497b460c85c4f1bf743c47e843ff323289efd5eb86632c6/polyglot_sql-0.5.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90a9cb9f011ac3b6f693cdd445bf002a8957db96c2f156c3096f47e973e4140d", size = 7396111, upload-time = "2026-06-07T12:54:50.31Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c7/9a62cfe1c76fa2e615f53875cf808f8616286e2c92efeea62b2bbd7e891b/polyglot_sql-0.5.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03e2af485bba5e641a77036b1d7012c470861ae543b4f913a349e1516976d8c6", size = 7458663, upload-time = "2026-06-07T12:54:52.54Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a6/d2c70c463340d1bb25e6371d2a0e9cf7478e0fb3d141a445bf1f824f9709/polyglot_sql-0.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:d84e6dd3eb37dd52d4277bc4c106e03acd94ddfce21b16eabf0c61a66588e904", size = 7006085, upload-time = "2026-06-07T12:54:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/27/6c/70f96ffcd4b804e60f40f49f6ff04da684cdede0a1e5bf974ba9dd636072/polyglot_sql-0.5.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe3cca7093ba71cc57c7d680d4e227ebfca140d485d21215bed014363b4b2543", size = 7395313, upload-time = "2026-06-07T12:54:56.726Z" },
+    { url = "https://files.pythonhosted.org/packages/21/17/96312cc4753f2e222c551f0776cb2b33e9d069fba296ba60f7be254ac688/polyglot_sql-0.5.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:2dd783d887f9bd7c20cf4534d14c8373a029bb5eb8cbd1f4e9b13c0ffd0d9a25", size = 6667871, upload-time = "2026-06-07T12:54:59.027Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b4/9bb7665da085557a1dc05d52820934cb149ef1ec12c7ea5a4c85bcec9ccb/polyglot_sql-0.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ccb3ce3de2dc18ffdf4b8caeabff0d93e2cc50f9504a7652d12a1039ec0aa41", size = 6349268, upload-time = "2026-06-07T12:55:01.045Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/64/6581e9158e0b9a0c104acb0f67f0b07010fb09343c767a57a3a0fc952666/polyglot_sql-0.5.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e1e2db96efa16636d0ada95518921eb4a4330e3e6a72d181fc2f37c32781494", size = 7393631, upload-time = "2026-06-07T12:55:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e1/d80a7d82890c2eb0b96b22320c31575c67cb6a15781503cc893d49e57c1f/polyglot_sql-0.5.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1b6f19233ff44da0753170ca650a242928fa7d192d68b086da9a282427c5707", size = 7459274, upload-time = "2026-06-07T12:55:05.805Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7e/249af581d471d6ab63dbe8d20190f801974d0c49508df13d427f2f7d2e47/polyglot_sql-0.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d5875b16197e84e618c275c616047595dcd637c6e591ab103f866e1ee38bdf2b", size = 7006851, upload-time = "2026-06-07T12:55:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/e5bbf7f598511e3a8719732fcbfbeabba854f432fe2f4e7752c8cf14a253/polyglot_sql-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9740aafd45b9a92b0997e6347535f05e91f582b43cffdd47b180c7b802de3b57", size = 7394433, upload-time = "2026-06-07T12:55:10.614Z" },
+    { url = "https://files.pythonhosted.org/packages/58/97/c991658584cd255d3ed7fc76405ad599a0a87f83251a60c5e74cd1d5d01a/polyglot_sql-0.5.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fa59afa4a9314ee6f160735eb365078f44b64c8d03fdac091eee1832bccfd98", size = 7459273, upload-time = "2026-06-07T12:55:12.945Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2889,6 +2915,7 @@ version = "0.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
+    { name = "polyglot-sql" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -2948,6 +2975,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.3.2" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.37.0" },
     { name = "ingestr", marker = "extra == 'ingestr'", specifier = ">=1.0.0" },
+    { name = "polyglot-sql", specifier = ">=0.3.12" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2.0" },
     { name = "pydantic-settings", specifier = ">=2,<3" },
     { name = "pymssql", marker = "extra == 'sqlserver'", specifier = ">=2.3.0" },


### PR DESCRIPTION
Holy moly. The compile times were absolutely dreadful on 10K model projects (with complex SQL). Have gotten it down considerably with this PR. I think more optimisations can be made, but it's fast enough now that it's defensible. Not trying to turn this into a full rust project right now, but polyglot does seem like more of a necessity at this point than a nice-to-have. SQLGlot will remain the fallback for lesser known dialects / for when polyglot has the occasional failure (polyglot seems reasonably reliable so far).

EDIT: 10K 'complex' models in about 15 seconds. 3k in <5 seconds. That's good enough for now.