### PR TITLE
fix(loaders): run external loaders before opening warehouse connection

### DIFF
--- a/src/sqlbuild/compiler/python_nodes/helpers/run_lifecycle.py
+++ b/src/sqlbuild/compiler/python_nodes/helpers/run_lifecycle.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from sqlbuild.compiler.discovery.types import LoaderConnectionMode
 from sqlbuild.compiler.python_nodes.models import (
+    DiscoveredPythonLoaderMetadata,
     PythonNodeGraph,
     PythonSqlRunLifecyclePlan,
     PythonSqlRunSelection,
@@ -20,6 +22,7 @@ def build_python_sql_run_lifecycle_plan(
         name
         for name in selected_python_names
         if python_graph.nodes_by_name[name].kind == PythonNodeKind.LOADER
+        if not _is_external_loader(node_name=name, python_graph=python_graph)
     )
     ingress_names: frozenset[str] = selected_loader_names | frozenset(
         upstream_name
@@ -40,6 +43,11 @@ def build_python_sql_run_lifecycle_plan(
         read_side_sql_keys=selection.sql_keys,
         read_side_python_node_names=read_side_names,
     )
+
+
+def _is_external_loader(*, node_name: str, python_graph: PythonNodeGraph) -> bool:
+    loader: DiscoveredPythonLoaderMetadata | None = python_graph.nodes_by_name[node_name].loader
+    return loader is not None and loader.connection_mode == LoaderConnectionMode.EXTERNAL
 
 
 def _upstream_closure(*, node_name: str, python_graph: PythonNodeGraph) -> frozenset[str]:

--- a/tests/e2e/src/sqlbuild/integrations/ingestr/conftest.py
+++ b/tests/e2e/src/sqlbuild/integrations/ingestr/conftest.py
@@ -1,19 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from pathlib import Path
 from typing import Any
 
 import pytest
-
-
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    test_dir: Path = Path(__file__).resolve().parent
-    for item in items:
-        if not Path(str(item.path)).resolve().is_relative_to(test_dir):
-            continue
-        item.add_marker(pytest.mark.real_warehouse)
-        item.add_marker(pytest.mark.postgres)
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/src/sqlbuild/integrations/ingestr/test_ingestr.py
+++ b/tests/e2e/src/sqlbuild/integrations/ingestr/test_ingestr.py
@@ -29,6 +29,7 @@ from tests.e2e.src.sqlbuild.integrations.ingestr.helpers import (
     ],
     ids=["loads postgres source into duckdb destination"],
 )
+@pytest.mark.postgres
 def test_given_postgres_source_when_loading_with_ingestr_then_duckdb_target_has_rows(
     tmp_path: Path,
     test_case: IngestrE2ETestCase,
@@ -140,6 +141,79 @@ def test_given_duckdb_source_when_loading_with_ingestr_to_duckdb_then_target_has
     "test_case",
     [
         IngestrE2ETestCase(
+            description="build runs ingestr duckdb source before building model without lock",
+            expected_rows=((1, "new"), (2, "paid")),
+            expected_stdout_fragments=(
+                "ingestr execution",
+                "raw_duckdb_orders",
+                "stg_duckdb_orders",
+            ),
+        )
+    ],
+    ids=["build runs ingestr duckdb source before building model without lock"],
+)
+def test_given_ingestr_duckdb_source_when_building_with_load_then_model_reads_loaded_source(
+    tmp_path: Path,
+    test_case: IngestrE2ETestCase,
+) -> None:
+    import duckdb
+
+    source_duckdb_path: Path = tmp_path / "source.duckdb"
+    source_connection: duckdb.DuckDBPyConnection = duckdb.connect(str(source_duckdb_path))
+    try:
+        source_connection.execute("CREATE TABLE orders (order_id INTEGER, status VARCHAR)")
+        source_connection.execute("INSERT INTO orders VALUES (1, 'new'), (2, 'paid')")
+    finally:
+        source_connection.close()
+    project_dir: Path = tmp_path / "build_duckdb_to_duckdb"
+    target_duckdb_path: Path = project_dir / "target.duckdb"
+    write_project_files(
+        project_dir=project_dir,
+        files={
+            "sqlbuild_project.toml": duckdb_project_toml(
+                project_name="build_duckdb_to_duckdb", database_path=target_duckdb_path
+            ),
+            "sources/raw.yml": (
+                "sources:\n"
+                "  - name: raw_duckdb_orders\n"
+                "    columns:\n"
+                "      - name: order_id\n"
+                "        type: INTEGER\n"
+                "      - name: status\n"
+                "        type: VARCHAR\n"
+                "    ingestr:\n"
+                f'      source_uri: "duckdb:///{source_duckdb_path}"\n'
+                "      source_table: orders\n"
+            ),
+            "models/stg_duckdb_orders.sql": """
+MODEL (materialized table);
+
+SELECT order_id, status FROM __source("raw_duckdb_orders")
+""".strip()
+            + "\n",
+        },
+    )
+
+    result: subprocess.CompletedProcess[str] = run_sqb_with_ingestr(
+        command=("--no-color", "build", "--load"), project_dir=project_dir
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    for fragment in test_case.expected_stdout_fragments:
+        assert fragment in result.stdout
+    assert (
+        fetch_duckdb_rows(
+            database_path=target_duckdb_path,
+            sql="SELECT order_id, status FROM stg_duckdb_orders ORDER BY order_id",
+        )
+        == test_case.expected_rows
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        IngestrE2ETestCase(
             description="build loads postgres source with ingestr before building model",
             expected_rows=((1, "new"), (2, "paid")),
             expected_stdout_fragments=("ingestr execution", "raw_pg_orders", "stg_pg_orders"),
@@ -147,6 +221,7 @@ def test_given_duckdb_source_when_loading_with_ingestr_to_duckdb_then_target_has
     ],
     ids=["build loads postgres source with ingestr before building model"],
 )
+@pytest.mark.postgres
 def test_given_ingestr_source_when_building_with_load_then_model_reads_loaded_source(
     tmp_path: Path,
     test_case: IngestrE2ETestCase,
@@ -221,6 +296,7 @@ SELECT order_id, status FROM __source("raw_pg_orders")
     ],
     ids=["loads duckdb source into postgres destination"],
 )
+@pytest.mark.postgres
 def test_given_duckdb_source_when_loading_with_ingestr_then_postgres_target_has_rows(
     tmp_path: Path,
     test_case: IngestrE2ETestCase,

--- a/tests/unit/src/sqlbuild/compiler/python_nodes/helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/python_nodes/helpers/helpers.py
@@ -26,6 +26,7 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSourceFile,
     DiscoveredTaskFunction,
 )
+from sqlbuild.compiler.discovery.types import LoaderConnectionMode
 from sqlbuild.compiler.pipeline.models import ProjectGraph
 from sqlbuild.compiler.python_nodes.helpers.inventory import build_python_node_graph
 from sqlbuild.compiler.python_nodes.models import PythonNodeGraph
@@ -85,6 +86,24 @@ def notify_orders(_ctx: object, slack_provider: SlackProvider) -> None:
 
 def check_loaded_orders(_ctx: object) -> bool:
     return True
+
+
+def build_external_loader_python_node_graph() -> PythonNodeGraph:
+    return build_python_node_graph(
+        discovered_inputs=DiscoveredProjectInputs(
+            project_config=ProjectConfig(name="demo", adapter="duckdb"),
+            local_config=LocalConfig(),
+            loader_functions=(
+                DiscoveredLoaderFunction(
+                    file_path=Path("/project/loaders/events.py"),
+                    relative_path=Path("loaders/events.py"),
+                    name="load_events",
+                    function=load_events,
+                    connection_mode=LoaderConnectionMode.EXTERNAL,
+                ),
+            ),
+        )
+    )
 
 
 def build_orders_python_node_graph() -> PythonNodeGraph:
@@ -384,6 +403,8 @@ def build_python_node_graph_for_case(case_name: str) -> PythonNodeGraph:
         return build_intermediate_loader_asset_dependency_python_node_graph()
     if case_name == "intermediate_loader_check_dependency":
         return build_intermediate_loader_check_dependency_python_node_graph()
+    if case_name == "external_loader":
+        return build_external_loader_python_node_graph()
     return build_orders_python_node_graph()
 
 

--- a/tests/unit/src/sqlbuild/compiler/python_nodes/helpers/test_run_lifecycle.py
+++ b/tests/unit/src/sqlbuild/compiler/python_nodes/helpers/test_run_lifecycle.py
@@ -64,6 +64,18 @@ RUN_LIFECYCLE_TEST_CASES: list[PythonSqlRunLifecycleTestCase] = [
         expected_read_side_python_names=frozenset({"export_orders"}),
         expected_read_side_sql_names=frozenset({"fetch_pages"}),
     ),
+    PythonSqlRunLifecycleTestCase(
+        description="excludes external loader from ingress so it runs pre-connection",
+        python_graph_case="external_loader",
+        selection=PythonSqlRunSelection(
+            sql_keys=frozenset(),
+            python_node_names=frozenset({"load_events"}),
+        ),
+        expected_ingress_python_names=frozenset(),
+        expected_ingress_loader_names=frozenset(),
+        expected_read_side_python_names=frozenset(),
+        expected_read_side_sql_names=frozenset(),
+    ),
 ]
 
 


### PR DESCRIPTION
External (subprocess) loaders such as ingestr were routed through the Python ingress lifecycle, which holds an open warehouse DuckDB connection. ingestr's ADBC subprocess then failed to open the same DuckDB file with a self-PID lock conflict during sqb build.

This fix excludes EXTERNAL-mode loaders from ingress classification so they run via the connection-free pre-connection external-source-load path, as the framework already requires external loaders to be runnable before any warehouse connection is open.

This fix also stops the ingestr e2e conftest from blanket-marking every test as real_warehouse (they used a testcontainer or pure DuckDB), so the build path is covered by make verify + added DuckDB-only build coverage plus a lifecycle-classifier unit case.

This was quite annoying as the tests did catch this, but they were just being accidentally skipped. Pain.