### PR TITLE
fix(plan): render all model change diffs

### DIFF
--- a/src/sqlbuild/cli/output/_helpers/plan_text.py
+++ b/src/sqlbuild/cli/output/_helpers/plan_text.py
@@ -1044,7 +1044,7 @@ def _append_query_diff(*, lines: list[str], entry: ModelPlanEntry) -> list[str]:
 
     if entry.previous_query_sql is None:
         return lines
-    if entry.reason != PlanReason.QUERY_CHANGED:
+    if not entry.query_changed:
         return lines
     style: CliStyle = CliStyle(use_color=True)
     lines.append(style.label("    query diff:"))
@@ -1057,7 +1057,7 @@ def _append_query_diff(*, lines: list[str], entry: ModelPlanEntry) -> list[str]:
 def _append_config_diff(*, lines: list[str], entry: ModelPlanEntry) -> list[str]:
     """Append version-identity config diff lines if metadata changed."""
 
-    if entry.reason != PlanReason.CONFIG_CHANGED:
+    if not entry.config_changed:
         return lines
     if entry.previous_metadata_json is None or entry.fingerprint_metadata_json is None:
         return lines

--- a/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
@@ -526,6 +526,8 @@ def plan_model_from_change(
         previous_metadata_json=change_result.previous_metadata_json,
         fingerprint_version_hash=change_result.fingerprint_version_hash,
         previous_version_hash=change_result.previous_version_hash,
+        query_changed=change_result.query_changed,
+        config_changed=change_result.config_changed,
         schema_actions=schema_actions,
         schema_findings=change_result.schema_findings,
         backfill=backfill,

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -652,6 +652,8 @@ class ModelPlanEntry:
     previous_metadata_json: str | None = None
     fingerprint_version_hash: str | None = None
     previous_version_hash: str | None = None
+    query_changed: bool = False
+    config_changed: bool = False
     schema_actions: tuple[SchemaAction, ...] = field(default_factory=tuple)
     schema_findings: tuple[SchemaFinding, ...] = field(default_factory=tuple)
     backfill: BackfillResult = field(

--- a/tests/unit/src/sqlbuild/cli/output/main/plan/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/plan/helpers.py
@@ -67,6 +67,8 @@ def build_model_entry(
     schema_findings: tuple[SchemaFinding, ...] = (),
     cascade: CascadeResult | None = None,
     custom_materialization_name: str | None = None,
+    query_changed: bool = False,
+    config_changed: bool = False,
 ) -> ModelPlanEntry:
     """Build a minimal ModelPlanEntry for formatter tests."""
 
@@ -106,6 +108,8 @@ def build_model_entry(
         backfill=BackfillResult(action=backfill_action, duration=backfill_duration),
         cascade=cascade,
         custom_materialization_name=custom_materialization_name,
+        query_changed=query_changed,
+        config_changed=config_changed,
     )
 
 

--- a/tests/unit/src/sqlbuild/cli/output/main/plan/test_plan_text.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/plan/test_plan_text.py
@@ -353,6 +353,7 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
                         incremental_mode="microbatch",
                         cursor_bounds=CursorBounds(start="2026-03-26", end="2026-04-25"),
                         previous_query_sql="SELECT order_id FROM raw",
+                        query_changed=True,
                     ),
                 ),
             ),
@@ -412,6 +413,7 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
                         fingerprint_metadata_json=(
                             '{"config":{"materialized":"table"},"model_name":"fact_orders"}'
                         ),
+                        config_changed=True,
                     ),
                 ),
             ),
@@ -423,6 +425,35 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
                 '"materialized": "table"',
             ),
             unexpected_fragments=("query diff:",),
+        ),
+        FormatPlanTestCase(
+            description="query and config changes show both diffs",
+            plan_output=build_plan_output(
+                model_entries=(
+                    build_model_entry(
+                        name="fact_orders",
+                        action=PlanAction.CREATE_TABLE,
+                        reason=PlanReason.QUERY_CHANGED,
+                        previous_query_sql="SELECT order_id FROM raw",
+                        previous_metadata_json=(
+                            '{"config":{"materialized":"view"},"model_name":"fact_orders"}'
+                        ),
+                        fingerprint_metadata_json=(
+                            '{"config":{"materialized":"table"},"model_name":"fact_orders"}'
+                        ),
+                        query_changed=True,
+                        config_changed=True,
+                    ),
+                ),
+            ),
+            expected_fragments=(
+                "Query changed (1)",
+                "fact_orders",
+                "query diff:",
+                "config diff:",
+                '"materialized": "view"',
+                '"materialized": "table"',
+            ),
         ),
         FormatPlanTestCase(
             description="full rebuild hides cursor range placeholders",
@@ -1291,6 +1322,7 @@ def test_given_plan_output_when_formatting_then_contains_expected_fragments(
                         action=PlanAction.CREATE_TABLE,
                         reason=PlanReason.QUERY_CHANGED,
                         previous_query_sql="SELECT old_amount FROM raw_orders",
+                        query_changed=True,
                     ),
                 ),
                 metadata={


### PR DESCRIPTION
## Summary

Fixes CHI-25 by retaining independent query/config change flags on `ModelPlanEntry` and using those facts to decide which detailed diffs to render. A model whose query and config change in one edit now shows both diffs under the single highest-priority headline reason.

This PR is stacked on #310.

## Verification

- `uv run pytest tests/unit/src/sqlbuild/cli/output/main/plan/test_plan_text.py -q` (50 passed)
- `make check-ci`
