### PR TITLE
fix: include license in source distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ module-name = "sqlbuild._kata_native"
 python-source = "src"
 features = ["extension-module"]
 include = [
+  { path = "LICENSE", format = ["sdist", "wheel"] },
   { path = "scripts", format = ["sdist", "wheel"] },
 ]
 


### PR DESCRIPTION
## Why

The `v0.54.0` native wheel matrix built successfully, but PyPI rejected the source distribution because package metadata declares `LICENSE` and Maturin did not include that file in the sdist.

## Changes

- include `LICENSE` explicitly in Maturin wheel and sdist inputs

## Verification

- `make check-ci`
- `uv lock --check --python 3.12`
- `uv run maturin sdist --out /tmp/opencode/sqlbuild-dist`
- verified the archive contains `sqlbuild-0.54.0/LICENSE` and `PKG-INFO`
