### PR TITLE
fix(kata): enable standard policy and tighten enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,19 +113,17 @@ project, reports coded faults with remediations, and never rewrites SQL. Its bui
 native: Rust resolves rule policy, parses each model, evaluates built-ins, applies suppressions,
 and owns the persistent cache and deterministic result ordering.
 
-Select the default policy namespace and opt into additional exact rules in
-`sqlbuild_project.toml`. Prefix selectors activate default-enabled rules; exact selectors also
-activate opt-in rules:
+Kata is disabled until the project selects at least one rule. Select the complete built-in policy
+in `sqlbuild_project.toml` with its namespace prefix:
 
 ```toml
 [kata]
-select = ["SQBK", "SQBKS001", "SQBKS201", "SQBKX001", "SQBKX002"]
-ignore = ["SQBKS302"]
-
-[kata.thresholds]
-min_audits_per_model = 1
-min_tests_per_model = 1
+select = ["SQBK"]
 ```
+
+`SQBK` activates every built-in rule. Narrower prefixes such as `SQBKS` activate one family, exact
+codes select individual rules, and `ignore` removes matching rules. Audit, unit-test, and custom-rule
+test-case minimums each default to one and can be overridden under `[kata.thresholds]`.
 
 Run `sqb kata`, inspect metadata with `sqb kata rule SQBKS101`, and generate agent guidance from
 the same active ruleset with `sqb kata skills`. Use `sqb kata skills --check` in CI to detect stale

--- a/crates/sqlbuild-kata-native/src/constants.rs
+++ b/crates/sqlbuild-kata-native/src/constants.rs
@@ -1,7 +1,6 @@
 pub(crate) const API_VERSION: u32 = 1;
 pub(crate) const BUILT_IN_RULE_NAMESPACE: &str = "SQBK";
 pub(crate) const CUSTOM_RULE_NAMESPACE: &str = "XSQBK";
-pub(crate) const DEFAULT_RULE_CODE: &str = "SQBKR401";
 pub(crate) const TARGET_DIRECTORY: &str = "target";
 pub(crate) const REFERENCE_KIND: &str = "ref";
 pub(crate) const VIEW_MATERIALIZATION: &str = "view";

--- a/crates/sqlbuild-kata-native/src/rules/_helpers/catalogue.rs
+++ b/crates/sqlbuild-kata-native/src/rules/_helpers/catalogue.rs
@@ -1,6 +1,4 @@
-use crate::constants::{
-    API_VERSION, BUILT_IN_RULE_NAMESPACE, CUSTOM_RULE_NAMESPACE, DEFAULT_RULE_CODE,
-};
+use crate::constants::{API_VERSION, BUILT_IN_RULE_NAMESPACE, CUSTOM_RULE_NAMESPACE};
 use crate::models::{CustomRule, ResolveRulesRequest, RuleMetadata};
 use fensu_policy::policy::errors::PolicyError;
 use fensu_policy::policy::main::resolve_policy::resolve_policy;
@@ -23,7 +21,7 @@ macro_rules! rule {
             message: $message.into(),
             remediation: $remediation.into(),
             implementation_fingerprint: env!("CARGO_PKG_VERSION").into(),
-            enabled_by_default: $code == DEFAULT_RULE_CODE,
+            enabled_by_default: true,
             project_wide: matches!($code, "SQBKH101" | "SQBKH201" | "SQBKX201"),
             custom: false,
         }
@@ -197,8 +195,8 @@ pub(crate) fn catalogue() -> Vec<RuleMetadata> {
             "SQBKH001",
             "hygiene",
             "named-enum-decisions",
-            "enum comparisons must use declared enum members",
-            "Replace this bare string with @enum(\"<enum>\").<MEMBER> so the decision uses the declared domain.",
+            "enum comparisons must use declared members and normalized operands",
+            "Compare directly to @enum(\"<enum>\").<MEMBER>. Only a direct source-side value may be normalized in the comparison; move other normalization upstream and never wrap the enum member.",
         ),
         rule!(
             "SQBKH002",

--- a/crates/sqlbuild-kata-native/src/rules/_helpers/evaluation.rs
+++ b/crates/sqlbuild-kata-native/src/rules/_helpers/evaluation.rs
@@ -29,6 +29,21 @@ struct ComparisonFact {
     columns: BTreeSet<String>,
     string_literals: Vec<String>,
     numeric_literals: Vec<String>,
+    modified_columns: BTreeSet<ColumnFact>,
+    modified_string_literal: bool,
+    source_context: SourceContext,
+}
+
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+struct ColumnFact {
+    name: String,
+    qualifier: Option<String>,
+}
+
+#[derive(Clone, Default)]
+struct SourceContext {
+    relations: BTreeSet<String>,
+    sole_relation: bool,
 }
 
 #[derive(Default)]
@@ -1075,7 +1090,16 @@ fn evaluate_literal_rules(
                 .string_literals
                 .iter()
                 .any(|literal| parsed.model.authored_sql.contains(literal));
-            if enum_column && bare_string {
+            let modified_controlled_column = comparison.modified_columns.iter().any(|column| {
+                parsed.model.enum_columns.contains(&column.name)
+                    && !column.qualifier.as_ref().is_some_and(|qualifier| {
+                        comparison.source_context.relations.contains(qualifier)
+                    })
+                    && !(column.qualifier.is_none() && comparison.source_context.sole_relation)
+            });
+            if enum_column
+                && (bare_string || modified_controlled_column || comparison.modified_string_literal)
+            {
                 faults.push(fault(parsed.model, rule, comparison.position.as_ref()));
             }
         }
@@ -1319,10 +1343,12 @@ fn set_expr_has_star(body: &SetExpr) -> bool {
 }
 
 fn select_facts(query: &Query) -> Vec<SelectFacts> {
+    let source_imports = source_import_names(query);
     all_queries(query)
         .into_iter()
         .filter_map(root_select)
         .map(|select| {
+            let source_context = select_source_context(select, &source_imports);
             let mut result = SelectFacts {
                 position: Some(location_position(select.select_token.0.span.start)),
                 from_count: select.from.len(),
@@ -1332,7 +1358,7 @@ fn select_facts(query: &Query) -> Vec<SelectFacts> {
                 for join in &source.joins {
                     result.joins.push(join_fact(&join.join_operator));
                     if let Some(JoinConstraint::On(expr)) = join_constraint(&join.join_operator) {
-                        comparison_facts(expr, &mut result.comparisons);
+                        comparison_facts(expr, &source_context, &mut result.comparisons);
                     }
                 }
             }
@@ -1344,11 +1370,68 @@ fn select_facts(query: &Query) -> Vec<SelectFacts> {
             .into_iter()
             .flatten()
             {
-                comparison_facts(expression, &mut result.comparisons);
+                comparison_facts(expression, &source_context, &mut result.comparisons);
             }
             result
         })
         .collect()
+}
+
+fn source_import_names(query: &Query) -> BTreeSet<String> {
+    top_ctes(query)
+        .iter()
+        .filter(|cte| {
+            dependency_import(&cte.query)
+                && root_select(&cte.query).is_some_and(|select| {
+                    select.from.len() == 1
+                        && select.from[0].joins.is_empty()
+                        && dependency_name(&select.from[0].relation).as_deref() == Some("__source")
+                })
+        })
+        .map(|cte| cte.alias.name.value.to_ascii_lowercase())
+        .collect()
+}
+
+fn select_source_context(select: &Select, source_imports: &BTreeSet<String>) -> SourceContext {
+    let mut relations: BTreeSet<String> = BTreeSet::new();
+    for source in &select.from {
+        if let Some(name) = source_relation_name(&source.relation, source_imports) {
+            relations.insert(name);
+        }
+        for join in &source.joins {
+            if let Some(name) = source_relation_name(&join.relation, source_imports) {
+                relations.insert(name);
+            }
+        }
+    }
+    let sole_relation = select.from.len() == 1
+        && select.from[0].joins.is_empty()
+        && source_relation_name(&select.from[0].relation, source_imports).is_some();
+    SourceContext {
+        relations,
+        sole_relation,
+    }
+}
+
+fn source_relation_name(factor: &TableFactor, source_imports: &BTreeSet<String>) -> Option<String> {
+    let TableFactor::Table {
+        name, args, alias, ..
+    } = factor
+    else {
+        return None;
+    };
+    let relation_name = name.0.last()?.as_ident()?.value.to_ascii_lowercase();
+    if args.is_none() && !source_imports.contains(&relation_name) {
+        return None;
+    }
+    if args.is_some() && dependency_name(factor).as_deref() != Some("__source") {
+        return None;
+    }
+    Some(
+        alias
+            .as_ref()
+            .map_or(relation_name, |value| value.name.value.to_ascii_lowercase()),
+    )
 }
 
 fn join_constraint(operator: &JoinOperator) -> Option<&JoinConstraint> {
@@ -1409,8 +1492,9 @@ fn numeric_value(expression: &Expr) -> Option<String> {
     }
 }
 
-fn comparison_facts(root: &Expr, output: &mut Vec<ComparisonFact>) {
+fn comparison_facts(root: &Expr, source_context: &SourceContext, output: &mut Vec<ComparisonFact>) {
     struct Comparisons<'a> {
+        source_context: &'a SourceContext,
         output: &'a mut Vec<ComparisonFact>,
     }
     impl Visitor for Comparisons<'_> {
@@ -1426,17 +1510,21 @@ fn comparison_facts(root: &Expr, output: &mut Vec<ComparisonFact>) {
                         | BinaryOperator::Lt
                         | BinaryOperator::LtEq
                 ) {
-                    self.output.push(comparison_fact(expression));
+                    self.output
+                        .push(comparison_fact(expression, self.source_context));
                 }
             }
             ControlFlow::Continue(())
         }
     }
-    let mut visitor = Comparisons { output };
+    let mut visitor = Comparisons {
+        source_context,
+        output,
+    };
     let _ = root.visit(&mut visitor);
 }
 
-fn comparison_fact(root: &Expr) -> ComparisonFact {
+fn comparison_fact(root: &Expr, source_context: &SourceContext) -> ComparisonFact {
     struct Values {
         fact: ComparisonFact,
     }
@@ -1480,9 +1568,100 @@ fn comparison_fact(root: &Expr) -> ComparisonFact {
     let mut visitor = Values {
         fact: ComparisonFact {
             position: Some(position(root)),
+            source_context: source_context.clone(),
             ..ComparisonFact::default()
         },
     };
     let _ = root.visit(&mut visitor);
+    if let Expr::BinaryOp { left, right, .. } = root {
+        for operand in [left.as_ref(), right.as_ref()] {
+            if direct_column(operand).is_none() {
+                visitor.fact.modified_columns.extend(column_facts(operand));
+            }
+            if direct_string_literal(operand).is_none() && contains_string_literal(operand) {
+                visitor.fact.modified_string_literal = true;
+            }
+        }
+    }
     visitor.fact
+}
+
+fn direct_column(expression: &Expr) -> Option<ColumnFact> {
+    match unwrap_nested(expression) {
+        Expr::Identifier(value) => Some(ColumnFact {
+            name: value.value.clone(),
+            qualifier: None,
+        }),
+        Expr::CompoundIdentifier(values) => {
+            let name = values.last()?.value.clone();
+            let qualifier = values
+                .get(values.len().checked_sub(2)?)
+                .map(|value| value.value.to_ascii_lowercase());
+            Some(ColumnFact { name, qualifier })
+        }
+        _ => None,
+    }
+}
+
+fn direct_string_literal(expression: &Expr) -> Option<String> {
+    let Expr::Value(value) = unwrap_nested(expression) else {
+        return None;
+    };
+    matches!(
+        value.value,
+        Value::SingleQuotedString(_)
+            | Value::DoubleQuotedString(_)
+            | Value::TripleSingleQuotedString(_)
+            | Value::TripleDoubleQuotedString(_)
+            | Value::EscapedStringLiteral(_)
+            | Value::UnicodeStringLiteral(_)
+            | Value::NationalStringLiteral(_)
+    )
+    .then(|| expression.to_string())
+}
+
+fn unwrap_nested(mut expression: &Expr) -> &Expr {
+    while let Expr::Nested(value) = expression {
+        expression = value;
+    }
+    expression
+}
+
+fn column_facts(root: &Expr) -> BTreeSet<ColumnFact> {
+    struct Columns {
+        values: BTreeSet<ColumnFact>,
+    }
+    impl Visitor for Columns {
+        type Break = ();
+        fn pre_visit_expr(&mut self, expression: &Expr) -> ControlFlow<Self::Break> {
+            if let Some(column) = direct_column(expression) {
+                self.values.insert(column);
+            }
+            ControlFlow::Continue(())
+        }
+    }
+    let mut visitor = Columns {
+        values: BTreeSet::new(),
+    };
+    let _ = root.visit(&mut visitor);
+    visitor.values
+}
+
+fn contains_string_literal(root: &Expr) -> bool {
+    struct Strings {
+        found: bool,
+    }
+    impl Visitor for Strings {
+        type Break = ();
+        fn pre_visit_expr(&mut self, expression: &Expr) -> ControlFlow<Self::Break> {
+            if direct_string_literal(expression).is_some() {
+                self.found = true;
+                return ControlFlow::Break(());
+            }
+            ControlFlow::Continue(())
+        }
+    }
+    let mut visitor = Strings { found: false };
+    let _ = root.visit(&mut visitor);
+    visitor.found
 }

--- a/src/sqlbuild/compiler/discovery/_helpers/sql/declarations.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/sql/declarations.py
@@ -194,6 +194,15 @@ def _parse_enum_declaration(
         raise DeclarationParseError(f"{file_path} enum '{name}' members must use [...] or (...)")
     if not members:
         raise DeclarationParseError(f"{file_path} enum '{name}' must declare at least one member")
+    invalid_member: EnumMember | None = next(
+        (member for member in members if member.name != member.name.upper()),
+        None,
+    )
+    if invalid_member is not None:
+        raise DeclarationParseError(
+            f"{file_path} enum '{name}' member identifiers must be uppercase: "
+            f"'{invalid_member.name}'"
+        )
     member_types: set[type[object]] = {type(member.value) for member in members}
     if len(member_types) != 1:
         raise DeclarationParseError(

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_declarations.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_declarations.py
@@ -329,6 +329,14 @@ def test_given_declaration_change_when_compiling_then_updates_dependent_identity
             expected_error_fragment="Unknown member 'MISSING' for enum 'state'",
         ),
         CompileDeclarationsErrorTestCase(
+            description="lowercase enum member access",
+            repo_files={
+                "enums/state.sql": 'ENUM (name state, members (WIN "win"));',
+                "models/orders.sql": ('MODEL ();\nSELECT @enum("state").win AS state\n'),
+            },
+            expected_error_fragment="Unknown member 'win' for enum 'state'",
+        ),
+        CompileDeclarationsErrorTestCase(
             description="unknown constant",
             repo_files={
                 "models/orders.sql": 'MODEL ();\nSELECT @const("missing") AS value\n',

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_declarations.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_declarations.py
@@ -135,6 +135,21 @@ def test_given_constant_declarations_when_parsing_then_returns_typed_values(
             contents="ENUM (name state, members [OPEN, OPEN]);",
             expected_error_fragment="duplicate member 'OPEN'",
         ),
+        ParseDeclarationFileErrorTestCase(
+            description="lowercase shorthand member",
+            contents="ENUM (name state, members [open]);",
+            expected_error_fragment="member identifiers must be uppercase: 'open'",
+        ),
+        ParseDeclarationFileErrorTestCase(
+            description="mixed-case shorthand member",
+            contents="ENUM (name state, members [Open]);",
+            expected_error_fragment="member identifiers must be uppercase: 'Open'",
+        ),
+        ParseDeclarationFileErrorTestCase(
+            description="lowercase explicit member with lowercase value",
+            contents='ENUM (name state, members (open "open"));',
+            expected_error_fragment="member identifiers must be uppercase: 'open'",
+        ),
     ],
     ids=lambda case: case.description,
 )

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/_test_types.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/_test_types.py
@@ -11,6 +11,14 @@ class KataConfigErrorTestCase:
 
 
 @dataclass(frozen=True)
+class KataSelectionTestCase:
+    description: str
+    select: tuple[str, ...]
+    ignore: tuple[str, ...]
+    expected_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class CustomRuleTestCase:
     description: str
     body: str
@@ -19,3 +27,5 @@ class CustomRuleTestCase:
     expected_error_pattern: str | None = None
     expected_cache_hits: int = 0
     minimum_custom_rule_cases: int = 0
+    select: tuple[str, ...] = ("XSQBKT001",)
+    enabled_by_default: bool = False

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/helpers.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/helpers.py
@@ -11,7 +11,7 @@ from tests.unit.src.sqlbuild.kata_engine.main.evaluate.helpers import build_proj
 _MODEL_SQL: str = "WITH final AS (SELECT 1 AS id) SELECT id FROM final"
 
 
-def write_rule(*, root: Path, body: str) -> Path:
+def write_rule(*, root: Path, body: str, enabled_by_default: bool = False) -> Path:
     path: Path = root / "kata" / "rules" / "custom.py"
     path.parent.mkdir(parents=True)
     path.write_text(
@@ -25,6 +25,7 @@ def write_rule(*, root: Path, body: str) -> Path:
                 '    slug="test-rule",',
                 '    message="test rule fault",',
                 '    remediation="Fix this model at its models/<domain>/ path.",',
+                f"    enabled_by_default={enabled_by_default},",
                 ")",
                 "def check(*, model, ctx: RuleContext):",
                 f"    {body}",
@@ -39,7 +40,11 @@ def write_rule(*, root: Path, body: str) -> Path:
 def custom_rule_inputs(
     *, tmp_path: Path, test_case: CustomRuleTestCase
 ) -> tuple[CompiledProject, KataConfig]:
-    rule_path: Path = write_rule(root=tmp_path, body=test_case.body)
+    rule_path: Path = write_rule(
+        root=tmp_path,
+        body=test_case.body,
+        enabled_by_default=test_case.enabled_by_default,
+    )
     project: CompiledProject = build_project(
         name="market__mart__prices",
         relative_path="models/mart/market__mart__prices.sql",
@@ -47,7 +52,7 @@ def custom_rule_inputs(
         config_values={},
     )
     config: KataConfig = KataConfig(
-        select=("XSQBKT001",),
+        select=test_case.select,
         rule_paths=(rule_path.as_posix(),),
         thresholds={MIN_CUSTOM_RULE_TEST_CASES: test_case.minimum_custom_rule_cases},
         cache=KataCacheConfig(require_cacheable=test_case.require_cacheable),

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_catalogue.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_catalogue.py
@@ -1,0 +1,126 @@
+"""Kata rule catalogue selection behavior tests."""
+
+from pathlib import Path
+
+import pytest
+
+from sqlbuild.kata_engine._helpers.engine.catalogue import build_catalogue, select_rules
+from sqlbuild.kata_engine.models import KataConfig, KataRule
+from tests.unit.src.sqlbuild.kata_engine._helpers.engine._test_types import (
+    KataSelectionTestCase,
+)
+
+BUILT_IN_CODES: tuple[str, ...] = (
+    "SQBKH001",
+    "SQBKH002",
+    "SQBKH101",
+    "SQBKH201",
+    "SQBKJ001",
+    "SQBKJ002",
+    "SQBKJ101",
+    "SQBKL001",
+    "SQBKL101",
+    "SQBKN001",
+    "SQBKN002",
+    "SQBKN003",
+    "SQBKR001",
+    "SQBKR002",
+    "SQBKR201",
+    "SQBKR301",
+    "SQBKR401",
+    "SQBKS000",
+    "SQBKS001",
+    "SQBKS002",
+    "SQBKS101",
+    "SQBKS201",
+    "SQBKS202",
+    "SQBKS301",
+    "SQBKS302",
+    "SQBKS401",
+    "SQBKS501",
+    "SQBKX001",
+    "SQBKX002",
+    "SQBKX201",
+)
+STRUCTURE_CODES: tuple[str, ...] = (
+    "SQBKS000",
+    "SQBKS001",
+    "SQBKS002",
+    "SQBKS101",
+    "SQBKS201",
+    "SQBKS202",
+    "SQBKS301",
+    "SQBKS302",
+    "SQBKS401",
+    "SQBKS501",
+)
+NON_STRUCTURE_CODES: tuple[str, ...] = (
+    "SQBKH001",
+    "SQBKH002",
+    "SQBKH101",
+    "SQBKH201",
+    "SQBKJ001",
+    "SQBKJ002",
+    "SQBKJ101",
+    "SQBKL001",
+    "SQBKL101",
+    "SQBKN001",
+    "SQBKN002",
+    "SQBKN003",
+    "SQBKR001",
+    "SQBKR002",
+    "SQBKR201",
+    "SQBKR301",
+    "SQBKR401",
+    "SQBKX001",
+    "SQBKX002",
+    "SQBKX201",
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        KataSelectionTestCase(
+            description="built-in namespace activates every built-in",
+            select=("SQBK",),
+            ignore=(),
+            expected_codes=BUILT_IN_CODES,
+        ),
+        KataSelectionTestCase(
+            description="built-in family activates every family rule",
+            select=("SQBKS",),
+            ignore=(),
+            expected_codes=STRUCTURE_CODES,
+        ),
+        KataSelectionTestCase(
+            description="exact built-in code activates one rule",
+            select=("SQBKS001",),
+            ignore=(),
+            expected_codes=("SQBKS001",),
+        ),
+        KataSelectionTestCase(
+            description="empty selection activates no rules",
+            select=(),
+            ignore=(),
+            expected_codes=(),
+        ),
+        KataSelectionTestCase(
+            description="ignored family is removed from selected namespace",
+            select=("SQBK",),
+            ignore=("SQBKS",),
+            expected_codes=NON_STRUCTURE_CODES,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_rule_selectors_when_resolving_then_returns_expected_codes(
+    tmp_path: Path,
+    test_case: KataSelectionTestCase,
+) -> None:
+    config: KataConfig = KataConfig(select=test_case.select, ignore=test_case.ignore)
+    catalogue: tuple[KataRule, ...] = build_catalogue(config=config, project_dir=tmp_path)
+
+    selected: tuple[KataRule, ...] = select_rules(catalogue=catalogue, config=config)
+
+    assert tuple(rule.code for rule in selected) == test_case.expected_codes

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_custom_rules.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_custom_rules.py
@@ -28,6 +28,20 @@ from tests.unit.src.sqlbuild.kata_engine._helpers.engine.helpers import custom_r
             expected_fault_codes=("SQBKX201",),
             minimum_custom_rule_cases=1,
         ),
+        CustomRuleTestCase(
+            description="default-off custom rule is not activated by prefix",
+            body="del model\n    return [ctx.path_fault()]",
+            require_cacheable=False,
+            select=("XSQBKT",),
+        ),
+        CustomRuleTestCase(
+            description="default-enabled custom rule is activated by prefix",
+            body="del model\n    return [ctx.path_fault()]",
+            require_cacheable=False,
+            expected_fault_codes=("XSQBKT001",),
+            select=("XSQBKT",),
+            enabled_by_default=True,
+        ),
     ],
     ids=lambda case: case.description,
 )

--- a/tests/unit/src/sqlbuild/kata_engine/main/evaluate/_test_types.py
+++ b/tests/unit/src/sqlbuild/kata_engine/main/evaluate/_test_types.py
@@ -17,6 +17,8 @@ class KataEvaluationTestCase:
     expected_codes: tuple[str, ...]
     kata_config: KataConfig = field(default_factory=KataConfig)
     references: tuple[CompileSqlReference, ...] = ()
+    authored_sql: str | None = None
+    enum_columns: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/kata_engine/main/evaluate/helpers.py
+++ b/tests/unit/src/sqlbuild/kata_engine/main/evaluate/helpers.py
@@ -11,6 +11,15 @@ from sqlbuild.compiler.compile.models import (
     CompileSqlReference,
 )
 from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.discovery.models import EnumDeclaration, EnumMember
+
+_ENUM_DECLARATION: EnumDeclaration = EnumDeclaration(
+    name="status",
+    members=(EnumMember(name="WIN", value="win"),),
+    scalar_type="VARCHAR",
+    relative_path=Path("enums/status.sql"),
+    model_name=None,
+)
 
 
 def build_project(
@@ -20,6 +29,8 @@ def build_project(
     sql: str,
     config_values: dict[str, object],
     references: tuple[CompileSqlReference, ...] = (),
+    authored_sql: str | None = None,
+    enum_columns: tuple[str, ...] = (),
 ) -> CompiledProject:
     model: CompiledModel = CompiledModel(
         key=CompiledObjectKey(resource_type=CompiledResourceType.MODEL, name=name),
@@ -27,9 +38,10 @@ def build_project(
         name=name,
         relative_path=Path(relative_path),
         query_sql=sql,
-        authored_sql=sql,
+        authored_sql=authored_sql or sql,
         config=CompileModelConfig(values=config_values),
         references=references,
+        enum_columns={name: _ENUM_DECLARATION for name in enum_columns},
         destination=CompiledRelationLocation(
             database=None,
             schema=None,

--- a/tests/unit/src/sqlbuild/kata_engine/main/evaluate/test_evaluate.py
+++ b/tests/unit/src/sqlbuild/kata_engine/main/evaluate/test_evaluate.py
@@ -79,6 +79,163 @@ from tests.unit.src.sqlbuild.kata_engine.main.evaluate.helpers import build_proj
             expected_codes=("SQBKJ002",),
         ),
         KataEvaluationTestCase(
+            description="direct enum member comparison passes",
+            model_name="market__int_clean__prices",
+            relative_path="models/intermediate/market__int_clean__prices.sql",
+            sql=(
+                'WITH upstream AS (SELECT * FROM __ref("market__stg__prices")), '
+                "filtered AS (SELECT status FROM upstream WHERE upstream.status = 'win') "
+                "SELECT status FROM filtered"
+            ),
+            authored_sql=(
+                'WITH upstream AS (SELECT * FROM __ref("market__stg__prices")), '
+                "filtered AS (SELECT status FROM upstream "
+                'WHERE upstream.status = @enum("status").WIN) SELECT status FROM filtered'
+            ),
+            config_values={"materialized": "table", "contract": "enforced"},
+            select=("SQBKH001",),
+            expected_codes=(),
+            references=(CompileSqlReference(ref_kind="ref", ref_name="market__stg__prices"),),
+            enum_columns=("status",),
+        ),
+        KataEvaluationTestCase(
+            description="modified controlled enum column faults",
+            model_name="market__int_clean__prices",
+            relative_path="models/intermediate/market__int_clean__prices.sql",
+            sql=(
+                'WITH upstream AS (SELECT * FROM __ref("market__stg__prices")), '
+                "filtered AS (SELECT status FROM upstream "
+                "WHERE LOWER(upstream.status) = 'win') SELECT status FROM filtered"
+            ),
+            authored_sql=(
+                'WITH upstream AS (SELECT * FROM __ref("market__stg__prices")), '
+                "filtered AS (SELECT status FROM upstream "
+                'WHERE LOWER(upstream.status) = @enum("status").WIN) '
+                "SELECT status FROM filtered"
+            ),
+            config_values={"materialized": "table", "contract": "enforced"},
+            select=("SQBKH001",),
+            expected_codes=("SQBKH001",),
+            references=(CompileSqlReference(ref_kind="ref", ref_name="market__stg__prices"),),
+            enum_columns=("status",),
+        ),
+        KataEvaluationTestCase(
+            description="uppercased controlled enum column faults",
+            model_name="market__int_clean__prices",
+            relative_path="models/intermediate/market__int_clean__prices.sql",
+            sql=(
+                'SELECT status FROM __ref("market__stg__prices") AS upstream '
+                "WHERE UPPER(upstream.status) = 'win'"
+            ),
+            authored_sql=(
+                'SELECT status FROM __ref("market__stg__prices") AS upstream '
+                'WHERE UPPER(upstream.status) = @enum("status").WIN'
+            ),
+            config_values={"materialized": "table", "contract": "enforced"},
+            select=("SQBKH001",),
+            expected_codes=("SQBKH001",),
+            references=(CompileSqlReference(ref_kind="ref", ref_name="market__stg__prices"),),
+            enum_columns=("status",),
+        ),
+        KataEvaluationTestCase(
+            description="cast controlled enum column faults",
+            model_name="market__int_clean__prices",
+            relative_path="models/intermediate/market__int_clean__prices.sql",
+            sql=(
+                'SELECT status FROM __ref("market__stg__prices") AS upstream '
+                "WHERE CAST(upstream.status AS VARCHAR) = 'win'"
+            ),
+            authored_sql=(
+                'SELECT status FROM __ref("market__stg__prices") AS upstream '
+                'WHERE CAST(upstream.status AS VARCHAR) = @enum("status").WIN'
+            ),
+            config_values={"materialized": "table", "contract": "enforced"},
+            select=("SQBKH001",),
+            expected_codes=("SQBKH001",),
+            references=(CompileSqlReference(ref_kind="ref", ref_name="market__stg__prices"),),
+            enum_columns=("status",),
+        ),
+        KataEvaluationTestCase(
+            description="direct source enum column modifier passes",
+            model_name="market__stg__prices__vendor",
+            relative_path="models/staging/market__stg__prices__vendor.sql",
+            sql=(
+                'WITH raw_prices AS (SELECT * FROM __source("vendor_prices")), '
+                "filtered AS (SELECT status FROM raw_prices "
+                "WHERE LOWER(raw_prices.status) = 'win') SELECT status FROM filtered"
+            ),
+            authored_sql=(
+                'WITH raw_prices AS (SELECT * FROM __source("vendor_prices")), '
+                "filtered AS (SELECT status FROM raw_prices "
+                'WHERE LOWER(raw_prices.status) = @enum("status").WIN) '
+                "SELECT status FROM filtered"
+            ),
+            config_values={"materialized": "table", "contract": "enforced"},
+            select=("SQBKH001",),
+            expected_codes=(),
+            references=(CompileSqlReference(ref_kind="source", ref_name="vendor_prices"),),
+            enum_columns=("status",),
+        ),
+        KataEvaluationTestCase(
+            description="transitive source enum column modifier faults",
+            model_name="market__stg__prices__vendor",
+            relative_path="models/staging/market__stg__prices__vendor.sql",
+            sql=(
+                'WITH raw_prices AS (SELECT * FROM __source("vendor_prices")), '
+                "renamed AS (SELECT status FROM raw_prices), "
+                "filtered AS (SELECT status FROM renamed "
+                "WHERE LOWER(renamed.status) = 'win') SELECT status FROM filtered"
+            ),
+            authored_sql=(
+                'WITH raw_prices AS (SELECT * FROM __source("vendor_prices")), '
+                "renamed AS (SELECT status FROM raw_prices), "
+                "filtered AS (SELECT status FROM renamed "
+                'WHERE LOWER(renamed.status) = @enum("status").WIN) '
+                "SELECT status FROM filtered"
+            ),
+            config_values={"materialized": "table", "contract": "enforced"},
+            select=("SQBKH001",),
+            expected_codes=("SQBKH001",),
+            references=(CompileSqlReference(ref_kind="source", ref_name="vendor_prices"),),
+            enum_columns=("status",),
+        ),
+        KataEvaluationTestCase(
+            description="modified enum member faults for direct source comparison",
+            model_name="market__stg__prices__vendor",
+            relative_path="models/staging/market__stg__prices__vendor.sql",
+            sql=(
+                'WITH raw_prices AS (SELECT * FROM __source("vendor_prices")), '
+                "filtered AS (SELECT status FROM raw_prices "
+                "WHERE raw_prices.status = LOWER('win')) SELECT status FROM filtered"
+            ),
+            authored_sql=(
+                'WITH raw_prices AS (SELECT * FROM __source("vendor_prices")), '
+                "filtered AS (SELECT status FROM raw_prices "
+                'WHERE raw_prices.status = LOWER(@enum("status").WIN)) '
+                "SELECT status FROM filtered"
+            ),
+            config_values={"materialized": "table", "contract": "enforced"},
+            select=("SQBKH001",),
+            expected_codes=("SQBKH001",),
+            references=(CompileSqlReference(ref_kind="source", ref_name="vendor_prices"),),
+            enum_columns=("status",),
+        ),
+        KataEvaluationTestCase(
+            description="bare string faults for direct source comparison",
+            model_name="market__stg__prices__vendor",
+            relative_path="models/staging/market__stg__prices__vendor.sql",
+            sql=(
+                'WITH raw_prices AS (SELECT * FROM __source("vendor_prices")), '
+                "filtered AS (SELECT status FROM raw_prices "
+                "WHERE LOWER(raw_prices.status) = 'win') SELECT status FROM filtered"
+            ),
+            config_values={"materialized": "table", "contract": "enforced"},
+            select=("SQBKH001",),
+            expected_codes=("SQBKH001",),
+            references=(CompileSqlReference(ref_kind="source", ref_name="vendor_prices"),),
+            enum_columns=("status",),
+        ),
+        KataEvaluationTestCase(
             description="numeric decision faults",
             model_name="market__mart__prices",
             relative_path="models/mart/market__mart__prices.sql",
@@ -244,6 +401,8 @@ def test_given_selected_rules_when_evaluating_then_reports_expected_faults(
             sql=test_case.sql,
             config_values=test_case.config_values,
             references=test_case.references,
+            authored_sql=test_case.authored_sql,
+            enum_columns=test_case.enum_columns,
         ),
         config=replace(test_case.kata_config, select=test_case.select),
         project_dir=tmp_path,


### PR DESCRIPTION
## Why

Kata accidentally marked almost every built-in rule as default-off, so the natural `select = ["SQBK"]` policy activated only one rule. Enum declarations and comparisons also lacked the agreed identifier and normalization constraints.

## Changes

- mark every current built-in Kata rule as enabled by default so `SQBK` adopts the complete standard policy
- require uppercase enum member identifiers while preserving independently cased values
- reject wrapped controlled operands and enum members in `SQBKH001`, except normalization on a direct source-side operand
- simplify the README and public docs and add selector, custom-rule, enum, and comparison regression coverage
- update `sqlbuild-docs/main` in `46d5c14` and `63c6036`

## Verification

- `make rust-check`
- `make check-ci`
- `uv run pytest tests/unit/src/sqlbuild/kata_engine tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_declarations.py tests/unit/src/sqlbuild/compiler/compile/_helpers/test_declarations.py -q`
- `uv run pytest tests/e2e/src/sqlbuild/cli/commands/main/kata/test_kata_performance.py -vv`
- GitHub static, unit, integration, DuckDB E2E, and PostgreSQL E2E checks

Linear: https://linear.app/chio-labs/issue/CHI-85/correct-kata-defaults-and-enum-policy-behavior
