### PR TITLE
fix(virtual): serialize microbatch state operations

### DIFF
--- a/src/sqlbuild/virtual/executor/_helpers/build.py
+++ b/src/sqlbuild/virtual/executor/_helpers/build.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, replace
@@ -1079,6 +1080,7 @@ def _execute_virtual_build_plan(
     microbatch_lease_check: Callable[[], None],
 ) -> BuildExecutionResult:
     options: VirtualBuildOptions = runtime.options
+    microbatch_state_lock: threading.Lock = threading.Lock()
     custom_materializations: dict[
         str, Callable[[MaterializationContext], MaterializationResult]
     ] = load_custom_materializations(runtime.discovered_inputs.materialization_files)
@@ -1128,6 +1130,7 @@ def _execute_virtual_build_plan(
                 entry=entry,
                 connection=connection,
                 model_version_hash=reads.semantics.expected_version_hashes.get(entry.name),
+                operation_lock=microbatch_state_lock,
             ),
             microbatch_lease_check=microbatch_lease_check,
         ),
@@ -1182,6 +1185,7 @@ def _resolve_virtual_microbatch_state(
     entry: ModelPlanEntry,
     connection: Any,
     model_version_hash: str | None,
+    operation_lock: threading.Lock,
 ) -> tuple[MicrobatchEventStore, MicrobatchScope]:
     version_hash: str = (
         model_version_hash
@@ -1219,6 +1223,7 @@ def _resolve_virtual_microbatch_state(
             backend=runtime.backend,
             connection_config=runtime.config.connection,
             schema=runtime.config.schema,
+            operation_lock=operation_lock,
         ),
         MicrobatchScope(
             scope_kind=VIRTUAL_MICROBATCH_SCOPE_KIND,

--- a/src/sqlbuild/virtual/state/classes/microbatch_store.py
+++ b/src/sqlbuild/virtual/state/classes/microbatch_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from typing import Any
 
@@ -14,7 +15,7 @@ from sqlbuild.virtual.state.classes.state_backend import StateBackend
 
 
 class VirtualMicrobatchEventStore:
-    """Open a short-lived backend connection for each event operation."""
+    """Serialize short-lived backend connections for each event operation."""
 
     def __init__(
         self,
@@ -22,42 +23,48 @@ class VirtualMicrobatchEventStore:
         backend: StateBackend,
         connection_config: dict[str, object],
         schema: str,
+        operation_lock: threading.Lock,
     ) -> None:
         self._backend = backend
         self._connection_config = connection_config
         self._schema = schema
+        self._operation_lock = operation_lock
 
     def write(self, event: MicrobatchEvent) -> None:
         for attempt in range(MICROBATCH_WRITE_ATTEMPTS):
-            connection: Any = self._backend.connect(self._connection_config)
             try:
-                self._backend.append_microbatch_event(
-                    connection=connection, schema=self._schema, event=event
-                )
+                with self._operation_lock:
+                    connection: Any = self._backend.connect(self._connection_config)
+                    try:
+                        self._backend.append_microbatch_event(
+                            connection=connection, schema=self._schema, event=event
+                        )
+                    finally:
+                        self._backend.close(connection)
                 return
             except Exception:
                 if attempt + 1 == MICROBATCH_WRITE_ATTEMPTS:
                     raise
                 time.sleep(MICROBATCH_WRITE_RETRY_BASE_SECONDS * (attempt + 1))
+
+    def read_scope_history(self, scope: MicrobatchScope) -> tuple[MicrobatchEvent, ...]:
+        with self._operation_lock:
+            connection: Any = self._backend.connect(self._connection_config)
+            try:
+                return self._backend.read_microbatch_scope_history(
+                    connection=connection, schema=self._schema, scope=scope
+                )
             finally:
                 self._backend.close(connection)
 
-    def read_scope_history(self, scope: MicrobatchScope) -> tuple[MicrobatchEvent, ...]:
-        connection: Any = self._backend.connect(self._connection_config)
-        try:
-            return self._backend.read_microbatch_scope_history(
-                connection=connection, schema=self._schema, scope=scope
-            )
-        finally:
-            self._backend.close(connection)
-
     def read_model_history(self, scope: MicrobatchScope) -> tuple[MicrobatchEvent, ...]:
-        connection: Any = self._backend.connect(self._connection_config)
-        try:
-            return self._backend.read_microbatch_model_history(
-                connection=connection,
-                schema=self._schema,
-                scope=scope,
-            )
-        finally:
-            self._backend.close(connection)
+        with self._operation_lock:
+            connection: Any = self._backend.connect(self._connection_config)
+            try:
+                return self._backend.read_microbatch_model_history(
+                    connection=connection,
+                    schema=self._schema,
+                    scope=scope,
+                )
+            finally:
+                self._backend.close(connection)


### PR DESCRIPTION
## Why

Concurrent virtual microbatch completions can open overlapping connections to the same DuckDB state file. DuckDB intermittently reports a unique file-handle conflict, turning successful target DML into a microbatch-state failure and making the E2E suite flaky. This is tracked by CHI-100.

## Changes

- share one build-scoped lock across virtual microbatch event stores
- serialize only state connection operations while preserving concurrent warehouse DML
- include connection creation in the existing retry boundary
- keep retry backoff outside the shared lock

## Verification

- failing partial replay lifecycle test passed 6 times after the fix
- complete virtual microbatch lifecycle file: 6 passed
- DuckDB state and microbatch lease integration tests: 27 passed
- Ruff passed
- ty passed
- Fensu passed with 0 faults
