### PR TITLE
perf(compiler): complete large-project roadmap

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/compile/pipeline.py
+++ b/src/sqlbuild/cli/commands/_helpers/compile/pipeline.py
@@ -60,6 +60,7 @@ def analyze_compile_project(
     _ = start_compile_phase(status=status, message="Discovering project...")
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(
         project_dir=project_dir,
+        extract_output_column_locations=False,
         sql_analysis_enabled_override=(
             False if profile_flags.skip_discovery_sql_analysis else None
         ),

--- a/src/sqlbuild/cli/commands/_helpers/compile/target_writer.py
+++ b/src/sqlbuild/cli/commands/_helpers/compile/target_writer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import shutil
 from pathlib import Path
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
@@ -37,12 +36,14 @@ def write_compile_target(
 ) -> WrittenTarget:
     """Write compiled output files under target_dir."""
 
-    _clean_target(target_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
-    _write_models(target_dir=target_dir, plan_output=plan_output)
-    _write_functions(target_dir=target_dir, adapter=adapter, plan_output=plan_output)
-    _write_audits(target_dir=target_dir, plan_output=plan_output)
-    _write_tests(target_dir=target_dir, adapter=adapter, plan_output=plan_output)
+    managed_paths: set[Path] = set().union(
+        _write_models(target_dir=target_dir, plan_output=plan_output),
+        _write_functions(target_dir=target_dir, adapter=adapter, plan_output=plan_output),
+        _write_audits(target_dir=target_dir, plan_output=plan_output),
+        _write_tests(target_dir=target_dir, adapter=adapter, plan_output=plan_output),
+    )
+    _remove_stale_compiled_files(target_dir=target_dir, managed_paths=managed_paths)
     if manifest is not None:
         _write_manifest(target_dir=target_dir, manifest=manifest)
 
@@ -65,12 +66,14 @@ def write_static_compile_target(
 ) -> WrittenTarget:
     """Write offline compiled output files under target_dir."""
 
-    _clean_target(target_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
-    _write_static_models(target_dir=target_dir, project=project)
-    _write_static_functions(target_dir=target_dir, adapter=adapter, project=project)
-    _write_static_audits(target_dir=target_dir, project=project)
-    _write_static_tests(target_dir=target_dir, adapter=adapter, project=project)
+    managed_paths: set[Path] = set().union(
+        _write_static_models(target_dir=target_dir, project=project),
+        _write_static_functions(target_dir=target_dir, adapter=adapter, project=project),
+        _write_static_audits(target_dir=target_dir, project=project),
+        _write_static_tests(target_dir=target_dir, adapter=adapter, project=project),
+    )
+    _remove_stale_compiled_files(target_dir=target_dir, managed_paths=managed_paths)
     if manifest is not None:
         _write_manifest(target_dir=target_dir, manifest=manifest)
 
@@ -84,33 +87,37 @@ def write_static_compile_target(
     )
 
 
-def _clean_target(target_dir: Path) -> None:
-    """Remove generated compile output directories from target/."""
-
-    compiled_dir: Path = target_dir / _COMPILED_DIR
-    if compiled_dir.exists():
-        shutil.rmtree(compiled_dir)
-
-
-def _write_models(*, target_dir: Path, plan_output: PlanOutput) -> None:
+def _write_models(*, target_dir: Path, plan_output: PlanOutput) -> set[Path]:
     """Write model resolved SQL."""
 
+    managed_paths: set[Path] = set()
     for entry in plan_output.model_entries:
         compiled_path: Path = target_dir / _COMPILED_DIR / _model_output_path(entry.relative_path)
         _write_sql(path=compiled_path, sql=entry.resolved_sql)
+        managed_paths.add(compiled_path)
+    return managed_paths
 
 
-def _write_static_models(*, target_dir: Path, project: CompiledProject) -> None:
+def _write_static_models(*, target_dir: Path, project: CompiledProject) -> set[Path]:
     """Write offline model query SQL."""
 
+    managed_paths: set[Path] = set()
     for model in project.models:
         compiled_path: Path = target_dir / _COMPILED_DIR / _model_output_path(model.relative_path)
         _write_sql(path=compiled_path, sql=model.query_sql)
+        managed_paths.add(compiled_path)
+    return managed_paths
 
 
-def _write_functions(*, target_dir: Path, adapter: BaseAdapter, plan_output: PlanOutput) -> None:
+def _write_functions(
+    *,
+    target_dir: Path,
+    adapter: BaseAdapter,
+    plan_output: PlanOutput,
+) -> set[Path]:
     """Write executable SQL function DDL."""
 
+    managed_paths: set[Path] = set()
     for entry in plan_output.function_entries:
         if entry.destination.qualified_name is None:
             continue
@@ -130,14 +137,23 @@ def _write_functions(*, target_dir: Path, adapter: BaseAdapter, plan_output: Pla
             / _COMPILED_DIR
             / _function_output_path(relative_path=entry.relative_path, language=entry.language)
         )
-        _write_sql(path=function_path, sql=";\n\n".join(statements))
+        _write_sql(
+            path=function_path,
+            sql=";\n\n".join(statements),
+        )
+        managed_paths.add(function_path)
+    return managed_paths
 
 
 def _write_static_functions(
-    *, target_dir: Path, adapter: BaseAdapter, project: CompiledProject
-) -> None:
+    *,
+    target_dir: Path,
+    adapter: BaseAdapter,
+    project: CompiledProject,
+) -> set[Path]:
     """Write offline rendered SQL function DDL."""
 
+    managed_paths: set[Path] = set()
     for function in project.functions:
         if function.destination.qualified_name is None:
             continue
@@ -159,22 +175,31 @@ def _write_static_functions(
                 relative_path=function.relative_path, language=function.language
             )
         )
-        _write_sql(path=function_path, sql=";\n\n".join(statements))
+        _write_sql(
+            path=function_path,
+            sql=";\n\n".join(statements),
+        )
+        managed_paths.add(function_path)
+    return managed_paths
 
 
-def _write_audits(*, target_dir: Path, plan_output: PlanOutput) -> None:
+def _write_audits(*, target_dir: Path, plan_output: PlanOutput) -> set[Path]:
     """Write resolved audit SQL."""
 
+    managed_paths: set[Path] = set()
     for entry in plan_output.audit_entries:
         folder: Path = _audit_folder(entry)
         file_name: str = _audit_file_name(entry)
         audit_path: Path = target_dir / _COMPILED_DIR / _AUDITS_DIR / folder / file_name
         _write_sql(path=audit_path, sql=entry.resolved_sql)
+        managed_paths.add(audit_path)
+    return managed_paths
 
 
-def _write_static_audits(*, target_dir: Path, project: CompiledProject) -> None:
+def _write_static_audits(*, target_dir: Path, project: CompiledProject) -> set[Path]:
     """Write offline resolved audit SQL."""
 
+    managed_paths: set[Path] = set()
     for audit in project.audits:
         folder: Path = _static_audit_folder(attached_target_name=audit.attached_target_name)
         file_name: str = _static_audit_file_name(
@@ -184,11 +209,19 @@ def _write_static_audits(*, target_dir: Path, project: CompiledProject) -> None:
         )
         audit_path: Path = target_dir / _COMPILED_DIR / _AUDITS_DIR / folder / file_name
         _write_sql(path=audit_path, sql=audit.sql_body)
+        managed_paths.add(audit_path)
+    return managed_paths
 
 
-def _write_tests(*, target_dir: Path, adapter: BaseAdapter, plan_output: PlanOutput) -> None:
+def _write_tests(
+    *,
+    target_dir: Path,
+    adapter: BaseAdapter,
+    plan_output: PlanOutput,
+) -> set[Path]:
     """Write resolved SQL-native test SQL."""
 
+    managed_paths: set[Path] = set()
     for entry in plan_output.test_entries:
         test_path: Path = (
             target_dir / _COMPILED_DIR / _TESTS_DIR / _test_folder(entry) / f"{entry.name}.sql"
@@ -201,13 +234,19 @@ def _write_tests(*, target_dir: Path, adapter: BaseAdapter, plan_output: PlanOut
                 sql_analysis_dialect=adapter.sql_analysis_dialect(),
             ),
         )
+        managed_paths.add(test_path)
+    return managed_paths
 
 
 def _write_static_tests(
-    *, target_dir: Path, adapter: BaseAdapter, project: CompiledProject
-) -> None:
+    *,
+    target_dir: Path,
+    adapter: BaseAdapter,
+    project: CompiledProject,
+) -> set[Path]:
     """Write offline SQL-native test SQL."""
 
+    managed_paths: set[Path] = set()
     for test in project.sql_tests:
         entry, _warnings = build_sql_test_plan_entry(
             test=test,
@@ -226,20 +265,47 @@ def _write_static_tests(
                 sql_analysis_dialect=adapter.sql_analysis_dialect(),
             ),
         )
+        managed_paths.add(test_path)
+    return managed_paths
 
 
 def _write_manifest(*, target_dir: Path, manifest: dict[str, object]) -> None:
     """Write manifest.json."""
 
     manifest_path: Path = target_dir / _MANIFEST_FILE
-    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    _write_text_if_changed(path=manifest_path, contents=json.dumps(manifest, indent=2) + "\n")
 
 
 def _write_sql(*, path: Path, sql: str) -> None:
     """Write one SQL file."""
 
+    _write_text_if_changed(path=path, contents=sql.rstrip() + "\n")
+
+
+def _write_text_if_changed(*, path: Path, contents: str) -> None:
+    if path.is_file() and path.read_text(encoding="utf-8") == contents:
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(sql.rstrip() + "\n", encoding="utf-8")
+    path.write_text(contents, encoding="utf-8")
+
+
+def _remove_stale_compiled_files(*, target_dir: Path, managed_paths: set[Path]) -> None:
+    compiled_dir: Path = target_dir / _COMPILED_DIR
+    if not compiled_dir.is_dir():
+        return
+    for path in compiled_dir.rglob("*"):
+        if path.is_file() and path not in managed_paths:
+            path.unlink()
+    directories: list[Path] = sorted(
+        (path for path in compiled_dir.rglob("*") if path.is_dir()),
+        key=lambda path: len(path.parts),
+        reverse=True,
+    )
+    for directory in (*directories, compiled_dir):
+        try:
+            directory.rmdir()
+        except OSError:
+            pass
 
 
 def _model_output_path(relative_path: Path) -> Path:

--- a/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
+++ b/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
-import os
 import platform
-import tempfile
+import sqlite3
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from string import hexdigits
 from typing import Any, cast
 
 from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
@@ -32,8 +30,16 @@ from sqlbuild.compiler.lineage.types import (
 _ANALYSIS_CACHE_VERSION: int = 1
 _ANALYSIS_ALGORITHM_FINGERPRINT: str = "model-sql-analysis-v1"
 _MAX_CACHE_ENTRY_BYTES: int = 10_000_000
-_SHA256_HEX_LENGTH: int = 64
 _LOCAL_QUALNAME_MARKER: str = "<locals>"
+_SQLITE_QUERY_CHUNK_SIZE: int = 500
+_SQLITE_TIMEOUT_SECONDS: float = 0.1
+_CACHE_DATABASE_NAME: str = "model-analysis.sqlite3"
+_CREATE_CACHE_TABLE_SQL: str = """
+CREATE TABLE IF NOT EXISTS model_analysis (
+    cache_key TEXT PRIMARY KEY,
+    payload TEXT NOT NULL
+)
+"""
 
 
 def build_analysis_cache_context(
@@ -98,59 +104,89 @@ def model_analysis_cache_key(
     )
 
 
-def read_model_analysis(
-    *, context: AnalysisCacheContext, cache_key: str
-) -> PolyglotAnalysisResult | None:
-    """Read a successful cached analysis, treating any invalid entry as a miss."""
-
-    try:
-        path: Path = _cache_path(context=context, cache_key=cache_key)
-        with path.open(encoding="utf-8") as cache_file:
-            if os.fstat(cache_file.fileno()).st_size > _MAX_CACHE_ENTRY_BYTES:
-                return None
-            payload: object = json.load(cache_file)
-        return _analysis_from_payload(payload=payload, expected_cache_key=cache_key)
-    except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
-        return None
-
-
-def write_model_analysis(
+def read_model_analyses(
     *,
     context: AnalysisCacheContext,
-    cache_key: str,
-    analysis: PolyglotAnalysisResult,
-) -> None:
-    """Atomically persist one successful analysis; cache failures never fail compilation."""
+    cache_keys: tuple[str, ...],
+) -> dict[str, PolyglotAnalysisResult]:
+    """Read cached analyses in batches, treating invalid entries or storage as misses."""
 
-    if not analysis.analysis_succeeded:
+    database_path: Path = _cache_database_path(context=context)
+    if not database_path.is_file() or not cache_keys:
+        return {}
+    analyses: dict[str, PolyglotAnalysisResult] = {}
+    try:
+        connection_uri: str = f"file:{database_path}?mode=ro"
+        with sqlite3.connect(
+            connection_uri,
+            uri=True,
+            timeout=_SQLITE_TIMEOUT_SECONDS,
+        ) as connection:
+            for start in range(0, len(cache_keys), _SQLITE_QUERY_CHUNK_SIZE):
+                chunk: tuple[str, ...] = cache_keys[start : start + _SQLITE_QUERY_CHUNK_SIZE]
+                placeholders: str = ",".join("?" for _ in chunk)
+                rows: list[tuple[str, str]] = connection.execute(
+                    f"SELECT cache_key, payload FROM model_analysis "
+                    f"WHERE cache_key IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+                for cache_key, contents in rows:
+                    analysis: PolyglotAnalysisResult | None = _analysis_from_contents(
+                        contents=contents,
+                        expected_cache_key=cache_key,
+                    )
+                    if analysis is not None:
+                        analyses[cache_key] = analysis
+    except (OSError, sqlite3.DatabaseError):
+        return {}
+    return analyses
+
+
+def write_model_analyses(
+    *,
+    context: AnalysisCacheContext,
+    analyses_by_key: dict[str, PolyglotAnalysisResult],
+) -> None:
+    """Transactionally persist successful analyses; cache failures never fail compilation."""
+
+    rows: list[tuple[str, str]] = [
+        (
+            cache_key,
+            json.dumps(
+                _analysis_payload(cache_key=cache_key, analysis=analysis),
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        )
+        for cache_key, analysis in analyses_by_key.items()
+        if analysis.analysis_succeeded
+    ]
+    if not rows:
         return
     try:
-        path: Path = _cache_path(context=context, cache_key=cache_key)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        contents: str = json.dumps(
-            _analysis_payload(cache_key=cache_key, analysis=analysis),
-            ensure_ascii=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        )
-        temporary_path: Path | None = None
-        try:
-            with tempfile.NamedTemporaryFile(
-                mode="w",
-                encoding="utf-8",
-                dir=path.parent,
-                prefix=f".{path.name}.",
-                suffix=".tmp",
-                delete=False,
-            ) as temporary:
-                temporary.write(contents)
-                temporary_path = Path(temporary.name)
-            os.replace(temporary_path, path)
-        finally:
-            if temporary_path is not None and temporary_path.exists():
-                temporary_path.unlink()
-    except OSError:
+        database_path: Path = _cache_database_path(context=context)
+        database_path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(database_path, timeout=_SQLITE_TIMEOUT_SECONDS) as connection:
+            _ = connection.execute(_CREATE_CACHE_TABLE_SQL)
+            _ = connection.executemany(
+                "INSERT OR REPLACE INTO model_analysis (cache_key, payload) VALUES (?, ?)",
+                rows,
+            )
+    except (OSError, sqlite3.DatabaseError):
         return
+
+
+def _analysis_from_contents(
+    *, contents: str, expected_cache_key: str
+) -> PolyglotAnalysisResult | None:
+    if len(contents.encode("utf-8")) > _MAX_CACHE_ENTRY_BYTES:
+        return None
+    try:
+        payload: object = json.loads(contents)
+        return _analysis_from_payload(payload=payload, expected_cache_key=expected_cache_key)
+    except (ValueError, TypeError, KeyError, json.JSONDecodeError):
+        return None
 
 
 def _inference_profile_payload(
@@ -314,13 +350,8 @@ def _lineage_column_from_payload(payload: dict[str, Any]) -> CompiledLineageColu
     )
 
 
-def _cache_path(*, context: AnalysisCacheContext, cache_key: str) -> Path:
-    if len(cache_key) != _SHA256_HEX_LENGTH or any(
-        character not in hexdigits for character in cache_key
-    ):
-        raise AnalysisCacheEntryError("analysis cache key must be a SHA-256 digest")
-    root: Path = context.root / f"v{_ANALYSIS_CACHE_VERSION}" / "objects"
-    return root / cache_key[:2] / f"{cache_key}.json"
+def _cache_database_path(*, context: AnalysisCacheContext) -> Path:
+    return context.root / f"v{_ANALYSIS_CACHE_VERSION}" / _CACHE_DATABASE_NAME
 
 
 def _payload_digest(payload: object) -> str:

--- a/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
+++ b/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
@@ -235,9 +235,7 @@ def _nullability_payload(
     return payload
 
 
-def _analysis_payload(
-    *, cache_key: str, analysis: PolyglotAnalysisResult
-) -> dict[str, object]:
+def _analysis_payload(*, cache_key: str, analysis: PolyglotAnalysisResult) -> dict[str, object]:
     analysis_payload: dict[str, object] = {
         "columns": (
             None
@@ -251,9 +249,7 @@ def _analysis_payload(
                 for column in analysis.columns
             ]
         ),
-        "lineage_columns": [
-            _lineage_column_payload(column) for column in analysis.lineage_columns
-        ],
+        "lineage_columns": [_lineage_column_payload(column) for column in analysis.lineage_columns],
         "has_star": analysis.has_star,
     }
     return {
@@ -281,9 +277,7 @@ def _lineage_column_payload(column: CompiledLineageColumnFact) -> dict[str, obje
     }
 
 
-def _analysis_from_payload(
-    *, payload: object, expected_cache_key: str
-) -> PolyglotAnalysisResult:
+def _analysis_from_payload(*, payload: object, expected_cache_key: str) -> PolyglotAnalysisResult:
     if not isinstance(payload, dict):
         raise AnalysisCacheEntryError("analysis cache entry must be an object")
     values: dict[str, Any] = cast(dict[str, Any], payload)

--- a/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
+++ b/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
@@ -1,0 +1,340 @@
+"""Versioned project-local cache for successful model SQL analysis facts."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+import platform
+import tempfile
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from string import hexdigits
+from typing import Any, cast
+
+from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
+from sqlbuild.compiler.compile.exceptions import AnalysisCacheEntryError
+from sqlbuild.compiler.compile.models import (
+    AnalysisCacheContext,
+    CompiledLineageColumnFact,
+    CompiledLineageSourceFact,
+    CompileSqlReference,
+    InferredColumn,
+    PolyglotAnalysisResult,
+)
+from sqlbuild.compiler.lineage.types import (
+    ColumnLineageConfidence,
+    ColumnTransformKind,
+    InferredNullability,
+)
+
+_ANALYSIS_CACHE_VERSION: int = 1
+_ANALYSIS_ALGORITHM_FINGERPRINT: str = "model-sql-analysis-v1"
+_MAX_CACHE_ENTRY_BYTES: int = 10_000_000
+_SHA256_HEX_LENGTH: int = 64
+_LOCAL_QUALNAME_MARKER: str = "<locals>"
+
+
+def build_analysis_cache_context(
+    *,
+    root: Path | None,
+    inference_profile: ExpressionInferenceProfile,
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+    column_types_by_table: dict[str, dict[str, str]],
+    allow_compact_analysis: bool,
+) -> AnalysisCacheContext | None:
+    """Build a reusable cache context, or bypass when profile identity is unstable."""
+
+    if root is None:
+        return None
+    profile_payload: dict[str, object] | None = _inference_profile_payload(inference_profile)
+    if profile_payload is None:
+        return None
+    shared_payload: dict[str, object] = {
+        "algorithm": _ANALYSIS_ALGORITHM_FINGERPRINT,
+        "cache_version": _ANALYSIS_CACHE_VERSION,
+        "sqlbuild_version": _package_version("sqlbuild"),
+        "polyglot_version": _package_version("polyglot-sql"),
+        "python_version": platform.python_version_tuple()[:2],
+        "allow_compact_analysis": allow_compact_analysis,
+        "inference_profile": profile_payload,
+        "column_nullability_by_table": _nullability_payload(column_nullability_by_table),
+        "column_types_by_table": {
+            table: dict(sorted(columns.items()))
+            for table, columns in sorted(column_types_by_table.items())
+        },
+    }
+    return AnalysisCacheContext(
+        root=root,
+        shared_fingerprint=_payload_digest(shared_payload),
+    )
+
+
+def model_analysis_cache_key(
+    *,
+    context: AnalysisCacheContext,
+    query_sql: str,
+    references: tuple[CompileSqlReference, ...],
+    placeholders: dict[str, str] | None,
+) -> str:
+    """Return the exact analysis identity for one expanded model query."""
+
+    return _payload_digest(
+        {
+            "shared_fingerprint": context.shared_fingerprint,
+            "query_sql": query_sql,
+            "references": [
+                {
+                    "kind": str(reference.ref_kind),
+                    "name": reference.ref_name,
+                    "package": reference.ref_package,
+                    "call_argument_count": reference.call_argument_count,
+                }
+                for reference in references
+            ],
+            "placeholders": dict(sorted((placeholders or {}).items())),
+        }
+    )
+
+
+def read_model_analysis(
+    *, context: AnalysisCacheContext, cache_key: str
+) -> PolyglotAnalysisResult | None:
+    """Read a successful cached analysis, treating any invalid entry as a miss."""
+
+    try:
+        path: Path = _cache_path(context=context, cache_key=cache_key)
+        with path.open(encoding="utf-8") as cache_file:
+            if os.fstat(cache_file.fileno()).st_size > _MAX_CACHE_ENTRY_BYTES:
+                return None
+            payload: object = json.load(cache_file)
+        return _analysis_from_payload(payload=payload, expected_cache_key=cache_key)
+    except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+        return None
+
+
+def write_model_analysis(
+    *,
+    context: AnalysisCacheContext,
+    cache_key: str,
+    analysis: PolyglotAnalysisResult,
+) -> None:
+    """Atomically persist one successful analysis; cache failures never fail compilation."""
+
+    if not analysis.analysis_succeeded:
+        return
+    try:
+        path: Path = _cache_path(context=context, cache_key=cache_key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        contents: str = json.dumps(
+            _analysis_payload(cache_key=cache_key, analysis=analysis),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=path.parent,
+                prefix=f".{path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as temporary:
+                temporary.write(contents)
+                temporary_path = Path(temporary.name)
+            os.replace(temporary_path, path)
+        finally:
+            if temporary_path is not None and temporary_path.exists():
+                temporary_path.unlink()
+    except OSError:
+        return
+
+
+def _inference_profile_payload(
+    profile: ExpressionInferenceProfile,
+) -> dict[str, object] | None:
+    rules: list[dict[str, str]] = []
+    for name, rule in sorted(profile.function_nullability_rules.items()):
+        if not inspect.isfunction(rule):
+            return None
+        module: str = rule.__module__
+        qualname: str = rule.__qualname__
+        if (
+            not module.startswith("sqlbuild.")
+            or _LOCAL_QUALNAME_MARKER in qualname
+            or rule.__closure__ is not None
+            or rule.__defaults__ is not None
+            or rule.__kwdefaults__ is not None
+        ):
+            return None
+        try:
+            source: str = inspect.getsource(rule)
+        except (OSError, TypeError):
+            return None
+        rules.append(
+            {
+                "name": name,
+                "module": module,
+                "qualname": qualname,
+                "source_digest": hashlib.sha256(source.encode("utf-8")).hexdigest(),
+            }
+        )
+    return {
+        "sql_analysis_dialect": profile.sql_analysis_dialect,
+        "function_nullability_rules": rules,
+    }
+
+
+def _nullability_payload(
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+) -> dict[str, dict[str, str]]:
+    payload: dict[str, dict[str, str]] = {}
+    for table, columns in sorted(column_nullability_by_table.items()):
+        payload[table] = {
+            column: nullability.value for column, nullability in sorted(columns.items())
+        }
+    return payload
+
+
+def _analysis_payload(
+    *, cache_key: str, analysis: PolyglotAnalysisResult
+) -> dict[str, object]:
+    analysis_payload: dict[str, object] = {
+        "columns": (
+            None
+            if analysis.columns is None
+            else [
+                {
+                    "name": column.name,
+                    "type": column.type,
+                    "nullability": column.nullability.value,
+                }
+                for column in analysis.columns
+            ]
+        ),
+        "lineage_columns": [
+            _lineage_column_payload(column) for column in analysis.lineage_columns
+        ],
+        "has_star": analysis.has_star,
+    }
+    return {
+        "version": _ANALYSIS_CACHE_VERSION,
+        "cache_key": cache_key,
+        "analysis_succeeded": True,
+        "analysis_digest": _payload_digest(analysis_payload),
+        "analysis": analysis_payload,
+    }
+
+
+def _lineage_column_payload(column: CompiledLineageColumnFact) -> dict[str, object]:
+    return {
+        "output_column": column.output_column,
+        "transform_kind": column.transform_kind.value,
+        "confidence": column.confidence.value,
+        "upstream_columns": [
+            {
+                "resource_type": str(source.resource_type),
+                "resource_name": source.resource_name,
+                "column_name": source.column_name,
+            }
+            for source in column.upstream_columns
+        ],
+    }
+
+
+def _analysis_from_payload(
+    *, payload: object, expected_cache_key: str
+) -> PolyglotAnalysisResult:
+    if not isinstance(payload, dict):
+        raise AnalysisCacheEntryError("analysis cache entry must be an object")
+    values: dict[str, Any] = cast(dict[str, Any], payload)
+    version_value: object = values["version"]
+    if type(version_value) is not int or version_value != _ANALYSIS_CACHE_VERSION:
+        raise AnalysisCacheEntryError("analysis cache version mismatch")
+    if values["cache_key"] != expected_cache_key:
+        raise AnalysisCacheEntryError("analysis cache key mismatch")
+    if values["analysis_succeeded"] is not True:
+        raise AnalysisCacheEntryError("analysis cache contains an unsuccessful result")
+    analysis_payload: object = values["analysis"]
+    if not isinstance(analysis_payload, dict):
+        raise AnalysisCacheEntryError("analysis cache facts must be an object")
+    if values["analysis_digest"] != _payload_digest(analysis_payload):
+        raise AnalysisCacheEntryError("analysis cache facts checksum mismatch")
+    analysis_values: dict[str, Any] = cast(dict[str, Any], analysis_payload)
+    columns_payload: object = analysis_values["columns"]
+    columns: tuple[InferredColumn, ...] | None = (
+        None
+        if columns_payload is None
+        else tuple(
+            InferredColumn(
+                name=str(column["name"]),
+                type=None if column.get("type") is None else str(column["type"]),
+                nullability=InferredNullability(str(column["nullability"])),
+            )
+            for column in _object_list(columns_payload)
+        )
+    )
+    lineage_columns: tuple[CompiledLineageColumnFact, ...] = tuple(
+        _lineage_column_from_payload(column)
+        for column in _object_list(analysis_values["lineage_columns"])
+    )
+    has_star: object = analysis_values["has_star"]
+    if not isinstance(has_star, bool):
+        raise AnalysisCacheEntryError("analysis cache has_star must be a boolean")
+    return PolyglotAnalysisResult(
+        analysis_succeeded=True,
+        columns=columns,
+        lineage_columns=lineage_columns,
+        has_star=has_star,
+    )
+
+
+def _object_list(payload: object) -> list[dict[str, Any]]:
+    if not isinstance(payload, list) or not all(isinstance(item, dict) for item in payload):
+        raise AnalysisCacheEntryError("analysis cache collection must contain objects")
+    return cast(list[dict[str, Any]], payload)
+
+
+def _lineage_column_from_payload(payload: dict[str, Any]) -> CompiledLineageColumnFact:
+    return CompiledLineageColumnFact(
+        output_column=str(payload["output_column"]),
+        transform_kind=ColumnTransformKind(str(payload["transform_kind"])),
+        confidence=ColumnLineageConfidence(str(payload["confidence"])),
+        upstream_columns=tuple(
+            CompiledLineageSourceFact(
+                resource_type=str(source["resource_type"]),
+                resource_name=str(source["resource_name"]),
+                column_name=str(source["column_name"]),
+            )
+            for source in _object_list(payload["upstream_columns"])
+        ),
+    )
+
+
+def _cache_path(*, context: AnalysisCacheContext, cache_key: str) -> Path:
+    if len(cache_key) != _SHA256_HEX_LENGTH or any(
+        character not in hexdigits for character in cache_key
+    ):
+        raise AnalysisCacheEntryError("analysis cache key must be a SHA-256 digest")
+    root: Path = context.root / f"v{_ANALYSIS_CACHE_VERSION}" / "objects"
+    return root / cache_key[:2] / f"{cache_key}.json"
+
+
+def _payload_digest(payload: object) -> str:
+    encoded: bytes = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _package_version(package: str) -> str:
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return "unknown"

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -65,6 +65,9 @@ from sqlbuild.compiler.compile.types import (
     CompiledResourceType,
     SqlTestMode,
 )
+from sqlbuild.compiler.discovery.main._model_output_column_locations import (
+    extract_model_output_column_locations,
+)
 from sqlbuild.compiler.lineage.types import ColumnLineageMode, InferredNullability
 from sqlbuild.compiler.references.types import SqlReferenceKind
 from sqlbuild.spec.contracts.main.resolve_effective_adapter_name import (
@@ -80,6 +83,7 @@ from sqlbuild.spec.contracts.models import (
     SchemaSeedEntry,
     SourceColumnEntry,
     SourceEntry,
+    SourceLocation,
     TargetConfig,
 )
 
@@ -274,6 +278,22 @@ def _assemble_compiled_model(
             placeholders=placeholders,
             dialect=profile.sql_analysis_dialect,
         )
+    output_column_locations: dict[str, SourceLocation] = (
+        model_input.model_file.output_column_locations
+    )
+    if (
+        not model_input.model_file.output_column_locations_extracted
+        and inferred_columns is not None
+        and model_input.schema_entry is not None
+        and model_input.schema_entry.columns
+    ):
+        output_column_locations = extract_model_output_column_locations(
+            contents=model_input.model_file.contents,
+            relative_path=model_input.model_file.relative_path,
+            extract_implicit_alias_columns=(
+                model_input.model_file.extract_implicit_alias_columns
+            ),
+        )
     return CompiledModel(
         key=CompiledObjectKey(resource_type=CompiledResourceType.MODEL, name=model_name),
         deps=model_build_deps(references=model_input.references, seed_names=seed_names),
@@ -288,7 +308,7 @@ def _assemble_compiled_model(
         fast_lineage_columns=fast_lineage_columns,
         fast_lineage_has_star=fast_lineage_has_star,
         authored_sql=model_input.model_file.contents,
-        output_column_locations=model_input.model_file.output_column_locations,
+        output_column_locations=output_column_locations,
         macro_deps=find_macro_call_names(model_input.macro_source_sql),
         enum_declarations=model_input.enum_declarations,
         constant_declarations=model_input.constant_declarations,

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -120,6 +120,7 @@ def assemble_compiled_project(
     skip_column_inference: bool = False,
     column_lineage_mode: ColumnLineageMode = ColumnLineageMode.FAST,
     analysis_cache_dir: Path | None = None,
+    analysis_model_names: frozenset[str] | None = None,
 ) -> CompiledProject:
     """Convert attached compile inputs into the planner-ready project view."""
 
@@ -135,17 +136,26 @@ def assemble_compiled_project(
     column_types_by_table: dict[str, dict[str, str]] = _build_column_types_by_table(inputs)
     profile: ExpressionInferenceProfile = inference_profile or ExpressionInferenceProfile()
     allow_compact_analysis: bool = column_lineage_mode == ColumnLineageMode.RICH
-    analysis_cache: AnalysisCacheContext | None = build_analysis_cache_context(
-        root=analysis_cache_dir,
-        inference_profile=profile,
-        column_nullability_by_table=column_nullability_by_table,
-        column_types_by_table=column_types_by_table,
-        allow_compact_analysis=allow_compact_analysis,
+    analysis_cache: AnalysisCacheContext | None = (
+        build_analysis_cache_context(
+            root=analysis_cache_dir,
+            inference_profile=profile,
+            column_nullability_by_table=column_nullability_by_table,
+            column_types_by_table=column_types_by_table,
+            allow_compact_analysis=allow_compact_analysis,
+        )
+        if sql_analysis_enabled and analysis_model_names != frozenset()
+        else None
     )
     model_sql_analysis_by_name: dict[str, _ModelSqlAnalysis] = {}
     if sql_analysis_enabled:
         model_sql_analysis_by_name = _analyze_model_sql_in_parallel(
-            model_inputs=inputs.model_inputs,
+            model_inputs=tuple(
+                model_input
+                for model_input in inputs.model_inputs
+                if analysis_model_names is None
+                or _model_name(model_input) in analysis_model_names
+            ),
             column_nullability_by_table=column_nullability_by_table,
             column_types_by_table=column_types_by_table,
             inference_profile=profile,
@@ -173,7 +183,17 @@ def assemble_compiled_project(
         models=tuple(
             _assemble_compiled_model(
                 model_input=model_input,
-                sql_analysis_enabled=sql_analysis_enabled,
+                sql_analysis_enabled=(
+                    sql_analysis_enabled
+                    and (
+                        analysis_model_names is None
+                        or _model_name(model_input) in analysis_model_names
+                    )
+                ),
+                sql_validation_enabled=(
+                    analysis_model_names is None
+                    or _model_name(model_input) in analysis_model_names
+                ),
                 seed_names=seed_names,
                 column_nullability_by_table=column_nullability_by_table,
                 column_types_by_table=column_types_by_table,
@@ -243,6 +263,7 @@ def _assemble_compiled_model(
     *,
     model_input: CompileModelInput,
     sql_analysis_enabled: bool,
+    sql_validation_enabled: bool = True,
     seed_names: frozenset[str] = frozenset(),
     column_nullability_by_table: dict[str, dict[str, InferredNullability]] | None = None,
     column_types_by_table: dict[str, dict[str, str]] | None = None,
@@ -295,7 +316,7 @@ def _assemble_compiled_model(
                 column_nullability_by_table=column_nullability_by_table,
                 inference_profile=profile,
             )
-    elif model_input.sql_validation_enabled:
+    elif sql_validation_enabled and model_input.sql_validation_enabled:
         profile = inference_profile or ExpressionInferenceProfile()
         validate_sql_syntax(
             query_sql=analysis_query_sql,

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -153,8 +153,7 @@ def assemble_compiled_project(
             model_inputs=tuple(
                 model_input
                 for model_input in inputs.model_inputs
-                if analysis_model_names is None
-                or _model_name(model_input) in analysis_model_names
+                if analysis_model_names is None or _model_name(model_input) in analysis_model_names
             ),
             column_nullability_by_table=column_nullability_by_table,
             column_types_by_table=column_types_by_table,
@@ -191,8 +190,7 @@ def assemble_compiled_project(
                     )
                 ),
                 sql_validation_enabled=(
-                    analysis_model_names is None
-                    or _model_name(model_input) in analysis_model_names
+                    analysis_model_names is None or _model_name(model_input) in analysis_model_names
                 ),
                 seed_names=seed_names,
                 column_nullability_by_table=column_nullability_by_table,
@@ -337,9 +335,7 @@ def _assemble_compiled_model(
         output_column_locations = extract_model_output_column_locations(
             contents=model_input.model_file.contents,
             relative_path=model_input.model_file.relative_path,
-            extract_implicit_alias_columns=(
-                model_input.model_file.extract_implicit_alias_columns
-            ),
+            extract_implicit_alias_columns=(model_input.model_file.extract_implicit_alias_columns),
         )
     return CompiledModel(
         key=CompiledObjectKey(resource_type=CompiledResourceType.MODEL, name=model_name),

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -5,9 +5,16 @@ from __future__ import annotations
 import re
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
+from pathlib import Path
 
 from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
 from sqlbuild.adapter.contract.types import BuiltinAdapter
+from sqlbuild.compiler.compile._helpers.analysis.cache import (
+    build_analysis_cache_context,
+    model_analysis_cache_key,
+    read_model_analysis,
+    write_model_analysis,
+)
 from sqlbuild.compiler.compile._helpers.analysis.columns import (
     analyze_columns_and_lineage_with_polyglot,
     infer_columns_with_sql_analysis,
@@ -32,6 +39,7 @@ from sqlbuild.compiler.compile._helpers.render.templating import expand_template
 from sqlbuild.compiler.compile.constants import NOT_NULL_AUDIT_NAME, PRESERVE_TARGET_VALUE
 from sqlbuild.compiler.compile.main.function_node_type import function_node_type
 from sqlbuild.compiler.compile.models import (
+    AnalysisCacheContext,
     CompileAuditInput,
     CompiledAudit,
     CompiledDirectLogicSqlTestPayload,
@@ -103,6 +111,7 @@ def assemble_compiled_project(
     inference_profile: ExpressionInferenceProfile | None = None,
     skip_column_inference: bool = False,
     column_lineage_mode: ColumnLineageMode = ColumnLineageMode.FAST,
+    analysis_cache_dir: Path | None = None,
 ) -> CompiledProject:
     """Convert attached compile inputs into the planner-ready project view."""
 
@@ -117,6 +126,14 @@ def assemble_compiled_project(
     )
     column_types_by_table: dict[str, dict[str, str]] = _build_column_types_by_table(inputs)
     profile: ExpressionInferenceProfile = inference_profile or ExpressionInferenceProfile()
+    allow_compact_analysis: bool = column_lineage_mode == ColumnLineageMode.RICH
+    analysis_cache: AnalysisCacheContext | None = build_analysis_cache_context(
+        root=analysis_cache_dir,
+        inference_profile=profile,
+        column_nullability_by_table=column_nullability_by_table,
+        column_types_by_table=column_types_by_table,
+        allow_compact_analysis=allow_compact_analysis,
+    )
     model_sql_analysis_by_name: dict[str, _ModelSqlAnalysis] = {}
     if sql_analysis_enabled:
         model_sql_analysis_by_name = _analyze_model_sql_in_parallel(
@@ -124,7 +141,8 @@ def assemble_compiled_project(
             column_nullability_by_table=column_nullability_by_table,
             column_types_by_table=column_types_by_table,
             inference_profile=profile,
-            allow_compact_analysis=column_lineage_mode == ColumnLineageMode.RICH,
+            allow_compact_analysis=allow_compact_analysis,
+            analysis_cache=analysis_cache,
         )
     return CompiledProject(
         run_id=inputs.run_id,
@@ -153,7 +171,7 @@ def assemble_compiled_project(
                 column_types_by_table=column_types_by_table,
                 inference_profile=profile,
                 sql_analysis=model_sql_analysis_by_name.get(model_input.model_file.file_path.stem),
-                allow_compact_analysis=column_lineage_mode == ColumnLineageMode.RICH,
+                allow_compact_analysis=allow_compact_analysis,
             )
             for model_input in inputs.model_inputs
         ),
@@ -323,6 +341,7 @@ def _analyze_model_sql_in_parallel(
     column_types_by_table: dict[str, dict[str, str]],
     inference_profile: ExpressionInferenceProfile,
     allow_compact_analysis: bool,
+    analysis_cache: AnalysisCacheContext | None,
 ) -> dict[str, _ModelSqlAnalysis]:
     if not model_inputs:
         return {}
@@ -334,6 +353,7 @@ def _analyze_model_sql_in_parallel(
                 column_types_by_table=column_types_by_table,
                 inference_profile=inference_profile,
                 allow_compact_analysis=allow_compact_analysis,
+                analysis_cache=analysis_cache,
             )
             for model_input in model_inputs
         }
@@ -347,6 +367,7 @@ def _analyze_model_sql_in_parallel(
                     column_types_by_table=column_types_by_table,
                     inference_profile=inference_profile,
                     allow_compact_analysis=allow_compact_analysis,
+                    analysis_cache=analysis_cache,
                 ),
                 model_inputs,
             )
@@ -364,21 +385,50 @@ def _analyze_model_sql(
     column_types_by_table: dict[str, dict[str, str]],
     inference_profile: ExpressionInferenceProfile,
     allow_compact_analysis: bool,
+    analysis_cache: AnalysisCacheContext | None,
 ) -> _ModelSqlAnalysis:
     placeholders: dict[str, str] | None = _model_placeholders(model_input)
-    return _ModelSqlAnalysis(
-        polyglot_analysis=analyze_columns_and_lineage_with_polyglot(
-            query_sql=cursor_intrinsics_analysis_sql(
-                sql=model_input.query_sql,
-                cursor_type=model_input.config.values.get("cursor_type"),
-            ),
+    query_sql: str = cursor_intrinsics_analysis_sql(
+        sql=model_input.query_sql,
+        cursor_type=model_input.config.values.get("cursor_type"),
+    )
+    cache_key: str | None = (
+        model_analysis_cache_key(
+            context=analysis_cache,
+            query_sql=query_sql,
             references=model_input.references,
             placeholders=placeholders,
-            column_nullability_by_table=column_nullability_by_table,
-            column_types_by_table=column_types_by_table,
-            inference_profile=inference_profile,
-            allow_compact_analysis=allow_compact_analysis,
-        ),
+        )
+        if analysis_cache is not None
+        else None
+    )
+    cached_analysis: PolyglotAnalysisResult | None = (
+        read_model_analysis(context=analysis_cache, cache_key=cache_key)
+        if analysis_cache is not None and cache_key is not None
+        else None
+    )
+    if cached_analysis is not None:
+        return _ModelSqlAnalysis(
+            polyglot_analysis=cached_analysis,
+            placeholders=placeholders,
+        )
+    polyglot_analysis: PolyglotAnalysisResult = analyze_columns_and_lineage_with_polyglot(
+        query_sql=query_sql,
+        references=model_input.references,
+        placeholders=placeholders,
+        column_nullability_by_table=column_nullability_by_table,
+        column_types_by_table=column_types_by_table,
+        inference_profile=inference_profile,
+        allow_compact_analysis=allow_compact_analysis,
+    )
+    if analysis_cache is not None and cache_key is not None:
+        write_model_analysis(
+            context=analysis_cache,
+            cache_key=cache_key,
+            analysis=polyglot_analysis,
+        )
+    return _ModelSqlAnalysis(
+        polyglot_analysis=polyglot_analysis,
         placeholders=placeholders,
     )
 

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -12,8 +12,8 @@ from sqlbuild.adapter.contract.types import BuiltinAdapter
 from sqlbuild.compiler.compile._helpers.analysis.cache import (
     build_analysis_cache_context,
     model_analysis_cache_key,
-    read_model_analysis,
-    write_model_analysis,
+    read_model_analyses,
+    write_model_analyses,
 )
 from sqlbuild.compiler.compile._helpers.analysis.columns import (
     analyze_columns_and_lineage_with_polyglot,
@@ -103,6 +103,14 @@ _POLYGLOT_PARALLEL_ANALYSIS_MIN_MODELS: int = 32
 class _ModelSqlAnalysis:
     polyglot_analysis: PolyglotAnalysisResult
     placeholders: dict[str, str] | None
+
+
+@dataclass(frozen=True)
+class _ModelSqlAnalysisRequest:
+    model_input: CompileModelInput
+    query_sql: str
+    placeholders: dict[str, str] | None
+    cache_key: str | None
 
 
 def assemble_compiled_project(
@@ -345,32 +353,64 @@ def _analyze_model_sql_in_parallel(
 ) -> dict[str, _ModelSqlAnalysis]:
     if not model_inputs:
         return {}
+    requests: tuple[_ModelSqlAnalysisRequest, ...] = tuple(
+        _model_sql_analysis_request(model_input=model_input, analysis_cache=analysis_cache)
+        for model_input in model_inputs
+    )
+    cached_analyses: dict[str, PolyglotAnalysisResult] = (
+        read_model_analyses(
+            context=analysis_cache,
+            cache_keys=tuple(
+                request.cache_key for request in requests if request.cache_key is not None
+            ),
+        )
+        if analysis_cache is not None
+        else {}
+    )
     if len(model_inputs) < _POLYGLOT_PARALLEL_ANALYSIS_MIN_MODELS:
-        return {
-            _model_name(model_input): _analyze_model_sql(
-                model_input=model_input,
+        analyses: tuple[_ModelSqlAnalysis, ...] = tuple(
+            _analyze_model_sql(
+                request=request,
+                cached_analysis=(
+                    cached_analyses.get(request.cache_key)
+                    if request.cache_key is not None
+                    else None
+                ),
                 column_nullability_by_table=column_nullability_by_table,
                 column_types_by_table=column_types_by_table,
                 inference_profile=inference_profile,
                 allow_compact_analysis=allow_compact_analysis,
-                analysis_cache=analysis_cache,
             )
-            for model_input in model_inputs
-        }
-    workers: int = min(_POLYGLOT_ANALYSIS_WORKERS, len(model_inputs))
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        analyses: tuple[_ModelSqlAnalysis, ...] = tuple(
-            executor.map(
-                lambda model_input: _analyze_model_sql(
-                    model_input=model_input,
-                    column_nullability_by_table=column_nullability_by_table,
-                    column_types_by_table=column_types_by_table,
-                    inference_profile=inference_profile,
-                    allow_compact_analysis=allow_compact_analysis,
-                    analysis_cache=analysis_cache,
-                ),
-                model_inputs,
+            for request in requests
+        )
+    else:
+        workers: int = min(_POLYGLOT_ANALYSIS_WORKERS, len(model_inputs))
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            analyses = tuple(
+                executor.map(
+                    lambda request: _analyze_model_sql(
+                        request=request,
+                        cached_analysis=(
+                            cached_analyses.get(request.cache_key)
+                            if request.cache_key is not None
+                            else None
+                        ),
+                        column_nullability_by_table=column_nullability_by_table,
+                        column_types_by_table=column_types_by_table,
+                        inference_profile=inference_profile,
+                        allow_compact_analysis=allow_compact_analysis,
+                    ),
+                    requests,
+                )
             )
+    if analysis_cache is not None:
+        write_model_analyses(
+            context=analysis_cache,
+            analyses_by_key={
+                request.cache_key: analysis.polyglot_analysis
+                for request, analysis in zip(requests, analyses, strict=True)
+                if request.cache_key is not None and request.cache_key not in cached_analyses
+            },
         )
     return {
         _model_name(model_input): analysis
@@ -380,13 +420,38 @@ def _analyze_model_sql_in_parallel(
 
 def _analyze_model_sql(
     *,
-    model_input: CompileModelInput,
+    request: _ModelSqlAnalysisRequest,
+    cached_analysis: PolyglotAnalysisResult | None,
     column_nullability_by_table: dict[str, dict[str, InferredNullability]],
     column_types_by_table: dict[str, dict[str, str]],
     inference_profile: ExpressionInferenceProfile,
     allow_compact_analysis: bool,
-    analysis_cache: AnalysisCacheContext | None,
 ) -> _ModelSqlAnalysis:
+    if cached_analysis is not None:
+        return _ModelSqlAnalysis(
+            polyglot_analysis=cached_analysis,
+            placeholders=request.placeholders,
+        )
+    polyglot_analysis: PolyglotAnalysisResult = analyze_columns_and_lineage_with_polyglot(
+        query_sql=request.query_sql,
+        references=request.model_input.references,
+        placeholders=request.placeholders,
+        column_nullability_by_table=column_nullability_by_table,
+        column_types_by_table=column_types_by_table,
+        inference_profile=inference_profile,
+        allow_compact_analysis=allow_compact_analysis,
+    )
+    return _ModelSqlAnalysis(
+        polyglot_analysis=polyglot_analysis,
+        placeholders=request.placeholders,
+    )
+
+
+def _model_sql_analysis_request(
+    *,
+    model_input: CompileModelInput,
+    analysis_cache: AnalysisCacheContext | None,
+) -> _ModelSqlAnalysisRequest:
     placeholders: dict[str, str] | None = _model_placeholders(model_input)
     query_sql: str = cursor_intrinsics_analysis_sql(
         sql=model_input.query_sql,
@@ -402,34 +467,11 @@ def _analyze_model_sql(
         if analysis_cache is not None
         else None
     )
-    cached_analysis: PolyglotAnalysisResult | None = (
-        read_model_analysis(context=analysis_cache, cache_key=cache_key)
-        if analysis_cache is not None and cache_key is not None
-        else None
-    )
-    if cached_analysis is not None:
-        return _ModelSqlAnalysis(
-            polyglot_analysis=cached_analysis,
-            placeholders=placeholders,
-        )
-    polyglot_analysis: PolyglotAnalysisResult = analyze_columns_and_lineage_with_polyglot(
+    return _ModelSqlAnalysisRequest(
+        model_input=model_input,
         query_sql=query_sql,
-        references=model_input.references,
         placeholders=placeholders,
-        column_nullability_by_table=column_nullability_by_table,
-        column_types_by_table=column_types_by_table,
-        inference_profile=inference_profile,
-        allow_compact_analysis=allow_compact_analysis,
-    )
-    if analysis_cache is not None and cache_key is not None:
-        write_model_analysis(
-            context=analysis_cache,
-            cache_key=cache_key,
-            analysis=polyglot_analysis,
-        )
-    return _ModelSqlAnalysis(
-        polyglot_analysis=polyglot_analysis,
-        placeholders=placeholders,
+        cache_key=cache_key,
     )
 
 

--- a/src/sqlbuild/compiler/compile/constants.py
+++ b/src/sqlbuild/compiler/compile/constants.py
@@ -104,3 +104,5 @@ RESERVED_SQL_TEST_CTE_NAMES: frozenset[str] = frozenset(
         "__unexpected__",
     }
 )
+COMPILE_CACHE_DISABLE_ENV_VAR: str = "SQLBUILD_DISABLE_COMPILE_CACHE"
+COMPILE_CACHE_DISABLE_VALUE: str = "1"

--- a/src/sqlbuild/compiler/compile/exceptions.py
+++ b/src/sqlbuild/compiler/compile/exceptions.py
@@ -13,3 +13,7 @@ class CompileInputError(ValueError):
         self.message = message
         self.code = code if code is not None else self.code
         self.help = help
+
+
+class AnalysisCacheEntryError(ValueError):
+    """Raised when a persisted model analysis cache entry is invalid."""

--- a/src/sqlbuild/compiler/compile/main/_assemble_project.py
+++ b/src/sqlbuild/compiler/compile/main/_assemble_project.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
 from sqlbuild.compiler.compile._helpers.assembly.project import assemble_compiled_project
 from sqlbuild.compiler.compile.models import (
@@ -17,6 +19,7 @@ def assemble_project(
     inference_profile: ExpressionInferenceProfile | None = None,
     skip_column_inference: bool = False,
     column_lineage_mode: ColumnLineageMode = ColumnLineageMode.FAST,
+    analysis_cache_dir: Path | None = None,
 ) -> CompiledProject:
     """Convert compile inputs into the planner-ready project view."""
 
@@ -25,4 +28,5 @@ def assemble_project(
         inference_profile=inference_profile,
         skip_column_inference=skip_column_inference,
         column_lineage_mode=column_lineage_mode,
+        analysis_cache_dir=analysis_cache_dir,
     )

--- a/src/sqlbuild/compiler/compile/main/_assemble_project.py
+++ b/src/sqlbuild/compiler/compile/main/_assemble_project.py
@@ -20,6 +20,7 @@ def assemble_project(
     skip_column_inference: bool = False,
     column_lineage_mode: ColumnLineageMode = ColumnLineageMode.FAST,
     analysis_cache_dir: Path | None = None,
+    analysis_model_names: frozenset[str] | None = None,
 ) -> CompiledProject:
     """Convert compile inputs into the planner-ready project view."""
 
@@ -29,4 +30,5 @@ def assemble_project(
         skip_column_inference=skip_column_inference,
         column_lineage_mode=column_lineage_mode,
         analysis_cache_dir=analysis_cache_dir,
+        analysis_model_names=analysis_model_names,
     )

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -231,6 +231,15 @@ class AnalysisCacheContext:
 
 
 @dataclass(frozen=True)
+class CompileAnalysisSelection:
+    """Selection inputs used to limit deep model SQL analysis."""
+
+    select: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+    auto_load_sources: bool = False
+
+
+@dataclass(frozen=True)
 class CompiledObjectKey:
     """Stable logical identity for one compiled resource or external dependency."""
 

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -223,6 +223,14 @@ class PolyglotAnalysisResult:
 
 
 @dataclass(frozen=True)
+class AnalysisCacheContext:
+    """Shared project-local analysis cache identity for one compile invocation."""
+
+    root: Path
+    shared_fingerprint: str
+
+
+@dataclass(frozen=True)
 class CompiledObjectKey:
     """Stable logical identity for one compiled resource or external dependency."""
 

--- a/src/sqlbuild/compiler/discovery/_helpers/filesystem/aggregation.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/filesystem/aggregation.py
@@ -46,6 +46,7 @@ def build_discovered_project_inputs(
     project_config: ProjectConfig,
     local_config: LocalConfig,
     sql_analysis_enabled: bool,
+    extract_output_column_locations: bool = True,
 ) -> DiscoveredProjectInputs:
     """Discover all project files and functions into one inputs bundle."""
 
@@ -67,6 +68,7 @@ def build_discovered_project_inputs(
         model_files=discover_model_files(
             project_dir=project_dir,
             extract_implicit_alias_columns=sql_analysis_enabled,
+            extract_output_column_locations=extract_output_column_locations,
         ),
         enum_files=discover_enum_files(project_dir=project_dir),
         constant_files=discover_constant_files(project_dir=project_dir),

--- a/src/sqlbuild/compiler/discovery/_helpers/filesystem/aggregation.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/filesystem/aggregation.py
@@ -65,6 +65,7 @@ def build_discovered_project_inputs(
     return DiscoveredProjectInputs(
         project_config=project_config,
         local_config=local_config,
+        project_dir=project_dir,
         model_files=discover_model_files(
             project_dir=project_dir,
             extract_implicit_alias_columns=sql_analysis_enabled,

--- a/src/sqlbuild/compiler/discovery/_helpers/filesystem/core.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/filesystem/core.py
@@ -123,7 +123,10 @@ class _PythonNodeDiscoveryBucket:
 
 
 def discover_model_files(
-    *, project_dir: Path, extract_implicit_alias_columns: bool = True
+    *,
+    project_dir: Path,
+    extract_implicit_alias_columns: bool = True,
+    extract_output_column_locations: bool = True,
 ) -> tuple[DiscoveredSqlModelFile, ...]:
     """Discover SQL model files under models/."""
 
@@ -149,10 +152,14 @@ def discover_model_files(
                     contents=contents,
                     relative_path=relative_path,
                 ),
-                output_column_locations=model_output_column_locations(
-                    contents=contents,
-                    relative_path=relative_path,
-                    extract_implicit_alias_columns=extract_implicit_alias_columns,
+                output_column_locations=(
+                    model_output_column_locations(
+                        contents=contents,
+                        relative_path=relative_path,
+                        extract_implicit_alias_columns=extract_implicit_alias_columns,
+                    )
+                    if extract_output_column_locations
+                    else {}
                 ),
                 query_sql=query_sql,
                 enum_declarations=parse_model_enum_declarations(
@@ -165,6 +172,8 @@ def discover_model_files(
                     model_name=file_path.stem,
                     relative_path=relative_path,
                 ),
+                output_column_locations_extracted=extract_output_column_locations,
+                extract_implicit_alias_columns=extract_implicit_alias_columns,
             )
         )
     return tuple(discovered_model_files)

--- a/src/sqlbuild/compiler/discovery/main/_model_output_column_locations.py
+++ b/src/sqlbuild/compiler/discovery/main/_model_output_column_locations.py
@@ -1,0 +1,25 @@
+"""Public access to authored model output-column locations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlbuild.compiler.discovery._helpers.sql.model_files import (
+    model_output_column_locations,
+)
+from sqlbuild.spec.contracts.models import SourceLocation
+
+
+def extract_model_output_column_locations(
+    *,
+    contents: str,
+    relative_path: Path,
+    extract_implicit_alias_columns: bool,
+) -> dict[str, SourceLocation]:
+    """Locate authored output projections only when a compiler consumer needs them."""
+
+    return model_output_column_locations(
+        contents=contents,
+        relative_path=relative_path,
+        extract_implicit_alias_columns=extract_implicit_alias_columns,
+    )

--- a/src/sqlbuild/compiler/discovery/main/discover.py
+++ b/src/sqlbuild/compiler/discovery/main/discover.py
@@ -18,7 +18,10 @@ from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig
 
 
 def discover_project_inputs(
-    *, project_dir: Path, sql_analysis_enabled_override: bool | None = None
+    *,
+    project_dir: Path,
+    sql_analysis_enabled_override: bool | None = None,
+    extract_output_column_locations: bool = True,
 ) -> DiscoveredProjectInputs:
     """Load all raw project inputs from disk before semantic resolution."""
 
@@ -38,6 +41,7 @@ def discover_project_inputs(
         project_config=project_config,
         local_config=local_config,
         sql_analysis_enabled=sql_analysis_enabled,
+        extract_output_column_locations=extract_output_column_locations,
     )
     validate_discovered_inputs(discovered_inputs)
     return discovered_inputs

--- a/src/sqlbuild/compiler/discovery/models.py
+++ b/src/sqlbuild/compiler/discovery/models.py
@@ -53,6 +53,8 @@ class DiscoveredSqlModelFile:
     query_sql: str
     enum_declarations: tuple[EnumDeclaration, ...] = field(default_factory=tuple)
     constant_declarations: tuple[ConstantDeclaration, ...] = field(default_factory=tuple)
+    output_column_locations_extracted: bool = True
+    extract_implicit_alias_columns: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/discovery/models.py
+++ b/src/sqlbuild/compiler/discovery/models.py
@@ -381,6 +381,7 @@ class DiscoveredProjectInputs:
 
     project_config: ProjectConfig
     local_config: LocalConfig
+    project_dir: Path | None = None
     model_files: tuple[DiscoveredSqlModelFile, ...] = field(default_factory=tuple)
     enum_files: tuple[DiscoveredEnumFile, ...] = field(default_factory=tuple)
     constant_files: tuple[DiscoveredConstantFile, ...] = field(default_factory=tuple)

--- a/src/sqlbuild/compiler/pipeline/_helpers/analysis_selection.py
+++ b/src/sqlbuild/compiler/pipeline/_helpers/analysis_selection.py
@@ -1,0 +1,29 @@
+"""Selection policy for deep model SQL analysis."""
+
+from __future__ import annotations
+
+from sqlbuild.compiler.compile.models import CompileAnalysisSelection
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.compiler.pipeline.models import CompilePipelineOptions
+
+
+def resolve_compile_analysis_selection(
+    *,
+    options: CompilePipelineOptions,
+    discovered_inputs: DiscoveredProjectInputs,
+) -> CompileAnalysisSelection | None:
+    """Limit analysis when selectors cannot resolve through Python graph nodes."""
+
+    has_python_nodes: bool = bool(
+        discovered_inputs.loader_functions
+        or discovered_inputs.task_functions
+        or discovered_inputs.asset_functions
+        or discovered_inputs.check_functions
+    )
+    if options.resolve_python_run_selectors and has_python_nodes:
+        return None
+    return CompileAnalysisSelection(
+        select=options.select,
+        exclude=options.exclude,
+        auto_load_sources=options.auto_load_sources,
+    )

--- a/src/sqlbuild/compiler/pipeline/main/compile.py
+++ b/src/sqlbuild/compiler/pipeline/main/compile.py
@@ -21,6 +21,9 @@ from sqlbuild.compiler.graph.main._build_lineage_downstream_deps import (
 from sqlbuild.compiler.graph.main._build_lineage_upstream_deps import (
     build_lineage_upstream_deps,
 )
+from sqlbuild.compiler.pipeline._helpers.analysis_selection import (
+    resolve_compile_analysis_selection,
+)
 from sqlbuild.compiler.pipeline._helpers.deferred_locations import (
     build_deferred_locations,
     gather_deferred_relations,
@@ -94,6 +97,10 @@ def run_compile_pipeline(
         cli_vars=resolved_options.cli_vars,
         external_sql_reference_resolver=resolved_options.external_sql_reference_resolver,
         resolved_connection=effective_config,
+        analysis_selection=resolve_compile_analysis_selection(
+            options=resolved_options,
+            discovered_inputs=discovered_inputs,
+        ),
     )
     if on_progress is not None:
         on_progress(f"Compiled project. ({time.monotonic() - compile_start:.2f}s)")

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
 from sqlbuild.compiler.compile.main._assemble_project import assemble_project
 from sqlbuild.compiler.compile.main._build_compile_inputs import build_compile_inputs
 from sqlbuild.compiler.compile.models import (
+    CompileAnalysisSelection,
     CompiledProject,
     CompileProjectInputs,
 )
@@ -17,6 +19,14 @@ from sqlbuild.compiler.pipeline._helpers.target_defaults import apply_target_def
 from sqlbuild.compiler.pipeline._helpers.target_validation import (
     validate_managed_loader_target_isolation,
     validate_project_targets,
+)
+from sqlbuild.compiler.planner.main.selection._resolve_planner_scopes import (
+    resolve_planner_scopes,
+)
+from sqlbuild.compiler.planner.models import (
+    PlannerPolicies,
+    PlannerScopeResolution,
+    PlannerSelection,
 )
 from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.contracts.main.resolve_effective_adapter_name import (
@@ -35,6 +45,7 @@ def build_compiled_project(
     cli_vars: dict[str, object] | None = None,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
     resolved_connection: dict[str, object] | None = None,
+    analysis_selection: CompileAnalysisSelection | None = None,
 ) -> CompiledProject:
     """Build one compiled project with adapter defaults and target validation applied."""
 
@@ -54,13 +65,21 @@ def build_compiled_project(
         ),
         external_sql_reference_resolver=external_sql_reference_resolver,
     )
+    inference_profile: ExpressionInferenceProfile = adapter.expression_inference_profile()
+    analysis_cache_dir: Path | None = _analysis_cache_dir(discovered_inputs=discovered_inputs)
+    analysis_model_names: frozenset[str] | None = _resolve_analysis_model_names(
+        compile_inputs=compile_inputs,
+        inference_profile=inference_profile,
+        selection=analysis_selection,
+    )
     project: CompiledProject = apply_target_defaults(
         project=assemble_project(
             inputs=compile_inputs,
-            inference_profile=adapter.expression_inference_profile(),
+            inference_profile=inference_profile,
             skip_column_inference=skip_column_inference,
             column_lineage_mode=column_lineage_mode,
-            analysis_cache_dir=_analysis_cache_dir(discovered_inputs=discovered_inputs),
+            analysis_cache_dir=analysis_cache_dir,
+            analysis_model_names=analysis_model_names,
         ),
         default_schema=adapter.default_schema(),
         default_database=adapter.default_database(),
@@ -82,3 +101,25 @@ def build_compiled_project(
 def _analysis_cache_dir(*, discovered_inputs: DiscoveredProjectInputs) -> Path | None:
     project_dir: Path | None = discovered_inputs.project_dir
     return project_dir / "target" / "compile-cache" if project_dir is not None else None
+
+
+def _resolve_analysis_model_names(
+    *,
+    compile_inputs: CompileProjectInputs,
+    inference_profile: ExpressionInferenceProfile,
+    selection: CompileAnalysisSelection | None,
+) -> frozenset[str] | None:
+    if selection is None or (not selection.select and not selection.exclude):
+        return None
+    structural_project: CompiledProject = assemble_project(
+        inputs=compile_inputs,
+        inference_profile=inference_profile,
+        skip_column_inference=True,
+        analysis_model_names=frozenset(),
+    )
+    scopes: PlannerScopeResolution = resolve_planner_scopes(
+        project=structural_project,
+        selection=PlannerSelection(select=selection.select, exclude=selection.exclude),
+        policies=PlannerPolicies(auto_load_sources=selection.auto_load_sources),
+    )
+    return frozenset(scopes.stale_warning_scope.models_by_name)

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.compile.main._assemble_project import assemble_project
 from sqlbuild.compiler.compile.main._build_compile_inputs import build_compile_inputs
@@ -58,6 +60,7 @@ def build_compiled_project(
             inference_profile=adapter.expression_inference_profile(),
             skip_column_inference=skip_column_inference,
             column_lineage_mode=column_lineage_mode,
+            analysis_cache_dir=_analysis_cache_dir(discovered_inputs=discovered_inputs),
         ),
         default_schema=adapter.default_schema(),
         default_database=adapter.default_database(),
@@ -74,3 +77,8 @@ def build_compiled_project(
         project=project,
     )
     return project
+
+
+def _analysis_cache_dir(*, discovered_inputs: DiscoveredProjectInputs) -> Path | None:
+    project_dir: Path | None = discovered_inputs.project_dir
+    return project_dir / "target" / "compile-cache" if project_dir is not None else None

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
+from sqlbuild.compiler.compile.constants import (
+    COMPILE_CACHE_DISABLE_ENV_VAR,
+    COMPILE_CACHE_DISABLE_VALUE,
+)
 from sqlbuild.compiler.compile.main._assemble_project import assemble_project
 from sqlbuild.compiler.compile.main._build_compile_inputs import build_compile_inputs
 from sqlbuild.compiler.compile.models import (
@@ -99,6 +104,8 @@ def build_compiled_project(
 
 
 def _analysis_cache_dir(*, discovered_inputs: DiscoveredProjectInputs) -> Path | None:
+    if os.environ.get(COMPILE_CACHE_DISABLE_ENV_VAR) == COMPILE_CACHE_DISABLE_VALUE:
+        return None
     project_dir: Path | None = discovered_inputs.project_dir
     return project_dir / "target" / "compile-cache" if project_dir is not None else None
 

--- a/src/sqlbuild/compiler/planner/_helpers/planning/scopes.py
+++ b/src/sqlbuild/compiler/planner/_helpers/planning/scopes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
 from sqlbuild.compiler.planner._helpers.graph.scope import build_planner_scope
 from sqlbuild.compiler.planner.models import (
     PlannerPolicies,
@@ -29,14 +29,30 @@ def resolve_planner_scopes(
         auto_load_sources=policies.auto_load_sources,
         selected_keys=selection.selected_keys,
     )
-    stale_warning_scope: PlannerScope = replace(
-        build_planner_scope(
-            project=project,
-            select=(),
-            exclude=(),
-            auto_load_sources=policies.auto_load_sources,
-        ),
+    full_scope: PlannerScope = build_planner_scope(
+        project=project,
+        select=(),
+        exclude=(),
+        auto_load_sources=policies.auto_load_sources,
+    )
+    stale_warning_keys: frozenset[CompiledObjectKey] = _upstream_closure(
         selected_keys=selected_scope.selected_keys,
+        upstream_deps=full_scope.upstream_deps,
+    )
+    stale_warning_scope: PlannerScope = replace(
+        full_scope,
+        all_keys={
+            name: key for name, key in full_scope.all_keys.items() if key in stale_warning_keys
+        },
+        models_by_name={
+            name: model
+            for name, model in full_scope.models_by_name.items()
+            if model.key in stale_warning_keys
+        },
+        selected_keys=selected_scope.selected_keys,
+        execution_order=tuple(
+            key for key in full_scope.execution_order if key in stale_warning_keys
+        ),
         user_selected_keys=selected_scope.user_selected_keys,
     )
     return PlannerScopeResolution(
@@ -44,3 +60,21 @@ def resolve_planner_scopes(
         stale_warning_scope=stale_warning_scope,
         inspection_scope=selected_scope,
     )
+
+
+def _upstream_closure(
+    *,
+    selected_keys: frozenset[CompiledObjectKey],
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+) -> frozenset[CompiledObjectKey]:
+    closure: set[CompiledObjectKey] = set(selected_keys)
+    pending: list[CompiledObjectKey] = list(selected_keys)
+    while pending:
+        key: CompiledObjectKey = pending.pop()
+        upstream_key: CompiledObjectKey
+        for upstream_key in upstream_deps.get(key, ()):
+            if upstream_key in closure:
+                continue
+            closure.add(upstream_key)
+            pending.append(upstream_key)
+    return frozenset(closure)

--- a/src/sqlbuild/compiler/planner/main/selection/_resolve_planner_scopes.py
+++ b/src/sqlbuild/compiler/planner/main/selection/_resolve_planner_scopes.py
@@ -1,0 +1,28 @@
+"""Planner scope resolution entrypoint for compiler orchestration."""
+
+from __future__ import annotations
+
+from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.planner._helpers.planning.scopes import (
+    resolve_planner_scopes as _resolve_planner_scopes,
+)
+from sqlbuild.compiler.planner.models import (
+    PlannerPolicies,
+    PlannerScopeResolution,
+    PlannerSelection,
+)
+
+
+def resolve_planner_scopes(
+    *,
+    project: CompiledProject,
+    selection: PlannerSelection,
+    policies: PlannerPolicies,
+) -> PlannerScopeResolution:
+    """Resolve selected, stale-warning, and inspection scopes for one plan."""
+
+    return _resolve_planner_scopes(
+        project=project,
+        selection=selection,
+        policies=policies,
+    )

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_command.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_command.py
@@ -306,6 +306,29 @@ def test_given_python_project_dag_flag_when_running_compile_then_writes_python_d
                 "FROM (SELECT 1) AS source\n"
             ),
         ),
+        CompileCommandTestCase(
+            description="reports output location for undeclared contract columns",
+            expected_exit_code=1,
+            expected_stdout_fragments=(
+                "error[K005]: column 'customer_id' is not declared in enforced contract",
+                "  --> models/orders.sql:11:3",
+                " 11 |   2 AS customer_id",
+                "    |   ^^^^^^^^^^^^^^^^",
+                "  = help: add the column to MODEL(columns) or remove it from the SELECT list",
+            ),
+            model_sql=(
+                "MODEL (\n"
+                "  materialized view,\n"
+                "  contract enforced,\n"
+                "  columns (\n"
+                "    order_id (type INTEGER),\n"
+                "  ),\n"
+                ");\n\n"
+                "SELECT\n"
+                "  1 AS order_id,\n"
+                "  2 AS customer_id\n"
+            ),
+        ),
     ),
     ids=lambda case: case.description,
 )

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
@@ -130,9 +130,7 @@ def test_given_compiled_project_when_writing_static_target_then_expected_files_a
     )
 
     assert written.summary_line() == test_case.expected_summary_line
-    assert (
-        read_target_files(target_dir, test_case.expected_files) == test_case.expected_files
-    )
+    assert read_target_files(target_dir, test_case.expected_files) == test_case.expected_files
     assert model_path.stat().st_mtime_ns == unchanged_mtime_ns
     assert not stale_path.exists()
     assert not (target_dir / "manifest.json").exists()

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -68,10 +70,20 @@ def test_given_plan_output_when_writing_target_then_expected_files_are_written(
         plan_output=plan_output,
         manifest=manifest,
     )
+    manifest_path: Path = tmp_path / "target" / "manifest.json"
+    unchanged_mtime_ns: int = 1_000_000_000
+    os.utime(manifest_path, ns=(unchanged_mtime_ns, unchanged_mtime_ns))
+    _ = write_compile_target(
+        target_dir=tmp_path / "target",
+        adapter=DuckDbAdapter(),
+        plan_output=plan_output,
+        manifest=manifest,
+    )
 
     assert written.summary_line() == test_case.expected_summary_line
     assert read_target_files(tmp_path / "target", expected_files) == expected_files
-    assert json.loads((tmp_path / "target" / "manifest.json").read_text()) == manifest
+    assert json.loads(manifest_path.read_text()) == manifest
+    assert manifest_path.stat().st_mtime_ns == unchanged_mtime_ns
     assert not (tmp_path / "target" / "run").exists()
 
 
@@ -98,15 +110,42 @@ def test_given_compiled_project_when_writing_static_target_then_expected_files_a
     tmp_path: Path,
 ) -> None:
     project: CompiledProject = build_static_target_writer_project()
+    target_dir: Path = tmp_path / "target"
+    stale_path: Path = target_dir / "compiled" / "models" / "deleted.sql"
+    stale_path.parent.mkdir(parents=True)
+    stale_path.write_text("SELECT 'stale'\n", encoding="utf-8")
 
     written: WrittenTarget = write_static_compile_target(
-        target_dir=tmp_path / "target",
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=project,
+    )
+    model_path: Path = target_dir / "compiled" / "models" / "staging" / "orders.sql"
+    unchanged_mtime_ns: int = 1_000_000_000
+    os.utime(model_path, ns=(unchanged_mtime_ns, unchanged_mtime_ns))
+    _ = write_static_compile_target(
+        target_dir=target_dir,
         adapter=DuckDbAdapter(),
         project=project,
     )
 
     assert written.summary_line() == test_case.expected_summary_line
     assert (
-        read_target_files(tmp_path / "target", test_case.expected_files) == test_case.expected_files
+        read_target_files(target_dir, test_case.expected_files) == test_case.expected_files
     )
-    assert not (tmp_path / "target" / "manifest.json").exists()
+    assert model_path.stat().st_mtime_ns == unchanged_mtime_ns
+    assert not stale_path.exists()
+    assert not (target_dir / "manifest.json").exists()
+
+    changed_project: CompiledProject = replace(
+        project,
+        models=(replace(project.models[0], query_sql="SELECT 3 AS order_id"),),
+    )
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=changed_project,
+    )
+
+    assert model_path.read_text(encoding="utf-8") == "SELECT 3 AS order_id\n"
+    assert model_path.stat().st_mtime_ns != unchanged_mtime_ns

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
@@ -13,6 +13,12 @@ from sqlbuild.compiler.lineage.types import InferredNullability
 
 
 @dataclass(frozen=True)
+class AnalysisCacheTestCase:
+    description: str
+    expected_count: int
+
+
+@dataclass(frozen=True)
 class FindMatchingPathDefaultTestCase:
     description: str
     model_relative_path: str

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/helpers.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import cast
 
+from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
 from sqlbuild.compiler.compile._helpers.render.macros import load_project_macros
 from sqlbuild.compiler.compile.main._assemble_project import assemble_project
 from sqlbuild.compiler.compile.main._build_compile_inputs import build_compile_inputs
@@ -17,6 +18,7 @@ from sqlbuild.compiler.compile.models import (
 )
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredMacroFile, DiscoveredProjectInputs
+from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 
 
 def build_loaded_macros(tmp_path: Path, macro_file_contents: str) -> dict[str, LoadedMacro]:
@@ -48,6 +50,15 @@ def compile_first_model(*, project_dir: Path) -> CompiledModel:
         skip_column_inference=True,
     )
     return compiled_project.models[0]
+
+
+def compile_project_with_cache(*, project_dir: Path) -> CompiledProject:
+    """Compile a discovered DuckDB fixture through the cache-enabled project boundary."""
+
+    return build_compiled_project(
+        discovered_inputs=discover_project_inputs(project_dir=project_dir),
+        adapter=DuckDbAdapter(),
+    )
 
 
 def compiled_sql_test_expected_model_names(test: CompiledSqlTest) -> tuple[str, ...]:

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/helpers.py
@@ -8,6 +8,7 @@ from sqlbuild.compiler.compile._helpers.render.macros import load_project_macros
 from sqlbuild.compiler.compile.main._assemble_project import assemble_project
 from sqlbuild.compiler.compile.main._build_compile_inputs import build_compile_inputs
 from sqlbuild.compiler.compile.models import (
+    CompileAnalysisSelection,
     CompiledDirectLogicSqlTestPayload,
     CompiledModel,
     CompiledModelSqlTestPayload,
@@ -52,12 +53,17 @@ def compile_first_model(*, project_dir: Path) -> CompiledModel:
     return compiled_project.models[0]
 
 
-def compile_project_with_cache(*, project_dir: Path) -> CompiledProject:
+def compile_project_with_cache(
+    *,
+    project_dir: Path,
+    analysis_selection: CompileAnalysisSelection | None = None,
+) -> CompiledProject:
     """Compile a discovered DuckDB fixture through the cache-enabled project boundary."""
 
     return build_compiled_project(
         discovered_inputs=discover_project_inputs(project_dir=project_dir),
         adapter=DuckDbAdapter(),
+        analysis_selection=analysis_selection,
     )
 
 

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
@@ -15,8 +15,11 @@ from sqlbuild.compiler.compile._helpers.analysis.cache import (
     write_model_analyses,
 )
 from sqlbuild.compiler.compile._helpers.assembly import project as assembly_project
+from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.models import (
     AnalysisCacheContext,
+    CompileAnalysisSelection,
+    CompiledModel,
     CompiledProject,
     CompileSqlReference,
     PolyglotAnalysisResult,
@@ -48,6 +51,13 @@ MODEL ();
 SELECT order_id FROM __source("raw_orders")
 """.strip()
     + "\n",
+}
+_SELECTION_REPO_FILES: dict[str, str] = {
+    "sqlbuild_project.toml": 'name = "selection_demo"\nadapter = "duckdb"\n',
+    "models/root.sql": "MODEL ();\n\nSELECT 1 AS id\n",
+    "models/middle.sql": 'MODEL ();\n\nSELECT id FROM __ref("root")\n',
+    "models/leaf.sql": 'MODEL ();\n\nSELECT id FROM __ref("middle")\n',
+    "models/unrelated.sql": "MODEL ();\n\nSELECT 2 AS id\n",
 }
 
 
@@ -239,3 +249,68 @@ def test_given_analysis_inputs_when_building_keys_then_all_semantic_inputs_affec
 
     assert len(changed_keys) == test_case.expected_count
     assert all(changed_key != base_key for changed_key in changed_keys)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="selected upstream analysis", expected_count=2),),
+    ids=lambda case: case.description,
+)
+def test_given_partial_selection_when_compiling_then_analyzes_only_upstream_closure(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _SELECTION_REPO_FILES)
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+
+    project: CompiledProject = compile_project_with_cache(
+        project_dir=tmp_path,
+        analysis_selection=CompileAnalysisSelection(select=("middle",)),
+    )
+
+    inferred_by_name: dict[str, bool] = {
+        model.name: model.inferred_columns is not None for model in project.models
+    }
+    assert analyzer.call_count == test_case.expected_count
+    assert inferred_by_name == {
+        "leaf": False,
+        "middle": True,
+        "root": True,
+        "unrelated": False,
+    }
+    full_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
+    full_models_by_name: dict[str, CompiledModel] = {
+        model.name: model for model in full_project.models
+    }
+    selected_models_by_name: dict[str, CompiledModel] = {
+        model.name: model for model in project.models
+    }
+    assert selected_models_by_name["root"] == full_models_by_name["root"]
+    assert selected_models_by_name["middle"] == full_models_by_name["middle"]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="unselected invalid reference", expected_count=0),),
+    ids=lambda case: case.description,
+)
+def test_given_unselected_invalid_reference_when_compiling_then_live_validation_still_fails(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    repo_files: dict[str, str] = _SELECTION_REPO_FILES | {
+        "models/unrelated.sql": 'MODEL ();\n\nSELECT id FROM __ref("missing")\n'
+    }
+    write_repo_files(tmp_path, repo_files)
+
+    with pytest.raises(CompileInputError, match="references unknown model"):
+        _ = compile_project_with_cache(
+            project_dir=tmp_path,
+            analysis_selection=CompileAnalysisSelection(select=("middle",)),
+        )
+
+    assert len(tuple((tmp_path / "target").rglob("*.sqlite3"))) == test_case.expected_count

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
@@ -186,9 +186,7 @@ def test_given_analysis_inputs_when_building_keys_then_all_semantic_inputs_affec
     schema_context: AnalysisCacheContext | None = build_analysis_cache_context(
         root=tmp_path,
         inference_profile=ExpressionInferenceProfile(sql_analysis_dialect="duckdb"),
-        column_nullability_by_table={
-            "raw_orders": {"order_id": InferredNullability.NON_NULL}
-        },
+        column_nullability_by_table={"raw_orders": {"order_id": InferredNullability.NON_NULL}},
         column_types_by_table={},
         allow_compact_analysis=False,
     )

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
+from sqlbuild.compiler.compile._helpers.analysis.cache import (
+    build_analysis_cache_context,
+    model_analysis_cache_key,
+    write_model_analysis,
+)
+from sqlbuild.compiler.compile._helpers.assembly import project as assembly_project
+from sqlbuild.compiler.compile.models import (
+    AnalysisCacheContext,
+    CompiledProject,
+    CompileSqlReference,
+    PolyglotAnalysisResult,
+)
+from sqlbuild.compiler.lineage.types import InferredNullability
+from sqlbuild.compiler.references.types import SqlReferenceKind
+from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
+    AnalysisCacheTestCase,
+)
+from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import (
+    compile_project_with_cache,
+)
+
+_CACHE_REPO_FILES: dict[str, str] = {
+    "sqlbuild_project.toml": 'name = "cache_demo"\nadapter = "duckdb"\n',
+    "sources/raw.yml": """
+sources:
+  - name: raw_orders
+    expression: "(SELECT 1 AS order_id)"
+    columns:
+      - name: order_id
+        type: INTEGER
+        nullable: false
+""".strip()
+    + "\n",
+    "models/orders.sql": """
+MODEL ();
+
+SELECT order_id FROM __source("raw_orders")
+""".strip()
+    + "\n",
+}
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="successful cache hit", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_successful_analysis_when_compiling_again_then_reuses_identical_cached_facts(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _CACHE_REPO_FILES)
+    cold_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
+    analyzer: Mock = Mock(
+        side_effect=AssertionError("Polyglot analysis must not run on a cache hit")
+    )
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+
+    warm_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
+
+    assert warm_project.models == cold_project.models
+    assert warm_project.diagnostics == cold_project.diagnostics
+    analyzer.assert_not_called()
+    assert (
+        len(tuple((tmp_path / "target" / "compile-cache").rglob("*.json")))
+        == test_case.expected_count
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="changed SQL cache miss", expected_count=2),),
+    ids=lambda case: case.description,
+)
+def test_given_changed_expanded_sql_when_compiling_then_writes_a_new_analysis_object(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _CACHE_REPO_FILES)
+    cold_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
+    changed_sql = 'MODEL ();\n\nSELECT order_id + 1 AS order_id FROM __source("raw_orders")\n'
+    (tmp_path / "models" / "orders.sql").write_text(changed_sql, encoding="utf-8")
+
+    changed_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
+
+    assert changed_project.models[0].query_sql != cold_project.models[0].query_sql
+    assert (
+        len(tuple((tmp_path / "target" / "compile-cache").rglob("*.json")))
+        == test_case.expected_count
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="corrupt cache fallback", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_corrupt_analysis_when_compiling_then_reanalyzes_and_repairs_the_entry(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _CACHE_REPO_FILES)
+    cold_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
+    cache_path: Path = next((tmp_path / "target" / "compile-cache").rglob("*.json"))
+    cache_path.write_text('{"analysis_succeeded":true}', encoding="utf-8")
+
+    repaired_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
+
+    repaired_payload: dict[str, object] = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert repaired_project.models == cold_project.models
+    assert repaired_payload["analysis_succeeded"] is True
+    assert isinstance(repaired_payload["analysis_digest"], str)
+    assert len(tuple((tmp_path / "target" / "compile-cache").rglob("*.json"))) == (
+        test_case.expected_count
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="unsuccessful result exclusion", expected_count=0),),
+    ids=lambda case: case.description,
+)
+def test_given_unsuccessful_analysis_when_writing_then_does_not_persist_it(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+) -> None:
+    write_model_analysis(
+        context=AnalysisCacheContext(root=tmp_path, shared_fingerprint="shared"),
+        cache_key="a" * 64,
+        analysis=PolyglotAnalysisResult(analysis_succeeded=False),
+    )
+
+    assert len(tuple(tmp_path.rglob("*.json"))) == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="semantic cache identities", expected_count=5),),
+    ids=lambda case: case.description,
+)
+def test_given_analysis_inputs_when_building_keys_then_all_semantic_inputs_affect_identity(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+) -> None:
+    base_context: AnalysisCacheContext | None = build_analysis_cache_context(
+        root=tmp_path,
+        inference_profile=ExpressionInferenceProfile(sql_analysis_dialect="duckdb"),
+        column_nullability_by_table={},
+        column_types_by_table={},
+        allow_compact_analysis=False,
+    )
+    schema_context: AnalysisCacheContext | None = build_analysis_cache_context(
+        root=tmp_path,
+        inference_profile=ExpressionInferenceProfile(sql_analysis_dialect="duckdb"),
+        column_nullability_by_table={
+            "raw_orders": {"order_id": InferredNullability.NON_NULL}
+        },
+        column_types_by_table={},
+        allow_compact_analysis=False,
+    )
+    profile_context: AnalysisCacheContext | None = build_analysis_cache_context(
+        root=tmp_path,
+        inference_profile=ExpressionInferenceProfile(sql_analysis_dialect="snowflake"),
+        column_nullability_by_table={},
+        column_types_by_table={},
+        allow_compact_analysis=True,
+    )
+    assert base_context is not None
+    assert schema_context is not None
+    assert profile_context is not None
+    reference: CompileSqlReference = CompileSqlReference(
+        ref_kind=SqlReferenceKind.SOURCE,
+        ref_name="raw_orders",
+        call_argument_count=1,
+    )
+    base_key: str = model_analysis_cache_key(
+        context=base_context,
+        query_sql="SELECT 1",
+        references=(),
+        placeholders=None,
+    )
+
+    changed_keys: tuple[str, ...] = (
+        model_analysis_cache_key(
+            context=base_context,
+            query_sql="SELECT 2",
+            references=(),
+            placeholders=None,
+        ),
+        model_analysis_cache_key(
+            context=base_context,
+            query_sql="SELECT 1",
+            references=(reference,),
+            placeholders=None,
+        ),
+        model_analysis_cache_key(
+            context=base_context,
+            query_sql="SELECT 1",
+            references=(),
+            placeholders={"value": "1"},
+        ),
+        model_analysis_cache_key(
+            context=schema_context,
+            query_sql="SELECT 1",
+            references=(),
+            placeholders=None,
+        ),
+        model_analysis_cache_key(
+            context=profile_context,
+            query_sql="SELECT 1",
+            references=(),
+            placeholders=None,
+        ),
+    )
+
+    assert len(changed_keys) == test_case.expected_count
+    assert all(changed_key != base_key for changed_key in changed_keys)

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import Mock
@@ -11,7 +12,7 @@ from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
 from sqlbuild.compiler.compile._helpers.analysis.cache import (
     build_analysis_cache_context,
     model_analysis_cache_key,
-    write_model_analysis,
+    write_model_analyses,
 )
 from sqlbuild.compiler.compile._helpers.assembly import project as assembly_project
 from sqlbuild.compiler.compile.models import (
@@ -73,34 +74,33 @@ def test_given_successful_analysis_when_compiling_again_then_reuses_identical_ca
     assert warm_project.models == cold_project.models
     assert warm_project.diagnostics == cold_project.diagnostics
     analyzer.assert_not_called()
-    assert (
-        len(tuple((tmp_path / "target" / "compile-cache").rglob("*.json")))
-        == test_case.expected_count
+    assert len(tuple((tmp_path / "target" / "compile-cache").rglob("*.sqlite3"))) == (
+        test_case.expected_count
     )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    (AnalysisCacheTestCase(description="changed SQL cache miss", expected_count=2),),
+    (AnalysisCacheTestCase(description="changed SQL cache miss", expected_count=1),),
     ids=lambda case: case.description,
 )
 def test_given_changed_expanded_sql_when_compiling_then_writes_a_new_analysis_object(
     test_case: AnalysisCacheTestCase,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     write_repo_files: Callable[[Path, dict[str, str]], None],
 ) -> None:
     write_repo_files(tmp_path, _CACHE_REPO_FILES)
     cold_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
     changed_sql = 'MODEL ();\n\nSELECT order_id + 1 AS order_id FROM __source("raw_orders")\n'
     (tmp_path / "models" / "orders.sql").write_text(changed_sql, encoding="utf-8")
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
 
     changed_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
 
     assert changed_project.models[0].query_sql != cold_project.models[0].query_sql
-    assert (
-        len(tuple((tmp_path / "target" / "compile-cache").rglob("*.json")))
-        == test_case.expected_count
-    )
+    assert analyzer.call_count == test_case.expected_count
 
 
 @pytest.mark.parametrize(
@@ -111,22 +111,31 @@ def test_given_changed_expanded_sql_when_compiling_then_writes_a_new_analysis_ob
 def test_given_corrupt_analysis_when_compiling_then_reanalyzes_and_repairs_the_entry(
     test_case: AnalysisCacheTestCase,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     write_repo_files: Callable[[Path, dict[str, str]], None],
 ) -> None:
     write_repo_files(tmp_path, _CACHE_REPO_FILES)
     cold_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
-    cache_path: Path = next((tmp_path / "target" / "compile-cache").rglob("*.json"))
-    cache_path.write_text('{"analysis_succeeded":true}', encoding="utf-8")
+    cache_path: Path = next((tmp_path / "target" / "compile-cache").rglob("*.sqlite3"))
+    with sqlite3.connect(cache_path) as connection:
+        _ = connection.execute(
+            "UPDATE model_analysis SET payload = ?",
+            ('{"analysis_succeeded":true}',),
+        )
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
 
     repaired_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
 
-    repaired_payload: dict[str, object] = json.loads(cache_path.read_text(encoding="utf-8"))
+    with sqlite3.connect(cache_path) as connection:
+        repaired_contents: str = connection.execute(
+            "SELECT payload FROM model_analysis"
+        ).fetchone()[0]
+    repaired_payload: dict[str, object] = json.loads(repaired_contents)
     assert repaired_project.models == cold_project.models
     assert repaired_payload["analysis_succeeded"] is True
     assert isinstance(repaired_payload["analysis_digest"], str)
-    assert len(tuple((tmp_path / "target" / "compile-cache").rglob("*.json"))) == (
-        test_case.expected_count
-    )
+    assert analyzer.call_count == test_case.expected_count
 
 
 @pytest.mark.parametrize(
@@ -138,13 +147,14 @@ def test_given_unsuccessful_analysis_when_writing_then_does_not_persist_it(
     test_case: AnalysisCacheTestCase,
     tmp_path: Path,
 ) -> None:
-    write_model_analysis(
+    write_model_analyses(
         context=AnalysisCacheContext(root=tmp_path, shared_fingerprint="shared"),
-        cache_key="a" * 64,
-        analysis=PolyglotAnalysisResult(analysis_succeeded=False),
+        analyses_by_key={
+            "a" * 64: PolyglotAnalysisResult(analysis_succeeded=False),
+        },
     )
 
-    assert len(tuple(tmp_path.rglob("*.json"))) == test_case.expected_count
+    assert len(tuple(tmp_path.rglob("*.sqlite3"))) == test_case.expected_count
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
@@ -15,6 +15,7 @@ from sqlbuild.compiler.compile._helpers.analysis.cache import (
     write_model_analyses,
 )
 from sqlbuild.compiler.compile._helpers.assembly import project as assembly_project
+from sqlbuild.compiler.compile.constants import COMPILE_CACHE_DISABLE_ENV_VAR
 from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.models import (
     AnalysisCacheContext,
@@ -312,3 +313,26 @@ def test_given_unselected_invalid_reference_when_compiling_then_live_validation_
         )
 
     assert len(tuple((tmp_path / "target").rglob("*.sqlite3"))) == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="explicit cache bypass", expected_count=2),),
+    ids=lambda case: case.description,
+)
+def test_given_compile_cache_bypass_when_compiling_twice_then_both_runs_analyze_cold(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _CACHE_REPO_FILES)
+    monkeypatch.setenv(COMPILE_CACHE_DISABLE_ENV_VAR, "1")
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    _ = compile_project_with_cache(project_dir=tmp_path)
+
+    assert analyzer.call_count == test_case.expected_count
+    assert not tuple((tmp_path / "target").rglob("*.sqlite3"))

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
@@ -4,6 +4,12 @@ from pathlib import Path
 
 
 @dataclass(frozen=True)
+class DeferredModelOutputLocationTestCase:
+    description: str
+    expected_extract_implicit_alias_columns: bool
+
+
+@dataclass(frozen=True)
 class ValidatePathDefaultsMatchModelsTestCase:
     description: str
     model_relative_paths: tuple[str, ...]

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_models.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_models.py
@@ -48,9 +48,7 @@ def test_given_deferred_output_locations_when_discovering_models_then_projection
 
     model_file: DiscoveredSqlModelFile = discover_model_files(
         project_dir=tmp_path,
-        extract_implicit_alias_columns=(
-            test_case.expected_extract_implicit_alias_columns
-        ),
+        extract_implicit_alias_columns=(test_case.expected_extract_implicit_alias_columns),
         extract_output_column_locations=False,
     )[0]
 

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_models.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_models.py
@@ -4,19 +4,62 @@ from pathlib import Path
 
 import pytest
 
+from sqlbuild.compiler.discovery._helpers.filesystem.core import discover_model_files
 from sqlbuild.compiler.discovery._helpers.sql.model_files import (
     model_header_column_locations,
     model_output_column_locations,
     parse_model_sql,
 )
-from sqlbuild.compiler.discovery.models import PythonHookEntry, SqlHookEntry
+from sqlbuild.compiler.discovery.models import (
+    DiscoveredSqlModelFile,
+    PythonHookEntry,
+    SqlHookEntry,
+)
 from sqlbuild.spec.contracts.models import SourceLocation
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
+    DeferredModelOutputLocationTestCase,
     ModelHeaderColumnLocationTestCase,
     ModelOutputColumnLocationTestCase,
     ParseModelSqlErrorTestCase,
     ParseModelSqlHeaderTestCase,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DeferredModelOutputLocationTestCase(
+            description="defers output locations without implicit alias extraction",
+            expected_extract_implicit_alias_columns=False,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_deferred_output_locations_when_discovering_models_then_projection_scan_is_skipped(
+    tmp_path: Path,
+    test_case: DeferredModelOutputLocationTestCase,
+) -> None:
+    models_dir: Path = tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "orders.sql").write_text(
+        "MODEL (materialized view);\n\nSELECT 1 AS order_id\n",
+        encoding="utf-8",
+    )
+
+    model_file: DiscoveredSqlModelFile = discover_model_files(
+        project_dir=tmp_path,
+        extract_implicit_alias_columns=(
+            test_case.expected_extract_implicit_alias_columns
+        ),
+        extract_output_column_locations=False,
+    )[0]
+
+    assert model_file.output_column_locations == {}
+    assert model_file.output_column_locations_extracted is False
+    assert (
+        model_file.extract_implicit_alias_columns
+        is test_case.expected_extract_implicit_alias_columns
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
@@ -761,3 +761,10 @@ class ReuseSatisfiedStalenessTestCase:
     description: str
     reuse_satisfied_model_names: frozenset[str]
     expected_warns: bool
+@dataclass(frozen=True)
+class PlannerStaleWarningScopeTestCase:
+    description: str
+    selected_model_name: str
+    expected_inspected_names: frozenset[str]
+    expected_execution_names: tuple[str, ...]
+

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
@@ -761,10 +761,11 @@ class ReuseSatisfiedStalenessTestCase:
     description: str
     reuse_satisfied_model_names: frozenset[str]
     expected_warns: bool
+
+
 @dataclass(frozen=True)
 class PlannerStaleWarningScopeTestCase:
     description: str
     selected_model_name: str
     expected_inspected_names: frozenset[str]
     expected_execution_names: tuple[str, ...]
-

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_selection_staleness.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_selection_staleness.py
@@ -158,9 +158,10 @@ def test_given_partial_selection_when_resolving_scopes_then_inspects_only_upstre
         policies=PlannerPolicies(),
     )
 
-    assert frozenset(
-        key.name for key in scopes.stale_warning_scope.all_keys.values()
-    ) == test_case.expected_inspected_names
+    assert (
+        frozenset(key.name for key in scopes.stale_warning_scope.all_keys.values())
+        == test_case.expected_inspected_names
+    )
     assert tuple(key.name for key in scopes.stale_warning_scope.execution_order) == (
         test_case.expected_execution_names
     )

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_selection_staleness.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_selection_staleness.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models import CompiledModel, CompiledObjectKey, CompiledProject
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.fingerprints.constants import NODE_TYPE_SEED
 from sqlbuild.compiler.fingerprints.models import Fingerprint
+from sqlbuild.compiler.planner._helpers.planning.scopes import resolve_planner_scopes
 from sqlbuild.compiler.planner._helpers.pruning.selection_classifier import (
     format_stale_upstream_warning_message,
 )
@@ -17,7 +19,10 @@ from sqlbuild.compiler.planner._helpers.pruning.selection_staleness import (
 from sqlbuild.compiler.planner.models import (
     ChangeDetectionResult,
     PlannerChangeResults,
+    PlannerPolicies,
     PlannerScope,
+    PlannerScopeResolution,
+    PlannerSelection,
     PlanWarning,
     StandardModelVersionIdentities,
     WarehouseFingerprints,
@@ -29,9 +34,13 @@ from sqlbuild.compiler.source_freshness.models import (
     StandardSourceFreshnessPlanningResult,
 )
 from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
+    PlannerStaleWarningScopeTestCase,
     SelectionStalenessGraphWarningTestCase,
     SelectionStalenessWarningTestCase,
     StaleWarningMessageTestCase,
+)
+from tests.unit.src.sqlbuild.compiler.planner._helpers.helpers import (
+    build_run_despite_unchanged_model,
 )
 
 MODEL_KEY: CompiledObjectKey = CompiledObjectKey(
@@ -72,6 +81,89 @@ SOURCE_ROOT_KEY: CompiledObjectKey = CompiledObjectKey(
     resource_type=CompiledResourceType.SOURCE,
     name="root_source",
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        PlannerStaleWarningScopeTestCase(
+            description="selected branch excludes unrelated warehouse inspection",
+            selected_model_name="leaf",
+            expected_inspected_names=frozenset({"root", "middle", "leaf"}),
+            expected_execution_names=("root", "middle", "leaf"),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_partial_selection_when_resolving_scopes_then_inspects_only_upstream_closure(
+    test_case: PlannerStaleWarningScopeTestCase,
+) -> None:
+    root_key: CompiledObjectKey = CompiledObjectKey(
+        resource_type=CompiledResourceType.MODEL,
+        name="root",
+    )
+    middle_key: CompiledObjectKey = CompiledObjectKey(
+        resource_type=CompiledResourceType.MODEL,
+        name="middle",
+    )
+    leaf_key: CompiledObjectKey = CompiledObjectKey(
+        resource_type=CompiledResourceType.MODEL,
+        name="leaf",
+    )
+    unrelated_key: CompiledObjectKey = CompiledObjectKey(
+        resource_type=CompiledResourceType.MODEL,
+        name="unrelated",
+    )
+    root: CompiledModel = build_run_despite_unchanged_model(
+        key=root_key,
+        name=root_key.name,
+        materialized="table",
+        run_despite_unchanged=None,
+    )
+    middle: CompiledModel = replace(
+        build_run_despite_unchanged_model(
+            key=middle_key,
+            name=middle_key.name,
+            materialized="table",
+            run_despite_unchanged=None,
+        ),
+        deps=(root_key,),
+    )
+    leaf: CompiledModel = replace(
+        build_run_despite_unchanged_model(
+            key=leaf_key,
+            name=leaf_key.name,
+            materialized="table",
+            run_despite_unchanged=None,
+        ),
+        deps=(middle_key,),
+    )
+    unrelated: CompiledModel = build_run_despite_unchanged_model(
+        key=unrelated_key,
+        name=unrelated_key.name,
+        materialized="table",
+        run_despite_unchanged=None,
+    )
+    project: CompiledProject = CompiledProject(
+        run_id="run",
+        effective_target_name=None,
+        effective_connection={},
+        effective_vars={},
+        models=(root, middle, leaf, unrelated),
+    )
+
+    scopes: PlannerScopeResolution = resolve_planner_scopes(
+        project=project,
+        selection=PlannerSelection(select=(test_case.selected_model_name,)),
+        policies=PlannerPolicies(),
+    )
+
+    assert frozenset(
+        key.name for key in scopes.stale_warning_scope.all_keys.values()
+    ) == test_case.expected_inspected_names
+    assert tuple(key.name for key in scopes.stale_warning_scope.execution_order) == (
+        test_case.expected_execution_names
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Large projects paid repeated costs for projection-location scans, Polyglot model analysis, broad warehouse inspection, and unchanged artifact rewrites. CHI-101 targets realistic 3K/10K projects while preserving the invariant that cached output equals a clean compile.

Polyglot-dependent work from upstream #422, #423, and #424 remains intentionally excluded.

## Changes

- Defer output-column location scans until contract diagnostics need them.
- Preserve unchanged compiled SQL and manifest files; remove stale generated files.
- Cache only successful per-model Polyglot facts in a versioned, content-addressed SQLite store.
- Treat corruption, unsupported profiles, storage failures, and version mismatches as misses.
- Support deterministic cold runs with `SQLBUILD_DISABLE_COMPILE_CACHE=1`.
- Keep discovery, macros, variables, declarations, references, and config validation live.
- Restrict warehouse inspection and deep SQL analysis to the selected upstream closure.

Measured on mixed-width dbt-shaped fixtures after rebasing onto v0.55.1:

| Fixture | Previous cold | New cold | Warm unchanged |
| --- | ---: | ---: | ---: |
| 3K / 21.25 MB SQL | 7.34s | 5.53s | 1.87s |
| 10K / 70.84 MB SQL | 25.82s | 18.24s | 6.98s |

An 11-model closure in the 10K project compiles in 3.54s, with 0.03s warehouse inspection and 0.89s plan generation. Cold and warm compiled artifact hashes match at 3K and 10K.

The remaining warm 10K cost is dominated by intentionally live scanning of 70.84 MB expanded SQL, not cache I/O.

## Verification

- `make check-ci`
- `make test` (4,156 passed)
- `make rust-check`
- dbt-shaped 3K and 10K performance guards
- focused selector and plan E2E tests

Linear: CHI-101
