### PR TITLE
perf(compiler): scope schema cache invalidation

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/build_planning/defer_clone.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_planning/defer_clone.py
@@ -22,15 +22,16 @@ from sqlbuild.cli.commands.models import (
     DeferClonePrephaseOutputContext,
 )
 from sqlbuild.compiler.compile.models import (
+    CompileAnalysisSelection,
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,
 )
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
-from sqlbuild.compiler.pipeline.main.clone import run_clone_pipeline
+from sqlbuild.compiler.pipeline.main.clone_with_options import run_clone_pipeline_with_options
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
-from sqlbuild.compiler.pipeline.models import ClonePipelineResult
+from sqlbuild.compiler.pipeline.models import ClonePipelineOptions, ClonePipelineResult
 from sqlbuild.compiler.planner.main.clone.resolve_clone_boundary import (
     resolve_clone_boundary,
 )
@@ -53,6 +54,7 @@ def build_defer_clone_boundary_selectors(
     adapter: BaseAdapter,
     selected_target: str | None,
     no_sql_validation: bool,
+    no_cache: bool,
     select: tuple[str, ...],
     exclude: tuple[str, ...],
     cli_vars: dict[str, object] | None,
@@ -66,6 +68,7 @@ def build_defer_clone_boundary_selectors(
         adapter=adapter,
         selected_target=selected_target,
         no_sql_validation=no_sql_validation,
+        analysis_selection=CompileAnalysisSelection(no_cache=no_cache),
         cli_vars=cli_vars,
         external_sql_reference_resolver=resolve_external_sql_reference_resolver(
             project_dir=project_dir,
@@ -139,6 +142,7 @@ def run_defer_clone_boundary_prephase(
         adapter=invocation.adapter,
         selected_target=request.selected_target,
         no_sql_validation=request.no_sql_validation,
+        no_cache=request.no_cache,
         select=request.select,
         exclude=request.exclude,
         cli_vars=request.cli_vars,
@@ -152,6 +156,7 @@ def run_defer_clone_boundary_prephase(
             origin_target_name=origin_target_name,
             destination_target_name=cloned_project.effective_target_name,
             no_sql_validation=request.no_sql_validation,
+            no_cache=request.no_cache,
             select=(*boundary_selectors, *view_chain_selectors),
             caused_by_names=request.select,
             cli_vars=request.cli_vars,
@@ -210,16 +215,18 @@ def run_defer_clone_prephase(
     )
     destination_connection: Any = adapter.connect(inputs.connection_config)
     try:
-        clone_pipeline: ClonePipelineResult = run_clone_pipeline(
+        clone_pipeline: ClonePipelineResult = run_clone_pipeline_with_options(
             discovered_inputs=discovered_inputs,
             adapter=adapter,
             origin_target_name=origin_target_name,
             destination_target_name=destination_target_name,
-            no_sql_validation=inputs.no_sql_validation,
-            select=inputs.select,
-            exclude=(),
-            cli_vars=cli_vars,
             destination_connection=destination_connection,
+            options=ClonePipelineOptions(
+                no_sql_validation=inputs.no_sql_validation,
+                no_cache=inputs.no_cache,
+                select=inputs.select,
+                cli_vars=cli_vars,
+            ),
             external_sql_reference_resolver=resolve_external_sql_reference_resolver(
                 project_dir=project_dir,
                 discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/cli/commands/_helpers/build_planning/planning.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_planning/planning.py
@@ -31,6 +31,7 @@ def compile_build_plan(
         adapter=invocation.adapter,
         options=CompilePipelineOptions(
             no_sql_validation=request.no_sql_validation,
+            no_cache=request.no_cache,
             selected_target=request.selected_target,
             defer_to=request.defer_to,
             defer_sources_to=request.defer_sources_to,

--- a/src/sqlbuild/cli/commands/_helpers/build_virtual/virtual_execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_virtual/virtual_execution.py
@@ -106,6 +106,7 @@ def execute_virtual_build(
             planning=VirtualPlanOptions(
                 selected_target=request.selected_target,
                 no_sql_validation=request.no_sql_validation,
+                no_cache=request.no_cache,
                 defer_sources_to=request.defer_sources_to,
                 cursor_overrides=request.cursor_overrides,
                 full_refresh=request.full_refresh,

--- a/src/sqlbuild/cli/commands/_helpers/compile/pipeline.py
+++ b/src/sqlbuild/cli/commands/_helpers/compile/pipeline.py
@@ -48,6 +48,7 @@ def analyze_compile_project(
     *,
     project_dir: Path,
     no_sql_validation: bool,
+    no_cache: bool,
     selected_target: str | None,
     lineage_mode: CompileLineageMode,
     cli_vars: dict[str, object] | None,
@@ -86,6 +87,7 @@ def analyze_compile_project(
         skip_column_inference=profile_flags.skip_column_inference,
         column_lineage_mode=compile_analysis_lineage_mode(lineage_mode),
         cli_vars=cli_vars,
+        no_cache=no_cache,
     )
     graph_ms: int = elapsed_ms(graph_start)
     _ = complete_compile_phase(

--- a/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
@@ -65,6 +65,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
             CompileCommandRequest(
                 project_dir=project_dir,
                 no_sql_validation=args.no_sql_validation,
+                no_cache=args.no_cache,
                 defer_to=args.defer_to,
                 selected_target=args.target,
                 json_output=args.json,
@@ -93,6 +94,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
             PlanCommandRequest(
                 project_dir=project_dir,
                 no_sql_validation=args.no_sql_validation,
+                no_cache=args.no_cache,
                 defer_to=args.defer_to,
                 defer_sources_to=args.defer_sources_to,
                 selected_target=args.target,
@@ -128,6 +130,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
             BuildCommandRequest(
                 project_dir=project_dir,
                 no_sql_validation=args.no_sql_validation,
+                no_cache=args.no_cache,
                 defer_to=args.defer_to,
                 defer_clone_from=args.defer_clone_from,
                 defer_sources_to=args.defer_sources_to,

--- a/src/sqlbuild/cli/commands/_helpers/entry/parser.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parser.py
@@ -57,6 +57,12 @@ def _add_compile_and_dag_parsers(
 ) -> None:
     compile_parser: argparse.ArgumentParser = subparsers.add_parser(CliCommand.COMPILE)
     compile_parser.add_argument("--no-sql-validation", action="store_true", default=False)
+    compile_parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        default=False,
+        help="Bypass the compile analysis cache for this invocation",
+    )
     compile_parser.add_argument("--defer-to", default=None)
     compile_parser.add_argument("--target", default=None)
     compile_parser.add_argument("--json", action="store_true", default=False)
@@ -108,6 +114,12 @@ def _add_plan_and_build_parsers(
 ) -> None:
     plan_parser: argparse.ArgumentParser = subparsers.add_parser(CliCommand.PLAN)
     plan_parser.add_argument("--no-sql-validation", action="store_true", default=False)
+    plan_parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        default=False,
+        help="Bypass the compile analysis cache for this invocation",
+    )
     plan_parser.add_argument("--defer-to", default=None)
     plan_parser.add_argument("--defer-sources-to", default=None)
     plan_parser.add_argument("--target", default=None)
@@ -135,6 +147,12 @@ def _add_plan_and_build_parsers(
 
     build_parser: argparse.ArgumentParser = subparsers.add_parser(CliCommand.BUILD)
     build_parser.add_argument("--no-sql-validation", action="store_true", default=False)
+    build_parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        default=False,
+        help="Bypass the compile analysis cache for this invocation",
+    )
     build_parser.add_argument("--defer-to", default=None)
     build_parser.add_argument("--defer-clone-from", default=None)
     build_parser.add_argument("--defer-sources-to", default=None)

--- a/src/sqlbuild/cli/commands/_helpers/plan/planning.py
+++ b/src/sqlbuild/cli/commands/_helpers/plan/planning.py
@@ -42,6 +42,7 @@ def compile_plan_pipeline(
             options=VirtualPlanOptions(
                 selected_target=request.selected_target,
                 no_sql_validation=request.no_sql_validation,
+                no_cache=request.no_cache,
                 defer_sources_to=request.defer_sources_to,
                 cursor_overrides=request.cursor_overrides,
                 full_refresh=request.full_refresh,
@@ -84,6 +85,7 @@ def compile_plan_pipeline(
         options=CompilePipelineOptions(
             selected_target=request.selected_target,
             no_sql_validation=request.no_sql_validation,
+            no_cache=request.no_cache,
             defer_to=request.defer_to,
             defer_sources_to=request.defer_sources_to,
             cursor_overrides=request.cursor_overrides,

--- a/src/sqlbuild/cli/commands/classes/cli_namespace.py
+++ b/src/sqlbuild/cli/commands/classes/cli_namespace.py
@@ -20,6 +20,7 @@ _DEFAULT_VALUES: dict[str, object] = {
     "overwrite": False,
     "skip_dbt_debug": False,
     "no_sql_validation": False,
+    "no_cache": False,
     "defer_to": None,
     "defer_clone_from": None,
     "defer_sources_to": None,
@@ -145,6 +146,7 @@ class CliNamespace:
     overwrite: bool
     skip_dbt_debug: bool
     no_sql_validation: bool
+    no_cache: bool
     defer_to: str | None
     defer_clone_from: str | None
     defer_sources_to: str | None

--- a/src/sqlbuild/cli/commands/main/execution/_build.py
+++ b/src/sqlbuild/cli/commands/main/execution/_build.py
@@ -69,6 +69,7 @@ def run_build(request: BuildCommandRequest) -> int:
                 request=VirtualBuildCliRequest(
                     selected_target=request.selected_target,
                     no_sql_validation=request.no_sql_validation,
+                    no_cache=request.no_cache,
                     defer_sources_to=request.defer_sources_to,
                     cursor_overrides=request.cursor_overrides,
                     full_refresh=request.full_refresh,

--- a/src/sqlbuild/cli/commands/main/project/_compile.py
+++ b/src/sqlbuild/cli/commands/main/project/_compile.py
@@ -65,6 +65,7 @@ def _run_compile_with_status(
     analysis: CompileAnalysis = analyze_compile_project(
         project_dir=project_dir,
         no_sql_validation=request.no_sql_validation,
+        no_cache=request.no_cache,
         selected_target=request.selected_target,
         lineage_mode=lineage_mode,
         cli_vars=request.cli_vars,

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -182,6 +182,7 @@ class BuildCommandRequest:
     manifest: bool = False
     json_output: bool = False
     json_output_path: Path | None = None
+    no_cache: bool = False
 
 
 @dataclass(frozen=True)
@@ -236,6 +237,7 @@ class DeferClonePrephaseInputs:
     cli_vars: dict[str, object] | None
     connection_config: dict[str, object]
     project_dir: Path
+    no_cache: bool = False
 
 
 @dataclass(frozen=True)
@@ -316,6 +318,7 @@ class VirtualBuildCliRequest:
     use_color: bool = False
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None
     providers: ProviderContainer | None = None
+    no_cache: bool = False
 
 
 @dataclass(frozen=True)
@@ -450,6 +453,7 @@ class CompileCommandRequest:
     lineage_mode: CompileLineageMode = CompileLineageMode.FAST
     cli_vars: dict[str, object] | None = None
     profile_flags: CompileProfileFlags = CompileProfileFlags()
+    no_cache: bool = False
 
 
 @dataclass(frozen=True)
@@ -951,6 +955,7 @@ class PlanCommandRequest:
     cli_vars: dict[str, object] | None = None
     include_stale_upstreams: bool = False
     changes_only: bool = False
+    no_cache: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
+++ b/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
+from sqlbuild.compiler.compile._helpers.analysis.columns import table_function_analysis_name
 from sqlbuild.compiler.compile.exceptions import AnalysisCacheEntryError
 from sqlbuild.compiler.compile.models import (
     AnalysisCacheContext,
@@ -26,9 +27,10 @@ from sqlbuild.compiler.lineage.types import (
     ColumnTransformKind,
     InferredNullability,
 )
+from sqlbuild.compiler.references.types import SqlReferenceKind
 
-_ANALYSIS_CACHE_VERSION: int = 1
-_ANALYSIS_ALGORITHM_FINGERPRINT: str = "model-sql-analysis-v1"
+_ANALYSIS_CACHE_VERSION: int = 2
+_ANALYSIS_ALGORITHM_FINGERPRINT: str = "model-sql-analysis-v2"
 _MAX_CACHE_ENTRY_BYTES: int = 10_000_000
 _LOCAL_QUALNAME_MARKER: str = "<locals>"
 _SQLITE_QUERY_CHUNK_SIZE: int = 500
@@ -40,15 +42,32 @@ CREATE TABLE IF NOT EXISTS model_analysis (
     payload TEXT NOT NULL
 )
 """
+_CREATE_SIGNATURE_TABLE_SQL: str = """
+CREATE TABLE IF NOT EXISTS model_analysis_signature (
+    shared_fingerprint TEXT NOT NULL,
+    signature_namespace TEXT NOT NULL,
+    model_name TEXT NOT NULL,
+    output_signature TEXT NOT NULL,
+    PRIMARY KEY (shared_fingerprint, signature_namespace, model_name)
+)
+"""
+_CREATE_DEPENDENCY_TABLE_SQL: str = """
+CREATE TABLE IF NOT EXISTS model_analysis_dependency (
+    signature_namespace TEXT NOT NULL,
+    cache_key TEXT NOT NULL,
+    upstream_model_name TEXT NOT NULL,
+    output_signature TEXT NOT NULL,
+    PRIMARY KEY (signature_namespace, cache_key, upstream_model_name)
+)
+"""
 
 
 def build_analysis_cache_context(
     *,
     root: Path | None,
     inference_profile: ExpressionInferenceProfile,
-    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
-    column_types_by_table: dict[str, dict[str, str]],
     allow_compact_analysis: bool,
+    signature_namespace: object = None,
 ) -> AnalysisCacheContext | None:
     """Build a reusable cache context, or bypass when profile identity is unstable."""
 
@@ -65,16 +84,15 @@ def build_analysis_cache_context(
         "python_version": platform.python_version_tuple()[:2],
         "allow_compact_analysis": allow_compact_analysis,
         "inference_profile": profile_payload,
-        "column_nullability_by_table": _nullability_payload(column_nullability_by_table),
-        "column_types_by_table": {
-            table: dict(sorted(columns.items()))
-            for table, columns in sorted(column_types_by_table.items())
-        },
     }
-    return AnalysisCacheContext(
-        root=root,
-        shared_fingerprint=_payload_digest(shared_payload),
-    )
+    try:
+        return AnalysisCacheContext(
+            root=root,
+            shared_fingerprint=_payload_digest(shared_payload),
+            signature_namespace=_payload_digest(signature_namespace),
+        )
+    except (TypeError, ValueError):
+        return None
 
 
 def model_analysis_cache_key(
@@ -83,6 +101,8 @@ def model_analysis_cache_key(
     query_sql: str,
     references: tuple[CompileSqlReference, ...],
     placeholders: dict[str, str] | None,
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+    column_types_by_table: dict[str, dict[str, str]],
 ) -> str:
     """Return the exact analysis identity for one expanded model query."""
 
@@ -100,6 +120,14 @@ def model_analysis_cache_key(
                 for reference in references
             ],
             "placeholders": dict(sorted((placeholders or {}).items())),
+            "referenced_column_nullability": _referenced_nullability_payload(
+                references=references,
+                column_nullability_by_table=column_nullability_by_table,
+            ),
+            "referenced_column_types": _referenced_types_payload(
+                references=references,
+                column_types_by_table=column_types_by_table,
+            ),
         }
     )
 
@@ -108,13 +136,16 @@ def read_model_analyses(
     *,
     context: AnalysisCacheContext,
     cache_keys: tuple[str, ...],
-) -> dict[str, PolyglotAnalysisResult]:
-    """Read cached analyses in batches, treating invalid entries or storage as misses."""
+    model_names: tuple[str, ...],
+    upstream_model_names_by_key: dict[str, tuple[str, ...]],
+) -> tuple[dict[str, PolyglotAnalysisResult], dict[str, str]]:
+    """Read one consistent snapshot of analyses, dependencies, and output signatures."""
 
     database_path: Path = _cache_database_path(context=context)
     if not database_path.is_file() or not cache_keys:
-        return {}
+        return {}, {}
     analyses: dict[str, PolyglotAnalysisResult] = {}
+    signatures: dict[str, str] = {}
     try:
         connection_uri: str = f"file:{database_path}?mode=ro"
         with sqlite3.connect(
@@ -122,6 +153,28 @@ def read_model_analyses(
             uri=True,
             timeout=_SQLITE_TIMEOUT_SECONDS,
         ) as connection:
+            _ = connection.execute("BEGIN")
+            signature_model_name_set: set[str] = set(model_names)
+            upstream_names: tuple[str, ...]
+            for upstream_names in upstream_model_names_by_key.values():
+                signature_model_name_set.update(upstream_names)
+            signature_model_names: tuple[str, ...] = tuple(sorted(signature_model_name_set))
+            for start in range(0, len(signature_model_names), _SQLITE_QUERY_CHUNK_SIZE):
+                model_chunk: tuple[str, ...] = signature_model_names[
+                    start : start + _SQLITE_QUERY_CHUNK_SIZE
+                ]
+                model_placeholders: str = ",".join("?" for _ in model_chunk)
+                signature_rows: list[tuple[str, str]] = connection.execute(
+                    f"SELECT model_name, output_signature FROM model_analysis_signature "
+                    f"WHERE shared_fingerprint = ? AND signature_namespace = ? "
+                    f"AND model_name IN ({model_placeholders})",
+                    (
+                        context.shared_fingerprint,
+                        context.signature_namespace,
+                        *model_chunk,
+                    ),
+                ).fetchall()
+                signatures.update(signature_rows)
             for start in range(0, len(cache_keys), _SQLITE_QUERY_CHUNK_SIZE):
                 chunk: tuple[str, ...] = cache_keys[start : start + _SQLITE_QUERY_CHUNK_SIZE]
                 placeholders: str = ",".join("?" for _ in chunk)
@@ -130,7 +183,25 @@ def read_model_analyses(
                     f"WHERE cache_key IN ({placeholders})",
                     chunk,
                 ).fetchall()
+                dependency_rows: list[tuple[str, str, str]] = connection.execute(
+                    f"SELECT cache_key, upstream_model_name, output_signature "
+                    f"FROM model_analysis_dependency WHERE signature_namespace = ? "
+                    f"AND cache_key IN ({placeholders})",
+                    (context.signature_namespace, *chunk),
+                ).fetchall()
+                dependencies_by_key: dict[str, dict[str, str]] = {}
+                for cache_key, upstream_name, output_signature in dependency_rows:
+                    dependencies_by_key.setdefault(cache_key, {})[upstream_name] = output_signature
                 for cache_key, contents in rows:
+                    expected_dependencies: dict[str, str] | None = _expected_dependencies(
+                        upstream_model_names=upstream_model_names_by_key.get(cache_key, ()),
+                        signatures=signatures,
+                    )
+                    if (
+                        expected_dependencies is None
+                        or dependencies_by_key.get(cache_key, {}) != expected_dependencies
+                    ):
+                        continue
                     analysis: PolyglotAnalysisResult | None = _analysis_from_contents(
                         contents=contents,
                         expected_cache_key=cache_key,
@@ -138,14 +209,16 @@ def read_model_analyses(
                     if analysis is not None:
                         analyses[cache_key] = analysis
     except (OSError, sqlite3.DatabaseError):
-        return {}
-    return analyses
+        return {}, {}
+    return analyses, signatures
 
 
 def write_model_analyses(
     *,
     context: AnalysisCacheContext,
     analyses_by_key: dict[str, PolyglotAnalysisResult],
+    latest_analyses_by_model: dict[str, PolyglotAnalysisResult] | None = None,
+    dependency_signatures_by_key: dict[str, dict[str, str]] | None = None,
 ) -> None:
     """Transactionally persist successful analyses; cache failures never fail compilation."""
 
@@ -162,19 +235,95 @@ def write_model_analyses(
         for cache_key, analysis in analyses_by_key.items()
         if analysis.analysis_succeeded
     ]
-    if not rows:
+    signature_rows: list[tuple[str, str, str, str]] = [
+        (
+            context.shared_fingerprint,
+            context.signature_namespace,
+            model_name,
+            model_analysis_output_signature(analysis),
+        )
+        for model_name, analysis in (latest_analyses_by_model or {}).items()
+        if analysis.analysis_succeeded
+    ]
+    dependency_rows: list[tuple[str, str, str, str]] = []
+    for cache_key, dependencies in (dependency_signatures_by_key or {}).items():
+        analysis: PolyglotAnalysisResult | None = analyses_by_key.get(cache_key)
+        if analysis is None or not analysis.analysis_succeeded:
+            continue
+        dependency_rows.extend(
+            (context.signature_namespace, cache_key, upstream_name, output_signature)
+            for upstream_name, output_signature in dependencies.items()
+        )
+    if not rows and not signature_rows:
         return
     try:
         database_path: Path = _cache_database_path(context=context)
         database_path.parent.mkdir(parents=True, exist_ok=True)
         with sqlite3.connect(database_path, timeout=_SQLITE_TIMEOUT_SECONDS) as connection:
             _ = connection.execute(_CREATE_CACHE_TABLE_SQL)
+            _ = connection.execute(_CREATE_SIGNATURE_TABLE_SQL)
+            _ = connection.execute(_CREATE_DEPENDENCY_TABLE_SQL)
             _ = connection.executemany(
                 "INSERT OR REPLACE INTO model_analysis (cache_key, payload) VALUES (?, ?)",
                 rows,
             )
+            written_cache_keys: tuple[str, ...] = tuple(cache_key for cache_key, _ in rows)
+            for start in range(0, len(written_cache_keys), _SQLITE_QUERY_CHUNK_SIZE):
+                chunk: tuple[str, ...] = written_cache_keys[
+                    start : start + _SQLITE_QUERY_CHUNK_SIZE
+                ]
+                placeholders: str = ",".join("?" for _ in chunk)
+                _ = connection.execute(
+                    f"DELETE FROM model_analysis_dependency "
+                    f"WHERE signature_namespace = ? AND cache_key IN ({placeholders})",
+                    (context.signature_namespace, *chunk),
+                )
+            _ = connection.executemany(
+                "INSERT INTO model_analysis_dependency "
+                "(signature_namespace, cache_key, upstream_model_name, output_signature) "
+                "VALUES (?, ?, ?, ?)",
+                dependency_rows,
+            )
+            _ = connection.executemany(
+                "INSERT OR REPLACE INTO model_analysis_signature "
+                "(shared_fingerprint, signature_namespace, model_name, output_signature) "
+                "VALUES (?, ?, ?, ?)",
+                signature_rows,
+            )
     except (OSError, sqlite3.DatabaseError):
         return
+
+
+def _expected_dependencies(
+    *,
+    upstream_model_names: tuple[str, ...],
+    signatures: dict[str, str],
+) -> dict[str, str] | None:
+    if any(name not in signatures for name in upstream_model_names):
+        return None
+    return {name: signatures[name] for name in upstream_model_names}
+
+
+def model_analysis_output_signature(analysis: PolyglotAnalysisResult) -> str:
+    """Return the exported column signature relevant to downstream analysis."""
+
+    return _payload_digest(
+        {
+            "columns": (
+                None
+                if analysis.columns is None
+                else [
+                    {
+                        "name": column.name,
+                        "type": column.type,
+                        "nullability": column.nullability.value,
+                    }
+                    for column in analysis.columns
+                ]
+            ),
+            "has_star": analysis.has_star,
+        }
+    )
 
 
 def _analysis_from_contents(
@@ -224,15 +373,48 @@ def _inference_profile_payload(
     }
 
 
-def _nullability_payload(
+def _referenced_nullability_payload(
+    *,
+    references: tuple[CompileSqlReference, ...],
     column_nullability_by_table: dict[str, dict[str, InferredNullability]],
 ) -> dict[str, dict[str, str]]:
     payload: dict[str, dict[str, str]] = {}
-    for table, columns in sorted(column_nullability_by_table.items()):
+    table: str
+    for table in _referenced_analysis_tables(references):
+        columns: dict[str, InferredNullability] | None = column_nullability_by_table.get(table)
+        if columns is None:
+            continue
         payload[table] = {
             column: nullability.value for column, nullability in sorted(columns.items())
         }
     return payload
+
+
+def _referenced_types_payload(
+    *,
+    references: tuple[CompileSqlReference, ...],
+    column_types_by_table: dict[str, dict[str, str]],
+) -> dict[str, dict[str, str]]:
+    payload: dict[str, dict[str, str]] = {}
+    table: str
+    for table in _referenced_analysis_tables(references):
+        columns: dict[str, str] | None = column_types_by_table.get(table)
+        if columns is not None:
+            payload[table] = dict(sorted(columns.items()))
+    return payload
+
+
+def _referenced_analysis_tables(
+    references: tuple[CompileSqlReference, ...],
+) -> tuple[str, ...]:
+    names: set[str] = set()
+    for reference in references:
+        names.add(
+            table_function_analysis_name(reference.ref_name)
+            if reference.ref_kind == SqlReferenceKind.TABLE_FUNCTION
+            else reference.ref_name
+        )
+    return tuple(sorted(names))
 
 
 def _analysis_payload(*, cache_key: str, analysis: PolyglotAnalysisResult) -> dict[str, object]:

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -12,6 +12,7 @@ from sqlbuild.adapter.contract.types import BuiltinAdapter
 from sqlbuild.compiler.compile._helpers.analysis.cache import (
     build_analysis_cache_context,
     model_analysis_cache_key,
+    model_analysis_output_signature,
     read_model_analyses,
     write_model_analyses,
 )
@@ -140,9 +141,11 @@ def assemble_compiled_project(
         build_analysis_cache_context(
             root=analysis_cache_dir,
             inference_profile=profile,
-            column_nullability_by_table=column_nullability_by_table,
-            column_types_by_table=column_types_by_table,
             allow_compact_analysis=allow_compact_analysis,
+            signature_namespace={
+                "target": inputs.effective_target_name,
+                "vars": inputs.effective_vars,
+            },
         )
         if sql_analysis_enabled and analysis_model_names != frozenset()
         else None
@@ -371,18 +374,31 @@ def _analyze_model_sql_in_parallel(
     if not model_inputs:
         return {}
     requests: tuple[_ModelSqlAnalysisRequest, ...] = tuple(
-        _model_sql_analysis_request(model_input=model_input, analysis_cache=analysis_cache)
+        _model_sql_analysis_request(
+            model_input=model_input,
+            analysis_cache=analysis_cache,
+            column_nullability_by_table=column_nullability_by_table,
+            column_types_by_table=column_types_by_table,
+        )
         for model_input in model_inputs
     )
-    cached_analyses: dict[str, PolyglotAnalysisResult] = (
+    cached_analyses: dict[str, PolyglotAnalysisResult]
+    previous_signatures: dict[str, str]
+    cached_analyses, previous_signatures = (
         read_model_analyses(
             context=analysis_cache,
             cache_keys=tuple(
                 request.cache_key for request in requests if request.cache_key is not None
             ),
+            model_names=tuple(_model_name(request.model_input) for request in requests),
+            upstream_model_names_by_key={
+                request.cache_key: _referenced_model_names(request.model_input)
+                for request in requests
+                if request.cache_key is not None
+            },
         )
         if analysis_cache is not None
-        else {}
+        else ({}, {})
     )
     if len(model_inputs) < _POLYGLOT_PARALLEL_ANALYSIS_MIN_MODELS:
         analyses: tuple[_ModelSqlAnalysis, ...] = tuple(
@@ -420,19 +436,146 @@ def _analyze_model_sql_in_parallel(
                     requests,
                 )
             )
+    current_analyses_by_name: dict[str, PolyglotAnalysisResult] = {
+        _model_name(request.model_input): analysis.polyglot_analysis
+        for request, analysis in zip(requests, analyses, strict=True)
+    }
+    current_signatures_by_name: dict[str, str] = {
+        model_name: model_analysis_output_signature(analysis)
+        for model_name, analysis in current_analyses_by_name.items()
+    }
+    analyses_to_record_by_name: dict[str, PolyglotAnalysisResult] = {
+        _model_name(request.model_input): analysis.polyglot_analysis
+        for request, analysis in zip(requests, analyses, strict=True)
+        if request.cache_key is None or request.cache_key not in cached_analyses
+    }
+    changed_signature_names: set[str] = {
+        model_name
+        for model_name, output_signature in current_signatures_by_name.items()
+        if previous_signatures.get(model_name) != output_signature
+    }
+    analyses_to_record_by_name.update(
+        {model_name: current_analyses_by_name[model_name] for model_name in changed_signature_names}
+    )
+    invalidated_names: set[str] = _downstream_model_names(
+        model_inputs=model_inputs,
+        changed_names=changed_signature_names,
+    )
+    if invalidated_names:
+        analyses = tuple(
+            (
+                _analyze_model_sql(
+                    request=request,
+                    cached_analysis=None,
+                    column_nullability_by_table=column_nullability_by_table,
+                    column_types_by_table=column_types_by_table,
+                    inference_profile=inference_profile,
+                    allow_compact_analysis=allow_compact_analysis,
+                )
+                if (
+                    _model_name(request.model_input) in invalidated_names
+                    and request.cache_key is not None
+                    and request.cache_key in cached_analyses
+                )
+                else analysis
+            )
+            for request, analysis in zip(requests, analyses, strict=True)
+        )
+        analyses_to_record_by_name.update(
+            {
+                _model_name(request.model_input): analysis.polyglot_analysis
+                for request, analysis in zip(requests, analyses, strict=True)
+                if _model_name(request.model_input) in invalidated_names
+            }
+        )
+        current_analyses_by_name = {
+            _model_name(request.model_input): analysis.polyglot_analysis
+            for request, analysis in zip(requests, analyses, strict=True)
+        }
+        current_signatures_by_name = {
+            model_name: model_analysis_output_signature(analysis)
+            for model_name, analysis in current_analyses_by_name.items()
+        }
     if analysis_cache is not None:
         write_model_analyses(
             context=analysis_cache,
             analyses_by_key={
                 request.cache_key: analysis.polyglot_analysis
                 for request, analysis in zip(requests, analyses, strict=True)
-                if request.cache_key is not None and request.cache_key not in cached_analyses
+                if request.cache_key is not None
+                and (
+                    request.cache_key not in cached_analyses
+                    or _model_name(request.model_input) in invalidated_names
+                )
             },
+            latest_analyses_by_model=analyses_to_record_by_name,
+            dependency_signatures_by_key=_dependency_signatures_by_key(
+                requests=requests,
+                cached_analyses=cached_analyses,
+                invalidated_names=invalidated_names,
+                current_signatures_by_name=current_signatures_by_name,
+            ),
         )
     return {
         _model_name(model_input): analysis
         for model_input, analysis in zip(model_inputs, analyses, strict=True)
     }
+
+
+def _downstream_model_names(
+    *,
+    model_inputs: tuple[CompileModelInput, ...],
+    changed_names: set[str],
+) -> set[str]:
+    downstream_by_name: dict[str, set[str]] = {}
+    for model_input in model_inputs:
+        model_name: str = _model_name(model_input)
+        for reference in model_input.references:
+            if reference.ref_kind == SqlReferenceKind.REF:
+                downstream_by_name.setdefault(reference.ref_name, set()).add(model_name)
+    downstream_names: set[str] = set()
+    pending: list[str] = list(changed_names)
+    while pending:
+        for downstream_name in downstream_by_name.get(pending.pop(), set()):
+            if downstream_name not in downstream_names and downstream_name not in changed_names:
+                downstream_names.add(downstream_name)
+                pending.append(downstream_name)
+    return downstream_names
+
+
+def _referenced_model_names(model_input: CompileModelInput) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                reference.ref_name
+                for reference in model_input.references
+                if reference.ref_kind == SqlReferenceKind.REF
+            }
+        )
+    )
+
+
+def _dependency_signatures_by_key(
+    *,
+    requests: tuple[_ModelSqlAnalysisRequest, ...],
+    cached_analyses: dict[str, PolyglotAnalysisResult],
+    invalidated_names: set[str],
+    current_signatures_by_name: dict[str, str],
+) -> dict[str, dict[str, str]]:
+    dependencies_by_key: dict[str, dict[str, str]] = {}
+    for request in requests:
+        cache_key: str | None = request.cache_key
+        if cache_key is None or (
+            cache_key in cached_analyses
+            and _model_name(request.model_input) not in invalidated_names
+        ):
+            continue
+        dependencies_by_key[cache_key] = {
+            upstream_name: current_signatures_by_name[upstream_name]
+            for upstream_name in _referenced_model_names(request.model_input)
+            if upstream_name in current_signatures_by_name
+        }
+    return dependencies_by_key
 
 
 def _analyze_model_sql(
@@ -468,6 +611,8 @@ def _model_sql_analysis_request(
     *,
     model_input: CompileModelInput,
     analysis_cache: AnalysisCacheContext | None,
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+    column_types_by_table: dict[str, dict[str, str]],
 ) -> _ModelSqlAnalysisRequest:
     placeholders: dict[str, str] | None = _model_placeholders(model_input)
     query_sql: str = cursor_intrinsics_analysis_sql(
@@ -480,6 +625,8 @@ def _model_sql_analysis_request(
             query_sql=query_sql,
             references=model_input.references,
             placeholders=placeholders,
+            column_nullability_by_table=column_nullability_by_table,
+            column_types_by_table=column_types_by_table,
         )
         if analysis_cache is not None
         else None

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -228,6 +228,7 @@ class AnalysisCacheContext:
 
     root: Path
     shared_fingerprint: str
+    signature_namespace: str = "default"
 
 
 @dataclass(frozen=True)
@@ -237,6 +238,7 @@ class CompileAnalysisSelection:
     select: tuple[str, ...] = ()
     exclude: tuple[str, ...] = ()
     auto_load_sources: bool = False
+    no_cache: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
@@ -524,6 +524,7 @@ def _load_targets(*, payload: object, file_path: Path) -> dict[str, TargetConfig
             defer_sources_to=_optional_str(payload=target_mapping, key="defer_sources_to"),
             defer_clone_from=_optional_str(payload=target_mapping, key="defer_clone_from"),
             changes_only=_optional_nullable_bool(mapping=target_mapping, key="changes_only"),
+            compile_cache=_optional_nullable_bool(mapping=target_mapping, key="compile_cache"),
             clone=ClonePolicy(
                 allow_as_clone_origin=_optional_bool(
                     mapping=clone_mapping,
@@ -586,6 +587,7 @@ def _load_local_targets(*, payload: object, file_path: Path) -> dict[str, LocalT
             defer_sources_to=_optional_str(payload=target_mapping, key="defer_sources_to"),
             defer_clone_from=_optional_str(payload=target_mapping, key="defer_clone_from"),
             changes_only=_optional_nullable_bool(mapping=target_mapping, key="changes_only"),
+            compile_cache=_optional_nullable_bool(mapping=target_mapping, key="compile_cache"),
             clone=LocalClonePolicy(
                 allow_as_clone_origin=_optional_nullable_bool(
                     mapping=clone_mapping,

--- a/src/sqlbuild/compiler/pipeline/_helpers/analysis_selection.py
+++ b/src/sqlbuild/compiler/pipeline/_helpers/analysis_selection.py
@@ -21,9 +21,10 @@ def resolve_compile_analysis_selection(
         or discovered_inputs.check_functions
     )
     if options.resolve_python_run_selectors and has_python_nodes:
-        return None
+        return CompileAnalysisSelection(no_cache=options.no_cache)
     return CompileAnalysisSelection(
         select=options.select,
         exclude=options.exclude,
         auto_load_sources=options.auto_load_sources,
+        no_cache=options.no_cache,
     )

--- a/src/sqlbuild/compiler/pipeline/_helpers/clone.py
+++ b/src/sqlbuild/compiler/pipeline/_helpers/clone.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models import CompileAnalysisSelection, CompiledProject
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
-from sqlbuild.compiler.pipeline.models import ClonePipelineResult
+from sqlbuild.compiler.pipeline.models import ClonePipelineOptions, ClonePipelineResult
 from sqlbuild.compiler.planner.main.clone._clone import run_clone_planning
 from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.contracts.main.resolve_target_config import resolve_target_config
@@ -21,27 +21,26 @@ def prepare_clone_pipeline(
     adapter: BaseAdapter,
     origin_target_name: str,
     destination_target_name: str,
-    no_sql_validation: bool,
-    select: tuple[str, ...],
-    exclude: tuple[str, ...],
-    cli_vars: dict[str, object] | None,
     destination_connection: Any,
+    options: ClonePipelineOptions,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> ClonePipelineResult:
     origin_project: CompiledProject = _compile_project_for_environment(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         target_name=origin_target_name,
-        no_sql_validation=no_sql_validation,
-        cli_vars=cli_vars,
+        no_sql_validation=options.no_sql_validation,
+        no_cache=options.no_cache,
+        cli_vars=options.cli_vars,
         external_sql_reference_resolver=external_sql_reference_resolver,
     )
     destination_project: CompiledProject = _compile_project_for_environment(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         target_name=destination_target_name,
-        no_sql_validation=no_sql_validation,
-        cli_vars=cli_vars,
+        no_sql_validation=options.no_sql_validation,
+        no_cache=options.no_cache,
+        cli_vars=options.cli_vars,
         external_sql_reference_resolver=external_sql_reference_resolver,
     )
     origin_read_target_name: str = _read_target_name(
@@ -59,8 +58,9 @@ def prepare_clone_pipeline(
             discovered_inputs=discovered_inputs,
             adapter=adapter,
             target_name=origin_read_target_name,
-            no_sql_validation=no_sql_validation,
-            cli_vars=cli_vars,
+            no_sql_validation=options.no_sql_validation,
+            no_cache=options.no_cache,
+            cli_vars=options.cli_vars,
             external_sql_reference_resolver=external_sql_reference_resolver,
         )
     )
@@ -71,8 +71,9 @@ def prepare_clone_pipeline(
             discovered_inputs=discovered_inputs,
             adapter=adapter,
             target_name=destination_read_target_name,
-            no_sql_validation=no_sql_validation,
-            cli_vars=cli_vars,
+            no_sql_validation=options.no_sql_validation,
+            no_cache=options.no_cache,
+            cli_vars=options.cli_vars,
             external_sql_reference_resolver=external_sql_reference_resolver,
         )
     )
@@ -86,8 +87,8 @@ def prepare_clone_pipeline(
         origin_source_entries,
     ) = run_clone_planning(
         project=destination_project,
-        select=select,
-        exclude=exclude,
+        select=options.select,
+        exclude=options.exclude,
         adapter=adapter,
         connection=destination_connection,
         origin_project=origin_project,
@@ -113,6 +114,7 @@ def _compile_project_for_environment(
     adapter: BaseAdapter,
     target_name: str,
     no_sql_validation: bool,
+    no_cache: bool,
     cli_vars: dict[str, object] | None,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None,
 ) -> CompiledProject:
@@ -121,6 +123,7 @@ def _compile_project_for_environment(
         adapter=adapter,
         selected_target=target_name,
         no_sql_validation=no_sql_validation,
+        analysis_selection=CompileAnalysisSelection(no_cache=no_cache),
         cli_vars=cli_vars,
         external_sql_reference_resolver=external_sql_reference_resolver,
     )

--- a/src/sqlbuild/compiler/pipeline/main/clone_with_options.py
+++ b/src/sqlbuild/compiler/pipeline/main/clone_with_options.py
@@ -1,4 +1,4 @@
-"""Public clone pipeline entrypoint."""
+"""Clone pipeline entrypoint with typed compilation options."""
 
 from __future__ import annotations
 
@@ -11,30 +11,24 @@ from sqlbuild.compiler.pipeline.models import ClonePipelineOptions, ClonePipelin
 from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver
 
 
-def run_clone_pipeline(
+def run_clone_pipeline_with_options(
     *,
     discovered_inputs: DiscoveredProjectInputs,
     adapter: BaseAdapter,
     origin_target_name: str,
     destination_target_name: str,
-    no_sql_validation: bool = False,
-    select: tuple[str, ...] = (),
-    exclude: tuple[str, ...] = (),
-    cli_vars: dict[str, object] | None = None,
     destination_connection: Any,
+    options: ClonePipelineOptions,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> ClonePipelineResult:
+    """Run a clone pipeline with explicit compilation controls."""
+
     return prepare_clone_pipeline(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
         origin_target_name=origin_target_name,
         destination_target_name=destination_target_name,
         destination_connection=destination_connection,
+        options=options,
         external_sql_reference_resolver=external_sql_reference_resolver,
-        options=ClonePipelineOptions(
-            no_sql_validation=no_sql_validation,
-            select=select,
-            exclude=exclude,
-            cli_vars=cli_vars,
-        ),
     )

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -37,6 +37,7 @@ from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.contracts.main.resolve_effective_adapter_name import (
     resolve_effective_adapter_name,
 )
+from sqlbuild.spec.contracts.models import TargetConfig
 
 
 def build_compiled_project(
@@ -71,7 +72,11 @@ def build_compiled_project(
         external_sql_reference_resolver=external_sql_reference_resolver,
     )
     inference_profile: ExpressionInferenceProfile = adapter.expression_inference_profile()
-    analysis_cache_dir: Path | None = _analysis_cache_dir(discovered_inputs=discovered_inputs)
+    analysis_cache_dir: Path | None = _analysis_cache_dir(
+        discovered_inputs=discovered_inputs,
+        target_config=compile_inputs.effective_target,
+        no_cache=analysis_selection is not None and analysis_selection.no_cache,
+    )
     analysis_model_names: frozenset[str] | None = _resolve_analysis_model_names(
         compile_inputs=compile_inputs,
         inference_profile=inference_profile,
@@ -103,8 +108,17 @@ def build_compiled_project(
     return project
 
 
-def _analysis_cache_dir(*, discovered_inputs: DiscoveredProjectInputs) -> Path | None:
-    if os.environ.get(COMPILE_CACHE_DISABLE_ENV_VAR) == COMPILE_CACHE_DISABLE_VALUE:
+def _analysis_cache_dir(
+    *,
+    discovered_inputs: DiscoveredProjectInputs,
+    target_config: TargetConfig | None,
+    no_cache: bool,
+) -> Path | None:
+    if (
+        no_cache
+        or (target_config is not None and target_config.compile_cache is False)
+        or os.environ.get(COMPILE_CACHE_DISABLE_ENV_VAR) == COMPILE_CACHE_DISABLE_VALUE
+    ):
         return None
     project_dir: Path | None = discovered_inputs.project_dir
     return project_dir / "target" / "compile-cache" if project_dir is not None else None

--- a/src/sqlbuild/compiler/pipeline/main/graph.py
+++ b/src/sqlbuild/compiler/pipeline/main/graph.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.compile.models import (
+    CompileAnalysisSelection,
     CompiledObjectKey,
     CompiledProject,
 )
@@ -41,6 +42,7 @@ def build_project_graph(
     cli_vars: dict[str, object] | None = None,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
     on_progress: Callable[[str], None] | None = None,
+    no_cache: bool = False,
 ) -> ProjectGraph:
     """Build the static dependency graph for a compiled project."""
 
@@ -56,6 +58,7 @@ def build_project_graph(
         column_lineage_mode=column_lineage_mode,
         cli_vars=cli_vars,
         external_sql_reference_resolver=external_sql_reference_resolver,
+        analysis_selection=CompileAnalysisSelection(no_cache=no_cache),
     )
     if on_progress is not None:
         on_progress(f"Compiled project. ({time.monotonic() - compile_start:.2f}s)")

--- a/src/sqlbuild/compiler/pipeline/models.py
+++ b/src/sqlbuild/compiler/pipeline/models.py
@@ -45,6 +45,7 @@ class CompilePipelineOptions:
     cli_vars: dict[str, object] | None = None
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None
     resolve_python_run_selectors: bool = False
+    no_cache: bool = False
 
 
 @dataclass(frozen=True)
@@ -80,6 +81,17 @@ class CompilePipelineResult:
     custom_materializations: dict[str, Callable[..., Any]] = field(default_factory=dict)
     python_node_names: frozenset[str] = field(default_factory=frozenset)
     python_plan_entries: tuple[PythonPlanEntry, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ClonePipelineOptions:
+    """Compilation and selection options for one clone pipeline."""
+
+    no_sql_validation: bool = False
+    select: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+    cli_vars: dict[str, object] | None = None
+    no_cache: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/spec/contracts/_helpers/targets.py
+++ b/src/sqlbuild/spec/contracts/_helpers/targets.py
@@ -75,6 +75,11 @@ def resolve_target_config(
             if local_target.changes_only is not None
             else project_target.changes_only
         ),
+        compile_cache=(
+            local_target.compile_cache
+            if local_target.compile_cache is not None
+            else project_target.compile_cache
+        ),
         clone=_merge_clone_policy(
             project_clone=project_target.clone,
             local_clone=local_target.clone,

--- a/src/sqlbuild/spec/contracts/models.py
+++ b/src/sqlbuild/spec/contracts/models.py
@@ -66,6 +66,7 @@ class TargetConfig:
     changes_only: bool | None = None
     clone: ClonePolicy = field(default_factory=ClonePolicy)
     state: StateConfig = field(default_factory=StateConfig)
+    compile_cache: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -82,6 +83,7 @@ class LocalTargetConfig:
     changes_only: bool | None = None
     clone: LocalClonePolicy = field(default_factory=LocalClonePolicy)
     state: LocalStateConfig = field(default_factory=LocalStateConfig)
+    compile_cache: bool | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/virtual/executor/_helpers/build.py
+++ b/src/sqlbuild/virtual/executor/_helpers/build.py
@@ -526,6 +526,7 @@ def _resolve_virtual_build(
         adapter=adapter,
         selected_target=options.planning.selected_target,
         no_sql_validation=options.planning.no_sql_validation,
+        no_cache=options.planning.no_cache,
         cli_vars=options.planning.cli_vars,
         external_sql_reference_resolver=options.planning.external_sql_reference_resolver,
         on_progress=hooks.on_progress,

--- a/src/sqlbuild/virtual/planner/models.py
+++ b/src/sqlbuild/virtual/planner/models.py
@@ -29,6 +29,7 @@ class VirtualPlanOptions:
     include_python: bool = True
     cli_vars: dict[str, object] | None = None
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None
+    no_cache: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/_test_types.py
@@ -16,6 +16,7 @@ class MainTestCase:
     expected_exit_code: int
     expected_project_dir: Path | None = None
     expected_no_sql_validation: bool = False
+    expected_no_cache: bool = False
     expected_full_refresh: bool = False
     expected_changes_only: bool = False
     expected_virtual_env: str | None = None

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -1832,6 +1832,12 @@ def test_given_skills_update_command_when_running_then_it_dispatches_handler(
             expected_no_sql_validation=True,
         ),
         MainTestCase(
+            description="passes no cache flag to compile handler",
+            argv=["compile", "--no-cache"],
+            expected_exit_code=3,
+            expected_no_cache=True,
+        ),
+        MainTestCase(
             description="passes manifest flag to compile handler",
             argv=["compile", "--manifest"],
             expected_exit_code=3,
@@ -1900,6 +1906,7 @@ def test_given_compile_no_sql_validation_when_running_then_dispatches_expected_f
         tuple[
             Path | None,
             bool,
+            bool,
             str | None,
             bool,
             bool,
@@ -1919,6 +1926,7 @@ def test_given_compile_no_sql_validation_when_running_then_dispatches_expected_f
             (
                 request.project_dir,
                 request.no_sql_validation,
+                request.no_cache,
                 request.defer_to,
                 request.json_output,
                 request.manifest,
@@ -1944,6 +1952,7 @@ def test_given_compile_no_sql_validation_when_running_then_dispatches_expected_f
         (
             test_case.expected_project_dir,
             test_case.expected_no_sql_validation,
+            test_case.expected_no_cache,
             None,
             False,
             test_case.expected_manifest,
@@ -2071,6 +2080,12 @@ def test_given_dag_command_arguments_when_running_then_dispatches_expected_handl
             expected_exit_code=5,
             expected_changes_only=True,
         ),
+        MainTestCase(
+            description="passes no cache to build handler",
+            argv=["build", "--no-cache"],
+            expected_exit_code=5,
+            expected_no_cache=True,
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -2078,7 +2093,21 @@ def test_given_build_full_refresh_when_running_then_dispatches_expected_flag(
     test_case: MainTestCase,
 ) -> None:
     received_args: list[
-        tuple[bool, bool, bool, str | None, bool | None, bool, bool, bool, bool, bool, bool, bool]
+        tuple[
+            bool,
+            bool,
+            bool,
+            str | None,
+            bool | None,
+            bool,
+            bool,
+            bool,
+            bool,
+            bool,
+            bool,
+            bool,
+            bool,
+        ]
     ] = []
 
     def run_build(request: BuildCommandRequest) -> int:
@@ -2096,6 +2125,7 @@ def test_given_build_full_refresh_when_running_then_dispatches_expected_flag(
                 request.run_audits,
                 request.debug,
                 request.changes_only,
+                request.no_cache,
             )
         )
         return test_case.expected_exit_code
@@ -2120,6 +2150,7 @@ def test_given_build_full_refresh_when_running_then_dispatches_expected_flag(
             test_case.expected_run_audits,
             test_case.expected_debug,
             test_case.expected_changes_only,
+            test_case.expected_no_cache,
         )
     ]
 
@@ -2140,6 +2171,12 @@ def test_given_build_full_refresh_when_running_then_dispatches_expected_flag(
             argv=["plan", "--changes-only"],
             expected_exit_code=4,
             expected_changes_only=True,
+        ),
+        MainTestCase(
+            description="passes no cache to plan handler",
+            argv=["plan", "--no-cache"],
+            expected_exit_code=4,
+            expected_no_cache=True,
         ),
     ],
     ids=lambda case: case.description,
@@ -2164,6 +2201,7 @@ def test_given_plan_flags_when_running_then_dispatches_expected_arguments(
             bool,
             dict[str, object] | None,
             bool,
+            bool,
         ]
     ] = []
 
@@ -2185,6 +2223,7 @@ def test_given_plan_flags_when_running_then_dispatches_expected_arguments(
                 request.verbose,
                 request.cli_vars,
                 request.changes_only,
+                request.no_cache,
             )
         )
         return test_case.expected_exit_code
@@ -2207,6 +2246,7 @@ def test_given_plan_flags_when_running_then_dispatches_expected_arguments(
         False,
         {},
         test_case.expected_changes_only,
+        test_case.expected_no_cache,
     )
 
 

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/helpers.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 from types import MappingProxyType
 from typing import cast
@@ -57,13 +58,18 @@ def compile_project_with_cache(
     *,
     project_dir: Path,
     analysis_selection: CompileAnalysisSelection | None = None,
+    no_cache: bool = False,
 ) -> CompiledProject:
     """Compile a discovered DuckDB fixture through the cache-enabled project boundary."""
 
+    effective_selection: CompileAnalysisSelection = replace(
+        analysis_selection or CompileAnalysisSelection(),
+        no_cache=no_cache,
+    )
     return build_compiled_project(
         discovered_inputs=discover_project_inputs(project_dir=project_dir),
         adapter=DuckDbAdapter(),
-        analysis_selection=analysis_selection,
+        analysis_selection=effective_selection,
     )
 
 

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
@@ -180,74 +180,253 @@ def test_given_analysis_inputs_when_building_keys_then_all_semantic_inputs_affec
     base_context: AnalysisCacheContext | None = build_analysis_cache_context(
         root=tmp_path,
         inference_profile=ExpressionInferenceProfile(sql_analysis_dialect="duckdb"),
-        column_nullability_by_table={},
-        column_types_by_table={},
-        allow_compact_analysis=False,
-    )
-    schema_context: AnalysisCacheContext | None = build_analysis_cache_context(
-        root=tmp_path,
-        inference_profile=ExpressionInferenceProfile(sql_analysis_dialect="duckdb"),
-        column_nullability_by_table={"raw_orders": {"order_id": InferredNullability.NON_NULL}},
-        column_types_by_table={},
         allow_compact_analysis=False,
     )
     profile_context: AnalysisCacheContext | None = build_analysis_cache_context(
         root=tmp_path,
         inference_profile=ExpressionInferenceProfile(sql_analysis_dialect="snowflake"),
-        column_nullability_by_table={},
-        column_types_by_table={},
         allow_compact_analysis=True,
     )
     assert base_context is not None
-    assert schema_context is not None
     assert profile_context is not None
     reference: CompileSqlReference = CompileSqlReference(
         ref_kind=SqlReferenceKind.SOURCE,
         ref_name="raw_orders",
         call_argument_count=1,
     )
+    changed_reference: CompileSqlReference = CompileSqlReference(
+        ref_kind=SqlReferenceKind.SOURCE,
+        ref_name="raw_customers",
+        call_argument_count=1,
+    )
     base_key: str = model_analysis_cache_key(
         context=base_context,
         query_sql="SELECT 1",
-        references=(),
+        references=(reference,),
         placeholders=None,
+        column_nullability_by_table={},
+        column_types_by_table={},
     )
 
     changed_keys: tuple[str, ...] = (
         model_analysis_cache_key(
             context=base_context,
             query_sql="SELECT 2",
-            references=(),
+            references=(reference,),
             placeholders=None,
+            column_nullability_by_table={},
+            column_types_by_table={},
+        ),
+        model_analysis_cache_key(
+            context=base_context,
+            query_sql="SELECT 1",
+            references=(changed_reference,),
+            placeholders=None,
+            column_nullability_by_table={},
+            column_types_by_table={},
+        ),
+        model_analysis_cache_key(
+            context=base_context,
+            query_sql="SELECT 1",
+            references=(reference,),
+            placeholders={"value": "1"},
+            column_nullability_by_table={},
+            column_types_by_table={},
         ),
         model_analysis_cache_key(
             context=base_context,
             query_sql="SELECT 1",
             references=(reference,),
             placeholders=None,
-        ),
-        model_analysis_cache_key(
-            context=base_context,
-            query_sql="SELECT 1",
-            references=(),
-            placeholders={"value": "1"},
-        ),
-        model_analysis_cache_key(
-            context=schema_context,
-            query_sql="SELECT 1",
-            references=(),
-            placeholders=None,
+            column_nullability_by_table={"raw_orders": {"order_id": InferredNullability.NON_NULL}},
+            column_types_by_table={},
         ),
         model_analysis_cache_key(
             context=profile_context,
             query_sql="SELECT 1",
-            references=(),
+            references=(reference,),
             placeholders=None,
+            column_nullability_by_table={},
+            column_types_by_table={},
         ),
+    )
+    unrelated_schema_key: str = model_analysis_cache_key(
+        context=base_context,
+        query_sql="SELECT 1",
+        references=(reference,),
+        placeholders=None,
+        column_nullability_by_table={"unrelated": {"order_id": InferredNullability.NON_NULL}},
+        column_types_by_table={},
     )
 
     assert len(changed_keys) == test_case.expected_count
     assert all(changed_key != base_key for changed_key in changed_keys)
+    assert unrelated_schema_key == base_key
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="scoped schema invalidation", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_schema_change_when_compiling_then_only_direct_consumers_miss_cache(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(
+        tmp_path,
+        {
+            **_SELECTION_REPO_FILES,
+            "models/root.sql": "MODEL ();\n\nSELECT CAST(NULL AS INTEGER) AS id\n",
+        },
+    )
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+    unrelated_path: Path = tmp_path / "models" / "unrelated.sql"
+    unrelated_path.write_text(
+        unrelated_path.read_text(encoding="utf-8").replace(
+            "MODEL ();",
+            "MODEL (columns (id (nullable false)));",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    _ = compile_project_with_cache(project_dir=tmp_path)
+
+    analyzer.assert_not_called()
+    root_path: Path = tmp_path / "models" / "root.sql"
+    root_path.write_text(
+        root_path.read_text(encoding="utf-8").replace(
+            "MODEL ();",
+            "MODEL (columns (id (nullable false)));",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    _ = compile_project_with_cache(project_dir=tmp_path)
+
+    assert analyzer.call_count == test_case.expected_count
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    assert analyzer.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="stable exported signature", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_model_sql_change_with_stable_signature_when_compiling_then_downstream_hits_cache(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _SELECTION_REPO_FILES)
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+    (tmp_path / "models" / "root.sql").write_text(
+        "MODEL ();\n\nSELECT 3 AS id\n",
+        encoding="utf-8",
+    )
+
+    _ = compile_project_with_cache(project_dir=tmp_path)
+
+    assert analyzer.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="changed exported signature", expected_count=3),),
+    ids=lambda case: case.description,
+)
+def test_given_model_output_change_when_compiling_then_downstream_closure_misses_cache(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _SELECTION_REPO_FILES)
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+    (tmp_path / "models" / "root.sql").write_text(
+        "MODEL ();\n\nSELECT 1 AS id, 2 AS extra\n",
+        encoding="utf-8",
+    )
+
+    _ = compile_project_with_cache(project_dir=tmp_path)
+
+    assert analyzer.call_count == test_case.expected_count
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    assert analyzer.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="restored exported signature", expected_count=2),),
+    ids=lambda case: case.description,
+)
+def test_given_cached_model_signature_is_restored_when_compiling_then_downstream_reanalyzes(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _SELECTION_REPO_FILES)
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    root_path: Path = tmp_path / "models" / "root.sql"
+    original_sql: str = root_path.read_text(encoding="utf-8")
+    root_path.write_text("MODEL ();\n\nSELECT 1 AS id, 2 AS extra\n", encoding="utf-8")
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+    root_path.write_text(original_sql, encoding="utf-8")
+
+    _ = compile_project_with_cache(project_dir=tmp_path)
+
+    assert analyzer.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="selected upstream change", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_selected_upstream_change_when_compiling_full_project_then_stale_consumer_misses(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(
+        tmp_path,
+        {
+            **_SELECTION_REPO_FILES,
+            "models/middle.sql": 'MODEL ();\n\nSELECT * FROM __ref("root")\n',
+            "models/leaf.sql": 'MODEL ();\n\nSELECT * FROM __ref("middle")\n',
+        },
+    )
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    (tmp_path / "models" / "root.sql").write_text(
+        "MODEL ();\n\nSELECT 1 AS id, 2 AS extra\n",
+        encoding="utf-8",
+    )
+    _ = compile_project_with_cache(
+        project_dir=tmp_path,
+        analysis_selection=CompileAnalysisSelection(select=("root",)),
+    )
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+
+    _ = compile_project_with_cache(project_dir=tmp_path)
+
+    assert analyzer.call_count == test_case.expected_count
 
 
 @pytest.mark.parametrize(
@@ -328,6 +507,63 @@ def test_given_compile_cache_bypass_when_compiling_twice_then_both_runs_analyze_
 ) -> None:
     write_repo_files(tmp_path, _CACHE_REPO_FILES)
     monkeypatch.setenv(COMPILE_CACHE_DISABLE_ENV_VAR, "1")
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    _ = compile_project_with_cache(project_dir=tmp_path)
+
+    assert analyzer.call_count == test_case.expected_count
+    assert not tuple((tmp_path / "target").rglob("*.sqlite3"))
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="command cache bypass", expected_count=2),),
+    ids=lambda case: case.description,
+)
+def test_given_command_cache_bypass_when_compiling_twice_then_both_runs_analyze_cold(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _CACHE_REPO_FILES)
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+    _ = compile_project_with_cache(project_dir=tmp_path, no_cache=True)
+    _ = compile_project_with_cache(project_dir=tmp_path, no_cache=True)
+
+    assert analyzer.call_count == test_case.expected_count
+    assert not tuple((tmp_path / "target").rglob("*.sqlite3"))
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="target cache bypass", expected_count=2),),
+    ids=lambda case: case.description,
+)
+def test_given_target_cache_disabled_when_compiling_twice_then_both_runs_analyze_cold(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(
+        tmp_path,
+        {
+            **_CACHE_REPO_FILES,
+            "sqlbuild_project.toml": """
+name = "cache_demo"
+adapter = "duckdb"
+default_target = "prod"
+
+[targets.prod]
+compile_cache = false
+""".strip()
+            + "\n",
+        },
+    )
     analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
     monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
 

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
@@ -157,6 +157,7 @@ schema = "dev"
                     "defer_sources_to": None,
                     "defer_clone_from": None,
                     "changes_only": None,
+                    "compile_cache": None,
                     "allow_as_clone_origin": False,
                     "allow_as_clone_destination": False,
                 }
@@ -209,6 +210,7 @@ loader_schema = "raw_${user}"
 defer_sources_to = "prod"
 defer_clone_from = "prod"
 changes_only = true
+compile_cache = false
 
 [targets.dev.connection]
 warehouse = "dev_wh"
@@ -290,6 +292,7 @@ enabled = true
                     "defer_sources_to": "prod",
                     "defer_clone_from": "prod",
                     "changes_only": True,
+                    "compile_cache": False,
                     "allow_as_clone_origin": True,
                     "allow_as_clone_destination": True,
                 }
@@ -359,6 +362,7 @@ def test_given_project_config_file_when_loading_project_config_then_it_returns_e
             "defer_sources_to": target_config.defer_sources_to,
             "defer_clone_from": target_config.defer_clone_from,
             "changes_only": target_config.changes_only,
+            "compile_cache": target_config.compile_cache,
             "allow_as_clone_origin": target_config.clone.allow_as_clone_origin,
             "allow_as_clone_destination": target_config.clone.allow_as_clone_destination,
         }
@@ -542,6 +546,7 @@ loader_schema = "local_raw"
 defer_sources_to = "prod"
 defer_clone_from = "prod"
 changes_only = false
+compile_cache = false
 
 [targets.dev.connection]
 warehouse = "local_wh"
@@ -572,6 +577,7 @@ allow_as_clone_destination = false
                     "defer_sources_to": "prod",
                     "defer_clone_from": "prod",
                     "changes_only": False,
+                    "compile_cache": False,
                     "allow_as_clone_origin": True,
                     "allow_as_clone_destination": False,
                 }
@@ -622,6 +628,7 @@ def test_given_local_config_state_when_loading_local_config_then_it_returns_expe
             "defer_sources_to": target_config.defer_sources_to,
             "defer_clone_from": target_config.defer_clone_from,
             "changes_only": target_config.changes_only,
+            "compile_cache": target_config.compile_cache,
             "allow_as_clone_origin": target_config.clone.allow_as_clone_origin,
             "allow_as_clone_destination": target_config.clone.allow_as_clone_destination,
         }

--- a/tests/unit/src/sqlbuild/spec/contracts/main/test_targets.py
+++ b/tests/unit/src/sqlbuild/spec/contracts/main/test_targets.py
@@ -96,6 +96,7 @@ def test_given_changes_only_config_when_resolving_then_precedence_is_applied(
                 targets={
                     "dev": TargetConfig(
                         changes_only=True,
+                        compile_cache=True,
                         loader_schema="raw_shared",
                         state=StateConfig(
                             backend="postgres",
@@ -117,6 +118,7 @@ def test_given_changes_only_config_when_resolving_then_precedence_is_applied(
                             allow_reset=True,
                         ),
                         changes_only=False,
+                        compile_cache=False,
                         loader_schema="raw_local",
                         defer_clone_from="staging",
                     )
@@ -154,3 +156,4 @@ def test_given_project_and_local_state_config_when_resolving_then_local_override
     assert target_config.loader_schema == test_case.expected_loader_schema
     assert target_config.defer_clone_from == test_case.expected_defer_clone_from
     assert target_config.changes_only is test_case.expected_changes_only
+    assert target_config.compile_cache is False


### PR DESCRIPTION
## Why

The v1 analysis cache fingerprints project-wide schema facts, so one unrelated declaration makes every model miss. Operators also need explicit command and target policy controls for deterministic cold analysis.

Tracks CHI-101.

## Changes

- Key each model by only the nullability/type facts consumed through its direct references.
- Store exported signatures and direct-upstream signature metadata; validate them in one SQLite snapshot and conservatively reanalyze descendants only when an exported signature changes.
- Keep partial selections and target/variable contexts safe with namespaced dependency metadata.
- Add `--no-cache` to `compile`, `plan`, and `build`, including virtual/defer-clone paths.
- Add target and local-target `compile_cache = false` policy.

Generated chain benchmarks:

| Models | Cold | Warm | Unrelated declaration | One-consumer declaration |
| --- | ---: | ---: | ---: | ---: |
| 3,000 | 6.014s | 1.889s | 1.933s, 0 rows | 2.156s, 1 row |
| 10,000 | 18.979s | 6.534s | 6.568s, 0 rows | 6.677s, 1 row |

A root declaration whose exported signature changes still invalidates its full downstream chain.

## Verification

- `make check-ci`
- `make test`: 4,167 passed
- Focused cache/config/CLI/defer-clone suite: 174 passed
- Independent review of selection, concurrency, API compatibility, and multi-target behavior
