### PR TITLE
perf(compiler): parallelize cache closure analysis

### DIFF
--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -98,6 +98,7 @@ from sqlbuild.spec.contracts.models import (
 
 _POLYGLOT_ANALYSIS_WORKERS: int = 2
 _POLYGLOT_PARALLEL_ANALYSIS_MIN_MODELS: int = 32
+_POLYGLOT_PARALLEL_REANALYSIS_MIN_MODELS: int = 2
 
 
 @dataclass(frozen=True)
@@ -400,42 +401,14 @@ def _analyze_model_sql_in_parallel(
         if analysis_cache is not None
         else ({}, {})
     )
-    if len(model_inputs) < _POLYGLOT_PARALLEL_ANALYSIS_MIN_MODELS:
-        analyses: tuple[_ModelSqlAnalysis, ...] = tuple(
-            _analyze_model_sql(
-                request=request,
-                cached_analysis=(
-                    cached_analyses.get(request.cache_key)
-                    if request.cache_key is not None
-                    else None
-                ),
-                column_nullability_by_table=column_nullability_by_table,
-                column_types_by_table=column_types_by_table,
-                inference_profile=inference_profile,
-                allow_compact_analysis=allow_compact_analysis,
-            )
-            for request in requests
-        )
-    else:
-        workers: int = min(_POLYGLOT_ANALYSIS_WORKERS, len(model_inputs))
-        with ThreadPoolExecutor(max_workers=workers) as executor:
-            analyses = tuple(
-                executor.map(
-                    lambda request: _analyze_model_sql(
-                        request=request,
-                        cached_analysis=(
-                            cached_analyses.get(request.cache_key)
-                            if request.cache_key is not None
-                            else None
-                        ),
-                        column_nullability_by_table=column_nullability_by_table,
-                        column_types_by_table=column_types_by_table,
-                        inference_profile=inference_profile,
-                        allow_compact_analysis=allow_compact_analysis,
-                    ),
-                    requests,
-                )
-            )
+    analyses: tuple[_ModelSqlAnalysis, ...] = _analyze_model_sql_requests(
+        requests=requests,
+        cached_analyses=cached_analyses,
+        column_nullability_by_table=column_nullability_by_table,
+        column_types_by_table=column_types_by_table,
+        inference_profile=inference_profile,
+        allow_compact_analysis=allow_compact_analysis,
+    )
     current_analyses_by_name: dict[str, PolyglotAnalysisResult] = {
         _model_name(request.model_input): analysis.polyglot_analysis
         for request, analysis in zip(requests, analyses, strict=True)
@@ -462,23 +435,33 @@ def _analyze_model_sql_in_parallel(
         changed_names=changed_signature_names,
     )
     if invalidated_names:
-        analyses = tuple(
-            (
-                _analyze_model_sql(
-                    request=request,
-                    cached_analysis=None,
+        invalidated_requests: tuple[_ModelSqlAnalysisRequest, ...] = tuple(
+            request
+            for request in requests
+            if (
+                _model_name(request.model_input) in invalidated_names
+                and request.cache_key is not None
+                and request.cache_key in cached_analyses
+            )
+        )
+        invalidated_analyses_by_name: dict[str, _ModelSqlAnalysis] = {
+            _model_name(request.model_input): analysis
+            for request, analysis in zip(
+                invalidated_requests,
+                _analyze_model_sql_requests(
+                    requests=invalidated_requests,
+                    cached_analyses={},
                     column_nullability_by_table=column_nullability_by_table,
                     column_types_by_table=column_types_by_table,
                     inference_profile=inference_profile,
                     allow_compact_analysis=allow_compact_analysis,
-                )
-                if (
-                    _model_name(request.model_input) in invalidated_names
-                    and request.cache_key is not None
-                    and request.cache_key in cached_analyses
-                )
-                else analysis
+                    parallel_min_models=_POLYGLOT_PARALLEL_REANALYSIS_MIN_MODELS,
+                ),
+                strict=True,
             )
+        }
+        analyses = tuple(
+            invalidated_analyses_by_name.get(_model_name(request.model_input), analysis)
             for request, analysis in zip(requests, analyses, strict=True)
         )
         analyses_to_record_by_name.update(
@@ -520,6 +503,35 @@ def _analyze_model_sql_in_parallel(
         _model_name(model_input): analysis
         for model_input, analysis in zip(model_inputs, analyses, strict=True)
     }
+
+
+def _analyze_model_sql_requests(
+    *,
+    requests: tuple[_ModelSqlAnalysisRequest, ...],
+    cached_analyses: dict[str, PolyglotAnalysisResult],
+    column_nullability_by_table: dict[str, dict[str, InferredNullability]],
+    column_types_by_table: dict[str, dict[str, str]],
+    inference_profile: ExpressionInferenceProfile,
+    allow_compact_analysis: bool,
+    parallel_min_models: int = _POLYGLOT_PARALLEL_ANALYSIS_MIN_MODELS,
+) -> tuple[_ModelSqlAnalysis, ...]:
+    def analyze(request: _ModelSqlAnalysisRequest) -> _ModelSqlAnalysis:
+        return _analyze_model_sql(
+            request=request,
+            cached_analysis=(
+                cached_analyses.get(request.cache_key) if request.cache_key is not None else None
+            ),
+            column_nullability_by_table=column_nullability_by_table,
+            column_types_by_table=column_types_by_table,
+            inference_profile=inference_profile,
+            allow_compact_analysis=allow_compact_analysis,
+        )
+
+    if len(requests) < parallel_min_models:
+        return tuple(analyze(request) for request in requests)
+    workers: int = min(_POLYGLOT_ANALYSIS_WORKERS, len(requests))
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        return tuple(executor.map(analyze, requests))
 
 
 def _downstream_model_names(

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import Mock
@@ -365,6 +366,61 @@ def test_given_model_output_change_when_compiling_then_downstream_closure_misses
     assert analyzer.call_count == test_case.expected_count
     _ = compile_project_with_cache(project_dir=tmp_path)
     assert analyzer.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="parallel downstream invalidation", expected_count=2),),
+    ids=lambda case: case.description,
+)
+def test_given_changed_output_signature_when_reanalyzing_downstream_then_uses_parallel_workers(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _SELECTION_REPO_FILES)
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    root_path: Path = tmp_path / "models" / "root.sql"
+    original_sql: str = root_path.read_text(encoding="utf-8")
+    root_path.write_text("MODEL ();\n\nSELECT 1 AS id, 2 AS extra\n", encoding="utf-8")
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    barrier: threading.Barrier = threading.Barrier(test_case.expected_count)
+    worker_ids: set[int] = set()
+    real_analyzer: Callable[..., PolyglotAnalysisResult] = (
+        assembly_project.analyze_columns_and_lineage_with_polyglot
+    )
+
+    def analyze_with_barrier(
+        *,
+        query_sql: str,
+        references: tuple[CompileSqlReference, ...],
+        placeholders: dict[str, str] | None,
+        column_nullability_by_table: dict[str, dict[str, InferredNullability]] | None,
+        column_types_by_table: dict[str, dict[str, str]] | None,
+        inference_profile: ExpressionInferenceProfile | None,
+        allow_compact_analysis: bool,
+    ) -> PolyglotAnalysisResult:
+        worker_ids.add(threading.get_ident())
+        _ = barrier.wait(timeout=5)
+        return real_analyzer(
+            query_sql=query_sql,
+            references=references,
+            placeholders=placeholders,
+            column_nullability_by_table=column_nullability_by_table,
+            column_types_by_table=column_types_by_table,
+            inference_profile=inference_profile,
+            allow_compact_analysis=allow_compact_analysis,
+        )
+
+    monkeypatch.setattr(
+        assembly_project, "analyze_columns_and_lineage_with_polyglot", analyze_with_barrier
+    )
+    root_path.write_text(original_sql, encoding="utf-8")
+
+    _ = compile_project_with_cache(project_dir=tmp_path)
+
+    assert len(worker_ids) == test_case.expected_count
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

The schema-closure scaling matrix exposed a serial second-pass path after an exported signature change. Cache hit/miss behavior was correct, but 50 affected descendants took 10.79s and 500 took 14.72s on the heavy-tail 10K fixture because stale cached descendants were reanalyzed one at a time.

Tracks CHI-101.

## Changes

- Route initial and invalidated model subsets through one bounded analysis helper.
- Submit only stale cached descendants during the second pass; freshly analyzed and unrelated models are not repeated.
- Parallelize closure reanalysis from two affected requests onward while preserving request/result order.
- Add a barrier-based regression test proving invalidated descendants execute on two workers.

Uniform-width 10K closure scaling after the fix:

| Affected | Total |
| ---: | ---: |
| 0 | 4.023s |
| 50 | 4.252s |
| 500 | 4.416s |
| 3,000 | 5.737s |
| 5,000 | 6.786s |
| 9,999 | 9.087s |

Linear fit: approximately 0.499ms per affected model, R² 0.9974. The heavy-tail fixture also improved: 500 affected fell from 14.72s to 11.60s and 3K from 20.78s to 15.93s; its final models hold a disproportionate share of SQL bytes.

## Verification

- `make check-ci`
- `make test`: 4,168 passed
- Analysis-cache tests: 16 passed
- Fensu: zero faults
- Independent ordering, cache-semantics, concurrency, and benchmark review
