### PR TITLE
docs: simplify README positioning and CI scope

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -56,10 +56,7 @@ jobs:
                 ;;
               tests/unit/*|tests/integration/*)
                 ;;
-              .github/workflows/verify.yml)
-                duckdb=true
-                ;;
-              .github/*|docs/*|*.md|LICENSE)
+              .github/*|docs/*|*.md|.gitignore|LICENSE)
                 ;;
               *)
                 broad=true

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ sqlbuild_local.toml
 # Claude Code
 .claude/
 
+# Local agent instructions
+AGENTS.md
+
 # Fensu
 .fensu/cache/
 .fensu/memory/

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 **Valid isn't the same as correct.** Your SQL compiles, runs, and returns rows; none of that means the number is right, and a silently-wrong number a stakeholder already trusted is the bug that actually hurts.
 
-SQLBuild brings software-engineering rigor to SQL pipelines: catch errors before the warehouse runs them, test your logic locally, and opt into change-aware execution when you need it. It works as a standalone framework or points at your existing dbt project with no migration and no edits to your dbt files.
+SQLBuild brings software-engineering rigor to SQL pipelines: catch errors before the warehouse runs them, test your logic locally, and opt into change-aware execution when you need it. It is a standalone, open-source framework for building SQL and Python data pipelines.
 
-All state is persisted as append-only tables in the warehouse alongside your data: no external state database, no manifest files, no paid add-on. It keeps a low, dbt-like floor for SQL models and adds ingestion, Python nodes, and opt-in virtual environments as your project grows.
+All state is persisted as append-only tables in the warehouse alongside your data: no external state database, no manifest files, no paid add-on. Start with straightforward SQL models, then add ingestion, Python nodes, and opt-in virtual environments as your project grows.
 
 ## Key features
 
@@ -20,28 +20,11 @@ All state is persisted as append-only tables in the warehouse alongside your dat
 - **Audits that block bad data.** Audits run before data reaches the target table. Full table builds materialize into a staging table and only promote if audits pass; incremental models validate each batch before DML.
 - **Deploy reversibly (opt-in).** Virtual environments add instant low-copy branching, partial promotion, rollback, checkpoints, and reconciliation. Opt-in, not a tax you pay upfront.
 - **Opt-in change-aware execution.** Models, seeds, UDFs, and Python nodes are fingerprinted, and source freshness is tracked. In virtual environments, pass `--changes-only` or set `changes_only = true` to skip work that is already current; commands otherwise run the full selected scope.
-- **Works with your existing dbt project.** Point SQLBuild at a dbt project and run ordinary dbt selections alongside SQLBuild models. It reads the manifest and drives the `dbt` CLI as a subprocess; it never edits your dbt files. dbt-native `--state` and `--defer` remain available for production-shaped, state-aware selections. See [dbt compatibility](https://docs.sqlbuild.com/concepts/dbt-compatibility/overview).
 - **Warehouse-native state.** All change-tracking state lives in append-only tables (`_sqlbuild_fingerprints`, `_sqlbuild_source_freshness`, `_sqlbuild_node_results`) in your warehouse schemas. No external state machine, no corruption risk.
 - **Cursor-based incremental processing.** Automatic gap detection and resume, with microbatch mode for large ranges. No external checkpoint to maintain.
 - **Ingestion and Python nodes.** Load external data with Python `@loader` functions, and run `@task`, `@asset`, and `@check` nodes as first-class members of the same DAG as your SQL models.
 
-See the [documentation](https://docs.sqlbuild.com) for the full feature set, including providers, lifecycle hooks, Python macros, UDFs, custom materializations, data diffs, zero-copy cloning, and virtual environments.
-
-## Works with your existing dbt project
-
-Point SQLBuild at a dbt project and run a `sqb dbt` command. The first time, it bootstraps a minimal twin project from your `dbt_project.yml` and profile (reusing your dbt connection), then runs your selection through dbt:
-
-```bash
-sqb dbt build --select path:models/marts
-```
-
-SQLBuild preserves dbt-native state and defer arguments when you need dbt's own state-aware selection:
-
-```bash
-sqb dbt build --state path/to/state --defer --select state:modified+
-```
-
-Ordinary `sqb dbt plan`, `run`, and `build` commands do not fingerprint dbt models or inspect production state automatically. Use dbt-native `--state`/`--defer` for production-shaped comparisons. See [dbt compatibility](https://docs.sqlbuild.com/concepts/dbt-compatibility/overview).
+See the [documentation](https://docs.sqlbuild.com) for the full feature set, including providers, lifecycle hooks, Python macros, UDFs, custom materializations, data diffs, zero-copy cloning, and virtual environments. If you are evaluating a migration from dbt, see the [dbt compatibility guide](https://docs.sqlbuild.com/concepts/dbt-compatibility/overview).
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -106,61 +106,6 @@ SELECT 1
 
 See the [documentation](https://docs.sqlbuild.com) for incremental models, scenarios, loaders, and more.
 
-## Concurrent microbatches
-
-Native `delete_insert` microbatch models can opt into parallel batch execution. Serial execution is
-the default and remains recommended unless parallel batches provide a meaningful runtime benefit.
-Enable the project capability and set a per-model ceiling:
-
-```toml
-[settings]
-microbatch_concurrency = true
-microbatch_unaccounted_partition_policy = "synthesize"
-```
-
-```sql
-MODEL (
-  materialized incremental,
-  incremental_mode microbatch,
-  incremental_strategy delete_insert,
-  cursor event_time,
-  cursor_type timestamp,
-  cursor_grain hour,
-  batch_size 1h,
-  batch_concurrency 4,
-);
-```
-
-`batch_concurrency` is a model ceiling, not a separate worker pool. Batches share the build's global
-`concurrency` limit and connection pool with every other DAG node. First-run and full-refresh target
-bootstrap remain serialized. Concurrent batches are rejected for adapters that have not explicitly
-declared same-target concurrent delete/insert support.
-
-Every native microbatch, including serial models and projects where the capability is disabled,
-records successful half-open partitions and their model fingerprints. Standard builds use the
-warehouse `_sqlbuild_microbatches` table. Virtual builds store equivalent events in the configured
-DuckDB or Postgres state backend and scope them to the immutable physical model version. Virtual
-builds renew a physical-version lease while mutating shared data; standard-mode orchestrators must
-prevent overlapping invocations for the same model destination.
-
-Janitor may read microbatch history to protect active physical versions, but it never drops or
-prunes `_sqlbuild_microbatches` or virtual `microbatch_events`. Removing virtual event history is an
-explicit `sqb state reset` operator action, not ordinary retention cleanup.
-
-The append-only history distinguishes physical continuity from fingerprint continuity. Known gaps
-are recovered before new normal work. Automatic `replay_on_change` ranges are durable and
-version-specific, while explicit backfills remain one-shot requests. If destination progress is not
-explained by retained history, `microbatch_unaccounted_partition_policy` controls reconciliation:
-
-- `synthesize` accepts inferred physical coverage and records an unknown fingerprint.
-- `recover_empty` counts candidates in bounded chunks, reruns empty intervals, and synthesizes
-  non-empty intervals.
-- `recover_all` reruns every unaccounted interval without a preliminary count.
-
-Synthetic coverage preserves forward progress but weakens version guarantees and remains visible in
-warnings and JSON output. Target DML and event insertion do not require a cross-system transaction;
-idempotent `delete_insert` recovery handles failures between those operations.
-
 ## Kata SQL architecture checks
 
 Kata is SQLBuild's opt-in, error-only SQL model shape checker. It runs offline over the compiled


### PR DESCRIPTION
## Why

The top-level README included implementation-level microbatch internals and prominently positioned SQLBuild as a zero-migration dbt compatibility layer. Neither belongs in the concise project overview, and the dbt positioning overstates the current interoperability surface.

README and local-ignore changes should not run the DuckDB and PostgreSQL E2E suites. The classifier treated `.gitignore` as a broad runtime change, and a temporary CPU-diagnostic exception also made `verify.yml` trigger DuckDB E2E.

## Changes

- Position SQLBuild directly as a standalone SQL and Python data-pipeline framework.
- Remove the dbt key-feature bullet and command walkthrough.
- Retain one neutral link to the dbt compatibility guide for readers evaluating migration.
- Remove the `Concurrent microbatches` implementation section from the README.
- Retain the concise key-feature reference to cursor-based incremental processing and microbatch mode.
- Ignore local `AGENTS.md` files repository-wide so agent-specific instructions cannot be committed accidentally.
- Treat `.gitignore`, documentation, and workflow-only changes as focused changes that skip warehouse E2E suites.

## Verification

- `make check-ci`
- Fensu: zero faults
- `git diff --check`
- Classifier matrix: focused changes skip both suites; DuckDB, PostgreSQL, and source changes select the expected suites.
