### PR TITLE
perf(compiler): reduce warm compile overhead

### DIFF
--- a/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
+++ b/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import inspect
 import json
 import platform
 import sqlite3
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from string import hexdigits
 from typing import Any, cast
 
 from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
@@ -29,9 +31,11 @@ from sqlbuild.compiler.lineage.types import (
 )
 from sqlbuild.compiler.references.types import SqlReferenceKind
 
-_ANALYSIS_CACHE_VERSION: int = 2
-_ANALYSIS_ALGORITHM_FINGERPRINT: str = "model-sql-analysis-v2"
+_ANALYSIS_CACHE_VERSION: int = 4
+_ANALYSIS_ALGORITHM_FINGERPRINT: str = "model-sql-analysis-v4"
 _MAX_CACHE_ENTRY_BYTES: int = 10_000_000
+_SHA256_HEX_LENGTH: int = 64
+_CACHE_ENTRY_SEPARATOR: str = "\n"
 _LOCAL_QUALNAME_MARKER: str = "<locals>"
 _SQLITE_QUERY_CHUNK_SIZE: int = 500
 _SQLITE_TIMEOUT_SECONDS: float = 0.1
@@ -138,14 +142,15 @@ def read_model_analyses(
     cache_keys: tuple[str, ...],
     model_names: tuple[str, ...],
     upstream_model_names_by_key: dict[str, tuple[str, ...]],
-) -> tuple[dict[str, PolyglotAnalysisResult], dict[str, str]]:
+) -> tuple[dict[str, PolyglotAnalysisResult], dict[str, str], dict[str, str]]:
     """Read one consistent snapshot of analyses, dependencies, and output signatures."""
 
     database_path: Path = _cache_database_path(context=context)
     if not database_path.is_file() or not cache_keys:
-        return {}, {}
+        return {}, {}, {}
     analyses: dict[str, PolyglotAnalysisResult] = {}
     signatures: dict[str, str] = {}
+    output_signatures_by_key: dict[str, str] = {}
     try:
         connection_uri: str = f"file:{database_path}?mode=ro"
         with sqlite3.connect(
@@ -202,15 +207,19 @@ def read_model_analyses(
                         or dependencies_by_key.get(cache_key, {}) != expected_dependencies
                     ):
                         continue
-                    analysis: PolyglotAnalysisResult | None = _analysis_from_contents(
-                        contents=contents,
-                        expected_cache_key=cache_key,
+                    cached_result: tuple[PolyglotAnalysisResult, str] | None = (
+                        _analysis_from_contents(
+                            contents=contents,
+                            expected_cache_key=cache_key,
+                        )
                     )
-                    if analysis is not None:
+                    if cached_result is not None:
+                        analysis, output_signature = cached_result
                         analyses[cache_key] = analysis
+                        output_signatures_by_key[cache_key] = output_signature
     except (OSError, sqlite3.DatabaseError):
-        return {}, {}
-    return analyses, signatures
+        return {}, {}, {}
+    return analyses, signatures, output_signatures_by_key
 
 
 def write_model_analyses(
@@ -225,12 +234,7 @@ def write_model_analyses(
     rows: list[tuple[str, str]] = [
         (
             cache_key,
-            json.dumps(
-                _analysis_payload(cache_key=cache_key, analysis=analysis),
-                ensure_ascii=False,
-                separators=(",", ":"),
-                sort_keys=True,
-            ),
+            _analysis_contents(cache_key=cache_key, analysis=analysis),
         )
         for cache_key, analysis in analyses_by_key.items()
         if analysis.analysis_succeeded
@@ -328,11 +332,21 @@ def model_analysis_output_signature(analysis: PolyglotAnalysisResult) -> str:
 
 def _analysis_from_contents(
     *, contents: str, expected_cache_key: str
-) -> PolyglotAnalysisResult | None:
-    if len(contents.encode("utf-8")) > _MAX_CACHE_ENTRY_BYTES:
+) -> tuple[PolyglotAnalysisResult, str] | None:
+    encoded_contents: bytes = contents.encode("utf-8")
+    if len(encoded_contents) > _MAX_CACHE_ENTRY_BYTES:
         return None
     try:
-        payload: object = json.loads(contents)
+        stored_digest, separator, serialized_payload = contents.partition(_CACHE_ENTRY_SEPARATOR)
+        if not separator or not hmac.compare_digest(
+            stored_digest,
+            _cache_entry_digest(
+                cache_key=expected_cache_key,
+                serialized_payload=serialized_payload,
+            ),
+        ):
+            return None
+        payload: object = json.loads(serialized_payload)
         return _analysis_from_payload(payload=payload, expected_cache_key=expected_cache_key)
     except (ValueError, TypeError, KeyError, json.JSONDecodeError):
         return None
@@ -418,116 +432,152 @@ def _referenced_analysis_tables(
 
 
 def _analysis_payload(*, cache_key: str, analysis: PolyglotAnalysisResult) -> dict[str, object]:
-    analysis_payload: dict[str, object] = {
-        "columns": (
+    return {
+        "v": _ANALYSIS_CACHE_VERSION,
+        "k": cache_key,
+        "s": model_analysis_output_signature(analysis),
+        "c": (
             None
             if analysis.columns is None
             else [
-                {
-                    "name": column.name,
-                    "type": column.type,
-                    "nullability": column.nullability.value,
-                }
-                for column in analysis.columns
+                [column.name, column.type, column.nullability.value] for column in analysis.columns
             ]
         ),
-        "lineage_columns": [_lineage_column_payload(column) for column in analysis.lineage_columns],
-        "has_star": analysis.has_star,
-    }
-    return {
-        "version": _ANALYSIS_CACHE_VERSION,
-        "cache_key": cache_key,
-        "analysis_succeeded": True,
-        "analysis_digest": _payload_digest(analysis_payload),
-        "analysis": analysis_payload,
+        "l": [_lineage_column_payload(column) for column in analysis.lineage_columns],
+        "h": analysis.has_star,
     }
 
 
-def _lineage_column_payload(column: CompiledLineageColumnFact) -> dict[str, object]:
-    return {
-        "output_column": column.output_column,
-        "transform_kind": column.transform_kind.value,
-        "confidence": column.confidence.value,
-        "upstream_columns": [
-            {
-                "resource_type": str(source.resource_type),
-                "resource_name": source.resource_name,
-                "column_name": source.column_name,
-            }
+def _lineage_column_payload(column: CompiledLineageColumnFact) -> list[object]:
+    return [
+        column.output_column,
+        column.transform_kind.value,
+        column.confidence.value,
+        [
+            [
+                str(source.resource_type),
+                source.resource_name,
+                source.column_name,
+            ]
             for source in column.upstream_columns
         ],
-    }
+    ]
 
 
-def _analysis_from_payload(*, payload: object, expected_cache_key: str) -> PolyglotAnalysisResult:
+def _analysis_from_payload(
+    *, payload: object, expected_cache_key: str
+) -> tuple[PolyglotAnalysisResult, str]:
     if not isinstance(payload, dict):
         raise AnalysisCacheEntryError("analysis cache entry must be an object")
     values: dict[str, Any] = cast(dict[str, Any], payload)
-    version_value: object = values["version"]
+    version_value: object = values["v"]
     if type(version_value) is not int or version_value != _ANALYSIS_CACHE_VERSION:
         raise AnalysisCacheEntryError("analysis cache version mismatch")
-    if values["cache_key"] != expected_cache_key:
+    if values["k"] != expected_cache_key:
         raise AnalysisCacheEntryError("analysis cache key mismatch")
-    if values["analysis_succeeded"] is not True:
-        raise AnalysisCacheEntryError("analysis cache contains an unsuccessful result")
-    analysis_payload: object = values["analysis"]
-    if not isinstance(analysis_payload, dict):
-        raise AnalysisCacheEntryError("analysis cache facts must be an object")
-    if values["analysis_digest"] != _payload_digest(analysis_payload):
-        raise AnalysisCacheEntryError("analysis cache facts checksum mismatch")
-    analysis_values: dict[str, Any] = cast(dict[str, Any], analysis_payload)
-    columns_payload: object = analysis_values["columns"]
+    output_signature: object = values["s"]
+    if not (
+        isinstance(output_signature, str)
+        and len(output_signature) == _SHA256_HEX_LENGTH
+        and all(character in hexdigits for character in output_signature)
+    ):
+        raise AnalysisCacheEntryError("analysis cache output signature is invalid")
+    columns_payload: object = values["c"]
     columns: tuple[InferredColumn, ...] | None = (
         None
         if columns_payload is None
-        else tuple(
-            InferredColumn(
-                name=str(column["name"]),
-                type=None if column.get("type") is None else str(column["type"]),
-                nullability=InferredNullability(str(column["nullability"])),
-            )
-            for column in _object_list(columns_payload)
-        )
+        else tuple(_column_from_payload(column) for column in _value_lists(columns_payload))
     )
     lineage_columns: tuple[CompiledLineageColumnFact, ...] = tuple(
-        _lineage_column_from_payload(column)
-        for column in _object_list(analysis_values["lineage_columns"])
+        _lineage_column_from_payload(column) for column in _value_lists(values["l"])
     )
-    has_star: object = analysis_values["has_star"]
+    has_star: object = values["h"]
     if not isinstance(has_star, bool):
         raise AnalysisCacheEntryError("analysis cache has_star must be a boolean")
-    return PolyglotAnalysisResult(
-        analysis_succeeded=True,
-        columns=columns,
-        lineage_columns=lineage_columns,
-        has_star=has_star,
+    return (
+        PolyglotAnalysisResult(
+            analysis_succeeded=True,
+            columns=columns,
+            lineage_columns=lineage_columns,
+            has_star=has_star,
+        ),
+        output_signature,
     )
 
 
-def _object_list(payload: object) -> list[dict[str, Any]]:
-    if not isinstance(payload, list) or not all(isinstance(item, dict) for item in payload):
-        raise AnalysisCacheEntryError("analysis cache collection must contain objects")
-    return cast(list[dict[str, Any]], payload)
+def _value_lists(payload: object) -> list[list[object]]:
+    if not isinstance(payload, list) or not all(isinstance(item, list) for item in payload):
+        raise AnalysisCacheEntryError("analysis cache collection must contain arrays")
+    return cast(list[list[object]], payload)
 
 
-def _lineage_column_from_payload(payload: dict[str, Any]) -> CompiledLineageColumnFact:
+def _column_from_payload(payload: list[object]) -> InferredColumn:
+    column_value_count: int = 3
+    if len(payload) != column_value_count:
+        raise AnalysisCacheEntryError("analysis cache column must contain three values")
+    name, column_type, nullability = payload
+    if not isinstance(name, str) or not isinstance(nullability, str):
+        raise AnalysisCacheEntryError("analysis cache column name and nullability must be strings")
+    if column_type is not None and not isinstance(column_type, str):
+        raise AnalysisCacheEntryError("analysis cache column type must be a string or null")
+    return InferredColumn(
+        name=name,
+        type=column_type,
+        nullability=InferredNullability(nullability),
+    )
+
+
+def _lineage_column_from_payload(payload: list[object]) -> CompiledLineageColumnFact:
+    lineage_value_count: int = 4
+    if len(payload) != lineage_value_count:
+        raise AnalysisCacheEntryError("analysis cache lineage column must contain four values")
+    output_column, transform_kind, confidence, upstream_columns = payload
+    if not all(isinstance(value, str) for value in (output_column, transform_kind, confidence)):
+        raise AnalysisCacheEntryError("analysis cache lineage attributes must be strings")
     return CompiledLineageColumnFact(
-        output_column=str(payload["output_column"]),
-        transform_kind=ColumnTransformKind(str(payload["transform_kind"])),
-        confidence=ColumnLineageConfidence(str(payload["confidence"])),
+        output_column=cast(str, output_column),
+        transform_kind=ColumnTransformKind(cast(str, transform_kind)),
+        confidence=ColumnLineageConfidence(cast(str, confidence)),
         upstream_columns=tuple(
-            CompiledLineageSourceFact(
-                resource_type=str(source["resource_type"]),
-                resource_name=str(source["resource_name"]),
-                column_name=str(source["column_name"]),
-            )
-            for source in _object_list(payload["upstream_columns"])
+            _lineage_source_from_payload(source) for source in _value_lists(upstream_columns)
         ),
+    )
+
+
+def _lineage_source_from_payload(payload: list[object]) -> CompiledLineageSourceFact:
+    source_value_count: int = 3
+    if len(payload) != source_value_count or not all(isinstance(value, str) for value in payload):
+        raise AnalysisCacheEntryError("analysis cache lineage source must contain three strings")
+    resource_type, resource_name, column_name = cast(list[str], payload)
+    return CompiledLineageSourceFact(
+        resource_type=resource_type,
+        resource_name=resource_name,
+        column_name=column_name,
     )
 
 
 def _cache_database_path(*, context: AnalysisCacheContext) -> Path:
     return context.root / f"v{_ANALYSIS_CACHE_VERSION}" / _CACHE_DATABASE_NAME
+
+
+def _analysis_contents(*, cache_key: str, analysis: PolyglotAnalysisResult) -> str:
+    serialized_payload: str = json.dumps(
+        _analysis_payload(cache_key=cache_key, analysis=analysis),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return _CACHE_ENTRY_SEPARATOR.join(
+        (
+            _cache_entry_digest(cache_key=cache_key, serialized_payload=serialized_payload),
+            serialized_payload,
+        )
+    )
+
+
+def _cache_entry_digest(*, cache_key: str, serialized_payload: str) -> str:
+    encoded: bytes = f"{cache_key}\0{serialized_payload}".encode()
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _payload_digest(payload: object) -> str:

--- a/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
+++ b/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
@@ -231,14 +231,13 @@ def write_model_analyses(
 ) -> None:
     """Transactionally persist successful analyses; cache failures never fail compilation."""
 
-    rows: list[tuple[str, str]] = [
-        (
-            cache_key,
-            _analysis_contents(cache_key=cache_key, analysis=analysis),
-        )
-        for cache_key, analysis in analyses_by_key.items()
-        if analysis.analysis_succeeded
-    ]
+    rows: list[tuple[str, str]] = []
+    for cache_key, analysis in analyses_by_key.items():
+        if not analysis.analysis_succeeded:
+            continue
+        contents: str = _analysis_contents(cache_key=cache_key, analysis=analysis)
+        if len(contents.encode()) <= _MAX_CACHE_ENTRY_BYTES:
+            rows.append((cache_key, contents))
     signature_rows: list[tuple[str, str, str, str]] = [
         (
             context.shared_fingerprint,
@@ -331,12 +330,13 @@ def model_analysis_output_signature(analysis: PolyglotAnalysisResult) -> str:
 
 
 def _analysis_from_contents(
-    *, contents: str, expected_cache_key: str
+    *, contents: object, expected_cache_key: str
 ) -> tuple[PolyglotAnalysisResult, str] | None:
-    encoded_contents: bytes = contents.encode("utf-8")
-    if len(encoded_contents) > _MAX_CACHE_ENTRY_BYTES:
+    if not isinstance(contents, str):
         return None
     try:
+        if len(contents.encode()) > _MAX_CACHE_ENTRY_BYTES:
+            return None
         stored_digest, separator, serialized_payload = contents.partition(_CACHE_ENTRY_SEPARATOR)
         if not separator or not hmac.compare_digest(
             stored_digest,
@@ -348,7 +348,7 @@ def _analysis_from_contents(
             return None
         payload: object = json.loads(serialized_payload)
         return _analysis_from_payload(payload=payload, expected_cache_key=expected_cache_key)
-    except (ValueError, TypeError, KeyError, json.JSONDecodeError):
+    except (ValueError, TypeError, KeyError, RecursionError, json.JSONDecodeError):
         return None
 
 

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -385,7 +385,8 @@ def _analyze_model_sql_in_parallel(
     )
     cached_analyses: dict[str, PolyglotAnalysisResult]
     previous_signatures: dict[str, str]
-    cached_analyses, previous_signatures = (
+    cached_output_signatures_by_key: dict[str, str]
+    cached_analyses, previous_signatures, cached_output_signatures_by_key = (
         read_model_analyses(
             context=analysis_cache,
             cache_keys=tuple(
@@ -399,7 +400,7 @@ def _analyze_model_sql_in_parallel(
             },
         )
         if analysis_cache is not None
-        else ({}, {})
+        else ({}, {}, {})
     )
     analyses: tuple[_ModelSqlAnalysis, ...] = _analyze_model_sql_requests(
         requests=requests,
@@ -414,8 +415,12 @@ def _analyze_model_sql_in_parallel(
         for request, analysis in zip(requests, analyses, strict=True)
     }
     current_signatures_by_name: dict[str, str] = {
-        model_name: model_analysis_output_signature(analysis)
-        for model_name, analysis in current_analyses_by_name.items()
+        _model_name(request.model_input): (
+            cached_output_signatures_by_key[request.cache_key]
+            if request.cache_key is not None and request.cache_key in cached_analyses
+            else model_analysis_output_signature(analysis.polyglot_analysis)
+        )
+        for request, analysis in zip(requests, analyses, strict=True)
     }
     analyses_to_record_by_name: dict[str, PolyglotAnalysisResult] = {
         _model_name(request.model_input): analysis.polyglot_analysis
@@ -475,10 +480,12 @@ def _analyze_model_sql_in_parallel(
             _model_name(request.model_input): analysis.polyglot_analysis
             for request, analysis in zip(requests, analyses, strict=True)
         }
-        current_signatures_by_name = {
-            model_name: model_analysis_output_signature(analysis)
-            for model_name, analysis in current_analyses_by_name.items()
-        }
+        current_signatures_by_name.update(
+            {
+                model_name: model_analysis_output_signature(invalidated_analysis.polyglot_analysis)
+                for model_name, invalidated_analysis in invalidated_analyses_by_name.items()
+            }
+        )
     if analysis_cache is not None:
         write_model_analyses(
             context=analysis_cache,

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, fields, replace
 from datetime import UTC, datetime
 from inspect import Parameter, Signature
@@ -33,7 +34,7 @@ from sqlbuild.compiler.compile._helpers.config.model_validation import (
     validate_placeholder_config,
     validate_snapshot_config,
 )
-from sqlbuild.compiler.compile._helpers.refs.references import extract_sql_references
+from sqlbuild.compiler.compile._helpers.refs.cache import cached_sql_reference_extractor
 from sqlbuild.compiler.compile._helpers.render.cursor_intrinsics import (
     cursor_intrinsics_analysis_sql,
     get_validated_model_cursor_intrinsics,
@@ -124,8 +125,30 @@ def build_model_inputs(
     no_sql_validation: bool = False,
     defer_model_sql_validation: bool = False,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
+    reference_cache_dir: Path | None = None,
 ) -> tuple[CompileModelInput, ...]:
     """Attach schema metadata to discovered model files."""
+
+    with cached_sql_reference_extractor(root=reference_cache_dir) as extract_references:
+        return _build_model_inputs(
+            discovered_inputs=discovered_inputs,
+            context=context,
+            no_sql_validation=no_sql_validation,
+            defer_model_sql_validation=defer_model_sql_validation,
+            external_sql_reference_resolver=external_sql_reference_resolver,
+            extract_references=extract_references,
+        )
+
+
+def _build_model_inputs(
+    *,
+    discovered_inputs: DiscoveredProjectInputs,
+    context: ModelInputBuildContext,
+    no_sql_validation: bool,
+    defer_model_sql_validation: bool,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None,
+    extract_references: Callable[[str], tuple[CompileSqlReference, ...]],
+) -> tuple[CompileModelInput, ...]:
 
     effective_vars: dict[str, object] = context.effective_vars
     effective_settings: SettingsConfig = context.effective_settings
@@ -223,7 +246,7 @@ def build_model_inputs(
                 file_path=model_file.file_path,
                 placeholders=sql_validation_placeholders,
             )
-        references: tuple[CompileSqlReference, ...] = extract_sql_references(expanded_query_sql)
+        references: tuple[CompileSqlReference, ...] = extract_references(expanded_query_sql)
         validate_model_references(
             references=references,
             model_file=model_file,

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/target.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/target.py
@@ -1,0 +1,49 @@
+"""Effective target and compile-cache resolution helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from sqlbuild.compiler.compile.constants import (
+    COMPILE_CACHE_DISABLE_ENV_VAR,
+    COMPILE_CACHE_DISABLE_VALUE,
+)
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.spec.contracts.main.resolve_target_config import resolve_target_config
+from sqlbuild.spec.contracts.main.resolve_target_name import resolve_target_name
+from sqlbuild.spec.contracts.models import TargetConfig
+
+
+def build_compile_target_context(
+    *,
+    discovered_inputs: DiscoveredProjectInputs,
+    selected_target: str | None,
+    no_cache: bool,
+) -> tuple[str | None, TargetConfig | None, Path | None]:
+    """Resolve the effective target and shared project-local compile-cache directory."""
+
+    target_name: str | None = resolve_target_name(
+        project_config=discovered_inputs.project_config,
+        local_config=discovered_inputs.local_config,
+        selected_target=selected_target,
+    )
+    target_config: TargetConfig | None = (
+        resolve_target_config(
+            project_config=discovered_inputs.project_config,
+            local_config=discovered_inputs.local_config,
+            target_name=target_name,
+        )
+        if target_name is not None
+        else None
+    )
+    cache_disabled: bool = (
+        no_cache
+        or (target_config is not None and target_config.compile_cache is False)
+        or os.environ.get(COMPILE_CACHE_DISABLE_ENV_VAR) == COMPILE_CACHE_DISABLE_VALUE
+    )
+    project_dir: Path | None = discovered_inputs.project_dir
+    cache_dir: Path | None = (
+        None if cache_disabled or project_dir is None else project_dir / "target" / "compile-cache"
+    )
+    return target_name, target_config, cache_dir

--- a/src/sqlbuild/compiler/compile/_helpers/refs/cache.py
+++ b/src/sqlbuild/compiler/compile/_helpers/refs/cache.py
@@ -112,10 +112,12 @@ class _SqlReferenceCache:
         references: tuple[CompileSqlReference, ...] = extract_sql_references(sql)
         if self._database_path is not None:
             try:
-                self._pending_contents_by_key[cache_key] = _reference_contents(
+                contents: str = _reference_contents(
                     cache_key=cache_key,
                     references=references,
                 )
+                if len(contents.encode()) <= _MAX_CACHE_ENTRY_BYTES:
+                    self._pending_contents_by_key[cache_key] = contents
             except (TypeError, ValueError):
                 pass
         return references
@@ -180,12 +182,13 @@ def _reference_contents(*, cache_key: str, references: tuple[CompileSqlReference
 
 
 def _references_from_contents(
-    *, contents: str, expected_cache_key: str
+    *, contents: object, expected_cache_key: str
 ) -> tuple[CompileSqlReference, ...] | None:
-    encoded_contents: bytes = contents.encode()
-    if len(encoded_contents) > _MAX_CACHE_ENTRY_BYTES:
+    if not isinstance(contents, str):
         return None
     try:
+        if len(contents.encode()) > _MAX_CACHE_ENTRY_BYTES:
+            return None
         stored_digest, separator, serialized_payload = contents.partition(_CACHE_ENTRY_SEPARATOR)
         if not separator or not hmac.compare_digest(
             stored_digest,
@@ -212,7 +215,7 @@ def _references_from_contents(
             _reference_from_payload(cast(list[object], reference))
             for reference in references_payload
         )
-    except (ValueError, TypeError, KeyError, json.JSONDecodeError):
+    except (ValueError, TypeError, KeyError, RecursionError, json.JSONDecodeError):
         return None
 
 

--- a/src/sqlbuild/compiler/compile/_helpers/refs/cache.py
+++ b/src/sqlbuild/compiler/compile/_helpers/refs/cache.py
@@ -1,0 +1,252 @@
+"""Versioned project-local cache for SQL reference extraction."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sqlite3
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from types import TracebackType
+from typing import Any, cast
+
+from sqlbuild.compiler.compile._helpers.refs.references import extract_sql_references
+from sqlbuild.compiler.compile.exceptions import AnalysisCacheEntryError
+from sqlbuild.compiler.compile.models import CompileSqlReference
+from sqlbuild.compiler.references.types import SqlReferenceKind
+
+_REFERENCE_CACHE_VERSION: int = 2
+_CACHE_DATABASE_NAME: str = "sql-references.sqlite3"
+_CACHE_ENTRY_SEPARATOR: str = "\n"
+_MAX_CACHE_ENTRY_BYTES: int = 1_000_000
+_SQLITE_TIMEOUT_SECONDS: float = 0.1
+_CREATE_CACHE_TABLE_SQL: str = """
+CREATE TABLE IF NOT EXISTS sql_reference (
+    cache_key TEXT PRIMARY KEY,
+    payload TEXT NOT NULL
+)
+"""
+
+
+class _SqlReferenceCache:
+    """Reuse exact SQL reference facts while preserving safe scanner fallback."""
+
+    def __init__(self, *, root: Path | None) -> None:
+        self._root: Path | None = root
+        self._database_path: Path | None = None
+        self._connection: sqlite3.Connection | None = None
+        self._pending_contents_by_key: dict[str, str] = {}
+
+    def __enter__(self) -> _SqlReferenceCache:
+        if self._root is None:
+            return self
+        self._database_path = (
+            self._root / f"references-v{_REFERENCE_CACHE_VERSION}" / _CACHE_DATABASE_NAME
+        )
+        if not self._database_path.is_file():
+            return self
+        try:
+            self._connection = sqlite3.connect(
+                self._database_path,
+                timeout=_SQLITE_TIMEOUT_SECONDS,
+            )
+        except (OSError, sqlite3.DatabaseError):
+            self._disable()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_value, traceback
+        connection: sqlite3.Connection | None = self._connection
+        self._connection = None
+        try:
+            if exc_type is None:
+                connection = self._write_pending(connection=connection)
+            elif connection is not None:
+                connection.rollback()
+        except (OSError, sqlite3.DatabaseError):
+            pass
+        finally:
+            self._pending_contents_by_key.clear()
+            if connection is not None:
+                try:
+                    connection.close()
+                except sqlite3.DatabaseError:
+                    pass
+
+    def references(self, sql: str) -> tuple[CompileSqlReference, ...]:
+        """Return cached references or scan and record this exact expanded SQL."""
+
+        cache_key: str = _reference_cache_key(sql)
+        pending_contents: str | None = self._pending_contents_by_key.get(cache_key)
+        if pending_contents is not None:
+            pending_references: tuple[CompileSqlReference, ...] | None = _references_from_contents(
+                contents=pending_contents,
+                expected_cache_key=cache_key,
+            )
+            if pending_references is not None:
+                return pending_references
+        connection: sqlite3.Connection | None = self._connection
+        if connection is not None:
+            try:
+                row: tuple[str] | None = connection.execute(
+                    "SELECT payload FROM sql_reference WHERE cache_key = ?",
+                    (cache_key,),
+                ).fetchone()
+                if row is not None:
+                    cached_references: tuple[CompileSqlReference, ...] | None = (
+                        _references_from_contents(contents=row[0], expected_cache_key=cache_key)
+                    )
+                    if cached_references is not None:
+                        return cached_references
+            except sqlite3.DatabaseError:
+                self._disable()
+                connection = None
+
+        references: tuple[CompileSqlReference, ...] = extract_sql_references(sql)
+        if self._database_path is not None:
+            try:
+                self._pending_contents_by_key[cache_key] = _reference_contents(
+                    cache_key=cache_key,
+                    references=references,
+                )
+            except (TypeError, ValueError):
+                pass
+        return references
+
+    def _write_pending(self, *, connection: sqlite3.Connection | None) -> sqlite3.Connection | None:
+        if not self._pending_contents_by_key or self._database_path is None:
+            return connection
+        if connection is None:
+            self._database_path.parent.mkdir(parents=True, exist_ok=True)
+            connection = sqlite3.connect(
+                self._database_path,
+                timeout=_SQLITE_TIMEOUT_SECONDS,
+            )
+        _ = connection.execute(_CREATE_CACHE_TABLE_SQL)
+        _ = connection.executemany(
+            "INSERT OR REPLACE INTO sql_reference (cache_key, payload) VALUES (?, ?)",
+            self._pending_contents_by_key.items(),
+        )
+        connection.commit()
+        return connection
+
+    def _disable(self) -> None:
+        connection: sqlite3.Connection | None = self._connection
+        self._connection = None
+        if connection is None:
+            return
+        try:
+            connection.close()
+        except sqlite3.DatabaseError:
+            pass
+
+
+def _reference_cache_key(sql: str) -> str:
+    return hashlib.sha256(sql.encode()).hexdigest()
+
+
+def _reference_contents(*, cache_key: str, references: tuple[CompileSqlReference, ...]) -> str:
+    serialized_payload: str = json.dumps(
+        {
+            "v": _REFERENCE_CACHE_VERSION,
+            "k": cache_key,
+            "r": [
+                [
+                    str(reference.ref_kind),
+                    reference.ref_name,
+                    reference.ref_package,
+                    reference.call_argument_count,
+                ]
+                for reference in references
+            ],
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return _CACHE_ENTRY_SEPARATOR.join(
+        (
+            _cache_entry_digest(cache_key=cache_key, serialized_payload=serialized_payload),
+            serialized_payload,
+        )
+    )
+
+
+def _references_from_contents(
+    *, contents: str, expected_cache_key: str
+) -> tuple[CompileSqlReference, ...] | None:
+    encoded_contents: bytes = contents.encode()
+    if len(encoded_contents) > _MAX_CACHE_ENTRY_BYTES:
+        return None
+    try:
+        stored_digest, separator, serialized_payload = contents.partition(_CACHE_ENTRY_SEPARATOR)
+        if not separator or not hmac.compare_digest(
+            stored_digest,
+            _cache_entry_digest(
+                cache_key=expected_cache_key,
+                serialized_payload=serialized_payload,
+            ),
+        ):
+            return None
+        payload: object = json.loads(serialized_payload)
+        if not isinstance(payload, dict):
+            raise AnalysisCacheEntryError("reference cache entry must be an object")
+        values: dict[str, Any] = cast(dict[str, Any], payload)
+        if values["v"] != _REFERENCE_CACHE_VERSION:
+            raise AnalysisCacheEntryError("reference cache version mismatch")
+        if values["k"] != expected_cache_key:
+            raise AnalysisCacheEntryError("reference cache key mismatch")
+        references_payload: object = values["r"]
+        if not isinstance(references_payload, list) or not all(
+            isinstance(reference, list) for reference in references_payload
+        ):
+            raise AnalysisCacheEntryError("reference cache facts must be arrays")
+        return tuple(
+            _reference_from_payload(cast(list[object], reference))
+            for reference in references_payload
+        )
+    except (ValueError, TypeError, KeyError, json.JSONDecodeError):
+        return None
+
+
+def _reference_from_payload(payload: list[object]) -> CompileSqlReference:
+    reference_value_count: int = 4
+    if len(payload) != reference_value_count:
+        raise AnalysisCacheEntryError("reference cache fact must contain four values")
+    kind, name, package, call_argument_count = payload
+    if not isinstance(kind, str) or not isinstance(name, str):
+        raise AnalysisCacheEntryError("reference cache kind and name must be strings")
+    if package is not None and not isinstance(package, str):
+        raise AnalysisCacheEntryError("reference cache package must be a string or null")
+    if call_argument_count is not None and type(call_argument_count) is not int:
+        raise AnalysisCacheEntryError("reference cache argument count must be an integer or null")
+    return CompileSqlReference(
+        ref_kind=SqlReferenceKind(kind),
+        ref_name=name,
+        ref_package=package,
+        call_argument_count=call_argument_count,
+    )
+
+
+def _cache_entry_digest(*, cache_key: str, serialized_payload: str) -> str:
+    digest: Any = hashlib.sha256(cache_key.encode())
+    digest.update(b"\0")
+    digest.update(serialized_payload.encode())
+    return digest.hexdigest()
+
+
+@contextmanager
+def cached_sql_reference_extractor(
+    *, root: Path | None
+) -> Iterator[Callable[[str], tuple[CompileSqlReference, ...]]]:
+    """Yield an exact cached reference extractor for one compile invocation."""
+
+    with _SqlReferenceCache(root=root) as cache:
+        yield cache.references

--- a/src/sqlbuild/compiler/compile/main/_build_compile_inputs.py
+++ b/src/sqlbuild/compiler/compile/main/_build_compile_inputs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
 
 from sqlbuild.compiler.auditing.main._builtins import build_builtin_audit_resolution
 from sqlbuild.compiler.compile._helpers.attachment.audits import (
@@ -26,6 +27,7 @@ from sqlbuild.compiler.compile._helpers.attachment.sql_tests import (
     build_scenario_inputs,
     build_test_inputs,
 )
+from sqlbuild.compiler.compile._helpers.attachment.target import build_compile_target_context
 from sqlbuild.compiler.compile._helpers.render.declarations import (
     build_public_declaration_indexes,
     build_public_model_schema_index,
@@ -58,8 +60,6 @@ from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.contracts.main.resolve_effective_adapter_name import (
     resolve_effective_adapter_name,
 )
-from sqlbuild.spec.contracts.main.resolve_target_config import resolve_target_config
-from sqlbuild.spec.contracts.main.resolve_target_name import resolve_target_name
 from sqlbuild.spec.contracts.models import SettingsConfig, TargetConfig
 
 
@@ -74,21 +74,18 @@ def build_compile_inputs(
     python_functions_inherit_default_namespace: bool = True,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
     resolved_connection: dict[str, object] | None = None,
+    no_cache: bool = False,
 ) -> CompileProjectInputs:
     """Attach discovered metadata into the first compile input snapshot."""
 
-    effective_target_name: str | None = resolve_target_name(
-        project_config=discovered_inputs.project_config,
-        local_config=discovered_inputs.local_config,
+    effective_target_name: str | None
+    effective_target: TargetConfig | None
+    compile_cache_dir: Path | None
+    effective_target_name, effective_target, compile_cache_dir = build_compile_target_context(
+        discovered_inputs=discovered_inputs,
         selected_target=selected_target,
+        no_cache=no_cache,
     )
-    effective_target: TargetConfig | None = None
-    if effective_target_name is not None:
-        effective_target = resolve_target_config(
-            project_config=discovered_inputs.project_config,
-            local_config=discovered_inputs.local_config,
-            target_name=effective_target_name,
-        )
 
     effective_vars: dict[str, object] = build_effective_vars(
         project_config=discovered_inputs.project_config,
@@ -128,6 +125,7 @@ def build_compile_inputs(
         no_sql_validation=no_sql_validation,
         defer_model_sql_validation=defer_model_sql_validation,
         external_sql_reference_resolver=external_sql_reference_resolver,
+        reference_cache_dir=compile_cache_dir,
     )
     seed_inputs: tuple[CompileSeedInput, ...] = build_seed_inputs(discovered_inputs)
     sql_function_inputs: tuple[CompileSqlFunctionInput, ...] = _build_sql_functions(
@@ -194,6 +192,7 @@ def build_compile_inputs(
         run_id=resolved_run_id,
         effective_target_name=effective_target_name,
         effective_target=effective_target,
+        compile_cache_dir=compile_cache_dir,
         effective_connection=(
             resolved_connection
             if resolved_connection is not None
@@ -256,6 +255,7 @@ def _build_models_with_declarations(
     no_sql_validation: bool,
     defer_model_sql_validation: bool,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None,
+    reference_cache_dir: Path | None,
 ) -> tuple[
     tuple[CompileModelInput, ...],
     DeclarationResolutionContext,
@@ -283,5 +283,6 @@ def _build_models_with_declarations(
         no_sql_validation=no_sql_validation,
         defer_model_sql_validation=defer_model_sql_validation,
         external_sql_reference_resolver=external_sql_reference_resolver,
+        reference_cache_dir=reference_cache_dir,
     )
     return model_inputs, declarations

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -398,6 +398,7 @@ class CompileProjectInputs:
     run_id: str = ""
     effective_target_name: str | None = None
     effective_target: TargetConfig | None = None
+    compile_cache_dir: Path | None = None
     effective_connection: dict[str, object] = field(default_factory=dict)
     effective_settings: SettingsConfig = field(default_factory=SettingsConfig)
     effective_vars: dict[str, object] = field(default_factory=dict)

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -2,15 +2,8 @@
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
-from sqlbuild.compiler.compile.constants import (
-    COMPILE_CACHE_DISABLE_ENV_VAR,
-    COMPILE_CACHE_DISABLE_VALUE,
-)
 from sqlbuild.compiler.compile.main._assemble_project import assemble_project
 from sqlbuild.compiler.compile.main._build_compile_inputs import build_compile_inputs
 from sqlbuild.compiler.compile.models import (
@@ -37,7 +30,6 @@ from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.contracts.main.resolve_effective_adapter_name import (
     resolve_effective_adapter_name,
 )
-from sqlbuild.spec.contracts.models import TargetConfig
 
 
 def build_compiled_project(
@@ -59,6 +51,7 @@ def build_compiled_project(
         discovered_inputs=discovered_inputs,
         adapter=adapter,
     )
+    no_cache: bool = analysis_selection is not None and analysis_selection.no_cache
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs=discovered_inputs,
         selected_target=selected_target,
@@ -70,13 +63,9 @@ def build_compiled_project(
             adapter.python_functions_inherit_default_namespace()
         ),
         external_sql_reference_resolver=external_sql_reference_resolver,
+        no_cache=no_cache,
     )
     inference_profile: ExpressionInferenceProfile = adapter.expression_inference_profile()
-    analysis_cache_dir: Path | None = _analysis_cache_dir(
-        discovered_inputs=discovered_inputs,
-        target_config=compile_inputs.effective_target,
-        no_cache=analysis_selection is not None and analysis_selection.no_cache,
-    )
     analysis_model_names: frozenset[str] | None = _resolve_analysis_model_names(
         compile_inputs=compile_inputs,
         inference_profile=inference_profile,
@@ -88,7 +77,7 @@ def build_compiled_project(
             inference_profile=inference_profile,
             skip_column_inference=skip_column_inference,
             column_lineage_mode=column_lineage_mode,
-            analysis_cache_dir=analysis_cache_dir,
+            analysis_cache_dir=compile_inputs.compile_cache_dir,
             analysis_model_names=analysis_model_names,
         ),
         default_schema=adapter.default_schema(),
@@ -106,22 +95,6 @@ def build_compiled_project(
         project=project,
     )
     return project
-
-
-def _analysis_cache_dir(
-    *,
-    discovered_inputs: DiscoveredProjectInputs,
-    target_config: TargetConfig | None,
-    no_cache: bool,
-) -> Path | None:
-    if (
-        no_cache
-        or (target_config is not None and target_config.compile_cache is False)
-        or os.environ.get(COMPILE_CACHE_DISABLE_ENV_VAR) == COMPILE_CACHE_DISABLE_VALUE
-    ):
-        return None
-    project_dir: Path | None = discovered_inputs.project_dir
-    return project_dir / "target" / "compile-cache" if project_dir is not None else None
 
 
 def _resolve_analysis_model_names(

--- a/src/sqlbuild/compiler/sql_analysis/_helpers/scanning.py
+++ b/src/sqlbuild/compiler/sql_analysis/_helpers/scanning.py
@@ -17,18 +17,18 @@ def skip_quoted_text_impl(*, sql: str, start: int, context: str = "SQL") -> int:
 
     quote_character: str = sql[start]
     index: int = start + 1
-    while index < len(sql):
-        if sql[index] == quote_character:
-            if (
-                quote_character in SQL_ESCAPABLE_QUOTE_CHARACTERS
-                and index + 1 < len(sql)
-                and sql[index + 1] == quote_character
-            ):
-                index += 2
-                continue
-            return index + 1
-        index += 1
-    raise CompileInputError(f"{context} contains an unclosed quoted string")
+    while True:
+        index = sql.find(quote_character, index)
+        if index == -1:
+            raise CompileInputError(f"{context} contains an unclosed quoted string")
+        if (
+            quote_character in SQL_ESCAPABLE_QUOTE_CHARACTERS
+            and index + 1 < len(sql)
+            and sql[index + 1] == quote_character
+        ):
+            index += 2
+            continue
+        return index + 1
 
 
 def skip_line_comment_impl(*, sql: str, start: int) -> int:

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
@@ -169,6 +169,33 @@ def test_given_corrupt_analysis_when_compiling_then_reanalyzes_and_repairs_the_e
 
 @pytest.mark.parametrize(
     "test_case",
+    (AnalysisCacheTestCase(description="non-text analysis cache fallback", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_non_text_analysis_cache_when_compiling_then_reanalyzes_safely(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _CACHE_REPO_FILES)
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    cache_path: Path = tmp_path / "target" / "compile-cache" / "v4" / "model-analysis.sqlite3"
+    with sqlite3.connect(cache_path) as connection:
+        _ = connection.execute(
+            "UPDATE model_analysis SET payload = ?",
+            (sqlite3.Binary(b"broken"),),
+        )
+    analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
+    monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+
+    _ = compile_project_with_cache(project_dir=tmp_path)
+
+    assert analyzer.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
     (AnalysisCacheTestCase(description="corrupt reference cache fallback", expected_count=1),),
     ids=lambda case: case.description,
 )
@@ -204,6 +231,35 @@ def test_given_corrupt_reference_cache_when_compiling_then_rescans_and_repairs_t
         ]
     assert repaired_project.models == cold_project.models
     assert "raw_orders" in repaired_contents
+    assert scanner.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="non-text reference cache fallback", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_non_text_reference_cache_when_compiling_then_rescans_safely(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _CACHE_REPO_FILES)
+    _ = compile_project_with_cache(project_dir=tmp_path)
+    cache_path: Path = next(
+        (tmp_path / "target" / "compile-cache" / "references-v2").glob("*.sqlite3")
+    )
+    with sqlite3.connect(cache_path) as connection:
+        _ = connection.execute(
+            "UPDATE sql_reference SET payload = ?",
+            (sqlite3.Binary(b"broken"),),
+        )
+    scanner: Mock = Mock(wraps=reference_cache.extract_sql_references)
+    monkeypatch.setattr(reference_cache, "extract_sql_references", scanner)
+
+    _ = compile_project_with_cache(project_dir=tmp_path)
+
     assert scanner.call_count == test_case.expected_count
 
 

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
@@ -16,6 +16,7 @@ from sqlbuild.compiler.compile._helpers.analysis.cache import (
     write_model_analyses,
 )
 from sqlbuild.compiler.compile._helpers.assembly import project as assembly_project
+from sqlbuild.compiler.compile._helpers.refs import cache as reference_cache
 from sqlbuild.compiler.compile.constants import COMPILE_CACHE_DISABLE_ENV_VAR
 from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.models import (
@@ -80,14 +81,24 @@ def test_given_successful_analysis_when_compiling_again_then_reuses_identical_ca
         side_effect=AssertionError("Polyglot analysis must not run on a cache hit")
     )
     monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
+    signature_builder: Mock = Mock(
+        side_effect=AssertionError("output signatures must not be rebuilt on a cache hit")
+    )
+    monkeypatch.setattr(assembly_project, "model_analysis_output_signature", signature_builder)
+    reference_scanner: Mock = Mock(
+        side_effect=AssertionError("SQL references must not be scanned on a cache hit")
+    )
+    monkeypatch.setattr(reference_cache, "extract_sql_references", reference_scanner)
 
     warm_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
 
     assert warm_project.models == cold_project.models
     assert warm_project.diagnostics == cold_project.diagnostics
     analyzer.assert_not_called()
+    signature_builder.assert_not_called()
+    reference_scanner.assert_not_called()
     assert len(tuple((tmp_path / "target" / "compile-cache").rglob("*.sqlite3"))) == (
-        test_case.expected_count
+        test_case.expected_count + 1
     )
 
 
@@ -128,11 +139,16 @@ def test_given_corrupt_analysis_when_compiling_then_reanalyzes_and_repairs_the_e
 ) -> None:
     write_repo_files(tmp_path, _CACHE_REPO_FILES)
     cold_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
-    cache_path: Path = next((tmp_path / "target" / "compile-cache").rglob("*.sqlite3"))
+    cache_path: Path = tmp_path / "target" / "compile-cache" / "v4" / "model-analysis.sqlite3"
     with sqlite3.connect(cache_path) as connection:
+        persisted_contents: str = connection.execute(
+            "SELECT payload FROM model_analysis"
+        ).fetchone()[0]
+        corrupt_contents: str = persisted_contents.replace("order_id", "tampered", 1)
+        assert corrupt_contents != persisted_contents
         _ = connection.execute(
             "UPDATE model_analysis SET payload = ?",
-            ('{"analysis_succeeded":true}',),
+            (corrupt_contents,),
         )
     analyzer: Mock = Mock(wraps=assembly_project.analyze_columns_and_lineage_with_polyglot)
     monkeypatch.setattr(assembly_project, "analyze_columns_and_lineage_with_polyglot", analyzer)
@@ -143,11 +159,52 @@ def test_given_corrupt_analysis_when_compiling_then_reanalyzes_and_repairs_the_e
         repaired_contents: str = connection.execute(
             "SELECT payload FROM model_analysis"
         ).fetchone()[0]
-    repaired_payload: dict[str, object] = json.loads(repaired_contents)
+    _digest, _separator, serialized_payload = repaired_contents.partition("\n")
+    repaired_payload: dict[str, object] = json.loads(serialized_payload)
     assert repaired_project.models == cold_project.models
-    assert repaired_payload["analysis_succeeded"] is True
-    assert isinstance(repaired_payload["analysis_digest"], str)
+    assert repaired_payload["v"] == 4
+    assert isinstance(repaired_payload["s"], str)
     assert analyzer.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AnalysisCacheTestCase(description="corrupt reference cache fallback", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_corrupt_reference_cache_when_compiling_then_rescans_and_repairs_the_entry(
+    test_case: AnalysisCacheTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, _CACHE_REPO_FILES)
+    cold_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
+    cache_path: Path = next(
+        (tmp_path / "target" / "compile-cache" / "references-v2").glob("*.sqlite3")
+    )
+    with sqlite3.connect(cache_path) as connection:
+        persisted_contents: str = connection.execute(
+            "SELECT payload FROM sql_reference"
+        ).fetchone()[0]
+        corrupt_contents: str = persisted_contents.replace("raw_orders", "tampered", 1)
+        assert corrupt_contents != persisted_contents
+        _ = connection.execute(
+            "UPDATE sql_reference SET payload = ?",
+            (corrupt_contents,),
+        )
+    scanner: Mock = Mock(wraps=reference_cache.extract_sql_references)
+    monkeypatch.setattr(reference_cache, "extract_sql_references", scanner)
+
+    repaired_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
+
+    with sqlite3.connect(cache_path) as connection:
+        repaired_contents: str = connection.execute("SELECT payload FROM sql_reference").fetchone()[
+            0
+        ]
+    assert repaired_project.models == cold_project.models
+    assert "raw_orders" in repaired_contents
+    assert scanner.call_count == test_case.expected_count
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/sql_analysis/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/sql_analysis/_helpers/_test_types.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SkipQuotedTextSuccessTestCase:
+    """Successful quoted-text scan case."""
+
+    description: str
+    quoted_sql: str
+    expected_end: int
+
+
+@dataclass(frozen=True)
+class SkipQuotedTextErrorTestCase:
+    """Invalid quoted-text scan case."""
+
+    description: str
+    sql: str
+    context: str
+    expected_error: str

--- a/tests/unit/src/sqlbuild/compiler/sql_analysis/_helpers/test_scanning.py
+++ b/tests/unit/src/sqlbuild/compiler/sql_analysis/_helpers/test_scanning.py
@@ -23,6 +23,21 @@ from tests.unit.src.sqlbuild.compiler.sql_analysis._helpers._test_types import (
             quoted_sql="`order status`",
             expected_end=len("`order status`"),
         ),
+        SkipQuotedTextSuccessTestCase(
+            description="doubled double quote escape",
+            quoted_sql='"customer""name"',
+            expected_end=len('"customer""name"'),
+        ),
+        SkipQuotedTextSuccessTestCase(
+            description="empty quoted value",
+            quoted_sql="''",
+            expected_end=2,
+        ),
+        SkipQuotedTextSuccessTestCase(
+            description="multiple adjacent escapes",
+            quoted_sql="'a''''b'",
+            expected_end=len("'a''''b'"),
+        ),
     ),
     ids=lambda case: case.description,
 )

--- a/tests/unit/src/sqlbuild/compiler/sql_analysis/_helpers/test_scanning.py
+++ b/tests/unit/src/sqlbuild/compiler/sql_analysis/_helpers/test_scanning.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.compiler.sql_analysis._helpers.scanning import skip_quoted_text_impl
+from tests.unit.src.sqlbuild.compiler.sql_analysis._helpers._test_types import (
+    SkipQuotedTextErrorTestCase,
+    SkipQuotedTextSuccessTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SkipQuotedTextSuccessTestCase(
+            description="doubled quote escape",
+            quoted_sql="'customer''s order'",
+            expected_end=len("'customer''s order'"),
+        ),
+        SkipQuotedTextSuccessTestCase(
+            description="backtick identifier",
+            quoted_sql="`order status`",
+            expected_end=len("`order status`"),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_quoted_text_when_skipping_then_returns_end_position(
+    test_case: SkipQuotedTextSuccessTestCase,
+) -> None:
+    sql: str = f"{test_case.quoted_sql} suffix"
+
+    result: int = skip_quoted_text_impl(sql=sql, start=0)
+
+    assert result == test_case.expected_end
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SkipQuotedTextErrorTestCase(
+            description="unclosed single quote",
+            sql="'customer",
+            context="SQL reference",
+            expected_error="SQL reference contains an unclosed quoted string",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_unclosed_quote_when_skipping_then_raises_contextual_error(
+    test_case: SkipQuotedTextErrorTestCase,
+) -> None:
+    with pytest.raises(CompileInputError, match=test_case.expected_error):
+        skip_quoted_text_impl(sql=test_case.sql, start=0, context=test_case.context)


### PR DESCRIPTION
## Why

After Polyglot 0.9.2 reduced cold compile time, unchanged 10K compilation still took about 6.79s. Profiling attributed 2.05s to repeated Python reference scanning and 0.92s to analysis-cache hydration. The remaining artifact phase already verifies exact contents and removes stale files, so it is intentionally unchanged.

## Changes

- Replace character-level quoted-text traversal with equivalent `str.find` scanning.
- Add a versioned, checksummed SQLite reference cache keyed by exact expanded SQL, with transactional writes and shared cache bypass controls.
- Replace analysis cache v2 with compact v4 payloads, exact serialized checksums, and checksummed output-signature reuse.
- Treat malformed, non-text, oversized, locked, or otherwise unusable cache state as a safe miss.
- Keep reference validation, dependency/signature validation, stale artifact reconciliation, and Python implementation boundaries unchanged.

## Verification

- `make check-ci`; Fensu zero faults.
- `make test`: 4,172 passed.
- `make rust-check`.
- Focused scanner/cache suite after review fixes: 25 passed.
- 2,774,493 quote-position equivalence checks.
- Cold, warm, and `--no-cache` artifact hashes match across all 3K and 10K generated files.
- Three-run median internal totals:
  - 3K cold: 3.112s to 2.957s; warm: 1.968s to 1.385s.
  - 10K cold: 10.363s to 9.724s; warm: 6.789s to 4.834s.
- Independent review findings for non-text and oversized payloads resolved.
