### PR TITLE
perf(cli): lazy-load command handlers

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/entry/lazy_handlers.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/lazy_handlers.py
@@ -1,0 +1,282 @@
+"""Lazy command implementation loading for the CLI entrypoint."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from importlib import import_module
+from types import ModuleType
+from typing import Any, cast
+
+from sqlbuild.cli.commands.models import CliEntrypointHandlers
+from sqlbuild.integrations.dbt.types import DbtInteropCommand
+
+
+def build_lazy_cli_handlers() -> CliEntrypointHandlers:
+    """Build command handlers that import only the selected implementation."""
+
+    lazy: dict[str, Callable[..., int]] = {
+        "scenario_capture": _lazy_handler(
+            module_name="sqlbuild.cli.commands._helpers.scenario_capture.capture",
+            function_name="run_scenario_capture",
+        ),
+        "dbt": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.dbt._dbt",
+            function_name="run_dbt_command",
+        ),
+        "dbt_init": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.dbt._dbt_init",
+            function_name="run_dbt_init_command",
+        ),
+        "audit": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.execution._audit",
+            function_name="run_audit",
+        ),
+        "build": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.execution._build",
+            function_name="run_build",
+        ),
+        "check": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.execution._check",
+            function_name="run_check",
+        ),
+        "freshness": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.execution._freshness",
+            function_name="run_freshness",
+        ),
+        "load": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.execution._load",
+            function_name="run_load",
+        ),
+        "scenario": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.execution._scenario",
+            function_name="run_scenario",
+        ),
+        "seed": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.execution._seed",
+            function_name="run_seed",
+        ),
+        "test": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.execution._test",
+            function_name="run_test",
+        ),
+        "clone": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.inspection._clone",
+            function_name="run_clone",
+        ),
+        "cost": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.inspection._cost",
+            function_name="run_cost",
+        ),
+        "debug": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.inspection._debug",
+            function_name="run_debug",
+        ),
+        "diff": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.inspection._diff",
+            function_name="run_diff",
+        ),
+        "lineage": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.inspection._lineage",
+            function_name="run_lineage",
+        ),
+        "query": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.inspection._query",
+            function_name="run_query",
+        ),
+        "compile": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.project._compile",
+            function_name="run_compile",
+        ),
+        "dag": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.project._dag",
+            function_name="run_dag",
+        ),
+        "format": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.project._format",
+            function_name="run_format_command",
+        ),
+        "kata": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.project._kata",
+            function_name="run_kata_command",
+        ),
+        "lint": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.project._lint",
+            function_name="run_lint_command",
+        ),
+        "plan": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.project._plan",
+            function_name="run_plan",
+        ),
+        "janitor": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.state._janitor",
+            function_name="run_janitor",
+        ),
+        "promote": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.state._promote",
+            function_name="run_promote",
+        ),
+        "reconcile": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.state._reconcile",
+            function_name="run_reconcile",
+        ),
+        "rollback": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.state._rollback",
+            function_name="run_rollback",
+        ),
+        "state": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.state._state",
+            function_name="run_state",
+        ),
+        "init": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.workspace._init",
+            function_name="run_init",
+        ),
+        "playground": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.workspace._playground",
+            function_name="run_playground",
+        ),
+        "skills": _lazy_handler(
+            module_name="sqlbuild.cli.commands.main.workspace._skills",
+            function_name="run_skills_update",
+        ),
+    }
+    return CliEntrypointHandlers(
+        run_compile=lazy["compile"],
+        run_cost=lazy["cost"],
+        run_dag=lambda project_dir, no_sql_validation, json_output, cli_vars: lazy["dag"](
+            project_dir=project_dir,
+            no_sql_validation=no_sql_validation,
+            json_output=json_output,
+            cli_vars=cli_vars,
+        ),
+        run_plan=lazy["plan"],
+        run_dbt_plan=lambda project_dir, args, no_color: lazy["dbt"](
+            command=DbtInteropCommand.PLAN,
+            project_dir=project_dir,
+            args=args,
+            no_color=no_color,
+        ),
+        run_dbt_run=lambda project_dir, args, no_color: lazy["dbt"](
+            command=DbtInteropCommand.RUN,
+            project_dir=project_dir,
+            args=args,
+            no_color=no_color,
+        ),
+        run_dbt_build=lambda project_dir, args, no_color: lazy["dbt"](
+            command=DbtInteropCommand.BUILD,
+            project_dir=project_dir,
+            args=args,
+            no_color=no_color,
+        ),
+        run_dbt_debug=lambda project_dir, args, no_color: lazy["dbt"](
+            command=DbtInteropCommand.DEBUG,
+            project_dir=project_dir,
+            args=args,
+            no_color=no_color,
+        ),
+        run_dbt_init=lazy["dbt_init"],
+        run_build=lazy["build"],
+        run_freshness=lazy["freshness"],
+        run_test=lazy["test"],
+        run_check=lazy["check"],
+        run_audit=lazy["audit"],
+        run_seed=lazy["seed"],
+        run_load=lazy["load"],
+        run_clone=lazy["clone"],
+        run_diff=lazy["diff"],
+        run_reconcile=lambda project_dir, no_color, virtual_environment, reconcile_command, model_name, seed_name, physical_relation_name, auto_approve, cli_vars: (  # noqa: E501
+            lazy["reconcile"](
+                project_dir=project_dir,
+                no_color=no_color,
+                virtual_environment=virtual_environment,
+                reconcile_command=reconcile_command,
+                model_name=model_name,
+                seed_name=seed_name,
+                physical_relation_name=physical_relation_name,
+                auto_approve=auto_approve,
+                cli_vars=cli_vars,
+            )
+        ),
+        run_promote=lazy["promote"],
+        run_rollback=lazy["rollback"],
+        run_query=lambda project_dir, sql, query_file, selected_target, output_format, limit: lazy[
+            "query"
+        ](
+            project_dir=project_dir,
+            sql=sql,
+            query_file=query_file,
+            selected_target=selected_target,
+            output_format=output_format,
+            limit=limit,
+        ),
+        run_debug=lambda project_dir, no_color, no_connection, selected_target, json_output: lazy[
+            "debug"
+        ](
+            project_dir=project_dir,
+            no_color=no_color,
+            no_connection=no_connection,
+            selected_target=selected_target,
+            json_output=json_output,
+        ),
+        run_lineage=lambda project_dir, no_sql_validation, target, output_format, direction, depth, select, exclude, lineage_mode, cli_vars: (  # noqa: E501
+            lazy["lineage"](
+                project_dir=project_dir,
+                no_sql_validation=no_sql_validation,
+                target=target,
+                output_format=output_format,
+                direction=direction,
+                depth=depth,
+                select=select,
+                exclude=exclude,
+                lineage_mode=lineage_mode,
+                cli_vars=cli_vars,
+            )
+        ),
+        run_janitor=lazy["janitor"],
+        run_state=lambda project_dir, state_command, backup_id, auto_approve, no_color, checkpoint_command, checkpoint_id, virtual_environment, allow_copy: (  # noqa: E501
+            lazy["state"](
+                project_dir=project_dir,
+                state_command=state_command,
+                backup_id=backup_id,
+                auto_approve=auto_approve,
+                no_color=no_color,
+                checkpoint_command=checkpoint_command,
+                checkpoint_id=checkpoint_id,
+                virtual_environment=virtual_environment,
+                allow_copy=allow_copy,
+            )
+        ),
+        run_init=lazy["init"],
+        run_playground=lazy["playground"],
+        run_skills_update=lambda project_dir, global_install, targets, force: lazy["skills"](
+            project_dir=project_dir,
+            global_install=global_install,
+            targets=targets,
+            force=force,
+        ),
+        run_lint=lambda project_dir, no_sqruff: lazy["lint"](
+            project_dir=project_dir,
+            no_sqruff=no_sqruff,
+        ),
+        run_format=lambda project_dir, no_sqruff: lazy["format"](
+            project_dir=project_dir,
+            no_sqruff=no_sqruff,
+        ),
+        run_scenario=lazy["scenario"],
+        run_scenario_capture=lazy["scenario_capture"],
+        run_kata=lazy["kata"],
+    )
+
+
+def _lazy_handler(*, module_name: str, function_name: str) -> Callable[..., int]:
+    """Load one command implementation only when its handler is invoked."""
+
+    def run(*args: Any, **kwargs: Any) -> int:
+        module: ModuleType = import_module(module_name)
+        handler: Callable[..., int] = cast(
+            Callable[..., int],
+            getattr(module, function_name),
+        )
+        return handler(*args, **kwargs)
+
+    return run

--- a/src/sqlbuild/cli/commands/main/entrypoint/entry.py
+++ b/src/sqlbuild/cli/commands/main/entrypoint/entry.py
@@ -12,15 +12,12 @@ from sqlbuild.cli.commands._helpers.entry.errors import (
     cli_error_use_color,
     format_expected_error,
 )
+from sqlbuild.cli.commands._helpers.entry.lazy_handlers import build_lazy_cli_handlers
 from sqlbuild.cli.commands._helpers.entry.parser import build_cli_parser
 from sqlbuild.cli.commands._helpers.entry.parsing import parse_cli_invocation
 from sqlbuild.cli.commands.exceptions import CliUserError
-from sqlbuild.cli.commands.models import (
-    CliEntrypointHandlers,
-    ParsedCliInvocation,
-)
+from sqlbuild.cli.commands.models import CliEntrypointHandlers, ParsedCliInvocation
 from sqlbuild.compiler.discovery.exceptions import DiscoveryError
-from sqlbuild.integrations.dbt.types import DbtInteropCommand
 from sqlbuild.kata_engine.exceptions import KataError
 from sqlbuild.lint.exceptions import LintError
 from sqlbuild.presentation.main.supports_color import supports_color
@@ -30,165 +27,7 @@ from sqlbuild.virtual.state.exceptions import StateBackendError
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI entrypoint."""
 
-    from sqlbuild.cli.commands._helpers.scenario_capture.capture import run_scenario_capture
-    from sqlbuild.cli.commands.main.dbt._dbt import run_dbt_command
-    from sqlbuild.cli.commands.main.dbt._dbt_init import run_dbt_init_command
-    from sqlbuild.cli.commands.main.execution._audit import run_audit
-    from sqlbuild.cli.commands.main.execution._build import run_build
-    from sqlbuild.cli.commands.main.execution._check import run_check
-    from sqlbuild.cli.commands.main.execution._freshness import run_freshness
-    from sqlbuild.cli.commands.main.execution._load import run_load
-    from sqlbuild.cli.commands.main.execution._scenario import run_scenario
-    from sqlbuild.cli.commands.main.execution._seed import run_seed
-    from sqlbuild.cli.commands.main.execution._test import run_test
-    from sqlbuild.cli.commands.main.inspection._clone import run_clone
-    from sqlbuild.cli.commands.main.inspection._cost import run_cost
-    from sqlbuild.cli.commands.main.inspection._debug import run_debug
-    from sqlbuild.cli.commands.main.inspection._diff import run_diff
-    from sqlbuild.cli.commands.main.inspection._lineage import run_lineage
-    from sqlbuild.cli.commands.main.inspection._query import run_query
-    from sqlbuild.cli.commands.main.project._compile import run_compile
-    from sqlbuild.cli.commands.main.project._dag import run_dag
-    from sqlbuild.cli.commands.main.project._format import run_format_command
-    from sqlbuild.cli.commands.main.project._kata import run_kata_command
-    from sqlbuild.cli.commands.main.project._lint import run_lint_command
-    from sqlbuild.cli.commands.main.project._plan import run_plan
-    from sqlbuild.cli.commands.main.state._janitor import run_janitor
-    from sqlbuild.cli.commands.main.state._promote import run_promote
-    from sqlbuild.cli.commands.main.state._reconcile import run_reconcile
-    from sqlbuild.cli.commands.main.state._rollback import run_rollback
-    from sqlbuild.cli.commands.main.state._state import run_state
-    from sqlbuild.cli.commands.main.workspace._init import run_init
-    from sqlbuild.cli.commands.main.workspace._playground import run_playground
-    from sqlbuild.cli.commands.main.workspace._skills import run_skills_update
-
-    handlers: CliEntrypointHandlers = CliEntrypointHandlers(
-        run_compile=run_compile,
-        run_cost=run_cost,
-        run_dag=lambda project_dir, no_sql_validation, json_output, cli_vars: run_dag(
-            project_dir=project_dir,
-            no_sql_validation=no_sql_validation,
-            json_output=json_output,
-            cli_vars=cli_vars,
-        ),
-        run_plan=run_plan,
-        run_dbt_plan=lambda project_dir, args, no_color: run_dbt_command(
-            command=DbtInteropCommand.PLAN,
-            project_dir=project_dir,
-            args=args,
-            no_color=no_color,
-        ),
-        run_dbt_run=lambda project_dir, args, no_color: run_dbt_command(
-            command=DbtInteropCommand.RUN,
-            project_dir=project_dir,
-            args=args,
-            no_color=no_color,
-        ),
-        run_dbt_build=lambda project_dir, args, no_color: run_dbt_command(
-            command=DbtInteropCommand.BUILD,
-            project_dir=project_dir,
-            args=args,
-            no_color=no_color,
-        ),
-        run_dbt_debug=lambda project_dir, args, no_color: run_dbt_command(
-            command=DbtInteropCommand.DEBUG,
-            project_dir=project_dir,
-            args=args,
-            no_color=no_color,
-        ),
-        run_dbt_init=run_dbt_init_command,
-        run_build=run_build,
-        run_freshness=run_freshness,
-        run_test=run_test,
-        run_check=run_check,
-        run_audit=run_audit,
-        run_seed=run_seed,
-        run_load=run_load,
-        run_clone=run_clone,
-        run_diff=run_diff,
-        run_reconcile=lambda project_dir, no_color, virtual_environment, reconcile_command, model_name, seed_name, physical_relation_name, auto_approve, cli_vars: (  # noqa: E501
-            run_reconcile(
-                project_dir=project_dir,
-                no_color=no_color,
-                virtual_environment=virtual_environment,
-                reconcile_command=reconcile_command,
-                model_name=model_name,
-                seed_name=seed_name,
-                physical_relation_name=physical_relation_name,
-                auto_approve=auto_approve,
-                cli_vars=cli_vars,
-            )
-        ),
-        run_promote=run_promote,
-        run_rollback=run_rollback,
-        run_query=lambda project_dir, sql, query_file, selected_target, output_format, limit: (
-            run_query(
-                project_dir=project_dir,
-                sql=sql,
-                query_file=query_file,
-                selected_target=selected_target,
-                output_format=output_format,
-                limit=limit,
-            )
-        ),
-        run_debug=lambda project_dir, no_color, no_connection, selected_target, json_output: (
-            run_debug(
-                project_dir=project_dir,
-                no_color=no_color,
-                no_connection=no_connection,
-                selected_target=selected_target,
-                json_output=json_output,
-            )
-        ),
-        run_lineage=lambda project_dir, no_sql_validation, target, output_format, direction, depth, select, exclude, lineage_mode, cli_vars: (  # noqa: E501
-            run_lineage(
-                project_dir=project_dir,
-                no_sql_validation=no_sql_validation,
-                target=target,
-                output_format=output_format,
-                direction=direction,
-                depth=depth,
-                select=select,
-                exclude=exclude,
-                lineage_mode=lineage_mode,
-                cli_vars=cli_vars,
-            )
-        ),
-        run_janitor=run_janitor,
-        run_state=lambda project_dir, state_command, backup_id, auto_approve, no_color, checkpoint_command, checkpoint_id, virtual_environment, allow_copy: (  # noqa: E501
-            run_state(
-                project_dir=project_dir,
-                state_command=state_command,
-                backup_id=backup_id,
-                auto_approve=auto_approve,
-                no_color=no_color,
-                checkpoint_command=checkpoint_command,
-                checkpoint_id=checkpoint_id,
-                virtual_environment=virtual_environment,
-                allow_copy=allow_copy,
-            )
-        ),
-        run_init=run_init,
-        run_playground=run_playground,
-        run_skills_update=lambda project_dir, global_install, targets, force: run_skills_update(
-            project_dir=project_dir,
-            global_install=global_install,
-            targets=targets,
-            force=force,
-        ),
-        run_lint=lambda project_dir, no_sqruff: run_lint_command(
-            project_dir=project_dir,
-            no_sqruff=no_sqruff,
-        ),
-        run_format=lambda project_dir, no_sqruff: run_format_command(
-            project_dir=project_dir,
-            no_sqruff=no_sqruff,
-        ),
-        run_scenario=run_scenario,
-        run_scenario_capture=run_scenario_capture,
-        run_kata=run_kata_command,
-    )
-    return _main_with_dependencies(argv=argv, handlers=handlers)
+    return _main_with_dependencies(argv=argv, handlers=build_lazy_cli_handlers())
 
 
 def _main_with_dependencies(

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 from _pytest.capture import CaptureResult
@@ -114,10 +115,20 @@ def test_given_cost_arguments_when_running_then_dispatches_typed_cost_request(
 )
 def test_given_root_help_arguments_when_running_main_then_it_returns_expected_exit_code(
     test_case: MainTestCase,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    command_importer: Mock = Mock(
+        side_effect=AssertionError("root help must not import command implementations")
+    )
+    monkeypatch.setattr(
+        "sqlbuild.cli.commands._helpers.entry.lazy_handlers.import_module",
+        command_importer,
+    )
+
     exit_code: int = main(test_case.argv)
 
     assert exit_code == test_case.expected_exit_code
+    command_importer.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Every `sqb` invocation imported all command implementations before parsing the selected command. A compile could therefore pay for and fail on unrelated dbt, scenario, build, virtual-state, inspection, lint, or workspace imports.

## Changes

- Replace eager command imports with typed lazy handlers backed by `importlib.import_module`.
- Keep parser, dispatch, injected-handler tests, argument routing, and command signatures unchanged.
- Move lazy handler construction out of the entrypoint into a focused helper.
- Assert that root help imports no command implementation.
- Leave the monolithic CLI request-model module unchanged.

## Verification

- Entry dispatch suite: 88 passed.
- `make check-ci`; Fensu zero faults.
- Ruff and Pyright passed.
- Real 3K and 10K warm compile commands succeeded.
- Seven-run `sqb --help` median: 0.891s to 0.645s (-246ms, -27.6%).
- Three-run warm compile wall medians:
  - 3K: 2.448s to 2.200s (-248ms, -10.1%).
  - 10K: 6.305s to 6.162s (-143ms, -2.3%).
