### PR TITLE
test(perf): tighten compile performance gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-e2e-duckdb:
 			fi; \
 		}; \
 		run_step "duckdb e2e" env PYTHONUNBUFFERED=1 SQLBUILD_CONCURRENCY=$(SQLBUILD_CONCURRENCY) uv run pytest tests/e2e -m "not real_warehouse and not dbt and not performance" -vv --color=yes -n auto --dist loadfile; \
-		run_step "duckdb performance" env PYTHONUNBUFFERED=1 SQLBUILD_CONCURRENCY=$(SQLBUILD_CONCURRENCY) uv run pytest tests/e2e -m "performance and not real_warehouse and not dbt" -vv --color=yes; \
+		run_step "duckdb performance" env PYTHONUNBUFFERED=1 SQLBUILD_CONCURRENCY=$(SQLBUILD_CONCURRENCY) uv run pytest tests/e2e -m "performance and not real_warehouse and not dbt" -vv --log-cli-level=INFO --color=yes; \
 		exit $$status; \
 	} 2>&1 | tee "$$log"; \
 	status=$${PIPESTATUS[0]}; \

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
@@ -33,3 +33,4 @@ class DbtShapedCompilePerformanceGuardTestCase:
     expected_min_sql_bytes: int
     expected_max_sql_bytes: int
     expected_max_seconds: float
+    expected_warm_max_seconds: float

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/helpers.py
@@ -54,18 +54,27 @@ def run_advanced_compile_benchmark(
 
 
 def run_dbt_shaped_compile_benchmark(
-    *, project_dir: Path, model_count: int, expected_max_seconds: float
-) -> float:
+    *,
+    project_dir: Path,
+    model_count: int,
+    expected_max_seconds: float,
+    expected_warm_max_seconds: float,
+) -> tuple[float, float]:
     skip_actions: dict[bool, Callable[[], None]] = {
         False: _continue_compile_benchmark,
         True: _skip_compile_benchmark,
     }
     skip_actions[os.environ.get("SQLBUILD_SKIP_PERFORMANCE_TESTS") == "1"]()
     write_dbt_shaped_compile_project(project_dir=project_dir, model_count=model_count)
-    return _run_compile_benchmark(
+    cold_seconds: float = _run_compile_benchmark(
         project_dir=project_dir,
         expected_max_seconds=expected_max_seconds,
     )
+    warm_seconds: float = _run_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_warm_max_seconds,
+    )
+    return cold_seconds, warm_seconds
 
 
 def _run_compile_benchmark(*, project_dir: Path, expected_max_seconds: float) -> float:

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_compile_performance.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_compile_performance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -17,20 +18,22 @@ from tests.e2e.src.sqlbuild.cli.commands.main.compile.helpers import (
     run_dbt_shaped_compile_benchmark,
 )
 
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
 
 @pytest.mark.performance
 @pytest.mark.parametrize(
     "test_case",
     [
         CompilePerformanceGuardTestCase(
-            description="advanced 3000 model compile stays under eight seconds",
+            description="advanced 3000 model compile stays under six seconds",
             model_count=3000,
-            expected_max_seconds=8.0,
+            expected_max_seconds=6.0,
         ),
         CompilePerformanceGuardTestCase(
-            description="advanced 10000 model compile stays under twenty-five seconds",
+            description="advanced 10000 model compile stays under fifteen seconds",
             model_count=10000,
-            expected_max_seconds=25.0,
+            expected_max_seconds=15.0,
         ),
     ],
     ids=lambda case: case.description,
@@ -43,6 +46,10 @@ def test_given_generated_advanced_project_when_compiling_then_finishes_within_bu
         project_dir=tmp_path / f"advanced_{test_case.model_count}",
         model_count=test_case.model_count,
         expected_max_seconds=test_case.expected_max_seconds,
+    )
+    _LOGGER.info(
+        f"advanced compile models={test_case.model_count} "
+        f"cold={elapsed_seconds:.3f}s budget={test_case.expected_max_seconds:.1f}s"
     )
 
     assert elapsed_seconds < test_case.expected_max_seconds
@@ -85,6 +92,11 @@ def test_given_wide_scan_heavy_projects_when_doubling_sql_size_then_compile_scal
         scan_event_lines_per_model=test_case.large_scan_event_lines_per_model,
         expected_max_seconds=test_case.expected_max_seconds,
     )
+    scaling_ratio: float = large_elapsed_seconds / small_elapsed_seconds
+    _LOGGER.info(
+        f"wide compile small={small_elapsed_seconds:.3f}s large={large_elapsed_seconds:.3f}s "
+        f"ratio={scaling_ratio:.3f} budget={test_case.expected_max_scaling_ratio:.1f}"
+    )
 
     assert measure_model_sql_bytes(small_project_dir) >= test_case.expected_min_small_sql_bytes
     assert measure_model_sql_bytes(large_project_dir) >= test_case.expected_min_large_sql_bytes
@@ -96,7 +108,7 @@ def test_given_wide_scan_heavy_projects_when_doubling_sql_size_then_compile_scal
         test_case.model_count * test_case.large_scan_event_lines_per_model
         == test_case.expected_large_scan_events
     )
-    assert large_elapsed_seconds / small_elapsed_seconds < test_case.expected_max_scaling_ratio
+    assert scaling_ratio < test_case.expected_max_scaling_ratio
 
 
 @pytest.mark.performance
@@ -104,34 +116,43 @@ def test_given_wide_scan_heavy_projects_when_doubling_sql_size_then_compile_scal
     "test_case",
     [
         DbtShapedCompilePerformanceGuardTestCase(
-            description="dbt-shaped 3000 model project stays within compile budget",
+            description="dbt-shaped 3000 model cold and warm compiles stay within budget",
             model_count=3_000,
             expected_min_sql_bytes=18_000_000,
             expected_max_sql_bytes=25_000_000,
-            expected_max_seconds=15.0,
+            expected_max_seconds=6.0,
+            expected_warm_max_seconds=3.0,
         ),
         DbtShapedCompilePerformanceGuardTestCase(
-            description="dbt-shaped 10000 model project stays within compile budget",
+            description="dbt-shaped 10000 model cold and warm compiles stay within budget",
             model_count=10_000,
             expected_min_sql_bytes=60_000_000,
             expected_max_sql_bytes=80_000_000,
-            expected_max_seconds=45.0,
+            expected_max_seconds=16.0,
+            expected_warm_max_seconds=8.0,
         ),
     ],
     ids=lambda case: case.description,
 )
-def test_given_dbt_shaped_project_when_compiling_then_finishes_within_budget(
+def test_given_dbt_shaped_project_when_compiling_cold_and_warm_then_finishes_within_budgets(
     tmp_path: Path,
     test_case: DbtShapedCompilePerformanceGuardTestCase,
 ) -> None:
     project_dir: Path = tmp_path / f"dbt_shaped_{test_case.model_count}"
-    elapsed_seconds: float = run_dbt_shaped_compile_benchmark(
+    cold_seconds, warm_seconds = run_dbt_shaped_compile_benchmark(
         project_dir=project_dir,
         model_count=test_case.model_count,
         expected_max_seconds=test_case.expected_max_seconds,
+        expected_warm_max_seconds=test_case.expected_warm_max_seconds,
+    )
+    _LOGGER.info(
+        f"dbt-shaped compile models={test_case.model_count} cold={cold_seconds:.3f}s "
+        f"warm={warm_seconds:.3f}s budgets={test_case.expected_max_seconds:.1f}s/"
+        f"{test_case.expected_warm_max_seconds:.1f}s"
     )
 
     total_sql_bytes: int = measure_model_sql_bytes(project_dir)
     assert test_case.expected_min_sql_bytes <= total_sql_bytes
     assert total_sql_bytes <= test_case.expected_max_sql_bytes
-    assert elapsed_seconds < test_case.expected_max_seconds
+    assert cold_seconds < test_case.expected_max_seconds
+    assert warm_seconds < test_case.expected_warm_max_seconds


### PR DESCRIPTION
## Why

The large-project compile performance tests run in DuckDB CI, but their cold ceilings still reflected pre-optimization behavior and they did not measure unchanged warm compilation. Regressions in the new analysis/reference cache path could therefore pass.

## Changes

- Tighten advanced cold budgets from 8s/25s to 6s/15s at 3K/10K.
- Tighten dbt-shaped cold budgets from 15s/45s to 6s/16s.
- Add immediate warm dbt-shaped compile gates of 3s/8s at 3K/10K.
- Keep the existing wide-SQL sub-quadratic scaling gate.
- Emit measured cold, warm, and scaling values through pytest live logging in CI.
- Keep performance tests sequential after ordinary DuckDB E2E.

## Verification

- Performance baseline before changes: 5 passed in 24.30s.
- Updated performance suite: 5 passed in 30.00s.
- Local measurements:
  - Advanced cold: 1.949s at 3K; 6.136s at 10K.
  - dbt-shaped cold/warm: 2.867s/1.290s at 3K.
  - dbt-shaped cold/warm: 9.768s/4.706s at 10K.
  - Wide-SQL doubling ratio: 1.561x against a 3.0x ceiling.
- Ruff, Pyright, Fensu, and `git diff --check` passed.
