### PR TITLE
test(perf): finalize compile performance budgets

### DIFF
--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_compile_performance.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_compile_performance.py
@@ -26,14 +26,14 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
     "test_case",
     [
         CompilePerformanceGuardTestCase(
-            description="advanced 3000 model compile stays under six seconds",
+            description="advanced 3000 model compile stays under three seconds",
             model_count=3000,
-            expected_max_seconds=6.0,
+            expected_max_seconds=3.0,
         ),
         CompilePerformanceGuardTestCase(
-            description="advanced 10000 model compile stays under fifteen seconds",
+            description="advanced 10000 model compile stays under nine seconds",
             model_count=10000,
-            expected_max_seconds=15.0,
+            expected_max_seconds=9.0,
         ),
     ],
     ids=lambda case: case.description,
@@ -49,7 +49,7 @@ def test_given_generated_advanced_project_when_compiling_then_finishes_within_bu
     )
     _LOGGER.info(
         f"advanced compile models={test_case.model_count} "
-        f"cold={elapsed_seconds:.3f}s budget={test_case.expected_max_seconds:.1f}s"
+        f"cold={elapsed_seconds:.3f}s budget={test_case.expected_max_seconds:g}s"
     )
 
     assert elapsed_seconds < test_case.expected_max_seconds
@@ -120,16 +120,16 @@ def test_given_wide_scan_heavy_projects_when_doubling_sql_size_then_compile_scal
             model_count=3_000,
             expected_min_sql_bytes=18_000_000,
             expected_max_sql_bytes=25_000_000,
-            expected_max_seconds=6.0,
-            expected_warm_max_seconds=3.0,
+            expected_max_seconds=4.0,
+            expected_warm_max_seconds=2.25,
         ),
         DbtShapedCompilePerformanceGuardTestCase(
             description="dbt-shaped 10000 model cold and warm compiles stay within budget",
             model_count=10_000,
             expected_min_sql_bytes=60_000_000,
             expected_max_sql_bytes=80_000_000,
-            expected_max_seconds=16.0,
-            expected_warm_max_seconds=8.0,
+            expected_max_seconds=13.0,
+            expected_warm_max_seconds=7.0,
         ),
     ],
     ids=lambda case: case.description,
@@ -147,8 +147,8 @@ def test_given_dbt_shaped_project_when_compiling_cold_and_warm_then_finishes_wit
     )
     _LOGGER.info(
         f"dbt-shaped compile models={test_case.model_count} cold={cold_seconds:.3f}s "
-        f"warm={warm_seconds:.3f}s budgets={test_case.expected_max_seconds:.1f}s/"
-        f"{test_case.expected_warm_max_seconds:.1f}s"
+        f"warm={warm_seconds:.3f}s budgets={test_case.expected_max_seconds:g}s/"
+        f"{test_case.expected_warm_max_seconds:g}s"
     )
 
     total_sql_bytes: int = measure_model_sql_bytes(project_dir)


### PR DESCRIPTION
## Why

PR #349 added current cold and warm compile gates, but its initial budgets intentionally left broad headroom until measurements were available from the standard GitHub runner. Those measurements show the shorter gates can be tightened further without using the impractically narrow 10K ceiling originally considered.

## Changes

- Tighten advanced cold budgets from 6s/15s to 3s/9s at 3K/10K.
- Tighten dbt-shaped cold budgets from 6s/16s to 4s/13s.
- Tighten dbt-shaped warm budgets from 3s/8s to 2.25s/7s.
- Log fractional budgets without rounding away precision.

## Verification

- PR #349 standard-runner measurements: advanced cold 1.979s/6.656s; dbt-shaped cold 2.629s/9.858s; dbt-shaped warm 1.487s/5.204s.
- Focused local performance suite: 5 passed in 33.79s with all final ceilings.
- Local measurements: advanced cold 2.775s/8.062s; dbt-shaped cold 3.084s/9.953s; dbt-shaped warm 1.292s/4.989s.
- Ruff format/check, ty, Fensu, and `git diff --check` passed.
