### PR TITLE
refactor: rename standard execution mode to direct

### DIFF
--- a/scripts/cli_preview/_helpers/workflow.py
+++ b/scripts/cli_preview/_helpers/workflow.py
@@ -37,12 +37,12 @@ def preview_scenes() -> tuple[PreviewScene, ...]:
         ),
         PreviewScene(
             name="plan",
-            description="standard first-run plan",
+            description="direct first-run plan",
             command=("plan",),
         ),
         PreviewScene(
             name="plan-changed",
-            description="standard query-change plan with a SQL diff",
+            description="direct query-change plan with a SQL diff",
             setup_commands=(("build",),),
             mutate_payments=True,
             command=("plan",),

--- a/scripts/fensu_policy/constants.py
+++ b/scripts/fensu_policy/constants.py
@@ -90,7 +90,7 @@ REUSE_FORBIDDEN_TERMS: tuple[str, ...] = (
     "target_cursor",
 )
 REUSE_PATH_MARKERS: tuple[str, ...] = (
-    "standard_reuse",
+    "direct_reuse",
     "reuse_candidates.py",
     "reuse_execute.py",
     "reuse_plan.py",

--- a/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
+++ b/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
@@ -181,13 +181,13 @@ State is plain append-only rows in your own warehouse (`_sqlbuild_fingerprints`,
 
 ### Deploy reversibly (opt-in)
 
-By default, SQLBuild runs in standard mode with state as append-only rows in your warehouse. When you want more, [virtual environments](/concepts/virtual-environments) add a reversibility layer on top:
+By default, SQLBuild runs in direct mode with state as append-only rows in your warehouse. When you want more, [virtual environments](/concepts/virtual-environments) add a reversibility layer on top:
 
 - **Instant branching, promotion, and rollback** as low-copy pointer operations.
 - **Partial promotion.** Promote the models that are ready without re-running everything downstream of them - you don't have to rebuild the whole closure to ship one fix.
 - **Checkpoints and reconciliation** so a bad change is something you undo, not an incident.
 
-Virtual environments are opt-in, not a tax you pay upfront - standard mode stays the default, so the floor stays low and you reach for them only when a workflow needs them.
+Virtual environments are opt-in, not a tax you pay upfront - direct mode stays the default, so the floor stays low and you reach for them only when a workflow needs them.
 
 ### Supported adapters
 
@@ -736,7 +736,7 @@ Run dbt and SQLBuild side by side with coordinated selection and SQLBuild models
 
 Use the dbt compatibility bridge to coordinate dbt selections with SQLBuild-owned models downstream of their outputs.
 
-SQLBuild reads the dbt manifest and drives the `dbt` CLI as a subprocess. dbt remains responsible for compiling and executing dbt-owned models; SQLBuild statically analyzes and executes only SQLBuild-owned models downstream. `sqb dbt` runs in standard mode, so change-aware execution and virtual environments are not supported by the bridge.
+SQLBuild reads the dbt manifest and drives the `dbt` CLI as a subprocess. dbt remains responsible for compiling and executing dbt-owned models; SQLBuild statically analyzes and executes only SQLBuild-owned models downstream. `sqb dbt` runs in direct mode, so change-aware execution and virtual environments are not supported by the bridge.
 
 ### Start with your existing dbt project
 
@@ -1239,20 +1239,20 @@ default_audit_run_scope = "final"
 | Field | Default | Description |
 |-------|---------|-------------|
 | `sql_analysis` | `true` | Enable SQL validation and static analysis at compile time |
-| `changes_only` | `false` | Enable [change-aware pruning](/concepts/planning#changes-only-mode) for `plan` and `build` without passing `--changes-only` each run. Requires `virtual_environments = true`; rejected in standard mode. Can also be set per target under `[targets.<name>]`. The CLI flag takes precedence, then the selected target, then local settings, then this project setting. |
-| `virtual_environments` | `false` | Enable [virtual environments](/concepts/virtual-environments) (versioned model outputs, promotion, rollback, state management). When `false`, the project runs in standard mode. |
+| `changes_only` | `false` | Enable [change-aware pruning](/concepts/planning#changes-only-mode) for `plan` and `build` without passing `--changes-only` each run. Requires `virtual_environments = true`; rejected in direct mode. Can also be set per target under `[targets.<name>]`. The CLI flag takes precedence, then the selected target, then local settings, then this project setting. |
+| `virtual_environments` | `false` | Enable [virtual environments](/concepts/virtual-environments) (versioned model outputs, promotion, rollback, state management). When `false`, the project runs in direct mode. |
 | `query_change_tracking` | `true` | Track query fingerprints for change detection |
 | `sql_validation` | `true` | Validate SQL syntax during compilation |
 | `concurrency` | `1` | Maximum parallel model execution (currently serial only) |
 | `auto_load_sources` | `true` | Automatically run source loaders before building dependent models during `sqb build`. See [Loaders](/concepts/python-nodes/loaders). |
-| `table_promotion_mode` | adapter default | `staged` (CTAS to staging, audit, then promote) or `direct` (CTAS directly to target) |
+| `table_promotion_mode` | adapter default | `staged` (CTAS to staging, audit, then promote) or `immediate` (CTAS directly to target, then audit) |
 | `default_audit_severity` | `warn` | Default severity for audits: `warn` or `error` |
 | `default_audit_run_scope` | `final` | Default run scope for audits: `final` or `delta_and_final` |
 
 #### Table promotion mode
 
 - **`staged`** (default for most adapters): Materializes into a staging table, runs audits, then swaps into the target. If audits fail, the production table is untouched.
-- **`direct`**: Creates the table directly at the target location. Audits run after materialization. Simpler but no pre-promotion safety net.
+- **`immediate`**: Creates the table directly at the target location. Audits run after materialization. Simpler but no pre-promotion safety net.
 
 ### Kata
 
@@ -2369,7 +2369,7 @@ FROM __ref("stg_orders")
 GROUP BY customer_id
 ```
 
-Projects may opt into `settings.table_promotion_mode = "direct"`. Direct mode replaces the destination before audits, so a failed audit does not restore the old table. Direct mode rejects models that require declared-type enforcement or `contract enforced`; use staged promotion for those guarantees.
+Projects may opt into `settings.table_promotion_mode = "immediate"`. Immediate promotion replaces the destination before audits, so a failed audit does not restore the old table. Immediate promotion rejects models that require declared-type enforcement or `contract enforced`; use staged promotion for those guarantees.
 
 ### Incremental
 
@@ -2614,9 +2614,9 @@ Runtime cast support currently depends on materialization:
 | View | No; the view query defines the warehouse output type |
 | Snapshot | No framework cast reconstruction |
 | Custom materialization | Owned by the custom materialization |
-| Full table with direct promotion | Rejected when type enforcement is required |
+| Full table with immediate promotion | Rejected when type enforcement is required |
 
-Staged promotion is the default table mode. If a project selects direct table promotion, a typed model fails with guidance to use staged promotion because SQLBuild cannot inspect and reconstruct output before mutating the destination.
+Staged promotion is the default table mode. If a project selects immediate table promotion, a typed model fails with guidance to use staged promotion because SQLBuild cannot inspect and reconstruct output before mutating the destination.
 
 ### Type enforcement versus contracts
 
@@ -2693,7 +2693,7 @@ Runtime exact-schema validation currently runs for:
 
 Views and custom materializations rely on compile-time contract analysis. Microbatch incrementals currently apply type enforcement and audits but do not perform the framework runtime exact-schema validation step.
 
-Staged table validation happens before promotion, so a failure leaves the existing destination untouched. Direct table promotion is incompatible with `contract enforced` because SQLBuild cannot validate output before replacing the destination.
+Staged table validation happens before promotion, so a failure leaves the existing destination untouched. Immediate table promotion is incompatible with `contract enforced` because SQLBuild cannot validate output before replacing the destination.
 
 ### Type enforcement
 
@@ -2873,7 +2873,7 @@ The model override can re-enable validation when the project-level `settings.sql
 |-------|-------------|
 | `run_despite_unchanged` | Table-only change-aware policy. `always` rebuilds whenever selected. A duration such as `30d`, `12h`, or `90m` rebuilds while the newest timestamp-based upstream source observation is within that age; it is not a periodic schedule. |
 
-Table promotion mode is a project setting rather than a `MODEL()` field. Staged promotion is the default. Direct promotion is incompatible with model type enforcement and exact contracts; see [Materializations](/concepts/models/materializations#table).
+Table promotion mode is a project setting rather than a `MODEL()` field. Staged promotion is the default. Immediate promotion is incompatible with model type enforcement and exact contracts; see [Materializations](/concepts/models/materializations#table).
 
 ### Incremental fields
 
@@ -4288,7 +4288,7 @@ By default, every selected node runs regardless of its reason. Under `--changes-
 
 ### Changes-only mode
 
-Change-aware pruning requires virtual environments (`virtual_environments = true`); it is rejected in standard mode. Within a virtual environment, `--changes-only` narrows the scope to only models that are actually stale:
+Change-aware pruning requires virtual environments (`virtual_environments = true`); it is rejected in direct mode. Within a virtual environment, `--changes-only` narrows the scope to only models that are actually stale:
 
 ```bash
 sqb build --virtual-env pr_123 --changes-only
@@ -4337,9 +4337,9 @@ When unchanged SQL models are skipped, read-side Python nodes (tasks, assets, ch
 
 Python nodes also have their own identity fingerprints: if a node's source code or dependencies change, it runs even if its SQL dependencies haven't.
 
-### Warehouse-native state (standard mode)
+### Warehouse-native state (direct mode)
 
-In standard mode, all change-tracking state lives in the warehouse as append-only tables in the same schemas as your data:
+In direct mode, all change-tracking state lives in the warehouse as append-only tables in the same schemas as your data:
 
 - **`_sqlbuild_fingerprints`** - version identities for models, functions, seeds, and Python nodes. One row per successful build per identity.
 - **`_sqlbuild_source_freshness`** - source freshness observations. One row per successful build per source identity.
@@ -6074,7 +6074,7 @@ SQLBuild can compare schemas and row-level data between two build contexts. This
 
 `sqb diff FROM:TO` compares:
 
-- **two targets** (e.g. `prod:dev`) in standard mode, or
+- **two targets** (e.g. `prod:dev`) in direct mode, or
 - **two virtual environments** (VDEs) when [virtual environments](/concepts/virtual-environments) are enabled.
 
 The mechanics below are identical for both; only what `FROM` and `TO` refer to changes.
@@ -6315,7 +6315,7 @@ Downstream nodes run only if at least one upstream succeeded. If all upstreams a
 
 ### Result persistence
 
-Node results (payload, metadata, status, errors) are persisted after each execution. In standard mode, results are stored in `_sqlbuild_node_results` in the warehouse alongside your data. In virtual mode, results are stored in the VDE state backend scoped per environment. Results persist across runs, so they are available for observability, debugging, and downstream consumption.
+Node results (payload, metadata, status, errors) are persisted after each execution. In direct mode, results are stored in `_sqlbuild_node_results` in the warehouse alongside your data. In virtual mode, results are stored in the VDE state backend scoped per environment. Results persist across runs, so they are available for observability, debugging, and downstream consumption.
 
 ### Selection
 
@@ -7492,7 +7492,7 @@ Virtual environments (VDEs) let you build, preview, and promote SQL pipeline cha
 - **Multi-developer isolation** - each developer works in their own VDE without conflicting with others, sharing physical versions when code is identical
 - **Instant rollback** - revert production to a prior finalized state by restoring a checkpoint's pointer set
 
-Virtual environments are opt-in via `virtual_environments = true` (under `[settings]`) and require a state store. Projects that don't need environment isolation or promotion workflows should use the default standard mode.
+Virtual environments are opt-in via `virtual_environments = true` (under `[settings]`) and require a state store. Projects that don't need environment isolation or promotion workflows should use the default direct mode.
 
 ### How it works
 
@@ -7615,7 +7615,7 @@ schema = "sqlbuild_state"
 database = "state.duckdb"
 ```
 
-The `virtual_environments` setting switches the project from standard mode (default) to virtual mode. All state, plan, build, promote, rollback, and reconcile commands route through the virtual path when this is enabled.
+The `virtual_environments` setting switches the project from direct mode (default) to virtual mode. All state, plan, build, promote, rollback, and reconcile commands route through the virtual path when this is enabled.
 
 ### State configuration
 
@@ -7764,9 +7764,9 @@ Source: `concepts/virtual-environments/building.mdx`
 
 Virtual builds, VDE creation, partial builds, and seeded incrementals.
 
-Virtual builds create versioned physical relations and update VDE pointer sets. The build lifecycle is the same as standard mode (seeds, tests, models, audits), but model outputs are written to versioned physical tables and exposed through logical VDE views.
+Virtual builds create versioned physical relations and update VDE pointer sets. The build lifecycle is the same as direct mode (seeds, tests, models, audits), but model outputs are written to versioned physical tables and exposed through logical VDE views.
 
-Virtual builds run ingress (loaders and Python nodes that feed sources) as a separate phase before SQL model execution. This means independent SQL models that do not depend on loaders will wait for all ingress to complete before starting. Standard mode does not have this limitation. This keeps VDE state persistence simpler and safer but may add wall time when ingress is slow and independent SQL work is available. A future optimization may allow overlapping ingress with independent SQL execution.
+Virtual builds run ingress (loaders and Python nodes that feed sources) as a separate phase before SQL model execution. This means independent SQL models that do not depend on loaders will wait for all ingress to complete before starting. Direct mode does not have this limitation. This keeps VDE state persistence simpler and safer but may add wall time when ingress is slow and independent SQL work is available. A future optimization may allow overlapping ingress with independent SQL execution.
 
 ### Default VDE
 
@@ -7849,7 +7849,7 @@ sqb build --virtual-env pr_123 --select fact_orders --include-stale-upstreams
 
 #### Stale-driven selection
 
-Virtual environment builds run the full selection by default, like standard mode. Add `--changes-only` to intersect the selection with the stale-driven set, so only models that are both selected and stale are built:
+Virtual environment builds run the full selection by default, like direct mode. Add `--changes-only` to intersect the selection with the stale-driven set, so only models that are both selected and stale are built:
 
 ```bash
 sqb build --virtual-env pr_123 --select path:models/marts --changes-only
@@ -7857,7 +7857,7 @@ sqb build --virtual-env pr_123 --select path:models/marts --changes-only
 
 This is useful when the stale cascade is large and you want to build a coherent subgraph without running unchanged models. Without `--changes-only`, every selected model is built regardless of state.
 
-Change-aware pruning is opt-in in both standard mode and virtual environments. See [Planning and Change Detection](/concepts/planning) for how fingerprints, source freshness, and identity tracking determine what gets built.
+Change-aware pruning is opt-in within virtual environments and unavailable in direct mode. See [Planning and Change Detection](/concepts/planning) for how fingerprints, source freshness, and identity tracking determine what gets built.
 
 ### Stale detection
 
@@ -7888,7 +7888,7 @@ For append models with bounded replay (`replay_on_change bounded-7d`), the seed 
 
 ### Custom materializations
 
-Custom materializations are supported in virtual mode. By default, SQLBuild seeds new physical versions using the standard clone/copy strategy before calling the custom `materialize` function.
+Custom materializations are supported in virtual mode. By default, SQLBuild seeds new physical versions using the direct clone/copy strategy before calling the custom `materialize` function.
 
 For custom materializations that need different seeding behavior, define a `prepare_version` function alongside `materialize`:
 
@@ -8205,7 +8205,7 @@ A detached VDE is blocked from further virtual operations:
 - `sqb promote --from <detached>` or `--to <detached>` blocks
 - `sqb rollback` on a detached VDE blocks
 
-The project can continue operating in standard mode, or you can re-adopt to return to virtual mode.
+The project can continue operating in direct mode, or you can re-adopt to return to virtual mode.
 
 #### Detached VDE cleanup
 
@@ -8293,9 +8293,9 @@ sqb clone --from prod --to dev --skip-locked
 
 Clone is a physical-layer operation. VDE pointer management is handled by [build](/concepts/virtual-environments/building) and [promote](/concepts/virtual-environments/promotion).
 
-### Comparison with standard-mode clone
+### Comparison with direct-mode clone
 
-In standard mode, `sqb clone` copies model relations between targets using zero-copy cloning where supported. In virtual mode, clone hydrates versioned physical relations instead. The source and target are still physical targets, but the copied objects are physical version relations rather than normal model targets.
+In direct mode, `sqb clone` copies model relations between targets using zero-copy cloning where supported. In virtual mode, clone hydrates versioned physical relations instead. The source and target are still physical targets, but the copied objects are physical version relations rather than normal model targets.
 
 ## Diff
 
@@ -8351,9 +8351,9 @@ sqb diff dev:pr_123 --allow-partial-diff
 
 This guard prevents misleading diff output when one VDE has pending changes that haven't been materialized yet.
 
-### Comparison with standard-mode diff
+### Comparison with direct-mode diff
 
-In standard mode, `sqb diff prod:dev` compares physical target schemas and data directly in the warehouse. In virtual mode, `sqb diff dev:pr_123` compares VDE pointer sets within a single physical target, then inspects the physical versions those pointers reference.
+In direct mode, `sqb diff prod:dev` compares physical target schemas and data directly in the warehouse. In virtual mode, `sqb diff dev:pr_123` compares VDE pointer sets within a single physical target, then inspects the physical versions those pointers reference.
 
 The output format is the same - schema diffs, row counts, changed columns, and example rows. The difference is what is being compared: physical targets vs virtual pointer sets.
 
@@ -8650,7 +8650,7 @@ After `sqb state detach`, the VDE is marked `detached` and blocked from further 
 | `sqb promote --to <detached>` | Blocks |
 | `sqb rollback` | Blocks |
 
-The project can continue in standard mode or re-adopt to return to virtual mode.
+The project can continue in direct mode or re-adopt to return to virtual mode.
 
 ### Adopt guards
 
@@ -10764,7 +10764,7 @@ Summary: observed=0 changed=1 unchanged=1 tolerated=1 unknown=0 errors=0
 
 #### Virtual environment state
 
-To compare against state stored in a virtual environment instead of standard mode state:
+To compare against state stored in a virtual environment instead of direct mode state:
 
 ```bash
 sqb freshness --state --virtual-env pr_123
@@ -10968,7 +10968,7 @@ Source: `cli/diff.mdx`
 
 Compare schemas and data between targets or virtual environments.
 
-Compares schemas and optionally row-level data between two build contexts: two targets (e.g. `prod:dev`) in standard mode, or two virtual environments when virtual mode is enabled. See [Data Diffs](/concepts/diff) for detailed usage.
+Compares schemas and optionally row-level data between two build contexts: two targets (e.g. `prod:dev`) in direct mode, or two virtual environments when virtual mode is enabled. See [Data Diffs](/concepts/diff) for detailed usage.
 
 ### Usage
 

--- a/src/sqlbuild/adapter/contract/classes/base_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/base_adapter.py
@@ -1860,7 +1860,7 @@ class BaseAdapter(StrictAdapter):
         )
 
     def render_create_microbatch_state_table_sql(self, *, database: str | None, schema: str) -> str:
-        """Render DDL that creates the standard microbatch state table when missing."""
+        """Render DDL that creates the direct microbatch state table when missing."""
 
         from sqlbuild.microbatches.main.create_table_sql import build_create_table_sql
 
@@ -1874,7 +1874,7 @@ class BaseAdapter(StrictAdapter):
     def render_create_microbatch_state_index_sqls(
         self, *, database: str | None, schema: str
     ) -> tuple[str, ...]:
-        """Render optional standard-state indexes for warehouses that support them."""
+        """Render optional direct-state indexes for warehouses that support them."""
 
         return ()
 

--- a/src/sqlbuild/adapter/contract/classes/microbatch.py
+++ b/src/sqlbuild/adapter/contract/classes/microbatch.py
@@ -37,7 +37,7 @@ class MicrobatchMixin:
         return relations[0].created_at.isoformat()
 
     def render_create_microbatch_state_table_sql(self, *, database: str | None, schema: str) -> str:
-        """Render portable DDL for the standard microbatch state table."""
+        """Render portable DDL for the direct microbatch state table."""
 
         from sqlbuild.microbatches.main.create_table_sql import build_create_table_sql
 

--- a/src/sqlbuild/adapter/contract/classes/strict_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/strict_adapter.py
@@ -115,14 +115,14 @@ class StrictAdapter(
 
     @abstractmethod
     def render_create_microbatch_state_table_sql(self, *, database: str | None, schema: str) -> str:
-        """Render DDL that creates the standard microbatch state table when missing."""
+        """Render DDL that creates the direct microbatch state table when missing."""
         ...
 
     @abstractmethod
     def render_create_microbatch_state_index_sqls(
         self, *, database: str | None, schema: str
     ) -> tuple[str, ...]:
-        """Render optional indexes for standard microbatch state."""
+        """Render optional indexes for direct microbatch state."""
         ...
 
     @abstractmethod

--- a/src/sqlbuild/adapter/contract/types.py
+++ b/src/sqlbuild/adapter/contract/types.py
@@ -37,7 +37,7 @@ class PromotionStrategy(StrEnum):
 
 
 class TablePromotionMode(StrEnum):
-    DIRECT = "direct"
+    IMMEDIATE = "immediate"
     STAGED = "staged"
 
 

--- a/src/sqlbuild/cli/commands/_helpers/build_execution/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_execution/execution.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 from sqlbuild.cli.commands._helpers.build_python_nodes.python_lifecycle import (
-    prepare_standard_python_lifecycle,
+    prepare_direct_python_lifecycle,
 )
 from sqlbuild.cli.commands._helpers.freshness.source_freshness import (
-    append_eligible_standard_source_freshness_records,
+    append_eligible_direct_source_freshness_records,
 )
 from sqlbuild.cli.commands._helpers.input.parsing import (
     parse_cursor_integer,
@@ -20,7 +20,7 @@ from sqlbuild.cli.commands.models import (
     BuildExecutionPreparation,
     BuildInvocation,
     BuildRunOutcome,
-    StandardLifecycleCallbacks,
+    DirectLifecycleCallbacks,
 )
 from sqlbuild.cli.progress.classes.connection_progress_reporter import (
     ConnectionProgressReporter,
@@ -79,7 +79,7 @@ def prepare_build_execution(
         callbacks=callbacks,
         effective_concurrency=effective_concurrency,
         execution_connection_progress=execution_connection_progress,
-        python_lifecycle=prepare_standard_python_lifecycle(
+        python_lifecycle=prepare_direct_python_lifecycle(
             discovered_inputs=invocation.discovered_inputs,
             pipeline_result=pipeline_result,
             plan_output=pipeline_result.plan_output,
@@ -93,7 +93,7 @@ def prepare_build_execution(
                 start_cursor_int=parse_cursor_integer(cursor_overrides.start_int),
                 end_cursor_int=parse_cursor_integer(cursor_overrides.end_int),
             ),
-            callbacks=StandardLifecycleCallbacks(
+            callbacks=DirectLifecycleCallbacks(
                 use_color=invocation.use_color,
                 progress_stream=invocation.progress_stream,
                 on_node_start=lambda name, resource_kind: callbacks.on_node_start(
@@ -171,7 +171,7 @@ def execute_build_plan(
             initial_failed_keys=preparation.python_lifecycle.blocked_keys,
         ),
     )
-    append_eligible_standard_source_freshness_records(
+    append_eligible_direct_source_freshness_records(
         plan=pipeline_result.plan_output,
         result=result,
         adapter=invocation.adapter,

--- a/src/sqlbuild/cli/commands/_helpers/build_execution/outputs.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_execution/outputs.py
@@ -45,7 +45,7 @@ def write_build_plan_text(
         full_refresh=request.full_refresh,
         use_color=invocation.use_color,
         python_plan_entries=pipeline_result.python_plan_entries,
-        include_standard_freshness_diagnostics=(
+        include_direct_freshness_diagnostics=(
             invocation.virtual_mode or invocation.effective_changes_only
         ),
     )

--- a/src/sqlbuild/cli/commands/_helpers/build_python_nodes/python_lifecycle.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_python_nodes/python_lifecycle.py
@@ -1,4 +1,4 @@
-"""Standard-mode Python lifecycle orchestration for build commands."""
+"""Direct-mode Python lifecycle orchestration for build commands."""
 
 from __future__ import annotations
 
@@ -14,10 +14,10 @@ from sqlbuild.cli.commands._helpers.build_python_nodes.python_lifecycle_selectio
 from sqlbuild.cli.commands._helpers.build_python_nodes.python_node_output import (
     write_python_node_results,
 )
-from sqlbuild.cli.commands.classes.standard_python_lifecycle_state import (
-    StandardPythonLifecycleState,
+from sqlbuild.cli.commands.classes.direct_python_lifecycle_state import (
+    DirectPythonLifecycleState,
 )
-from sqlbuild.cli.commands.models import StandardLifecycleCallbacks
+from sqlbuild.cli.commands.models import DirectLifecycleCallbacks
 from sqlbuild.compiler.compile.models import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
@@ -50,7 +50,7 @@ from sqlbuild.runtime.contracts.types import NodeStartCallback
 from sqlbuild.spec.contracts.models import SourceEntry
 
 
-def prepare_standard_python_lifecycle(
+def prepare_direct_python_lifecycle(
     *,
     discovered_inputs: DiscoveredProjectInputs,
     pipeline_result: CompilePipelineResult,
@@ -60,10 +60,10 @@ def prepare_standard_python_lifecycle(
     include_python: bool,
     reload_sources: bool,
     cursor_window: CursorWindow,
-    callbacks: StandardLifecycleCallbacks,
+    callbacks: DirectLifecycleCallbacks,
     providers: ProviderContainer | None = None,
-) -> StandardPythonLifecycleState:
-    """Execute ingress Python and prepare read-side dispatch for standard run/build."""
+) -> DirectPythonLifecycleState:
+    """Execute ingress Python and prepare read-side dispatch for direct run/build."""
 
     start_cursor_ts: datetime | None = cursor_window.start_cursor_ts
     end_cursor_ts: datetime | None = cursor_window.end_cursor_ts
@@ -194,7 +194,7 @@ def prepare_standard_python_lifecycle(
                 results=initial_read_side_results,
                 use_color=use_color,
             )
-    return StandardPythonLifecycleState(
+    return DirectPythonLifecycleState(
         plan_output=plan_output,
         discovered_inputs=discovered_inputs,
         adapter=adapter,

--- a/src/sqlbuild/cli/commands/_helpers/clone/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/clone/execution.py
@@ -30,7 +30,7 @@ def execute_clone_plan(
     connection_context: CloneConnectionContext,
     preparation: CloneExecutionPreparation,
 ) -> CloneRunOutcome:
-    """Execute the standard clone plan and copy fingerprints."""
+    """Execute the direct clone plan and copy fingerprints."""
 
     clone_start: float = time.monotonic()
     on_item: CloneItemCallback = _build_on_clone_item(

--- a/src/sqlbuild/cli/commands/_helpers/clone/outputs.py
+++ b/src/sqlbuild/cli/commands/_helpers/clone/outputs.py
@@ -21,7 +21,7 @@ def write_clone_execution_header(
     invocation: CloneInvocation,
     preparation: CloneExecutionPreparation,
 ) -> None:
-    """Write the standard clone execution header."""
+    """Write the direct clone execution header."""
 
     clone_total: int = (
         len(preparation.pipeline_result.destination_source_entries)
@@ -41,7 +41,7 @@ def write_clone_execution_header(
 
 
 def write_clone_completion_output(*, invocation: CloneInvocation, outcome: CloneRunOutcome) -> None:
-    """Render final standard clone command output."""
+    """Render final direct clone command output."""
 
     render_clone_output(
         result=outcome.result,
@@ -51,6 +51,6 @@ def write_clone_completion_output(*, invocation: CloneInvocation, outcome: Clone
 
 
 def resolve_clone_exit_code(outcome: CloneRunOutcome) -> int:
-    """Return the shell exit code for a standard clone outcome."""
+    """Return the shell exit code for a direct clone outcome."""
 
     return 0 if is_clone_success(outcome.result) else 1

--- a/src/sqlbuild/cli/commands/_helpers/clone/planning.py
+++ b/src/sqlbuild/cli/commands/_helpers/clone/planning.py
@@ -26,7 +26,7 @@ def prepare_clone_execution(
     invocation: CloneInvocation,
     connection_context: CloneConnectionContext,
 ) -> CloneExecutionPreparation:
-    """Prepare the standard clone plan."""
+    """Prepare the direct clone plan."""
 
     progress: PlanningProgressReporter = PlanningProgressReporter(
         stream=invocation.progress_stream,

--- a/src/sqlbuild/cli/commands/_helpers/diff/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/diff/execution.py
@@ -18,7 +18,7 @@ from sqlbuild.cli.commands.exceptions import CliUserError
 from sqlbuild.cli.commands.models import (
     DiffCommandRequest,
     DiffInvocation,
-    StandardDiffPreparation,
+    DirectDiffPreparation,
     VirtualDiffPreparation,
     VirtualDiffRunOutcome,
 )
@@ -36,10 +36,10 @@ from sqlbuild.virtual.diff.main.diff import run_virtual_diff
 from sqlbuild.virtual.diff.models import VirtualDiffOptions
 
 
-def prepare_standard_diff(
+def prepare_direct_diff(
     *, request: DiffCommandRequest, invocation: DiffInvocation
-) -> StandardDiffPreparation:
-    """Resolve standard target diff adapter, compiled projects, and limits."""
+) -> DirectDiffPreparation:
+    """Resolve direct target diff adapter, compiled projects, and limits."""
 
     from_target: str = request.from_name
     to_target: str = request.to_name
@@ -73,7 +73,7 @@ def prepare_standard_diff(
     )
     if not selected_names:
         raise CliUserError("no diffable models found in the selected scope", code="C207")
-    return StandardDiffPreparation(
+    return DirectDiffPreparation(
         from_target=from_target,
         to_target=to_target,
         adapter=adapter,
@@ -95,10 +95,10 @@ def prepare_standard_diff(
     )
 
 
-def execute_standard_diff(
-    *, request: DiffCommandRequest, preparation: StandardDiffPreparation
+def execute_direct_diff(
+    *, request: DiffCommandRequest, preparation: DirectDiffPreparation
 ) -> DiffExecutionResult:
-    """Execute a standard target-to-target diff."""
+    """Execute a direct target-to-target diff."""
 
     connection: Any = preparation.adapter.connect(preparation.connection_config)
     try:

--- a/src/sqlbuild/cli/commands/_helpers/diff/outputs.py
+++ b/src/sqlbuild/cli/commands/_helpers/diff/outputs.py
@@ -6,7 +6,7 @@ from sqlbuild.cli.commands._helpers.diff.output import has_diff_failures, render
 from sqlbuild.cli.commands._helpers.diff.virtual_output import format_virtual_diff_header
 from sqlbuild.cli.commands.models import (
     DiffCommandRequest,
-    StandardDiffPreparation,
+    DirectDiffPreparation,
     VirtualDiffPreparation,
     VirtualDiffRunOutcome,
 )
@@ -14,13 +14,13 @@ from sqlbuild.executor.diff.models import DiffExecutionResult
 from sqlbuild.presentation.main.supports_color import supports_color
 
 
-def write_standard_diff_output(
+def write_direct_diff_output(
     *,
     request: DiffCommandRequest,
-    preparation: StandardDiffPreparation,
+    preparation: DirectDiffPreparation,
     result: DiffExecutionResult,
 ) -> None:
-    """Write standard diff output."""
+    """Write direct diff output."""
 
     print(
         render_diff_output(

--- a/src/sqlbuild/cli/commands/_helpers/freshness/source_freshness.py
+++ b/src/sqlbuild/cli/commands/_helpers/freshness/source_freshness.py
@@ -9,17 +9,17 @@ from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.planner.models import ModelPlanEntry, PlanOutput
 from sqlbuild.compiler.source_freshness.main.write import write_source_freshness_records
 from sqlbuild.compiler.source_freshness.models import (
+    DirectSourceFreshnessPlanningResult,
     SourceFreshnessIdentity,
     SourceFreshnessRecord,
     SourceFreshnessRenderers,
-    StandardSourceFreshnessPlanningResult,
 )
 from sqlbuild.cost.classes.cost_context import CostContext
 from sqlbuild.executor.build.models import BuildExecutionResult
 from sqlbuild.executor.scheduling.types import ExecutionStatus
 
 
-def append_eligible_standard_source_freshness_records(
+def append_eligible_direct_source_freshness_records(
     *,
     plan: PlanOutput,
     result: BuildExecutionResult,
@@ -29,7 +29,7 @@ def append_eligible_standard_source_freshness_records(
 ) -> None:
     """Append observed source freshness only after affected selected models succeed."""
 
-    source_freshness: StandardSourceFreshnessPlanningResult | None = plan.source_freshness
+    source_freshness: DirectSourceFreshnessPlanningResult | None = plan.source_freshness
     if source_freshness is None or source_freshness.propagation is None:
         return
 

--- a/src/sqlbuild/cli/commands/_helpers/freshness/state.py
+++ b/src/sqlbuild/cli/commands/_helpers/freshness/state.py
@@ -16,10 +16,10 @@ from sqlbuild.virtual.state.main.environments.runtime import build_state_runtime
 from sqlbuild.virtual.state.models import SourceFreshnessRecord as VirtualSourceFreshnessRecord
 
 
-def read_standard_freshness_state_for_command(
+def read_direct_freshness_state_for_command(
     *, adapter: StrictAdapter, connection: Any, project: Any
 ) -> dict[SourceFreshnessIdentity, SourceFreshnessRecord]:
-    """Read standard source freshness state for all compiled target schemas."""
+    """Read direct source freshness state for all compiled target schemas."""
 
     records: dict[SourceFreshnessIdentity, SourceFreshnessRecord] = {}
     state_database: str | None = _resolve_state_database(project=project)
@@ -83,13 +83,13 @@ def read_virtual_freshness_state_for_command(
             )
         )
         return {
-            record.source_name: _standard_record_from_virtual_record(record) for record in records
+            record.source_name: _direct_record_from_virtual_record(record) for record in records
         }
     finally:
         backend.close(state_connection)
 
 
-def _standard_record_from_virtual_record(
+def _direct_record_from_virtual_record(
     record: VirtualSourceFreshnessRecord,
 ) -> SourceFreshnessRecord:
     return SourceFreshnessRecord(

--- a/src/sqlbuild/cli/commands/_helpers/load/outputs.py
+++ b/src/sqlbuild/cli/commands/_helpers/load/outputs.py
@@ -90,7 +90,7 @@ def write_load_plan_output(*, invocation: LoadInvocation) -> None:
 def write_load_execution_header(
     *, invocation: LoadInvocation, preparation: LoadExecutionPreparation
 ) -> None:
-    """Write standard execution header for load."""
+    """Write direct execution header for load."""
 
     write_execution_header(
         stream=invocation.progress_stream,

--- a/src/sqlbuild/cli/commands/_helpers/plan/outputs.py
+++ b/src/sqlbuild/cli/commands/_helpers/plan/outputs.py
@@ -38,7 +38,7 @@ def write_plan_command_output(
             use_color=invocation.use_color,
             display_options=display_options,
             python_plan_entries=pipeline_result.python_plan_entries,
-            include_standard_freshness_diagnostics=(
+            include_direct_freshness_diagnostics=(
                 invocation.virtual_mode or invocation.effective_changes_only
             ),
         )

--- a/src/sqlbuild/cli/commands/_helpers/plan/planning.py
+++ b/src/sqlbuild/cli/commands/_helpers/plan/planning.py
@@ -27,7 +27,7 @@ def compile_plan_pipeline(
     request: PlanCommandRequest,
     invocation: PlanInvocation,
 ) -> CompilePipelineResult:
-    """Compile the plan pipeline in virtual or standard mode."""
+    """Compile the plan pipeline in virtual or direct mode."""
 
     external_sql_reference_resolver: object | None = resolve_external_sql_reference_resolver(
         project_dir=invocation.effective_project_dir,

--- a/src/sqlbuild/cli/commands/_helpers/runtime/mode_policy.py
+++ b/src/sqlbuild/cli/commands/_helpers/runtime/mode_policy.py
@@ -28,7 +28,7 @@ def enforce_virtual_only_flags_in_virtual_mode(
     include_stale_upstreams: bool,
     changes_only: bool = False,
 ) -> None:
-    """Block virtual-environment-only flags on standard-mode projects."""
+    """Block virtual-environment-only flags on direct-mode projects."""
 
     if discovered_inputs.project_config.settings.virtual_environments:
         return

--- a/src/sqlbuild/cli/commands/classes/direct_python_lifecycle_state.py
+++ b/src/sqlbuild/cli/commands/classes/direct_python_lifecycle_state.py
@@ -1,4 +1,4 @@
-"""Mutable standard Python lifecycle state."""
+"""Mutable direct Python lifecycle state."""
 
 from __future__ import annotations
 
@@ -23,8 +23,8 @@ from sqlbuild.executor.load.models import LoadExecutionResult
 from sqlbuild.executor.python_nodes.models import PythonNodeExecutionResult
 
 
-class StandardPythonLifecycleState:
-    """Mutable state for standard-mode Python lifecycle execution."""
+class DirectPythonLifecycleState:
+    """Mutable state for direct-mode Python lifecycle execution."""
 
     def __init__(self, **kwargs: object) -> None:
         self.plan_output = cast(PlanOutput, kwargs["plan_output"])

--- a/src/sqlbuild/cli/commands/main/execution/_build.py
+++ b/src/sqlbuild/cli/commands/main/execution/_build.py
@@ -151,14 +151,14 @@ def run_build(request: BuildCommandRequest) -> int:
             )
         )
         try:
-            preparation, outcome, check_results = _execute_standard_build(
+            preparation, outcome, check_results = _execute_direct_build(
                 request=request,
                 invocation=invocation,
                 pipeline_result=pipeline_result,
                 providers=provider_session.providers,
             )
         except BaseException as error:
-            _ = _finalize_exceptional_standard_cost(
+            _ = _finalize_exceptional_direct_cost(
                 invocation=invocation,
                 pipeline_result=pipeline_result,
                 build_started_at=build_started_at,
@@ -209,7 +209,7 @@ def run_build(request: BuildCommandRequest) -> int:
         provider_session.close()
 
 
-def _execute_standard_build(
+def _execute_direct_build(
     *,
     request: BuildCommandRequest,
     invocation: BuildInvocation,
@@ -263,7 +263,7 @@ def _execute_standard_build(
     return preparation, outcome, check_results
 
 
-def _finalize_exceptional_standard_cost(
+def _finalize_exceptional_direct_cost(
     *,
     invocation: BuildInvocation,
     pipeline_result: CompilePipelineResult,

--- a/src/sqlbuild/cli/commands/main/execution/_freshness.py
+++ b/src/sqlbuild/cli/commands/main/execution/_freshness.py
@@ -17,7 +17,7 @@ from sqlbuild.cli.commands._helpers.freshness.output import (
 )
 from sqlbuild.cli.commands._helpers.freshness.selection import resolve_freshness_source_names
 from sqlbuild.cli.commands._helpers.freshness.state import (
-    read_standard_freshness_state_for_command,
+    read_direct_freshness_state_for_command,
     read_virtual_freshness_state_for_command,
 )
 from sqlbuild.cli.commands._helpers.runtime.adapters import resolve_adapter
@@ -100,7 +100,7 @@ def run_freshness(request: FreshnessCommandRequest) -> int:
                     virtual_environment_name=virtual_environment_name,
                 )
             elif compare_state:
-                previous_records = read_standard_freshness_state_for_command(
+                previous_records = read_direct_freshness_state_for_command(
                     adapter=adapter,
                     connection=connection,
                     project=graph.project,

--- a/src/sqlbuild/cli/commands/main/inspection/_diff.py
+++ b/src/sqlbuild/cli/commands/main/inspection/_diff.py
@@ -3,21 +3,21 @@
 from __future__ import annotations
 
 from sqlbuild.cli.commands._helpers.diff.execution import (
-    execute_standard_diff,
+    execute_direct_diff,
     execute_virtual_diff,
-    prepare_standard_diff,
+    prepare_direct_diff,
     prepare_virtual_diff,
 )
 from sqlbuild.cli.commands._helpers.diff.invocation import resolve_diff_invocation
 from sqlbuild.cli.commands._helpers.diff.outputs import (
     resolve_diff_exit_code,
-    write_standard_diff_output,
+    write_direct_diff_output,
     write_virtual_diff_output,
 )
 from sqlbuild.cli.commands.models import (
     DiffCommandRequest,
     DiffInvocation,
-    StandardDiffPreparation,
+    DirectDiffPreparation,
     VirtualDiffPreparation,
     VirtualDiffRunOutcome,
 )
@@ -45,17 +45,17 @@ def run_diff(request: DiffCommandRequest) -> int:
         )
         return resolve_diff_exit_code(virtual_outcome.result)
 
-    standard_preparation: StandardDiffPreparation = prepare_standard_diff(
+    direct_preparation: DirectDiffPreparation = prepare_direct_diff(
         request=request,
         invocation=invocation,
     )
-    result: DiffExecutionResult = execute_standard_diff(
+    result: DiffExecutionResult = execute_direct_diff(
         request=request,
-        preparation=standard_preparation,
+        preparation=direct_preparation,
     )
-    write_standard_diff_output(
+    write_direct_diff_output(
         request=request,
-        preparation=standard_preparation,
+        preparation=direct_preparation,
         result=result,
     )
     return resolve_diff_exit_code(result)

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from typing import Any, TextIO
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
-from sqlbuild.cli.commands.classes.standard_python_lifecycle_state import (
-    StandardPythonLifecycleState,
+from sqlbuild.cli.commands.classes.direct_python_lifecycle_state import (
+    DirectPythonLifecycleState,
 )
 from sqlbuild.cli.commands.types import (
     CompileLineageMode,
@@ -186,8 +186,8 @@ class BuildCommandRequest:
 
 
 @dataclass(frozen=True)
-class StandardLifecycleCallbacks:
-    """Node progress callbacks and output settings for standard Python lifecycle."""
+class DirectLifecycleCallbacks:
+    """Node progress callbacks and output settings for direct Python lifecycle."""
 
     on_node_complete: Callable[[object], None]
     progress_stream: TextIO
@@ -256,7 +256,7 @@ class BuildExecutionPreparation:
     callbacks: BuildProgressCallbacks
     effective_concurrency: int
     execution_connection_progress: ConnectionProgressReporter
-    python_lifecycle: StandardPythonLifecycleState
+    python_lifecycle: DirectPythonLifecycleState
     start_cursor_ts: datetime | None
     end_cursor_ts: datetime | None
     start_cursor_int: int | None
@@ -415,14 +415,14 @@ class CloneConnectionContext:
 
 @dataclass(frozen=True)
 class CloneExecutionPreparation:
-    """Prepared standard clone pipeline and selected destination entries."""
+    """Prepared direct clone pipeline and selected destination entries."""
 
     pipeline_result: ClonePipelineResult
 
 
 @dataclass(frozen=True)
 class CloneRunOutcome:
-    """Standard clone execution result and elapsed time."""
+    """Direct clone execution result and elapsed time."""
 
     result: CloneExecutionResult
     elapsed: float
@@ -604,8 +604,8 @@ class DiffInvocation:
 
 
 @dataclass(frozen=True)
-class StandardDiffPreparation:
-    """Resolved standard diff adapter and compiled target projects."""
+class DirectDiffPreparation:
+    """Resolved direct diff adapter and compiled target projects."""
 
     from_target: str
     to_target: str

--- a/src/sqlbuild/cli/output/_helpers/plan_text.py
+++ b/src/sqlbuild/cli/output/_helpers/plan_text.py
@@ -92,7 +92,7 @@ def format_plan(
     display_options: DisplayOptions | None = None,
     section_header_style: Callable[[str], str] | None = None,
     python_plan_entries: tuple[PythonPlanEntry, ...] = (),
-    include_standard_freshness_diagnostics: bool = True,
+    include_direct_freshness_diagnostics: bool = True,
 ) -> str:
     """Format plan output grouped by reason with inline detail."""
 
@@ -114,7 +114,7 @@ def format_plan(
         lines = _format_warnings(
             lines=lines,
             plan=plan,
-            include_standard_freshness_diagnostics=(include_standard_freshness_diagnostics),
+            include_direct_freshness_diagnostics=(include_direct_freshness_diagnostics),
         )
         result: str = "\n".join(lines)
         return result if use_color else _strip_ansi(result)
@@ -140,14 +140,14 @@ def format_plan(
         section_header_style=resolved_section_header_style,
         display_options=resolved_display_options,
     )
-    if include_standard_freshness_diagnostics:
-        lines = _format_standard_source_freshness_metadata(
+    if include_direct_freshness_diagnostics:
+        lines = _format_direct_source_freshness_metadata(
             lines=lines,
             plan=plan,
             section_header_style=resolved_section_header_style,
             display_options=resolved_display_options,
         )
-    lines = _format_standard_remaining_stale_metadata(
+    lines = _format_direct_remaining_stale_metadata(
         lines=lines,
         plan=plan,
         section_header_style=resolved_section_header_style,
@@ -160,7 +160,7 @@ def format_plan(
         display_options=resolved_display_options,
         section_header_style=resolved_section_header_style,
     )
-    lines = _format_standard_pruned_metadata(
+    lines = _format_direct_pruned_metadata(
         lines=lines,
         plan=plan,
         display_options=resolved_display_options,
@@ -282,7 +282,7 @@ def format_plan(
     lines = _format_warnings(
         lines=lines,
         plan=plan,
-        include_standard_freshness_diagnostics=include_standard_freshness_diagnostics,
+        include_direct_freshness_diagnostics=include_direct_freshness_diagnostics,
     )
 
     output: str = "\n".join(lines)
@@ -509,14 +509,14 @@ def _all_provider_usages(
     return tuple(usages)
 
 
-def _format_standard_pruned_metadata(
+def _format_direct_pruned_metadata(
     *,
     lines: list[str],
     plan: PlanOutput,
     display_options: DisplayOptions,
     skipped_header_style: Callable[[str], str],
 ) -> list[str]:
-    raw_names: object = plan.metadata.get("standard_pruned_model_names")
+    raw_names: object = plan.metadata.get("direct_pruned_model_names")
     if not isinstance(raw_names, tuple):
         return lines
     names: tuple[str, ...] = tuple(name for name in raw_names if isinstance(name, str))
@@ -1401,7 +1401,7 @@ def _format_warnings(
     *,
     lines: list[str],
     plan: PlanOutput,
-    include_standard_freshness_diagnostics: bool,
+    include_direct_freshness_diagnostics: bool,
 ) -> list[str]:
     """Append the warnings section."""
 
@@ -1410,7 +1410,7 @@ def _format_warnings(
         for warning in plan.warnings
         if warning.severity != WarningSeverity.INFO
         and (
-            include_standard_freshness_diagnostics
+            include_direct_freshness_diagnostics
             or not warning.message.startswith(_STALE_INPUT_WARNING_TITLE)
         )
     ]
@@ -1586,14 +1586,14 @@ def _format_virtual_metadata(
     return lines
 
 
-def _format_standard_source_freshness_metadata(
+def _format_direct_source_freshness_metadata(
     *,
     lines: list[str],
     plan: PlanOutput,
     section_header_style: Callable[[str], str],
     display_options: DisplayOptions,
 ) -> list[str]:
-    raw_metadata: object | None = plan.metadata.get("standard_source_freshness")
+    raw_metadata: object | None = plan.metadata.get("direct_source_freshness")
     if not isinstance(raw_metadata, dict):
         return lines
     source_freshness_metadata: dict[str, object] = cast(dict[str, object], raw_metadata)
@@ -1723,7 +1723,7 @@ def _format_standard_source_freshness_metadata(
     return lines
 
 
-def _format_standard_remaining_stale_metadata(
+def _format_direct_remaining_stale_metadata(
     *,
     lines: list[str],
     plan: PlanOutput,
@@ -1731,7 +1731,7 @@ def _format_standard_remaining_stale_metadata(
     display_options: DisplayOptions,
 ) -> list[str]:
     remaining_stale_model_names: tuple[str, ...] = _metadata_string_tuple(
-        plan.metadata.get("standard_remaining_stale_model_names")
+        plan.metadata.get("direct_remaining_stale_model_names")
     )
     if not remaining_stale_model_names:
         return lines

--- a/src/sqlbuild/cli/output/main/plan.py
+++ b/src/sqlbuild/cli/output/main/plan.py
@@ -19,7 +19,7 @@ def format_plan(
     display_options: DisplayOptions | None = None,
     section_header_style: Callable[[str], str] | None = None,
     python_plan_entries: tuple[PythonPlanEntry, ...] = (),
-    include_standard_freshness_diagnostics: bool = True,
+    include_direct_freshness_diagnostics: bool = True,
 ) -> str:
     """Format plan output grouped by reason with inline detail."""
 
@@ -31,5 +31,5 @@ def format_plan(
         display_options=display_options,
         section_header_style=section_header_style,
         python_plan_entries=python_plan_entries,
-        include_standard_freshness_diagnostics=include_standard_freshness_diagnostics,
+        include_direct_freshness_diagnostics=include_direct_freshness_diagnostics,
     )

--- a/src/sqlbuild/compiler/planner/_helpers/identity/direct.py
+++ b/src/sqlbuild/compiler/planner/_helpers/identity/direct.py
@@ -22,22 +22,22 @@ from sqlbuild.compiler.planner.main.identity.version_identity_model_metadata imp
     build_model_version_identity_metadata_json,
 )
 from sqlbuild.compiler.planner.models import (
+    DirectModelVersionIdentities,
     GraphIdentityNode,
     GraphNodeKey,
     PlannerScope,
-    StandardModelVersionIdentities,
 )
 from sqlbuild.compiler.planner.types import GraphResourceKind
 
 
-def build_standard_model_version_identities(
+def build_direct_model_version_identities(
     *,
     functions: tuple[CompiledFunction, ...],
     seeds: tuple[CompiledSeed, ...] = (),
     scope: PlannerScope,
     source_version_hashes: dict[str, str] | None = None,
-) -> StandardModelVersionIdentities:
-    """Compute current standard model identities from code and upstream identities."""
+) -> DirectModelVersionIdentities:
+    """Compute current direct model identities from code and upstream identities."""
 
     function_local_hashes: dict[str, str] = build_function_local_hashes(functions=functions)
     seed_version_hashes: dict[str, str] = {}
@@ -152,7 +152,7 @@ def build_standard_model_version_identities(
         if model_hash is not None:
             model_version_hashes[model_name] = model_hash
 
-    return StandardModelVersionIdentities(
+    return DirectModelVersionIdentities(
         function_local_hashes=function_local_hashes,
         seed_version_hashes=seed_version_hashes,
         seed_metadata_jsons=seed_metadata_jsons,

--- a/src/sqlbuild/compiler/planner/_helpers/identity/honest.py
+++ b/src/sqlbuild/compiler/planner/_helpers/identity/honest.py
@@ -1,4 +1,4 @@
-"""Build standard model write hashes from actually available upstream identities."""
+"""Build direct model write hashes from actually available upstream identities."""
 
 from __future__ import annotations
 
@@ -16,13 +16,13 @@ from sqlbuild.compiler.planner.main.identity._graph_write_identity import (
 )
 from sqlbuild.compiler.planner.models import (
     ChangeDetectionResult,
+    DirectModelVersionIdentities,
     GraphIdentityNode,
     GraphNodeKey,
     PlannerChangeResults,
     PlannerResolvedActions,
     PlannerScope,
     ResolvedModelAction,
-    StandardModelVersionIdentities,
     WarehouseSnapshot,
 )
 from sqlbuild.compiler.planner.types import ChangeKind, GraphResourceKind
@@ -33,7 +33,7 @@ def with_honest_model_write_hashes(
     scope: PlannerScope,
     snapshot: WarehouseSnapshot,
     changes: PlannerChangeResults,
-    version_identities: StandardModelVersionIdentities,
+    version_identities: DirectModelVersionIdentities,
     available_model_hashes: dict[str, str] | None = None,
 ) -> PlannerChangeResults:
     """Replace planned write hashes with hashes based on upstreams available this run."""
@@ -132,7 +132,7 @@ def _merged_recomputed_change(
 
 
 def _graph_identity_nodes(
-    *, scope: PlannerScope, version_identities: StandardModelVersionIdentities
+    *, scope: PlannerScope, version_identities: DirectModelVersionIdentities
 ) -> dict[GraphNodeKey, GraphIdentityNode]:
     nodes: dict[GraphNodeKey, GraphIdentityNode] = {}
     function_name: str
@@ -193,7 +193,7 @@ def _base_write_hashes(
     *,
     scope: PlannerScope,
     snapshot: WarehouseSnapshot,
-    version_identities: StandardModelVersionIdentities,
+    version_identities: DirectModelVersionIdentities,
     available_model_hashes: dict[str, str] | None,
 ) -> dict[GraphNodeKey, str]:
     hashes: dict[GraphNodeKey, str] = {}
@@ -240,7 +240,7 @@ def _seed_write_hashes(
     *,
     scope: PlannerScope,
     snapshot: WarehouseSnapshot,
-    version_identities: StandardModelVersionIdentities,
+    version_identities: DirectModelVersionIdentities,
 ) -> dict[str, str]:
     hashes: dict[str, str] = {}
     seed_name: str

--- a/src/sqlbuild/compiler/planner/_helpers/identity/seed.py
+++ b/src/sqlbuild/compiler/planner/_helpers/identity/seed.py
@@ -1,4 +1,4 @@
-"""Stable seed identity helpers for standard changes-only planning."""
+"""Stable seed identity helpers for direct changes-only planning."""
 
 from __future__ import annotations
 

--- a/src/sqlbuild/compiler/planner/_helpers/planning/entries.py
+++ b/src/sqlbuild/compiler/planner/_helpers/planning/entries.py
@@ -20,7 +20,7 @@ from sqlbuild.compiler.planner.models import (
     PlannerScopePruningResult,
     PlannerWarehouseState,
 )
-from sqlbuild.compiler.source_freshness.models import StandardSourceFreshnessPlanningResult
+from sqlbuild.compiler.source_freshness.models import DirectSourceFreshnessPlanningResult
 
 
 def build_planner_entry_results(
@@ -33,7 +33,7 @@ def build_planner_entry_results(
     deferral: DeferralInputs,
     pruning: PlannerScopePruningResult,
     reconciliation: PlannerChangeReconciliation,
-    source_freshness: StandardSourceFreshnessPlanningResult,
+    source_freshness: DirectSourceFreshnessPlanningResult,
 ) -> PlannerEntryResults:
     """Build execution model entries for one plan build."""
 

--- a/src/sqlbuild/compiler/planner/_helpers/planning/identities.py
+++ b/src/sqlbuild/compiler/planner/_helpers/planning/identities.py
@@ -6,8 +6,8 @@ from dataclasses import replace
 
 from sqlbuild.compiler.compile.models import CompiledProject
 from sqlbuild.compiler.planner._helpers.changes.detect import detect_changes
-from sqlbuild.compiler.planner._helpers.identity.standard import (
-    build_standard_model_version_identities,
+from sqlbuild.compiler.planner._helpers.identity.direct import (
+    build_direct_model_version_identities,
 )
 from sqlbuild.compiler.planner.models import (
     PlannerChangeResults,
@@ -25,12 +25,12 @@ def build_planner_identity_context(
     """Build expected version identities for the inspection and stale-warning scopes."""
 
     return PlannerIdentityContext(
-        version_identities=build_standard_model_version_identities(
+        version_identities=build_direct_model_version_identities(
             functions=project.functions,
             seeds=project.seeds,
             scope=scopes.inspection_scope,
         ),
-        stale_warning_identities=build_standard_model_version_identities(
+        stale_warning_identities=build_direct_model_version_identities(
             functions=project.functions,
             seeds=project.seeds,
             scope=scopes.stale_warning_scope,

--- a/src/sqlbuild/compiler/planner/_helpers/planning/output_assembly.py
+++ b/src/sqlbuild/compiler/planner/_helpers/planning/output_assembly.py
@@ -24,7 +24,7 @@ from sqlbuild.compiler.planner.models import (
     PlanWarning,
     RunDespiteUnchangedPlanningResult,
 )
-from sqlbuild.compiler.source_freshness.models import StandardSourceFreshnessPlanningResult
+from sqlbuild.compiler.source_freshness.models import DirectSourceFreshnessPlanningResult
 from sqlbuild.compiler.source_freshness.types import SourceFreshnessAgeStatus
 
 
@@ -37,7 +37,7 @@ def assemble_base_plan_output(
     pruning: PlannerScopePruningResult,
     reconciliation: PlannerChangeReconciliation,
     entries: PlannerEntryResults,
-    source_freshness: StandardSourceFreshnessPlanningResult,
+    source_freshness: DirectSourceFreshnessPlanningResult,
 ) -> PlanOutput:
     """Assemble the base plan output with freshness and pruning metadata attached."""
 
@@ -56,12 +56,12 @@ def assemble_base_plan_output(
         ),
     )
     plan_output = replace(plan_output, source_freshness=source_freshness)
-    if pruning.pruned_standard_model_names:
+    if pruning.pruned_direct_model_names:
         plan_output = replace(
             plan_output,
             metadata={
                 **plan_output.metadata,
-                "standard_pruned_model_names": pruning.pruned_standard_model_names,
+                "direct_pruned_model_names": pruning.pruned_direct_model_names,
             },
         )
     return plan_output
@@ -75,7 +75,7 @@ def with_plan_warnings(
     identities: PlannerIdentityContext,
     stale_warning_changes: PlannerChangeResults,
     pruning: PlannerScopePruningResult,
-    source_freshness: StandardSourceFreshnessPlanningResult,
+    source_freshness: DirectSourceFreshnessPlanningResult,
     plan_output: PlanOutput,
 ) -> PlanOutput:
     """Append stale-out-of-selection warnings to the plan."""
@@ -103,14 +103,14 @@ def with_plan_metadata(
     *,
     plan_output: PlanOutput,
     pruning: PlannerScopePruningResult,
-    source_freshness: StandardSourceFreshnessPlanningResult,
+    source_freshness: DirectSourceFreshnessPlanningResult,
 ) -> PlanOutput:
-    """Attach standard source-freshness metadata to the plan output."""
+    """Attach direct source-freshness metadata to the plan output."""
 
-    standard_remaining_stale_model_names: tuple[str, ...] = tuple(
+    direct_remaining_stale_model_names: tuple[str, ...] = tuple(
         sorted(
             (
-                pruning.standard_identity_stale_model_names
+                pruning.direct_identity_stale_model_names
                 | pruning.run_despite_unchanged.stale_model_names
             )
             - frozenset(
@@ -124,11 +124,11 @@ def with_plan_metadata(
         plan_output,
         metadata={
             **plan_output.metadata,
-            "standard_source_freshness": _serialize_standard_source_freshness_metadata(
+            "direct_source_freshness": _serialize_direct_source_freshness_metadata(
                 source_freshness
             ),
-            "standard_remaining_stale_model_names": standard_remaining_stale_model_names,
-            "standard_run_despite_unchanged": _serialize_run_despite_unchanged_metadata(
+            "direct_remaining_stale_model_names": direct_remaining_stale_model_names,
+            "direct_run_despite_unchanged": _serialize_run_despite_unchanged_metadata(
                 pruning.run_despite_unchanged
             ),
         },
@@ -136,8 +136,8 @@ def with_plan_metadata(
     return plan_output
 
 
-def _serialize_standard_source_freshness_metadata(
-    source_freshness: StandardSourceFreshnessPlanningResult,
+def _serialize_direct_source_freshness_metadata(
+    source_freshness: DirectSourceFreshnessPlanningResult,
 ) -> dict[str, object]:
     changed_source_names: tuple[str, ...] = tuple(
         sorted(identity.source_name for identity in source_freshness.changed_identities)

--- a/src/sqlbuild/compiler/planner/_helpers/planning/scope_pruning.py
+++ b/src/sqlbuild/compiler/planner/_helpers/planning/scope_pruning.py
@@ -1,4 +1,4 @@
-"""Standard unchanged-scope pruning phase for execution planning."""
+"""Direct unchanged-scope pruning phase for execution planning."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ def prune_planner_execution_scope(
         inspection_scope=inspection_scope,
         execution_scope=execution_scope,
         resolved_actions=resolved_actions,
-        pruned_standard_model_names=(),
-        standard_identity_stale_model_names=frozenset(),
+        pruned_direct_model_names=(),
+        direct_identity_stale_model_names=frozenset(),
         run_despite_unchanged=RunDespiteUnchangedPlanningResult(),
     )

--- a/src/sqlbuild/compiler/planner/_helpers/pruning/run_despite_unchanged.py
+++ b/src/sqlbuild/compiler/planner/_helpers/pruning/run_despite_unchanged.py
@@ -22,8 +22,8 @@ from sqlbuild.compiler.planner.models import (
 )
 from sqlbuild.compiler.planner.types import MaterializationType, RunDespiteUnchangedMode
 from sqlbuild.compiler.source_freshness.models import (
+    DirectSourceFreshnessPlanningResult,
     SourceFreshnessRecord,
-    StandardSourceFreshnessPlanningResult,
 )
 from sqlbuild.spec.contracts.types import SourceFreshnessValueKind
 
@@ -33,7 +33,7 @@ _DURATION_PATTERN: re.Pattern[str] = re.compile(r"^([1-9][0-9]*)([mhd])$")
 def build_run_despite_unchanged_planning_result(
     *,
     scope: PlannerScope,
-    source_freshness: StandardSourceFreshnessPlanningResult,
+    source_freshness: DirectSourceFreshnessPlanningResult,
     already_stale_model_names: frozenset[str],
     now: datetime,
 ) -> RunDespiteUnchangedPlanningResult:
@@ -106,7 +106,7 @@ def _validate_duration_prerequisites_if_needed(
     *,
     model: CompiledModel,
     scope: PlannerScope,
-    source_freshness: StandardSourceFreshnessPlanningResult,
+    source_freshness: DirectSourceFreshnessPlanningResult,
     now: datetime,
     raw_value: object,
 ) -> None:
@@ -126,7 +126,7 @@ def _decision_for_model(
     *,
     model: CompiledModel,
     scope: PlannerScope,
-    source_freshness: StandardSourceFreshnessPlanningResult,
+    source_freshness: DirectSourceFreshnessPlanningResult,
     now: datetime,
     raw_value: object,
 ) -> RunDespiteUnchangedDecision | None:
@@ -194,7 +194,7 @@ def _upstream_source_records(
     *,
     model: CompiledModel,
     scope: PlannerScope,
-    source_freshness: StandardSourceFreshnessPlanningResult,
+    source_freshness: DirectSourceFreshnessPlanningResult,
 ) -> tuple[SourceFreshnessRecord, ...]:
     upstream_source_names: frozenset[str] = _upstream_source_names(
         start_key=model.key,

--- a/src/sqlbuild/compiler/planner/_helpers/pruning/selection_staleness.py
+++ b/src/sqlbuild/compiler/planner/_helpers/pruning/selection_staleness.py
@@ -1,4 +1,4 @@
-"""Selection-aware stale warning helpers for standard planning."""
+"""Selection-aware stale warning helpers for direct planning."""
 
 from __future__ import annotations
 
@@ -12,17 +12,17 @@ from sqlbuild.compiler.planner._helpers.pruning.selection_classifier import (
 from sqlbuild.compiler.planner.main.changes._model_changes import detect_model_changes
 from sqlbuild.compiler.planner.models import (
     ChangeDetectionResult,
+    DirectModelVersionIdentities,
     PlannerChangeResults,
     PlannerScope,
     PlanWarning,
     SelectionStalenessGraph,
     SelectionStalenessNodeKey,
     SelectionStalenessWarning,
-    StandardModelVersionIdentities,
     WarehouseSnapshot,
 )
 from sqlbuild.compiler.planner.types import ChangeKind, WarningSeverity
-from sqlbuild.compiler.source_freshness.models import StandardSourceFreshnessPlanningResult
+from sqlbuild.compiler.source_freshness.models import DirectSourceFreshnessPlanningResult
 
 
 def build_stale_out_of_selection_warnings(
@@ -31,8 +31,8 @@ def build_stale_out_of_selection_warnings(
     execution_scope: PlannerScope,
     changes: PlannerChangeResults,
     snapshot: WarehouseSnapshot,
-    version_identities: StandardModelVersionIdentities,
-    source_freshness: StandardSourceFreshnessPlanningResult | None,
+    version_identities: DirectModelVersionIdentities,
+    source_freshness: DirectSourceFreshnessPlanningResult | None,
     include_sources: bool = True,
 ) -> tuple[PlanWarning, ...]:
     """Warn for selected models stale through changed upstreams outside the run set."""
@@ -128,7 +128,7 @@ def _changed_model_names(
     original_scope: PlannerScope,
     changes: PlannerChangeResults,
     snapshot: WarehouseSnapshot,
-    version_identities: StandardModelVersionIdentities,
+    version_identities: DirectModelVersionIdentities,
 ) -> frozenset[str]:
     changed: set[str] = {
         model_name
@@ -158,7 +158,7 @@ def _changed_model_names(
 def _changed_seed_names(
     *,
     snapshot: WarehouseSnapshot,
-    version_identities: StandardModelVersionIdentities,
+    version_identities: DirectModelVersionIdentities,
 ) -> frozenset[str]:
     return frozenset(
         seed_name
@@ -172,7 +172,7 @@ def _changed_seed_names(
 
 
 def _changed_source_names(
-    source_freshness: StandardSourceFreshnessPlanningResult | None,
+    source_freshness: DirectSourceFreshnessPlanningResult | None,
 ) -> frozenset[str]:
     if source_freshness is None:
         return frozenset()
@@ -185,7 +185,7 @@ def _model_own_identity_changed(
     original_scope: PlannerScope,
     changes: PlannerChangeResults,
     snapshot: WarehouseSnapshot,
-    version_identities: StandardModelVersionIdentities,
+    version_identities: DirectModelVersionIdentities,
 ) -> bool:
     selected_change: ChangeDetectionResult | None = changes.models.get(model_name)
     if selected_change is not None:
@@ -220,7 +220,7 @@ def _seed_identity_changed(
     *,
     seed_name: str,
     snapshot: WarehouseSnapshot,
-    version_identities: StandardModelVersionIdentities,
+    version_identities: DirectModelVersionIdentities,
 ) -> bool:
     expected_hash: str | None = version_identities.seed_version_hashes.get(seed_name)
     if expected_hash is None:

--- a/src/sqlbuild/compiler/planner/_helpers/warehouse/source_freshness.py
+++ b/src/sqlbuild/compiler/planner/_helpers/warehouse/source_freshness.py
@@ -1,4 +1,4 @@
-"""Standard planner source freshness orchestration helpers."""
+"""Direct planner source freshness orchestration helpers."""
 
 from __future__ import annotations
 
@@ -18,12 +18,12 @@ from sqlbuild.compiler.planner.models import (
     PlannerScope,
 )
 from sqlbuild.compiler.source_freshness.main._planning import (
-    build_standard_source_freshness_planning_result,
+    build_direct_source_freshness_planning_result,
 )
 from sqlbuild.compiler.source_freshness.main._propagation import (
-    build_standard_source_freshness_propagation_result,
+    build_direct_source_freshness_propagation_result,
 )
-from sqlbuild.compiler.source_freshness.models import StandardSourceFreshnessPlanningResult
+from sqlbuild.compiler.source_freshness.models import DirectSourceFreshnessPlanningResult
 
 
 def build_planner_source_freshness_result(
@@ -34,12 +34,12 @@ def build_planner_source_freshness_result(
     scope: PlannerScope,
     relations: PlannerRelationsContext,
     freshness_state_schemas: frozenset[str] = frozenset(),
-) -> StandardSourceFreshnessPlanningResult:
-    """Build standard source freshness comparison data for planner output."""
+) -> DirectSourceFreshnessPlanningResult:
+    """Build direct source freshness comparison data for planner output."""
 
     state_schemas: tuple[str, ...] = _collect_state_schemas(project=project, scope=scope)
-    source_freshness: StandardSourceFreshnessPlanningResult = (
-        build_standard_source_freshness_planning_result(
+    source_freshness: DirectSourceFreshnessPlanningResult = (
+        build_direct_source_freshness_planning_result(
             adapter=adapter,
             connection=connection,
             sources=tuple(relations.source_read_map.values()),
@@ -56,7 +56,7 @@ def build_planner_source_freshness_result(
     )
     return replace(
         source_freshness,
-        propagation=build_standard_source_freshness_propagation_result(
+        propagation=build_direct_source_freshness_propagation_result(
             source_freshness=source_freshness,
             scope=scope,
         ),

--- a/src/sqlbuild/compiler/planner/main/changes/run_despite_unchanged.py
+++ b/src/sqlbuild/compiler/planner/main/changes/run_despite_unchanged.py
@@ -8,13 +8,13 @@ from sqlbuild.compiler.planner._helpers.pruning.run_despite_unchanged import (
     build_run_despite_unchanged_planning_result as _build_result,
 )
 from sqlbuild.compiler.planner.models import PlannerScope, RunDespiteUnchangedPlanningResult
-from sqlbuild.compiler.source_freshness.models import StandardSourceFreshnessPlanningResult
+from sqlbuild.compiler.source_freshness.models import DirectSourceFreshnessPlanningResult
 
 
 def build_run_despite_unchanged_planning_result(
     *,
     scope: PlannerScope,
-    source_freshness: StandardSourceFreshnessPlanningResult,
+    source_freshness: DirectSourceFreshnessPlanningResult,
     already_stale_model_names: frozenset[str],
     now: datetime,
 ) -> RunDespiteUnchangedPlanningResult:

--- a/src/sqlbuild/compiler/planner/main/execution/execution.py
+++ b/src/sqlbuild/compiler/planner/main/execution/execution.py
@@ -48,7 +48,7 @@ from sqlbuild.compiler.planner.models import (
     PlannerWarehouseState,
     PlanOutput,
 )
-from sqlbuild.compiler.source_freshness.models import StandardSourceFreshnessPlanningResult
+from sqlbuild.compiler.source_freshness.models import DirectSourceFreshnessPlanningResult
 from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig
 
 
@@ -113,7 +113,7 @@ def build_execution_plan(
         scope=scopes.inspection_scope,
         changes=changes,
     )
-    source_freshness: StandardSourceFreshnessPlanningResult = build_planner_source_freshness_result(
+    source_freshness: DirectSourceFreshnessPlanningResult = build_planner_source_freshness_result(
         project=project,
         adapter=adapter,
         connection=connection,

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -49,7 +49,7 @@ from sqlbuild.compiler.planner.types import (
     WarningSeverity,
 )
 from sqlbuild.compiler.source_freshness.models import (
-    StandardSourceFreshnessPlanningResult,
+    DirectSourceFreshnessPlanningResult,
 )
 from sqlbuild.runtime.contracts.types import ExecutionResourceKind
 from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig, SeedCsvSettings, SourceEntry
@@ -307,7 +307,7 @@ class CursorInputRelation:
 
 @dataclass(frozen=True)
 class WarehouseFingerprints:
-    """Latest standard fingerprints grouped by node type."""
+    """Latest direct fingerprints grouped by node type."""
 
     models: dict[str, Fingerprint] = field(default_factory=dict)
     functions: dict[str, Fingerprint] = field(default_factory=dict)
@@ -555,8 +555,8 @@ class PlannerResolvedActions:
 
 
 @dataclass(frozen=True)
-class StandardModelVersionIdentities:
-    """Current standard model version identity values by model name."""
+class DirectModelVersionIdentities:
+    """Current direct model version identity values by model name."""
 
     function_local_hashes: dict[str, str]
     seed_version_hashes: dict[str, str]
@@ -944,7 +944,7 @@ class PlanOutput:
     source_read_map: dict[str, SourceEntry] = field(default_factory=dict)
     hook_functions: tuple[DiscoveredHookFunction, ...] = field(default_factory=tuple)
     provider_usages: tuple[PlanProviderUsage, ...] = field(default_factory=tuple)
-    source_freshness: StandardSourceFreshnessPlanningResult | None = None
+    source_freshness: DirectSourceFreshnessPlanningResult | None = None
     python_identity_fingerprints: dict[tuple[str, str], Fingerprint] = field(default_factory=dict)
     metadata: dict[str, object] = field(default_factory=dict)
 
@@ -1019,8 +1019,8 @@ class PlannerWarehouseState:
 class PlannerIdentityContext:
     """Expected version identities for inspection and stale-warning scopes."""
 
-    version_identities: StandardModelVersionIdentities
-    stale_warning_identities: StandardModelVersionIdentities
+    version_identities: DirectModelVersionIdentities
+    stale_warning_identities: DirectModelVersionIdentities
 
 
 @dataclass(frozen=True)
@@ -1030,8 +1030,8 @@ class PlannerScopePruningResult:
     inspection_scope: PlannerScope
     execution_scope: PlannerScope
     resolved_actions: PlannerResolvedActions
-    pruned_standard_model_names: tuple[str, ...]
-    standard_identity_stale_model_names: frozenset[str]
+    pruned_direct_model_names: tuple[str, ...]
+    direct_identity_stale_model_names: frozenset[str]
     run_despite_unchanged: RunDespiteUnchangedPlanningResult
 
 

--- a/src/sqlbuild/compiler/source_freshness/__init__.py
+++ b/src/sqlbuild/compiler/source_freshness/__init__.py
@@ -1,1 +1,1 @@
-"""Standard source freshness state package."""
+"""Direct source freshness state package."""

--- a/src/sqlbuild/compiler/source_freshness/_helpers/planning.py
+++ b/src/sqlbuild/compiler/source_freshness/_helpers/planning.py
@@ -1,4 +1,4 @@
-"""Standard source freshness planning observation and comparison helpers."""
+"""Direct source freshness planning observation and comparison helpers."""
 
 from __future__ import annotations
 
@@ -33,18 +33,18 @@ from sqlbuild.compiler.source_freshness.main.record_equivalence import (
     source_freshness_records_equivalent,
 )
 from sqlbuild.compiler.source_freshness.models import (
+    DirectSourceFreshnessPlanningResult,
     SourceFreshnessIdentity,
     SourceFreshnessObservation,
     SourceFreshnessRecord,
     SourceFreshnessSet,
-    StandardSourceFreshnessPlanningResult,
 )
 from sqlbuild.compiler.source_freshness.types import SourceFreshnessAgeStatus
 from sqlbuild.spec.contracts.models import SourceEntry, SourceFreshnessConfig
 from sqlbuild.spec.contracts.types import SourceFreshnessStrategy
 
 
-def build_standard_source_freshness_planning_result(
+def build_direct_source_freshness_planning_result(
     *,
     adapter: StrictAdapter,
     connection: Any,
@@ -55,7 +55,7 @@ def build_standard_source_freshness_planning_result(
     run_id: str,
     render_qualified_name: Callable[..., str | None],
     state_table_exists_by_schema: dict[str, bool],
-) -> StandardSourceFreshnessPlanningResult:
+) -> DirectSourceFreshnessPlanningResult:
     previous_records_by_identity: dict[SourceFreshnessIdentity, SourceFreshnessRecord] = (
         _read_previous_records(
             adapter=adapter,
@@ -158,7 +158,7 @@ def build_standard_source_freshness_planning_result(
         else:
             changed_identities.add(observed_record.identity)
 
-    return StandardSourceFreshnessPlanningResult(
+    return DirectSourceFreshnessPlanningResult(
         observed_records=tuple(sorted(observed_records, key=lambda record: str(record.identity))),
         previous_records=tuple(
             sorted(previous_records_by_identity.values(), key=lambda record: str(record.identity))

--- a/src/sqlbuild/compiler/source_freshness/_helpers/propagation.py
+++ b/src/sqlbuild/compiler/source_freshness/_helpers/propagation.py
@@ -1,4 +1,4 @@
-"""Standard source freshness downstream propagation helpers."""
+"""Direct source freshness downstream propagation helpers."""
 
 from __future__ import annotations
 
@@ -9,18 +9,18 @@ from sqlbuild.compiler.planner.main.selection.model_downstream_closure import (
 )
 from sqlbuild.compiler.planner.models import PlannerScope
 from sqlbuild.compiler.source_freshness.models import (
+    DirectSourceFreshnessPlanningResult,
+    DirectSourceFreshnessPropagationResult,
     SourceFreshnessIdentity,
-    StandardSourceFreshnessPlanningResult,
-    StandardSourceFreshnessPropagationResult,
 )
 from sqlbuild.compiler.source_freshness.types import SourceFreshnessAgeStatus
 
 
-def build_standard_source_freshness_propagation_result(
+def build_direct_source_freshness_propagation_result(
     *,
-    source_freshness: StandardSourceFreshnessPlanningResult,
+    source_freshness: DirectSourceFreshnessPlanningResult,
     scope: PlannerScope,
-) -> StandardSourceFreshnessPropagationResult:
+) -> DirectSourceFreshnessPropagationResult:
     """Map changed/unknown source freshness roots to downstream model names."""
 
     changed_source_model_names: dict[SourceFreshnessIdentity, frozenset[str]] = {}
@@ -51,7 +51,7 @@ def build_standard_source_freshness_propagation_result(
         error_source_model_names[identity] = model_names
         blocked_model_names.update(model_names)
 
-    return StandardSourceFreshnessPropagationResult(
+    return DirectSourceFreshnessPropagationResult(
         changed_source_model_names=changed_source_model_names,
         unknown_source_model_names=unknown_source_model_names,
         error_source_model_names=error_source_model_names,

--- a/src/sqlbuild/compiler/source_freshness/_helpers/sql.py
+++ b/src/sqlbuild/compiler/source_freshness/_helpers/sql.py
@@ -1,4 +1,4 @@
-"""SQL generation helpers for standard source freshness storage."""
+"""SQL generation helpers for direct source freshness storage."""
 
 from __future__ import annotations
 

--- a/src/sqlbuild/compiler/source_freshness/constants.py
+++ b/src/sqlbuild/compiler/source_freshness/constants.py
@@ -1,4 +1,4 @@
-"""Stable constants for standard source freshness storage."""
+"""Stable constants for direct source freshness storage."""
 
 from __future__ import annotations
 

--- a/src/sqlbuild/compiler/source_freshness/exceptions.py
+++ b/src/sqlbuild/compiler/source_freshness/exceptions.py
@@ -1,4 +1,4 @@
-"""Standard source freshness state exceptions."""
+"""Direct source freshness state exceptions."""
 
 from __future__ import annotations
 

--- a/src/sqlbuild/compiler/source_freshness/main/__init__.py
+++ b/src/sqlbuild/compiler/source_freshness/main/__init__.py
@@ -1,1 +1,1 @@
-"""Standard source freshness state operations."""
+"""Direct source freshness state operations."""

--- a/src/sqlbuild/compiler/source_freshness/main/_create_table_sql.py
+++ b/src/sqlbuild/compiler/source_freshness/main/_create_table_sql.py
@@ -1,4 +1,4 @@
-"""Public standard source freshness table DDL rendering entrypoint."""
+"""Public direct source freshness table DDL rendering entrypoint."""
 
 from __future__ import annotations
 

--- a/src/sqlbuild/compiler/source_freshness/main/_planning.py
+++ b/src/sqlbuild/compiler/source_freshness/main/_planning.py
@@ -1,4 +1,4 @@
-"""Public standard source freshness planning entrypoint."""
+"""Public direct source freshness planning entrypoint."""
 
 from __future__ import annotations
 
@@ -8,13 +8,13 @@ from typing import Any
 
 from sqlbuild.adapter.contract.classes.strict_adapter import StrictAdapter
 from sqlbuild.compiler.source_freshness._helpers.planning import (
-    build_standard_source_freshness_planning_result as _build_planning_result,
+    build_direct_source_freshness_planning_result as _build_planning_result,
 )
-from sqlbuild.compiler.source_freshness.models import StandardSourceFreshnessPlanningResult
+from sqlbuild.compiler.source_freshness.models import DirectSourceFreshnessPlanningResult
 from sqlbuild.spec.contracts.models import SourceEntry
 
 
-def build_standard_source_freshness_planning_result(
+def build_direct_source_freshness_planning_result(
     *,
     adapter: StrictAdapter,
     connection: Any,
@@ -25,8 +25,8 @@ def build_standard_source_freshness_planning_result(
     run_id: str,
     render_qualified_name: Callable[..., str | None],
     state_table_exists_by_schema: dict[str, bool],
-) -> StandardSourceFreshnessPlanningResult:
-    """Observe standard source freshness and compare it to latest append-only state."""
+) -> DirectSourceFreshnessPlanningResult:
+    """Observe direct source freshness and compare it to latest append-only state."""
 
     return _build_planning_result(
         adapter=adapter,

--- a/src/sqlbuild/compiler/source_freshness/main/_propagation.py
+++ b/src/sqlbuild/compiler/source_freshness/main/_propagation.py
@@ -1,23 +1,23 @@
-"""Public standard source freshness downstream propagation entrypoint."""
+"""Public direct source freshness downstream propagation entrypoint."""
 
 from __future__ import annotations
 
 from sqlbuild.compiler.planner.models import PlannerScope
 from sqlbuild.compiler.source_freshness._helpers import propagation as propagation_helpers
 from sqlbuild.compiler.source_freshness.models import (
-    StandardSourceFreshnessPlanningResult,
-    StandardSourceFreshnessPropagationResult,
+    DirectSourceFreshnessPlanningResult,
+    DirectSourceFreshnessPropagationResult,
 )
 
 
-def build_standard_source_freshness_propagation_result(
+def build_direct_source_freshness_propagation_result(
     *,
-    source_freshness: StandardSourceFreshnessPlanningResult,
+    source_freshness: DirectSourceFreshnessPlanningResult,
     scope: PlannerScope,
-) -> StandardSourceFreshnessPropagationResult:
+) -> DirectSourceFreshnessPropagationResult:
     """Map changed/unknown source freshness roots to downstream model names."""
 
-    return propagation_helpers.build_standard_source_freshness_propagation_result(
+    return propagation_helpers.build_direct_source_freshness_propagation_result(
         source_freshness=source_freshness,
         scope=scope,
     )

--- a/src/sqlbuild/compiler/source_freshness/main/read.py
+++ b/src/sqlbuild/compiler/source_freshness/main/read.py
@@ -1,4 +1,4 @@
-"""Standard source freshness read operations."""
+"""Direct source freshness read operations."""
 
 from __future__ import annotations
 

--- a/src/sqlbuild/compiler/source_freshness/main/read_latest_sql.py
+++ b/src/sqlbuild/compiler/source_freshness/main/read_latest_sql.py
@@ -1,4 +1,4 @@
-"""Public standard source freshness latest-read SQL rendering entrypoint."""
+"""Public direct source freshness latest-read SQL rendering entrypoint."""
 
 from __future__ import annotations
 

--- a/src/sqlbuild/compiler/source_freshness/main/write.py
+++ b/src/sqlbuild/compiler/source_freshness/main/write.py
@@ -1,4 +1,4 @@
-"""Standard source freshness write operations."""
+"""Direct source freshness write operations."""
 
 from __future__ import annotations
 

--- a/src/sqlbuild/compiler/source_freshness/models.py
+++ b/src/sqlbuild/compiler/source_freshness/models.py
@@ -1,4 +1,4 @@
-"""Standard source freshness state models."""
+"""Direct source freshness state models."""
 
 from __future__ import annotations
 
@@ -35,7 +35,7 @@ class SourceFreshnessObservation:
 
 @dataclass(frozen=True)
 class SourceFreshnessIdentity:
-    """Stable identity for one source freshness stream in standard state."""
+    """Stable identity for one source freshness stream in direct state."""
 
     source_name: str
     target_database: str | None
@@ -45,7 +45,7 @@ class SourceFreshnessIdentity:
 
 @dataclass(frozen=True)
 class SourceFreshnessRecord:
-    """One append-only standard source freshness observation."""
+    """One append-only direct source freshness observation."""
 
     source_name: str
     target_database: str | None
@@ -70,15 +70,15 @@ class SourceFreshnessRecord:
 
 @dataclass(frozen=True)
 class SourceFreshnessSet:
-    """Latest standard source freshness records for one target schema."""
+    """Latest direct source freshness records for one target schema."""
 
     schema: str
     records: dict[SourceFreshnessIdentity, SourceFreshnessRecord]
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessPropagationResult:
-    """Downstream model impact derived from standard source freshness roots."""
+class DirectSourceFreshnessPropagationResult:
+    """Downstream model impact derived from direct source freshness roots."""
 
     changed_source_model_names: dict[SourceFreshnessIdentity, frozenset[str]] = field(
         default_factory=dict
@@ -92,7 +92,7 @@ class StandardSourceFreshnessPropagationResult:
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessPlanningResult:
+class DirectSourceFreshnessPlanningResult:
     """Direct planning-time source freshness observations and comparisons."""
 
     observed_records: tuple[SourceFreshnessRecord, ...] = ()
@@ -103,4 +103,4 @@ class StandardSourceFreshnessPlanningResult:
     age_statuses: dict[SourceFreshnessIdentity, SourceFreshnessAgeStatus] = field(
         default_factory=dict
     )
-    propagation: StandardSourceFreshnessPropagationResult | None = None
+    propagation: DirectSourceFreshnessPropagationResult | None = None

--- a/src/sqlbuild/executor/build/_helpers/source_node.py
+++ b/src/sqlbuild/executor/build/_helpers/source_node.py
@@ -16,8 +16,8 @@ from sqlbuild.cost.classes.cost_context import CostContext
 from sqlbuild.executor.build.models import BuildCallbacks, BuildRuntimeParams
 from sqlbuild.executor.load.main._execute import execute_source_load
 from sqlbuild.executor.load.models import LoadExecutionResult, LoadRuntimeParams
-from sqlbuild.executor.node_results.classes.standard_store import StandardNodeResultStore
-from sqlbuild.executor.node_results.main._standard_store import build_standard_node_result_store
+from sqlbuild.executor.node_results.classes.direct_store import DirectNodeResultStore
+from sqlbuild.executor.node_results.main._direct_store import build_direct_node_result_store
 from sqlbuild.executor.node_results.models import NodeResultRecord
 from sqlbuild.runtime.contracts.types import ExecutionResourceKind
 from sqlbuild.spec.contracts.models import SourceEntry
@@ -53,7 +53,7 @@ def execute_build_source_node(
     if callbacks.on_node_start is not None:
         callbacks.on_node_start(name=source_entry.name, resource_kind=resource_kind)
     start: float = time.monotonic()
-    result_store: StandardNodeResultStore = build_standard_node_result_store(
+    result_store: DirectNodeResultStore = build_direct_node_result_store(
         adapter=adapter,
         connection=connection,
         database=adapter.default_database(),
@@ -109,18 +109,15 @@ def _persist_loader_result(
     loader_name: str,
     result: LoadExecutionResult,
     run_id: str,
-    result_store: StandardNodeResultStore | None = None,
+    result_store: DirectNodeResultStore | None = None,
 ) -> None:
     if connection is None and (result_store is None or result_store.connection is None):
         return
-    resolved_result_store: StandardNodeResultStore = (
-        result_store
-        or build_standard_node_result_store(
-            adapter=adapter,
-            connection=connection,
-            database=adapter.default_database(),
-            schema=adapter.default_schema(),
-        )
+    resolved_result_store: DirectNodeResultStore = result_store or build_direct_node_result_store(
+        adapter=adapter,
+        connection=connection,
+        database=adapter.default_database(),
+        schema=adapter.default_schema(),
     )
     resolved_result_store.write(
         NodeResultRecord(

--- a/src/sqlbuild/executor/build/classes/build_scheduler.py
+++ b/src/sqlbuild/executor/build/classes/build_scheduler.py
@@ -92,9 +92,9 @@ from sqlbuild.executor.testing.constants import SQL_TEST_ENTRY_MISSING_CODE
 from sqlbuild.executor.testing.main._execute import execute_sql_test
 from sqlbuild.executor.testing.models import SqlTestExecutionResult
 from sqlbuild.executor.testing.types import SqlTestOutcome
-from sqlbuild.microbatches.classes.standard_store import (
-    StandardMicrobatchEventStore,
-    standard_microbatch_scope,
+from sqlbuild.microbatches.classes.direct_store import (
+    DirectMicrobatchEventStore,
+    direct_microbatch_scope,
 )
 from sqlbuild.microbatches.models import MicrobatchScope
 from sqlbuild.microbatches.types import MicrobatchEventStore
@@ -218,7 +218,7 @@ class BuildScheduler:
         """Execute the full build schedule and return all results."""
 
         self._init_connection_pool()
-        self._provision_standard_microbatch_state()
+        self._provision_direct_microbatch_state()
         self._block_initial_failed_keys()
         self._compute_in_degrees()
         self._seed_ready_queue()
@@ -251,7 +251,7 @@ class BuildScheduler:
             end_audit_results,
         )
 
-    def _provision_standard_microbatch_state(self) -> None:
+    def _provision_direct_microbatch_state(self) -> None:
         if self._runtime.microbatch_state_resolver is not None:
             return
         locations: set[tuple[str | None, str]] = {
@@ -887,10 +887,10 @@ class BuildScheduler:
                             self._runtime.microbatch_state_resolver(model_entry, connection)
                         )
                     else:
-                        microbatch_event_store = StandardMicrobatchEventStore(
+                        microbatch_event_store = DirectMicrobatchEventStore(
                             adapter=self._adapter, connection=connection
                         )
-                        microbatch_scope = standard_microbatch_scope(
+                        microbatch_scope = direct_microbatch_scope(
                             adapter=self._adapter,
                             connection=connection,
                             entry=model_entry,
@@ -970,7 +970,7 @@ class BuildScheduler:
         ) = self._runtime.microbatch_state_resolver
         if resolver is not None:
             return resolver(model_entry, connection)[0]
-        return StandardMicrobatchEventStore(adapter=self._adapter, connection=connection)
+        return DirectMicrobatchEventStore(adapter=self._adapter, connection=connection)
 
     def _handle_completion(
         self,

--- a/src/sqlbuild/executor/load/_helpers/dag_runtime.py
+++ b/src/sqlbuild/executor/load/_helpers/dag_runtime.py
@@ -25,7 +25,7 @@ from sqlbuild.executor.load.models import (
     LoadRuntimeParams,
 )
 from sqlbuild.executor.load.types import LoadProgressCallback
-from sqlbuild.executor.node_results.main._standard_store import build_standard_node_result_store
+from sqlbuild.executor.node_results.main._direct_store import build_direct_node_result_store
 from sqlbuild.executor.scheduling.main._build_in_degree import build_python_node_in_degree
 from sqlbuild.executor.scheduling.main._build_ready_queue import build_python_node_ready_queue
 from sqlbuild.executor.scheduling.main._run_worker import run_worker_with_completion
@@ -124,7 +124,7 @@ def execute_ready_dag_source(
         )
     resolved_result_store: Any | None = runtime.result_store
     if resolved_result_store is None and connection is not None:
-        resolved_result_store = build_standard_node_result_store(
+        resolved_result_store = build_direct_node_result_store(
             adapter=adapter,
             connection=connection,
             database=adapter.default_database(),

--- a/src/sqlbuild/executor/node_results/classes/direct_store.py
+++ b/src/sqlbuild/executor/node_results/classes/direct_store.py
@@ -1,4 +1,4 @@
-"""Standard-mode runtime node result store."""
+"""Direct-mode runtime node result store."""
 
 from __future__ import annotations
 
@@ -16,8 +16,8 @@ from sqlbuild.executor.node_results.models import (
 )
 
 
-class StandardNodeResultStore(NodeResultStore):
-    """Warehouse-backed node result store for standard-mode execution."""
+class DirectNodeResultStore(NodeResultStore):
+    """Warehouse-backed node result store for direct-mode execution."""
 
     def __init__(
         self,

--- a/src/sqlbuild/executor/node_results/main/_direct_store.py
+++ b/src/sqlbuild/executor/node_results/main/_direct_store.py
@@ -1,23 +1,23 @@
-"""Standard node result store factory."""
+"""Direct node result store factory."""
 
 from __future__ import annotations
 
 from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
-from sqlbuild.executor.node_results.classes.standard_store import StandardNodeResultStore
+from sqlbuild.executor.node_results.classes.direct_store import DirectNodeResultStore
 
 
-def build_standard_node_result_store(
+def build_direct_node_result_store(
     *,
     adapter: BaseAdapter,
     connection: Any,
     database: str | None,
     schema: str | None,
-) -> StandardNodeResultStore:
-    """Build a standard-mode runtime node result store."""
+) -> DirectNodeResultStore:
+    """Build a direct-mode runtime node result store."""
 
-    return StandardNodeResultStore(
+    return DirectNodeResultStore(
         adapter=adapter,
         connection=connection,
         database=database,

--- a/src/sqlbuild/executor/python_nodes/_helpers/execution.py
+++ b/src/sqlbuild/executor/python_nodes/_helpers/execution.py
@@ -16,7 +16,7 @@ from sqlbuild.compiler.python_nodes.types import (
 )
 from sqlbuild.cost.classes.cost_context import CostContext
 from sqlbuild.errors.contracts.exceptions import ExecutorInputError
-from sqlbuild.executor.node_results.main._standard_store import build_standard_node_result_store
+from sqlbuild.executor.node_results.main._direct_store import build_direct_node_result_store
 from sqlbuild.executor.node_results.models import NodeResultRecord
 from sqlbuild.executor.node_results.types import NodeResultStatus
 from sqlbuild.executor.python_nodes._helpers.results import (
@@ -69,7 +69,7 @@ def execute_python_nodes(
         run_state if run_state is not None else PythonNodeRunState()
     )
     result_store: Any | None = (
-        build_standard_node_result_store(
+        build_direct_node_result_store(
             adapter=runtime.adapter,
             connection=runtime.connection,
             database=runtime.default_database,
@@ -159,7 +159,7 @@ def execute_ready_python_node(
         result_store=runtime.result_store
         if runtime.result_store is not None
         else (
-            build_standard_node_result_store(
+            build_direct_node_result_store(
                 adapter=runtime.adapter,
                 connection=runtime.connection,
                 database=runtime.default_database,

--- a/src/sqlbuild/executor/python_nodes/_helpers/ingress_execution.py
+++ b/src/sqlbuild/executor/python_nodes/_helpers/ingress_execution.py
@@ -24,7 +24,7 @@ from sqlbuild.executor.load.main._execute import execute_source_load
 from sqlbuild.executor.load.main._resource_kind import load_resource_kind
 from sqlbuild.executor.load.main._skipped_result import skipped_load_result
 from sqlbuild.executor.load.models import LoadExecutionResult, LoadRuntimeParams
-from sqlbuild.executor.node_results.main._standard_store import build_standard_node_result_store
+from sqlbuild.executor.node_results.main._direct_store import build_direct_node_result_store
 from sqlbuild.executor.node_results.models import NodeResultRecord
 from sqlbuild.executor.python_nodes._helpers.fingerprinting import (
     try_write_python_node_identity_fingerprint,
@@ -87,7 +87,7 @@ def execute_ingress_python_loader_nodes(
         runtime.result_store
         if runtime.result_store is not None
         else (
-            build_standard_node_result_store(
+            build_direct_node_result_store(
                 adapter=runtime.adapter,
                 connection=runtime.connection,
                 database=runtime.default_database,

--- a/src/sqlbuild/executor/python_nodes/_helpers/python_checks.py
+++ b/src/sqlbuild/executor/python_nodes/_helpers/python_checks.py
@@ -14,7 +14,7 @@ from sqlbuild.compiler.python_nodes.types import PythonNodeKind, PythonNodeStatu
 from sqlbuild.cost.classes.cost_context import CostContext
 from sqlbuild.errors.contracts.exceptions import ExecutorInputError
 from sqlbuild.executor.load.models import LoadExecutionResult
-from sqlbuild.executor.node_results.main._standard_store import build_standard_node_result_store
+from sqlbuild.executor.node_results.main._direct_store import build_direct_node_result_store
 from sqlbuild.executor.node_results.models import NodeResultRecord
 from sqlbuild.executor.node_results.types import NodeResultStatus
 from sqlbuild.executor.python_nodes._helpers.fingerprinting import (
@@ -79,7 +79,7 @@ def execute_python_check_nodes(
         runtime.result_store
         if runtime.result_store is not None
         else (
-            build_standard_node_result_store(
+            build_direct_node_result_store(
                 adapter=adapter,
                 connection=connection,
                 database=default_database,

--- a/src/sqlbuild/executor/python_nodes/classes/read_side_python_execution_tracker.py
+++ b/src/sqlbuild/executor/python_nodes/classes/read_side_python_execution_tracker.py
@@ -9,7 +9,7 @@ from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecord
 from sqlbuild.compiler.python_nodes.models import DiscoveredPythonNode, PythonNodeGraph
 from sqlbuild.compiler.python_nodes.types import PythonNodeKind, PythonNodeStatus
 from sqlbuild.cost.classes.cost_context import CostContext
-from sqlbuild.executor.node_results.main._standard_store import build_standard_node_result_store
+from sqlbuild.executor.node_results.main._direct_store import build_direct_node_result_store
 from sqlbuild.executor.python_nodes._helpers.fingerprinting import (
     try_write_python_node_identity_fingerprint,
 )
@@ -46,7 +46,7 @@ class ReadSidePythonExecutionTracker:
             runtime.result_store
             if runtime.result_store is not None
             else (
-                build_standard_node_result_store(
+                build_direct_node_result_store(
                     adapter=runtime.adapter,
                     connection=runtime.connection,
                     database=runtime.default_database,

--- a/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
@@ -83,14 +83,14 @@ from sqlbuild.executor.run.models import (
 )
 from sqlbuild.executor.run.types import ExecutionPhase, MicrobatchBatchRunner
 from sqlbuild.executor.scheduling.types import ExecutionStatus
-from sqlbuild.microbatches.classes.standard_store import (
-    StandardMicrobatchEventStore,
-    standard_microbatch_scope,
+from sqlbuild.microbatches.classes.direct_store import (
+    DirectMicrobatchEventStore,
+    direct_microbatch_scope,
 )
 from sqlbuild.microbatches.constants import (
+    DIRECT_MICROBATCH_SCOPE_KIND,
     MICROBATCH_GENERATION_WILDCARD,
     MICROBATCH_REPLAY_GENERATION_PREFIX,
-    STANDARD_MICROBATCH_SCOPE_KIND,
 )
 from sqlbuild.microbatches.main.latest_replay_requirement import (
     latest_active_replay_requirement,
@@ -828,10 +828,10 @@ def _read_microbatch_history(
     ]
     | ModelExecutionResult
 ):
-    store: MicrobatchEventStore = context.microbatch_event_store or StandardMicrobatchEventStore(
+    store: MicrobatchEventStore = context.microbatch_event_store or DirectMicrobatchEventStore(
         adapter=context.adapter, connection=context.connection
     )
-    scope: MicrobatchScope = context.microbatch_scope or standard_microbatch_scope(
+    scope: MicrobatchScope = context.microbatch_scope or direct_microbatch_scope(
         adapter=context.adapter, connection=context.connection, entry=context.entry
     )
     try:
@@ -845,7 +845,7 @@ def _read_microbatch_history(
             audit_results=state.audit_results,
             statement_recorder=state.statement_recorder,
         )
-    if is_full_refresh and scope.scope_kind == STANDARD_MICROBATCH_SCOPE_KIND:
+    if is_full_refresh and scope.scope_kind == DIRECT_MICROBATCH_SCOPE_KIND:
         if _microbatch_run_type(context=context) == MicrobatchRunType.REPLAY_ON_CHANGE:
             replay_generation: str = (
                 MICROBATCH_REPLAY_GENERATION_PREFIX + _expected_model_version_hash(context=context)
@@ -1156,7 +1156,7 @@ def _current_completion_scope(
     )
     if generation is None:
         return scope
-    if scope.scope_kind == STANDARD_MICROBATCH_SCOPE_KIND:
+    if scope.scope_kind == DIRECT_MICROBATCH_SCOPE_KIND:
         return replace(scope, physical_generation_id=generation)
     generation_hash: str = hashlib.sha256(generation.encode()).hexdigest()
     if scope.physical_generation_id.rpartition(":")[2] == generation_hash:

--- a/src/sqlbuild/executor/run/main/_execute.py
+++ b/src/sqlbuild/executor/run/main/_execute.py
@@ -195,7 +195,7 @@ def execute_table_entry(
             phase=ExecutionPhase.CONTRACT,
             error=ExecutorInputError(
                 f"model '{entry.name}': contract enforced requires staged table promotion; "
-                "direct table promotion cannot validate runtime output before target mutation",
+                "immediate table promotion cannot validate runtime output before target mutation",
                 code="K011",
             ),
             warnings=warnings,
@@ -204,7 +204,7 @@ def execute_table_entry(
             hook_results=hook_results,
         )
 
-    return _direct_lifecycle(
+    return _immediate_lifecycle(
         context=context,
         targets=targets,
         state=state,
@@ -395,14 +395,14 @@ def _staged_lifecycle(
     )
 
 
-def _direct_lifecycle(
+def _immediate_lifecycle(
     *,
     context: ModelMaterializationContext,
     targets: TableTargets,
     state: TableLifecycleState,
     declared_columns: tuple[ColumnInfo, ...],
 ) -> ModelExecutionResult:
-    """Direct table lifecycle: CTAS target, audit after, no staging."""
+    """Immediate table lifecycle: CTAS target, audit after, no staging."""
 
     entry: ModelPlanEntry = context.entry
     adapter: BaseAdapter = context.adapter
@@ -447,7 +447,7 @@ def _direct_lifecycle(
             hook_results=hook_results,
         )
 
-    direct_audit_run: FinalAuditRun = run_final_model_audits(
+    immediate_audit_run: FinalAuditRun = run_final_model_audits(
         relation_overrides=None,
         model_audits=context.model_audits,
         reuse_origin_fingerprint=reuse_origin_fingerprint,
@@ -457,9 +457,9 @@ def _direct_lifecycle(
         seed_locations=context.seed_locations,
         source_map=context.source_map,
     )
-    audit_results.extend(direct_audit_run.results)
+    audit_results.extend(immediate_audit_run.results)
 
-    if direct_audit_run.has_error:
+    if immediate_audit_run.has_error:
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.AUDIT,

--- a/src/sqlbuild/executor/scenario/main/_execute.py
+++ b/src/sqlbuild/executor/scenario/main/_execute.py
@@ -80,7 +80,7 @@ def execute_scenario_model(
                 hook_functions=scenario_plan.hook_functions,
             ),
             declared_columns=entry.declared_columns,
-            promotion_mode=TablePromotionMode.DIRECT,
+            promotion_mode=TablePromotionMode.IMMEDIATE,
         )
     )
 

--- a/src/sqlbuild/executor/seed/_helpers/fingerprinting.py
+++ b/src/sqlbuild/executor/seed/_helpers/fingerprinting.py
@@ -1,4 +1,4 @@
-"""Fingerprint writes for standard seed loads."""
+"""Fingerprint writes for direct seed loads."""
 
 from __future__ import annotations
 

--- a/src/sqlbuild/integrations/dbt/_helpers/cli/mode.py
+++ b/src/sqlbuild/integrations/dbt/_helpers/cli/mode.py
@@ -6,7 +6,7 @@ from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.integrations.dbt.exceptions import DbtInteropConfigError
 
 
-def enforce_dbt_interop_standard_mode(*, discovered_inputs: DiscoveredProjectInputs) -> None:
+def enforce_dbt_interop_direct_mode(*, discovered_inputs: DiscoveredProjectInputs) -> None:
     """Block dbt interop commands in virtual environment mode."""
 
     if discovered_inputs.project_config.settings.virtual_environments:

--- a/src/sqlbuild/integrations/dbt/_helpers/pipeline/interop_prologue.py
+++ b/src/sqlbuild/integrations/dbt/_helpers/pipeline/interop_prologue.py
@@ -19,8 +19,8 @@ from sqlbuild.integrations.dbt.classes.dbt_compile_reference_resolver import (
 )
 from sqlbuild.integrations.dbt.classes.dbt_runner import DbtRunner
 from sqlbuild.integrations.dbt.exceptions import DbtInteropRuntimeError
-from sqlbuild.integrations.dbt.main.cli._enforce_standard_mode import (
-    enforce_dbt_interop_standard_mode,
+from sqlbuild.integrations.dbt.main.cli._enforce_direct_mode import (
+    enforce_dbt_interop_direct_mode,
 )
 from sqlbuild.integrations.dbt.main.cli._parse_execution_args import parse_dbt_execution_args
 from sqlbuild.integrations.dbt.main.cli._resolve_executable import resolve_dbt_executable
@@ -72,7 +72,7 @@ def resolve_dbt_execution_invocation(
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(
         project_dir=request.project_dir
     )
-    enforce_dbt_interop_standard_mode(discovered_inputs=discovered_inputs)
+    enforce_dbt_interop_direct_mode(discovered_inputs=discovered_inputs)
     dbt_options: DbtCliOptions = resolve_dbt_plan_options(
         project_dir=request.project_dir,
         discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/integrations/dbt/main/cli/_enforce_direct_mode.py
+++ b/src/sqlbuild/integrations/dbt/main/cli/_enforce_direct_mode.py
@@ -2,11 +2,11 @@
 
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.integrations.dbt._helpers.cli.mode import (
-    enforce_dbt_interop_standard_mode as _enforce,
+    enforce_dbt_interop_direct_mode as _enforce,
 )
 
 
-def enforce_dbt_interop_standard_mode(*, discovered_inputs: DiscoveredProjectInputs) -> None:
+def enforce_dbt_interop_direct_mode(*, discovered_inputs: DiscoveredProjectInputs) -> None:
     """Reject dbt interop in virtual environment mode."""
 
     _ = _enforce(discovered_inputs=discovered_inputs)

--- a/src/sqlbuild/integrations/dbt/main/pipeline/debug.py
+++ b/src/sqlbuild/integrations/dbt/main/pipeline/debug.py
@@ -8,8 +8,8 @@ from typing import TextIO
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.integrations.dbt.classes.dbt_runner import DbtRunner
-from sqlbuild.integrations.dbt.main.cli._enforce_standard_mode import (
-    enforce_dbt_interop_standard_mode,
+from sqlbuild.integrations.dbt.main.cli._enforce_direct_mode import (
+    enforce_dbt_interop_direct_mode,
 )
 from sqlbuild.integrations.dbt.main.config._parse_config_overrides import (
     parse_dbt_config_overrides,
@@ -30,7 +30,7 @@ def debug_dbt_from_project(
     """Run dbt debug from SQLBuild project configuration."""
 
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=project_dir)
-    enforce_dbt_interop_standard_mode(discovered_inputs=discovered_inputs)
+    enforce_dbt_interop_direct_mode(discovered_inputs=discovered_inputs)
     resolved: ResolvedDbtConfig = resolve_dbt_config(
         project_root=project_dir,
         config=discovered_inputs.project_config.dbt,

--- a/src/sqlbuild/microbatches/_helpers/sql.py
+++ b/src/sqlbuild/microbatches/_helpers/sql.py
@@ -1,4 +1,4 @@
-"""Internal portable SQL for standard-mode microbatch history."""
+"""Internal portable SQL for direct-mode microbatch history."""
 
 from __future__ import annotations
 

--- a/src/sqlbuild/microbatches/classes/direct_store.py
+++ b/src/sqlbuild/microbatches/classes/direct_store.py
@@ -1,4 +1,4 @@
-"""Warehouse-backed standard-mode microbatch event store class."""
+"""Warehouse-backed direct-mode microbatch event store class."""
 
 from __future__ import annotations
 
@@ -14,16 +14,16 @@ from sqlbuild.microbatches._helpers.sql import (
 )
 from sqlbuild.microbatches.classes.event_codec import MicrobatchEventCodec
 from sqlbuild.microbatches.constants import (
+    DIRECT_MICROBATCH_SCOPE_KIND,
     MICROBATCH_GENERATION_WILDCARD,
     MICROBATCH_WRITE_ATTEMPTS,
     MICROBATCH_WRITE_RETRY_BASE_SECONDS,
-    STANDARD_MICROBATCH_SCOPE_KIND,
 )
 from sqlbuild.microbatches.exceptions import MicrobatchStateError
 from sqlbuild.microbatches.models import MicrobatchEvent, MicrobatchScope
 
 
-class StandardMicrobatchEventStore:
+class DirectMicrobatchEventStore:
     """Append/read microbatch history through a model worker's warehouse connection."""
 
     def __init__(self, *, adapter: BaseAdapter, connection: Any) -> None:
@@ -87,10 +87,10 @@ class StandardMicrobatchEventStore:
         )
 
 
-def standard_microbatch_scope(
+def direct_microbatch_scope(
     *, adapter: BaseAdapter, connection: Any, entry: ModelPlanEntry
 ) -> MicrobatchScope:
-    """Build the standard logical scope for one destination relation."""
+    """Build the direct logical scope for one destination relation."""
 
     qualified: str = (
         entry.destination.qualified_name
@@ -112,7 +112,7 @@ def standard_microbatch_scope(
         or MICROBATCH_GENERATION_WILDCARD
     )
     return MicrobatchScope(
-        scope_kind=STANDARD_MICROBATCH_SCOPE_KIND,
+        scope_kind=DIRECT_MICROBATCH_SCOPE_KIND,
         scope_key=scope_key,
         model_name=entry.name,
         target_database=entry.destination.database,

--- a/src/sqlbuild/microbatches/constants.py
+++ b/src/sqlbuild/microbatches/constants.py
@@ -1,7 +1,7 @@
 """Stable constants for microbatch state storage and retries."""
 
 MICROBATCH_TABLE_NAME: str = "_sqlbuild_microbatches"
-STANDARD_MICROBATCH_SCOPE_KIND: str = "standard_logical"
+DIRECT_MICROBATCH_SCOPE_KIND: str = "direct_logical"
 VIRTUAL_MICROBATCH_SCOPE_KIND: str = "virtual_physical"
 MICROBATCH_GENERATION_COMMENT_PREFIX: str = "sqlbuild-generation:"
 MICROBATCH_REPLAY_GENERATION_PREFIX: str = "replay:"
@@ -53,7 +53,7 @@ MICROBATCH_COLUMNS: tuple[str, ...] = (
     "created_at",
 )
 
-MICROBATCH_STANDARD_INDEXES: dict[str, tuple[str, ...]] = {
+MICROBATCH_DIRECT_INDEXES: dict[str, tuple[str, ...]] = {
     "_sqlbuild_microbatches_scope_idx": (
         "scope_kind",
         "scope_key",

--- a/src/sqlbuild/microbatches/main/create_index_sqls.py
+++ b/src/sqlbuild/microbatches/main/create_index_sqls.py
@@ -1,11 +1,11 @@
-"""Public standard microbatch-state index DDL rendering entrypoint."""
+"""Public direct microbatch-state index DDL rendering entrypoint."""
 
 from __future__ import annotations
 
 from collections.abc import Callable
 
 from sqlbuild.microbatches.constants import (
-    MICROBATCH_STANDARD_INDEXES,
+    MICROBATCH_DIRECT_INDEXES,
     MICROBATCH_TABLE_NAME,
 )
 
@@ -24,7 +24,7 @@ def build_create_index_sqls(
         or f"{schema}.{MICROBATCH_TABLE_NAME}"
     )
     statements: list[str] = []
-    for index_name, columns in MICROBATCH_STANDARD_INDEXES.items():
+    for index_name, columns in MICROBATCH_DIRECT_INDEXES.items():
         rendered_columns: tuple[str, ...] = tuple(render_identifier(column) for column in columns)
         statements.append(
             f"CREATE INDEX IF NOT EXISTS {render_identifier(index_name)} ON {table} "

--- a/src/sqlbuild/microbatches/main/create_table_sql.py
+++ b/src/sqlbuild/microbatches/main/create_table_sql.py
@@ -1,4 +1,4 @@
-"""Public standard microbatch-state DDL rendering entrypoint."""
+"""Public direct microbatch-state DDL rendering entrypoint."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ def build_create_table_sql(
     render_qualified_name: Callable[..., str | None],
     render_framework_type: Callable[[FrameworkType], str],
 ) -> str:
-    """Build standard microbatch-state DDL through the public entrypoint."""
+    """Build direct microbatch-state DDL through the public entrypoint."""
 
     return _build_create_table_sql(
         database=database,

--- a/src/sqlbuild/virtual/planner/_helpers/output.py
+++ b/src/sqlbuild/virtual/planner/_helpers/output.py
@@ -29,7 +29,7 @@ def rewrite_virtual_plan_entries(
     run_despite_unchanged: RunDespiteUnchangedPlanningResult | None = None,
     seed_plan_reasons: dict[str, PlanReason] | None = None,
 ) -> PlanOutput:
-    """Rewrite standard planner entries with virtual-specific reasons and causes."""
+    """Rewrite direct planner entries with virtual-specific reasons and causes."""
 
     rewritten_entries: list[ModelPlanEntry] = []
     cause_reasons: dict[str, PlanReason] = stale_root_cause_reasons or stale_root_reasons

--- a/src/sqlbuild/virtual/planner/_helpers/run_despite_unchanged.py
+++ b/src/sqlbuild/virtual/planner/_helpers/run_despite_unchanged.py
@@ -10,11 +10,11 @@ from sqlbuild.compiler.planner.main.changes.run_despite_unchanged import (
 )
 from sqlbuild.compiler.planner.models import PlannerScope, RunDespiteUnchangedPlanningResult
 from sqlbuild.compiler.source_freshness.models import (
+    DirectSourceFreshnessPlanningResult,
     SourceFreshnessIdentity,
-    StandardSourceFreshnessPlanningResult,
 )
 from sqlbuild.compiler.source_freshness.models import (
-    SourceFreshnessRecord as StandardSourceFreshnessRecord,
+    SourceFreshnessRecord as DirectSourceFreshnessRecord,
 )
 from sqlbuild.virtual.state.models import SourceFreshnessRecord
 
@@ -27,7 +27,7 @@ def build_virtual_run_despite_unchanged_planning_result(
 ) -> RunDespiteUnchangedPlanningResult:
     """Return VDE models selected by run_despite_unchanged semantics."""
 
-    source_freshness: StandardSourceFreshnessPlanningResult = _standard_source_freshness_result(
+    source_freshness: DirectSourceFreshnessPlanningResult = _direct_source_freshness_result(
         source_freshness_records
     )
     return build_run_despite_unchanged_planning_result(
@@ -53,11 +53,11 @@ def _planner_scope_from_graph(graph: ProjectGraph) -> PlannerScope:
     )
 
 
-def _standard_source_freshness_result(
+def _direct_source_freshness_result(
     records: tuple[SourceFreshnessRecord, ...],
-) -> StandardSourceFreshnessPlanningResult:
-    observed_records: tuple[StandardSourceFreshnessRecord, ...] = tuple(
-        StandardSourceFreshnessRecord(
+) -> DirectSourceFreshnessPlanningResult:
+    observed_records: tuple[DirectSourceFreshnessRecord, ...] = tuple(
+        DirectSourceFreshnessRecord(
             source_name=record.source_name,
             target_database=None,
             target_schema=None,
@@ -71,7 +71,7 @@ def _standard_source_freshness_result(
         )
         for record in records
     )
-    return StandardSourceFreshnessPlanningResult(
+    return DirectSourceFreshnessPlanningResult(
         observed_records=observed_records,
         unchanged_identities=frozenset(
             SourceFreshnessIdentity(

--- a/tests/e2e/src/sqlbuild/cli/commands/main/bigquery/test_bigquery.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/bigquery/test_bigquery.py
@@ -154,7 +154,7 @@ def test_given_bigquery_dbt_profile_when_running_dbt_init_then_builds_profile_li
     "test_case",
     [
         BigQueryNodeResultE2ETestCase(
-            description="standard node results persist and read on bigquery",
+            description="direct node results persist and read on bigquery",
             expected_rows=(
                 ("check", "check_produce_result", "success"),
                 ("task", "produce_result", "success"),

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/_test_types.py
@@ -161,7 +161,7 @@ class PythonTargetIsolationBuildE2ETestCase:
 
 
 @dataclass(frozen=True)
-class StandardPythonBuildHardeningE2ETestCase:
+class DirectPythonBuildHardeningE2ETestCase:
     """Test case for direct build Python lifecycle hardening behavior."""
 
     description: str

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/helpers.py
@@ -537,10 +537,10 @@ def replay_microbatch_model_sql(*, value_expression: str, replay_policy: str = "
     )
 
 
-def standard_microbatch_project_toml(
+def direct_microbatch_project_toml(
     *, project_name: str, database_name: str, settings_toml: str
 ) -> str:
-    """Build a standard DuckDB project config for microbatch lifecycle E2Es."""
+    """Build a direct DuckDB project config for microbatch lifecycle E2Es."""
 
     return (
         f'name = "{project_name}"\n'
@@ -598,13 +598,13 @@ def timestamp_microbatch_model_sql(
 def prepare_replay_microbatch_project(
     *, tmp_path: Path, project_name: str, database_name: str, replay_policy: str
 ) -> tuple[Path, Path]:
-    """Prepare a standard concurrent replay lifecycle project."""
+    """Prepare a direct concurrent replay lifecycle project."""
 
     project_dir: Path = prepare_inline_project(
         tmp_path=tmp_path,
         project_name=project_name,
         repo_files={
-            "sqlbuild_project.toml": standard_microbatch_project_toml(
+            "sqlbuild_project.toml": direct_microbatch_project_toml(
                 project_name=project_name,
                 database_name=database_name,
                 settings_toml=("\n[settings]\nconcurrency = 3\nmicrobatch_concurrency = true\n"),

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_build.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_build.py
@@ -15,13 +15,13 @@ from tests.e2e.src.sqlbuild.cli.commands.main.build._test_types import (
     BuildE2ETestCase,
     DeferCloneBuildE2ETestCase,
     DirectChangesOnlyBuildE2ETestCase,
+    DirectPythonBuildHardeningE2ETestCase,
     PythonBuildE2ETestCase,
     PythonLoaderPersistedResultBuildE2ETestCase,
     PythonLoaderStatusResultBuildE2ETestCase,
     PythonPersistedResultBuildE2ETestCase,
     PythonTargetIsolationBuildE2ETestCase,
     SelectionAwareStalenessBuildE2ETestCase,
-    StandardPythonBuildHardeningE2ETestCase,
 )
 from tests.e2e.src.sqlbuild.cli.commands.main.build.helpers import (
     assert_defer_clone_build_case,
@@ -239,7 +239,7 @@ def test_given_direct_function_dependency_when_building_then_persists_function_h
     "test_case",
     [
         DirectChangesOnlyBuildE2ETestCase(
-            description="standard changes-only persists plan-time source freshness observation",
+            description="direct changes-only persists plan-time source freshness observation",
             expected_exit_code=0,
             expected_output_fragments=("Plan ready  1 selected", "orders", "TOTAL=1"),
             unexpected_output_fragments=("Plan ready  0 selected",),
@@ -253,10 +253,10 @@ def test_given_source_freshness_changes_during_build_when_appending_then_persist
 ) -> None:
     project_dir: Path = prepare_inline_project(
         tmp_path=tmp_path,
-        project_name="standard_source_freshness_plan_time_persistence",
+        project_name="direct_source_freshness_plan_time_persistence",
         repo_files={
             "sqlbuild_project.toml": (
-                'name = "standard_source_freshness_plan_time_persistence"\n'
+                'name = "direct_source_freshness_plan_time_persistence"\n'
                 'adapter = "duckdb"\n\n'
                 "[connection]\n"
                 'database = "warehouse.duckdb"\n'
@@ -329,7 +329,7 @@ def test_given_source_freshness_changes_during_build_when_appending_then_persist
     "test_case",
     [
         DirectChangesOnlyBuildE2ETestCase(
-            description="standard source freshness appends independent successful branch only",
+            description="direct source freshness appends independent successful branch only",
             expected_exit_code=1,
             expected_output_fragments=("orders", "payments", "FAIL"),
         )
@@ -342,10 +342,10 @@ def test_given_independent_source_branch_failure_when_building_then_appends_succ
 ) -> None:
     project_dir: Path = prepare_inline_project(
         tmp_path=tmp_path,
-        project_name="standard_source_freshness_independent_branch_build",
+        project_name="direct_source_freshness_independent_branch_build",
         repo_files={
             "sqlbuild_project.toml": (
-                'name = "standard_source_freshness_independent_branch_build"\n'
+                'name = "direct_source_freshness_independent_branch_build"\n'
                 'adapter = "duckdb"\n\n'
                 "[connection]\n"
                 'database = "warehouse.duckdb"\n'
@@ -452,10 +452,10 @@ def test_given_source_freshness_error_when_building_then_blocks_only_affected_br
 ) -> None:
     project_dir: Path = prepare_inline_project(
         tmp_path=tmp_path,
-        project_name="standard_source_freshness_error_blocks_branch_build",
+        project_name="direct_source_freshness_error_blocks_branch_build",
         repo_files={
             "sqlbuild_project.toml": (
-                'name = "standard_source_freshness_error_blocks_branch_build"\n'
+                'name = "direct_source_freshness_error_blocks_branch_build"\n'
                 'adapter = "duckdb"\n\n'
                 "[connection]\n"
                 'database = "warehouse.duckdb"\n'
@@ -524,7 +524,7 @@ def test_given_source_freshness_error_when_building_then_blocks_only_affected_br
     "test_case",
     [
         DirectChangesOnlyBuildE2ETestCase(
-            description="standard source freshness shared downstream failure blocks all sources",
+            description="direct source freshness shared downstream failure blocks all sources",
             expected_exit_code=1,
             expected_output_fragments=("fact_orders", "FAIL"),
         )
@@ -537,10 +537,10 @@ def test_given_shared_downstream_failure_when_building_then_blocks_all_source_ap
 ) -> None:
     project_dir: Path = prepare_inline_project(
         tmp_path=tmp_path,
-        project_name="standard_source_freshness_shared_failure_build",
+        project_name="direct_source_freshness_shared_failure_build",
         repo_files={
             "sqlbuild_project.toml": (
-                'name = "standard_source_freshness_shared_failure_build"\n'
+                'name = "direct_source_freshness_shared_failure_build"\n'
                 'adapter = "duckdb"\n\n'
                 "[connection]\n"
                 'database = "warehouse.duckdb"\n'
@@ -626,7 +626,7 @@ def test_given_shared_downstream_failure_when_building_then_blocks_all_source_ap
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="ingress Python failure blocks downstream source load and model",
             project_name="python_build_ingress_failure_project",
             command=("--no-color", "build", "--select", "+fact_orders"),
@@ -672,7 +672,7 @@ def test_given_shared_downstream_failure_when_building_then_blocks_all_source_ap
             ),
             expected_absent_tables=("raw_orders", "fact_orders"),
         ),
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="ingress hard skip blocks downstream source load and model",
             project_name="python_build_ingress_skip_project",
             command=("--no-color", "build", "--select", "+fact_orders"),
@@ -719,7 +719,7 @@ def test_given_shared_downstream_failure_when_building_then_blocks_all_source_ap
             ),
             expected_absent_tables=("raw_orders", "fact_orders"),
         ),
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="non json python result payload fails at producer",
             project_name="python_build_non_json_result_project",
             command=("--no-color", "build", "--select", "produce_bad_result"),
@@ -743,7 +743,7 @@ def test_given_shared_downstream_failure_when_building_then_blocks_all_source_ap
                 "non-JSON-serializable payload",
             ),
         ),
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="non json python result metadata fails at producer",
             project_name="python_build_non_json_metadata_project",
             command=("--no-color", "build", "--select", "produce_bad_metadata"),
@@ -767,7 +767,7 @@ def test_given_shared_downstream_failure_when_building_then_blocks_all_source_ap
                 "non-JSON-serializable metadata",
             ),
         ),
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="read-side Python failure fails build after SQL succeeds",
             project_name="python_build_read_side_failure_project",
             command=("--no-color", "build", "--select", "fact_orders fail_after_fact"),
@@ -806,7 +806,7 @@ def test_given_shared_downstream_failure_when_building_then_blocks_all_source_ap
             ),
             expected_present_tables=("fact_orders",),
         ),
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="read-side hard skip is reported after SQL succeeds",
             project_name="python_build_read_side_hard_skip_project",
             command=("--no-color", "build", "--select", "fact_orders skip_after_fact"),
@@ -846,7 +846,7 @@ def test_given_shared_downstream_failure_when_building_then_blocks_all_source_ap
             ),
             expected_present_tables=("fact_orders",),
         ),
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="read-side soft skip is reported after SQL succeeds",
             project_name="python_build_read_side_soft_skip_project",
             command=("--no-color", "build", "--select", "fact_orders soft_skip_after_fact"),
@@ -886,7 +886,7 @@ def test_given_shared_downstream_failure_when_building_then_blocks_all_source_ap
             ),
             expected_present_tables=("fact_orders",),
         ),
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="no-python suppresses read-side Python but keeps ingress Python",
             project_name="python_build_no_python_project",
             command=("--no-color", "build", "--select", "+fact_orders", "--no-python"),
@@ -945,7 +945,7 @@ def test_given_shared_downstream_failure_when_building_then_blocks_all_source_ap
             expected_markers=(("prepared.txt", "prepared"),),
             expected_absent_paths=("profile.txt",),
         ),
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="source relation resolves in direct read-side Python task",
             project_name="python_build_source_relation_project",
             command=("--no-color", "build", "--select", "+raw_orders profile_raw_orders"),
@@ -996,7 +996,7 @@ def test_given_shared_downstream_failure_when_building_then_blocks_all_source_ap
     ids=lambda case: case.description,
 )
 def test_given_python_lifecycle_edge_case_when_building_then_direct_build_hardens_behavior(
-    test_case: StandardPythonBuildHardeningE2ETestCase,
+    test_case: DirectPythonBuildHardeningE2ETestCase,
     tmp_path: Path,
 ) -> None:
     project_dir: Path = prepare_inline_project(
@@ -1033,7 +1033,7 @@ def test_given_python_lifecycle_edge_case_when_building_then_direct_build_harden
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="direct build fails when skipped intermediate target is missing",
             project_name="direct_build_missing_intermediate_project",
             command=("--no-color", "build", "--select", "raw_events"),
@@ -1062,7 +1062,7 @@ def test_given_python_lifecycle_edge_case_when_building_then_direct_build_harden
             expected_exit_code=1,
             expected_output_fragments=("requires intermediate loader 'fetch_events'",),
         ),
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="direct build no-python source only warns and skips task ingress",
             project_name="direct_build_no_python_source_only_project",
             command=("--no-color", "build", "--select", "raw_events", "--no-python"),
@@ -1109,7 +1109,7 @@ def test_given_python_lifecycle_edge_case_when_building_then_direct_build_harden
 )
 def test_given_direct_source_only_build_when_loader_has_ingress_then_enforces_source_policy(
     tmp_path: Path,
-    test_case: StandardPythonBuildHardeningE2ETestCase,
+    test_case: DirectPythonBuildHardeningE2ETestCase,
 ) -> None:
     project_dir: Path = prepare_inline_project(
         tmp_path=tmp_path,
@@ -1139,7 +1139,7 @@ def test_given_direct_source_only_build_when_loader_has_ingress_then_enforces_so
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="direct build reuses existing intermediate target without rerunning loader",
             project_name="direct_build_existing_intermediate_project",
             command=("--no-color", "build", "--select", "raw_events"),
@@ -1174,7 +1174,7 @@ def test_given_direct_source_only_build_when_loader_has_ingress_then_enforces_so
 )
 def test_given_existing_intermediate_target_when_building_source_only_then_reuses_target(
     tmp_path: Path,
-    test_case: StandardPythonBuildHardeningE2ETestCase,
+    test_case: DirectPythonBuildHardeningE2ETestCase,
 ) -> None:
     project_dir: Path = prepare_inline_project(
         tmp_path=tmp_path,
@@ -1206,7 +1206,7 @@ def test_given_existing_intermediate_target_when_building_source_only_then_reuse
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardPythonBuildHardeningE2ETestCase(
+        DirectPythonBuildHardeningE2ETestCase(
             description="build json includes Python node results",
             project_name="python_build_json_project",
             command=("--no-color", "build", "--select", "observed_orders"),
@@ -1233,7 +1233,7 @@ def test_given_existing_intermediate_target_when_building_source_only_then_reuse
     ids=lambda case: case.description,
 )
 def test_given_python_asset_with_json_output_when_building_then_json_includes_python_result(
-    test_case: StandardPythonBuildHardeningE2ETestCase,
+    test_case: DirectPythonBuildHardeningE2ETestCase,
     tmp_path: Path,
 ) -> None:
     project_dir: Path = prepare_inline_project(

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_microbatch_direct_lifecycle.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_microbatch_direct_lifecycle.py
@@ -1,4 +1,4 @@
-"""E2E coverage for universal standard microbatch ledger lifecycle invariants."""
+"""E2E coverage for universal direct microbatch ledger lifecycle invariants."""
 
 from __future__ import annotations
 
@@ -12,8 +12,8 @@ from tests.e2e.src.sqlbuild.cli.commands.main.build._test_types import (
     SerialMicrobatchLedgerE2ETestCase,
 )
 from tests.e2e.src.sqlbuild.cli.commands.main.build.helpers import (
+    direct_microbatch_project_toml,
     raw_events_source_yml,
-    standard_microbatch_project_toml,
     timestamp_microbatch_model_sql,
 )
 from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
@@ -50,7 +50,7 @@ def test_given_serial_microbatch_when_building_then_universal_ledger_records_kno
         tmp_path=tmp_path,
         project_name=project_name,
         repo_files={
-            "sqlbuild_project.toml": standard_microbatch_project_toml(
+            "sqlbuild_project.toml": direct_microbatch_project_toml(
                 project_name=project_name,
                 database_name="serial.duckdb",
                 settings_toml=test_case.settings_toml,
@@ -145,7 +145,7 @@ def test_given_integer_cursor_maximum_when_building_then_half_open_batches_inclu
         tmp_path=tmp_path,
         project_name=project_name,
         repo_files={
-            "sqlbuild_project.toml": standard_microbatch_project_toml(
+            "sqlbuild_project.toml": direct_microbatch_project_toml(
                 project_name=project_name,
                 database_name="integer_maximum.duckdb",
                 settings_toml=("\n[settings]\nconcurrency = 3\nmicrobatch_concurrency = true\n"),
@@ -226,7 +226,7 @@ def test_given_concurrent_ceiling_when_first_run_and_full_refresh_then_target_bo
         tmp_path=tmp_path,
         project_name=project_name,
         repo_files={
-            "sqlbuild_project.toml": standard_microbatch_project_toml(
+            "sqlbuild_project.toml": direct_microbatch_project_toml(
                 project_name=project_name,
                 database_name="bootstrap.duckdb",
                 settings_toml=("\n[settings]\nconcurrency = 3\nmicrobatch_concurrency = true\n"),
@@ -312,7 +312,7 @@ def test_given_recreated_target_when_building_then_old_completion_generation_is_
         tmp_path=tmp_path,
         project_name=project_name,
         repo_files={
-            "sqlbuild_project.toml": standard_microbatch_project_toml(
+            "sqlbuild_project.toml": direct_microbatch_project_toml(
                 project_name=project_name,
                 database_name="recreated.duckdb",
                 settings_toml="",

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_microbatch_failure_windows.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_microbatch_failure_windows.py
@@ -11,8 +11,8 @@ from tests.e2e.src.sqlbuild.cli.commands.main.build._test_types import (
     ConcurrentMicrobatchBehaviorE2ETestCase,
 )
 from tests.e2e.src.sqlbuild.cli.commands.main.build.helpers import (
+    direct_microbatch_project_toml,
     raw_events_source_yml,
-    standard_microbatch_project_toml,
     timestamp_microbatch_model_sql,
 )
 from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
@@ -42,7 +42,7 @@ def test_given_completion_write_failure_after_dml_when_retried_then_unaccounted_
         tmp_path=tmp_path,
         project_name=project_name,
         repo_files={
-            "sqlbuild_project.toml": standard_microbatch_project_toml(
+            "sqlbuild_project.toml": direct_microbatch_project_toml(
                 project_name=project_name,
                 database_name="state_write_failure.duckdb",
                 settings_toml=(
@@ -156,7 +156,7 @@ def test_given_concurrent_delta_audit_failure_when_fixed_then_rejected_partition
         tmp_path=tmp_path,
         project_name=project_name,
         repo_files={
-            "sqlbuild_project.toml": standard_microbatch_project_toml(
+            "sqlbuild_project.toml": direct_microbatch_project_toml(
                 project_name=project_name,
                 database_name="delta_audit_failure.duckdb",
                 settings_toml=("\n[settings]\nconcurrency = 3\nmicrobatch_concurrency = true\n"),
@@ -267,7 +267,7 @@ def test_given_concurrent_batches_when_audit_and_hooks_wrap_model_then_aggregate
         tmp_path=tmp_path,
         project_name=project_name,
         repo_files={
-            "sqlbuild_project.toml": standard_microbatch_project_toml(
+            "sqlbuild_project.toml": direct_microbatch_project_toml(
                 project_name=project_name,
                 database_name="aggregate_hooks.duckdb",
                 settings_toml=("\n[settings]\nconcurrency = 3\nmicrobatch_concurrency = true\n"),

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_microbatch_replay_backfill_lifecycle.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_microbatch_replay_backfill_lifecycle.py
@@ -1,4 +1,4 @@
-"""E2E coverage for difficult standard microbatch backfill and replay transitions."""
+"""E2E coverage for difficult direct microbatch backfill and replay transitions."""
 
 from __future__ import annotations
 

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_promote.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_promote.py
@@ -614,7 +614,7 @@ def test_given_partial_virtual_promotion_when_target_stays_working_then_it_requi
     "test_case",
     [
         VirtualPromoteE2ETestCase(
-            description="standard mode promotion fails with mode error",
+            description="direct mode promotion fails with mode error",
             promote_command=("promote", "--from", "pr", "--to", "dev"),
             expected_promote_fragments=("promote requires virtual_environments = true",),
             expected_query_results=(),

--- a/tests/e2e/src/sqlbuild/cli/commands/main/check/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/check/_test_types.py
@@ -14,7 +14,7 @@ class CheckCommandTestCase:
     expected_returncode: int
     expected_stdout_fragments: tuple[str, ...]
     expected_absent_fragments: tuple[str, ...] = ()
-    project_kind: str = "standard"
+    project_kind: str = "direct"
     initialize_state: bool = False
     expected_file_fragments: tuple[tuple[str, tuple[str, ...]], ...] = ()
 

--- a/tests/e2e/src/sqlbuild/cli/commands/main/check/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/check/helpers.py
@@ -285,7 +285,7 @@ def prepare_check_project_by_kind(*, tmp_path: Path, project_kind: str) -> Path:
     """Create the project fixture for a check command test case."""
 
     project_factories: dict[str, Callable[..., Path]] = {
-        "standard": prepare_python_check_project,
+        "direct": prepare_python_check_project,
         "terminal_loader": prepare_terminal_loader_check_project,
         "virtual": prepare_virtual_python_check_project,
         "virtual_failure": prepare_virtual_failing_python_check_project,

--- a/tests/e2e/src/sqlbuild/cli/commands/main/check/test_check.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/check/test_check.py
@@ -280,7 +280,7 @@ def test_given_python_checks_when_running_check_then_reports_expected_results(
     "test_case",
     [
         CheckCommandTestCase(
-            description="standard selected Python check persists check identity",
+            description="direct selected Python check persists check identity",
             command=("--no-color", "check", "--select", "check_orders_export"),
             expected_returncode=0,
             expected_stdout_fragments=("check_orders_export",),
@@ -324,7 +324,7 @@ def test_given_successful_python_check_when_running_check_then_persists_check_id
     "test_case",
     [
         CheckCommandTestCase(
-            description="standard Python checks persist warn and fail result rows",
+            description="direct Python checks persist warn and fail result rows",
             command=("--no-color", "check", "--select", "check:warn_orders_export"),
             expected_returncode=0,
             expected_stdout_fragments=("warn_orders_export", "WARN"),

--- a/tests/e2e/src/sqlbuild/cli/commands/main/databricks/test_databricks.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/databricks/test_databricks.py
@@ -146,7 +146,7 @@ def test_given_databricks_dbt_profile_when_running_dbt_init_then_builds_profile_
     "test_case",
     [
         DatabricksNodeResultE2ETestCase(
-            description="standard node results persist and read on databricks",
+            description="direct node results persist and read on databricks",
             expected_rows=(
                 ("check", "check_produce_result", "success"),
                 ("task", "produce_result", "success"),

--- a/tests/e2e/src/sqlbuild/cli/commands/main/freshness/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/freshness/helpers.py
@@ -167,7 +167,7 @@ def freshness_sources_yml(
     )
 
 
-def persist_standard_source_freshness(*, project_dir: Path) -> None:
+def persist_direct_source_freshness(*, project_dir: Path) -> None:
     initial_build_result: subprocess.CompletedProcess[str] = run_sqb(
         command=("--no-color", "build"),
         project_dir=project_dir,

--- a/tests/e2e/src/sqlbuild/cli/commands/main/freshness/test_freshness.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/freshness/test_freshness.py
@@ -12,7 +12,7 @@ from tests.e2e.src.sqlbuild.cli.commands.main.freshness._test_types import (
 )
 from tests.e2e.src.sqlbuild.cli.commands.main.freshness.helpers import (
     freshness_sources_yml,
-    persist_standard_source_freshness,
+    persist_direct_source_freshness,
     persist_virtual_source_freshness,
     prepare_freshness_project,
     prepare_multi_schema_freshness_project,
@@ -334,7 +334,7 @@ def test_given_existing_source_freshness_state_when_running_then_does_not_write_
     [
         FreshnessE2ETestCase(
             description=(
-                "standard state comparison fails on timestamp movement beyond lag tolerance"
+                "direct state comparison fails on timestamp movement beyond lag tolerance"
             ),
             expected_fragments=(
                 "Changed (1)",
@@ -361,7 +361,7 @@ def test_given_timestamp_freshness_beyond_tolerance_when_state_then_returns_nonz
             "      lag_tolerance: 10m\n"
         ),
     )
-    persist_standard_source_freshness(project_dir=project_dir)
+    persist_direct_source_freshness(project_dir=project_dir)
     (project_dir / "sources" / "raw.yml").write_text(
         freshness_sources_yml(
             raw_orders_freshness=(
@@ -398,7 +398,7 @@ def test_given_timestamp_freshness_beyond_tolerance_when_state_then_returns_nonz
     "test_case",
     [
         FreshnessE2ETestCase(
-            description="standard state comparison fails on backwards timestamp movement",
+            description="direct state comparison fails on backwards timestamp movement",
             expected_fragments=(
                 "Changed (1)",
                 "raw_orders  previous 2026-01-01T00:10:00  current 2026-01-01T00:05:00",
@@ -424,7 +424,7 @@ def test_given_timestamp_freshness_moves_backwards_when_state_then_returns_nonze
             "      lag_tolerance: 10m\n"
         ),
     )
-    persist_standard_source_freshness(project_dir=project_dir)
+    persist_direct_source_freshness(project_dir=project_dir)
     (project_dir / "sources" / "raw.yml").write_text(
         freshness_sources_yml(
             raw_orders_freshness=(
@@ -461,7 +461,7 @@ def test_given_timestamp_freshness_moves_backwards_when_state_then_returns_nonze
     "test_case",
     [
         FreshnessE2ETestCase(
-            description="standard state comparison reads state from multiple target schemas",
+            description="direct state comparison reads state from multiple target schemas",
             expected_fragments=(
                 "Unchanged (1)",
                 "raw_orders  previous 1  current 1",
@@ -476,7 +476,7 @@ def test_given_source_freshness_state_in_secondary_schema_when_running_state_the
     tmp_path: Path,
 ) -> None:
     project_dir: Path = prepare_multi_schema_freshness_project(tmp_path=tmp_path)
-    persist_standard_source_freshness(project_dir=project_dir)
+    persist_direct_source_freshness(project_dir=project_dir)
     execute_duckdb(
         db_path=project_dir / "warehouse.duckdb",
         sql="DELETE FROM dev._sqlbuild_source_freshness",
@@ -497,7 +497,7 @@ def test_given_source_freshness_state_in_secondary_schema_when_running_state_the
     "test_case",
     [
         FreshnessE2ETestCase(
-            description="standard state comparison reports unchanged source freshness",
+            description="direct state comparison reports unchanged source freshness",
             expected_fragments=(
                 "Unchanged (1)",
                 "raw_orders  previous 1  current 1",
@@ -512,7 +512,7 @@ def test_given_persisted_source_freshness_when_running_state_then_reports_unchan
     tmp_path: Path,
 ) -> None:
     project_dir: Path = prepare_freshness_project(tmp_path=tmp_path, include_error_source=False)
-    persist_standard_source_freshness(project_dir=project_dir)
+    persist_direct_source_freshness(project_dir=project_dir)
 
     result: subprocess.CompletedProcess[str] = run_sqb(
         command=("--no-color", "freshness", "--select", "raw_orders", "--state"),
@@ -540,7 +540,7 @@ def test_given_persisted_source_freshness_when_running_state_then_reports_unchan
     "test_case",
     [
         FreshnessE2ETestCase(
-            description="standard state comparison fails on changed source freshness",
+            description="direct state comparison fails on changed source freshness",
             expected_fragments=(
                 "Changed (1)",
                 "raw_orders  previous 1  current 2",
@@ -555,7 +555,7 @@ def test_given_changed_source_freshness_when_running_state_fail_on_stale_then_re
     tmp_path: Path,
 ) -> None:
     project_dir: Path = prepare_freshness_project(tmp_path=tmp_path, include_error_source=False)
-    persist_standard_source_freshness(project_dir=project_dir)
+    persist_direct_source_freshness(project_dir=project_dir)
     (project_dir / "sources" / "raw.yml").write_text(
         freshness_sources_yml(
             raw_orders_query="SELECT 2 AS data_version",
@@ -605,7 +605,7 @@ def test_given_changed_source_freshness_when_running_state_fail_on_stale_then_re
     [
         FreshnessE2ETestCase(
             description=(
-                "standard state comparison tolerates timestamp movement within lag tolerance"
+                "direct state comparison tolerates timestamp movement within lag tolerance"
             ),
             expected_fragments=(
                 "Tolerated (1)",
@@ -632,7 +632,7 @@ def test_given_timestamp_freshness_within_tolerance_when_running_state_then_repo
             "      lag_tolerance: 10m\n"
         ),
     )
-    persist_standard_source_freshness(project_dir=project_dir)
+    persist_direct_source_freshness(project_dir=project_dir)
     (project_dir / "sources" / "raw.yml").write_text(
         freshness_sources_yml(
             raw_orders_freshness=(
@@ -687,7 +687,7 @@ def test_given_timestamp_freshness_within_tolerance_when_running_state_then_repo
     "test_case",
     [
         FreshnessE2ETestCase(
-            description="standard state comparison fails when previous state is missing",
+            description="direct state comparison fails when previous state is missing",
             expected_fragments=(
                 "Unknown (1)",
                 "raw_orders  previous source freshness state missing",

--- a/tests/e2e/src/sqlbuild/cli/commands/main/plan/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/plan/_test_types.py
@@ -84,7 +84,7 @@ class DirectFunctionSelectorE2ETestCase:
 
 
 @dataclass(frozen=True)
-class StandardModeVirtualFlagGuardE2ETestCase:
+class DirectModeVirtualFlagGuardE2ETestCase:
     description: str
     command: tuple[str, ...]
     expected_error_fragment: str

--- a/tests/e2e/src/sqlbuild/cli/commands/main/plan/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/plan/helpers.py
@@ -52,7 +52,7 @@ def build_virtual_plan_project_toml() -> str:
     )
 
 
-def standard_model_version_hashes(*, db_path: Path, model_name: str) -> list[tuple[object, ...]]:
+def direct_model_version_hashes(*, db_path: Path, model_name: str) -> list[tuple[object, ...]]:
     return query_duckdb(
         db_path=db_path,
         sql=(

--- a/tests/e2e/src/sqlbuild/cli/commands/main/plan/test_direct_mode_virtual_flag_guards.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/plan/test_direct_mode_virtual_flag_guards.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from tests.e2e.src.sqlbuild.cli.commands.main.plan._test_types import (
-    StandardModeVirtualFlagGuardE2ETestCase,
+    DirectModeVirtualFlagGuardE2ETestCase,
 )
 from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
     prepare_inline_project,
@@ -17,29 +17,29 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardModeVirtualFlagGuardE2ETestCase(
-            description="plan rejects --virtual-env on a standard-mode project",
+        DirectModeVirtualFlagGuardE2ETestCase(
+            description="plan rejects --virtual-env on a direct-mode project",
             command=("--no-color", "plan", "--virtual-env", "pr_123"),
             expected_error_fragment=(
                 "plan does not support --virtual-env unless virtual_environments = true"
             ),
         ),
-        StandardModeVirtualFlagGuardE2ETestCase(
-            description="plan rejects --include-stale-upstreams on a standard-mode project",
+        DirectModeVirtualFlagGuardE2ETestCase(
+            description="plan rejects --include-stale-upstreams on a direct-mode project",
             command=("--no-color", "plan", "--include-stale-upstreams"),
             expected_error_fragment=(
                 "plan does not support --include-stale-upstreams unless virtual_environments = true"
             ),
         ),
-        StandardModeVirtualFlagGuardE2ETestCase(
-            description="build rejects --virtual-env on a standard-mode project",
+        DirectModeVirtualFlagGuardE2ETestCase(
+            description="build rejects --virtual-env on a direct-mode project",
             command=("--no-color", "build", "--virtual-env", "pr_123"),
             expected_error_fragment=(
                 "build does not support --virtual-env unless virtual_environments = true"
             ),
         ),
-        StandardModeVirtualFlagGuardE2ETestCase(
-            description="build rejects --include-stale-upstreams on a standard-mode project",
+        DirectModeVirtualFlagGuardE2ETestCase(
+            description="build rejects --include-stale-upstreams on a direct-mode project",
             command=("--no-color", "build", "--include-stale-upstreams"),
             expected_error_fragment=(
                 "build does not support --include-stale-upstreams unless "
@@ -49,16 +49,16 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
     ],
     ids=lambda case: case.description,
 )
-def test_given_standard_mode_project_when_passing_virtual_only_flags_then_command_fails(
-    test_case: StandardModeVirtualFlagGuardE2ETestCase,
+def test_given_direct_mode_project_when_passing_virtual_only_flags_then_command_fails(
+    test_case: DirectModeVirtualFlagGuardE2ETestCase,
     tmp_path: Path,
 ) -> None:
     project_dir: Path = prepare_inline_project(
         tmp_path=tmp_path,
-        project_name="standard_mode_flag_guard",
+        project_name="direct_mode_flag_guard",
         repo_files={
             "sqlbuild_project.toml": (
-                'name = "standard_mode_flag_guard"\n'
+                'name = "direct_mode_flag_guard"\n'
                 'adapter = "duckdb"\n\n'
                 "[connection]\n"
                 'database = "warehouse.duckdb"\n'

--- a/tests/e2e/src/sqlbuild/cli/commands/main/postgres/test_postgres.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/postgres/test_postgres.py
@@ -234,7 +234,7 @@ def test_given_postgres_dbt_profile_when_running_dbt_init_then_plain_build_uses_
     "test_case",
     [
         PostgresNodeResultE2ETestCase(
-            description="standard node results persist and read on postgres",
+            description="direct node results persist and read on postgres",
             expected_rows=(
                 ("check", "check_produce_result", "success"),
                 ("task", "produce_result", "success"),

--- a/tests/e2e/src/sqlbuild/cli/commands/main/postgres/test_state.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/postgres/test_state.py
@@ -3287,7 +3287,7 @@ def test_given_postgres_function_change_when_promoting_then_publishes_function_d
     "test_case",
     [
         PostgresVirtualParityE2ETestCase(
-            description="postgres standard mode promotion guard",
+            description="postgres direct mode promotion guard",
             expected_stdout_fragments=("promote requires virtual_environments = true",),
             expected_exit_code=1,
         )

--- a/tests/e2e/src/sqlbuild/cli/commands/main/snowflake/test_snowflake.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/snowflake/test_snowflake.py
@@ -164,7 +164,7 @@ def test_given_snowflake_dbt_profile_when_running_dbt_init_then_builds_profile_l
     "test_case",
     [
         SnowflakeNodeResultE2ETestCase(
-            description="standard node results persist and read on snowflake",
+            description="direct node results persist and read on snowflake",
             expected_rows=(
                 ("check", "check_produce_result", "success"),
                 ("task", "produce_result", "success"),

--- a/tests/e2e/src/sqlbuild/cli/commands/main/sqlserver/test_sqlserver.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/sqlserver/test_sqlserver.py
@@ -414,7 +414,7 @@ def test_given_sqlserver_dbt_profile_when_running_dbt_init_then_builds_profile_l
     "test_case",
     [
         SqlServerNodeResultE2ETestCase(
-            description="standard node results persist and read on SQL Server",
+            description="direct node results persist and read on SQL Server",
             expected_rows=(
                 ("check", "check_produce_result", "success"),
                 ("task", "produce_result", "success"),

--- a/tests/integration/src/sqlbuild/executor/build/test_build_execution.py
+++ b/tests/integration/src/sqlbuild/executor/build/test_build_execution.py
@@ -42,14 +42,14 @@ _PROJECT_YML_WARN: str = (
     'default_audit_severity = "warn"\n'
 )
 
-_PROJECT_YML_DIRECT: str = (
+_PROJECT_YML_IMMEDIATE: str = (
     'name = "demo"\n'
     'adapter = "duckdb"\n\n'
     "[connection]\n"
     'database = ":memory:"\n\n'
     "[settings]\n"
     'default_audit_severity = "error"\n'
-    'table_promotion_mode = "direct"\n'
+    'table_promotion_mode = "immediate"\n'
 )
 
 _NOT_NULL_AUDIT: str = 'AUDIT ();\n\nSELECT @column FROM __ref("@model") WHERE @column IS NULL'
@@ -436,7 +436,7 @@ _FAILING_TEST_SQL: str = (
             ),
         ),
         BuildExecutionTestCase(
-            description="standard mode warn audit records warning and build succeeds",
+            description="immediate promotion warn audit records warning and build succeeds",
             project_files={
                 "sqlbuild_project.toml": (
                     'name = "demo"\n'
@@ -445,7 +445,7 @@ _FAILING_TEST_SQL: str = (
                     'database = ":memory:"\n\n'
                     "[settings]\n"
                     'default_audit_severity = "warn"\n'
-                    'table_promotion_mode = "direct"\n'
+                    'table_promotion_mode = "immediate"\n'
                 ),
                 "models/orders.sql": _TABLE_WITH_ID_NOT_NULL_AUDIT + "SELECT NULL AS id",
                 "audits/generic/not_null.sql": _NOT_NULL_AUDIT,
@@ -473,9 +473,9 @@ _FAILING_TEST_SQL: str = (
             ),
         ),
         BuildExecutionTestCase(
-            description="standard mode with passing audit creates table",
+            description="immediate promotion with passing audit creates table",
             project_files={
-                "sqlbuild_project.toml": _PROJECT_YML_DIRECT,
+                "sqlbuild_project.toml": _PROJECT_YML_IMMEDIATE,
                 "models/orders.sql": _TABLE_WITH_ID_NOT_NULL_AUDIT + "SELECT 5 AS id",
                 "audits/generic/not_null.sql": _NOT_NULL_AUDIT,
             },
@@ -697,9 +697,9 @@ def test_given_view_with_run_audits_false_when_executing_then_succeeds(
             expected_missing_relations=("main.orders",),
         ),
         BuildExecutionTestCase(
-            description="direct table promotion rejects enforced contract before mutation",
+            description="immediate table promotion rejects enforced contract before mutation",
             project_files={
-                "sqlbuild_project.toml": _PROJECT_YML_DIRECT,
+                "sqlbuild_project.toml": _PROJECT_YML_IMMEDIATE,
                 "models/orders.sql": (
                     "MODEL (\n"
                     "  materialized table,\n"
@@ -1003,9 +1003,9 @@ def test_given_view_with_run_audits_false_when_executing_then_succeeds(
             expected_missing_relations=("main.stg_orders", "main.orders"),
         ),
         BuildExecutionTestCase(
-            description="standard mode failing audit leaves target updated but build fails",
+            description="immediate promotion failing audit leaves target updated but build fails",
             project_files={
-                "sqlbuild_project.toml": _PROJECT_YML_DIRECT,
+                "sqlbuild_project.toml": _PROJECT_YML_IMMEDIATE,
                 "models/orders.sql": _TABLE_WITH_ID_NOT_NULL_AUDIT + "SELECT NULL AS id",
                 "audits/generic/not_null.sql": _NOT_NULL_AUDIT,
             },

--- a/tests/integration/src/sqlbuild/executor/run/test_table_execution.py
+++ b/tests/integration/src/sqlbuild/executor/run/test_table_execution.py
@@ -180,21 +180,21 @@ def test_given_staged_table_when_executing_then_fails(
     "test_case",
     [
         TableSuccessTestCase(
-            description="direct table creates target from query",
+            description="immediate table creates target from query",
             setup_sql=(),
             model_sql="SELECT 1 AS id, 'alice' AS name",
             target_schema="staging",
             target_name="orders",
-            promotion_mode=TablePromotionMode.DIRECT,
+            promotion_mode=TablePromotionMode.IMMEDIATE,
             expected_row_count=1,
         ),
         TableSuccessTestCase(
-            description="direct table with passing audit succeeds end-to-end",
+            description="immediate table with passing audit succeeds end-to-end",
             setup_sql=(),
             model_sql="SELECT 1 AS id, 'alice' AS name",
             target_schema="staging",
             target_name="orders",
-            promotion_mode=TablePromotionMode.DIRECT,
+            promotion_mode=TablePromotionMode.IMMEDIATE,
             audit_sql='SELECT id FROM __ref("orders") WHERE id IS NULL',
             audit_severity="error",
             expected_row_count=1,
@@ -203,7 +203,7 @@ def test_given_staged_table_when_executing_then_fails(
     ],
     ids=lambda case: case.description,
 )
-def test_given_direct_table_when_executing_then_succeeds(
+def test_given_immediate_table_when_executing_then_succeeds(
     test_case: TableSuccessTestCase,
     adapter: DuckDbAdapter,
     connection: Any,
@@ -222,36 +222,36 @@ def test_given_direct_table_when_executing_then_succeeds(
     "test_case",
     [
         TableFailureTestCase(
-            description="direct table with type enforcement fails",
+            description="immediate table with type enforcement fails",
             setup_sql=(),
             model_sql="SELECT 1 AS id",
             target_schema="staging",
             target_name="orders",
-            promotion_mode=TablePromotionMode.DIRECT,
+            promotion_mode=TablePromotionMode.IMMEDIATE,
             type_enforcement=True,
             declared_columns=(("id", "BIGINT"),),
             expected_failed_phase=ExecutionPhase.TYPE_ENFORCEMENT,
             expected_error_fragment="requires staged promotion mode",
         ),
         TableFailureTestCase(
-            description="direct failing post_hook marks model failed with promoted relation",
+            description="immediate failing post_hook marks model failed with promoted relation",
             setup_sql=(),
             model_sql="SELECT 1 AS id",
             target_schema="staging",
             target_name="orders",
-            promotion_mode=TablePromotionMode.DIRECT,
+            promotion_mode=TablePromotionMode.IMMEDIATE,
             post_hook=[SqlHookEntry(statement="THIS IS NOT VALID SQL")],
             expected_failed_phase=ExecutionPhase.POST_HOOK,
             expected_promoted_relation="staging.orders",
             expected_row_count=1,
         ),
         TableFailureTestCase(
-            description="direct failing error audit reports target already updated",
+            description="immediate failing error audit reports target already updated",
             setup_sql=(),
             model_sql="SELECT NULL AS id, 'alice' AS name",
             target_schema="staging",
             target_name="orders",
-            promotion_mode=TablePromotionMode.DIRECT,
+            promotion_mode=TablePromotionMode.IMMEDIATE,
             audit_sql='SELECT id FROM __ref("orders") WHERE id IS NULL',
             audit_severity="error",
             expected_failed_phase=ExecutionPhase.AUDIT,
@@ -262,7 +262,7 @@ def test_given_direct_table_when_executing_then_succeeds(
     ],
     ids=lambda case: case.description,
 )
-def test_given_direct_table_when_executing_then_fails(
+def test_given_immediate_table_when_executing_then_fails(
     test_case: TableFailureTestCase,
     adapter: DuckDbAdapter,
     connection: Any,

--- a/tests/unit/scripts/fensu_policy/rules/test_source_hygiene.py
+++ b/tests/unit/scripts/fensu_policy/rules/test_source_hygiene.py
@@ -18,7 +18,7 @@ from tests.unit.scripts.fensu_policy.rules._test_types import CustomRuleTestCase
         ),
         CustomRuleTestCase(
             description="target reuse source relation faults per line",
-            path="src/sqlbuild/compiler/planner/_helpers/standard_reuse_example.py",
+            path="src/sqlbuild/compiler/planner/_helpers/direct_reuse_example.py",
             source=(
                 "def build_origin() -> str:\n"
                 "    source_relation = 'prod.orders'\n"

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/runtime/test_mode_policy.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/runtime/test_mode_policy.py
@@ -54,7 +54,7 @@ def test_given_virtual_mode_defer_to_when_enforcing_flag_support_then_raises_cli
     "test_case",
     [
         ModeGuardTestCase(
-            description="blocks --virtual-env on standard-mode plan",
+            description="blocks --virtual-env on direct-mode plan",
             virtual_environments=False,
             command_name="plan",
             virtual_env="pr_123",
@@ -63,7 +63,7 @@ def test_given_virtual_mode_defer_to_when_enforcing_flag_support_then_raises_cli
             ),
         ),
         ModeGuardTestCase(
-            description="blocks --include-stale-upstreams on standard-mode build",
+            description="blocks --include-stale-upstreams on direct-mode build",
             virtual_environments=False,
             command_name="build",
             include_stale_upstreams=True,
@@ -75,7 +75,7 @@ def test_given_virtual_mode_defer_to_when_enforcing_flag_support_then_raises_cli
     ],
     ids=lambda case: case.description,
 )
-def test_given_standard_mode_virtual_only_flags_when_enforcing_then_raises_cli_user_error(
+def test_given_direct_mode_virtual_only_flags_when_enforcing_then_raises_cli_user_error(
     test_case: ModeGuardTestCase,
 ) -> None:
     discovered_inputs: DiscoveredProjectInputs = DiscoveredProjectInputs(
@@ -111,7 +111,7 @@ def test_given_standard_mode_virtual_only_flags_when_enforcing_then_raises_cli_u
             expected_error_fragment=None,
         ),
         ModeGuardTestCase(
-            description="allows standard-mode plan without virtual-only flags",
+            description="allows direct-mode plan without virtual-only flags",
             virtual_environments=False,
             command_name="plan",
             expected_error_fragment=None,

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/test_source_freshness.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/test_source_freshness.py
@@ -7,12 +7,12 @@ import pytest
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.cli.commands._helpers.freshness.source_freshness import (
-    append_eligible_standard_source_freshness_records,
+    append_eligible_direct_source_freshness_records,
 )
 from sqlbuild.compiler.planner.models import PlanOutput
 from sqlbuild.compiler.source_freshness.models import (
-    StandardSourceFreshnessPlanningResult,
-    StandardSourceFreshnessPropagationResult,
+    DirectSourceFreshnessPlanningResult,
+    DirectSourceFreshnessPropagationResult,
 )
 from sqlbuild.cost.classes.cost_context import CostContext
 from sqlbuild.cost.models import CostResourceContext
@@ -52,13 +52,13 @@ def test_given_source_freshness_observation_when_appending_then_requires_success
 ) -> None:
     adapter: RecordingAdapter = RecordingAdapter()
 
-    append_eligible_standard_source_freshness_records(
+    append_eligible_direct_source_freshness_records(
         plan=PlanOutput(
             model_entries=(model_entry("orders"),),
-            source_freshness=StandardSourceFreshnessPlanningResult(
+            source_freshness=DirectSourceFreshnessPlanningResult(
                 observed_records=(source_freshness_record(),),
                 changed_identities=frozenset({source_freshness_identity()}),
-                propagation=StandardSourceFreshnessPropagationResult(
+                propagation=DirectSourceFreshnessPropagationResult(
                     changed_source_model_names={source_freshness_identity(): frozenset({"orders"})},
                     stale_model_names=frozenset({"orders"}),
                 ),
@@ -101,13 +101,13 @@ def test_given_eligible_source_freshness_when_appending_then_uses_adapter_render
         resource_name="dev",
         phase="build",
     ):
-        append_eligible_standard_source_freshness_records(
+        append_eligible_direct_source_freshness_records(
             plan=PlanOutput(
                 model_entries=(model_entry("orders"),),
-                source_freshness=StandardSourceFreshnessPlanningResult(
+                source_freshness=DirectSourceFreshnessPlanningResult(
                     observed_records=(source_freshness_record(),),
                     changed_identities=frozenset({source_freshness_identity()}),
-                    propagation=StandardSourceFreshnessPropagationResult(
+                    propagation=DirectSourceFreshnessPropagationResult(
                         changed_source_model_names={
                             source_freshness_identity(): frozenset({"orders"})
                         },
@@ -154,10 +154,10 @@ def test_given_eligible_source_freshness_when_appending_then_reuses_plan_time_ob
 ) -> None:
     adapter: RecordingAdapter = RecordingAdapter()
 
-    append_eligible_standard_source_freshness_records(
+    append_eligible_direct_source_freshness_records(
         plan=PlanOutput(
             model_entries=(model_entry("orders"),),
-            source_freshness=StandardSourceFreshnessPlanningResult(
+            source_freshness=DirectSourceFreshnessPlanningResult(
                 observed_records=(
                     source_freshness_record(
                         run_id="planning-run",
@@ -166,7 +166,7 @@ def test_given_eligible_source_freshness_when_appending_then_reuses_plan_time_ob
                     ),
                 ),
                 changed_identities=frozenset({source_freshness_identity()}),
-                propagation=StandardSourceFreshnessPropagationResult(
+                propagation=DirectSourceFreshnessPropagationResult(
                     changed_source_model_names={source_freshness_identity(): frozenset({"orders"})},
                     stale_model_names=frozenset({"orders"}),
                 ),

--- a/tests/unit/src/sqlbuild/cli/output/main/plan/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/plan/_test_types.py
@@ -17,7 +17,7 @@ class FormatPlanTestCase:
     plan_output: PlanOutput
     full_refresh: bool = False
     display_options: DisplayOptions | None = None
-    include_standard_freshness_diagnostics: bool = True
+    include_direct_freshness_diagnostics: bool = True
     python_plan_entries: tuple[PythonPlanEntry, ...] = field(default_factory=tuple)
     expected_fragments: tuple[str, ...] = field(default_factory=tuple)
     unexpected_fragments: tuple[str, ...] = field(default_factory=tuple)

--- a/tests/unit/src/sqlbuild/cli/output/main/plan/test_plan_text.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/plan/test_plan_text.py
@@ -53,7 +53,7 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
         FormatPlanTestCase(
             description="changes-only pruned models are visible as current skips",
             plan_output=build_plan_output(
-                metadata={"standard_pruned_model_names": ("customer_revenue_check",)}
+                metadata={"direct_pruned_model_names": ("customer_revenue_check",)}
             ),
             expected_fragments=(
                 "Plan ready  0 selected",
@@ -64,7 +64,7 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
         FormatPlanTestCase(
             description="verbose changes-only pruned models show current model names",
             plan_output=build_plan_output(
-                metadata={"standard_pruned_model_names": ("customer_revenue_check",)}
+                metadata={"direct_pruned_model_names": ("customer_revenue_check",)}
             ),
             display_options=DisplayOptions(max_entries_per_section=None),
             expected_fragments=(
@@ -78,7 +78,7 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
             description="source freshness age warnings and errors are visible",
             plan_output=build_plan_output(
                 metadata={
-                    "standard_source_freshness": {
+                    "direct_source_freshness": {
                         "observed_source_names": ("raw.orders", "raw.payments"),
                         "changed_source_names": (),
                         "unchanged_source_names": ("raw.orders",),
@@ -101,7 +101,7 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
             ),
         ),
         FormatPlanTestCase(
-            description="standard non-changes-only output hides freshness diagnostics only",
+            description="direct non-changes-only output hides freshness diagnostics only",
             plan_output=build_plan_output(
                 source_load_entries=(build_source_load_entry(name="raw_orders"),),
                 warnings=(
@@ -118,7 +118,7 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
                     ),
                 ),
                 metadata={
-                    "standard_source_freshness": {
+                    "direct_source_freshness": {
                         "observed_source_names": ("raw_orders",),
                         "changed_source_names": ("raw_orders",),
                         "unchanged_source_names": (),
@@ -127,7 +127,7 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
                     }
                 },
             ),
-            include_standard_freshness_diagnostics=False,
+            include_direct_freshness_diagnostics=False,
             expected_fragments=(
                 "Sources to load (1)",
                 "raw_orders",
@@ -1144,7 +1144,7 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
             description="direct metadata caps remaining stale models after partial selection",
             plan_output=build_plan_output(
                 metadata={
-                    "standard_remaining_stale_model_names": tuple(
+                    "direct_remaining_stale_model_names": tuple(
                         f"model_{index:02d}" for index in range(55)
                     ),
                 },
@@ -1160,7 +1160,7 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
             description="direct metadata shows full remaining stale set in verbose output",
             plan_output=build_plan_output(
                 metadata={
-                    "standard_remaining_stale_model_names": tuple(
+                    "direct_remaining_stale_model_names": tuple(
                         f"model_{index:02d}" for index in range(3)
                     ),
                 },
@@ -1243,7 +1243,7 @@ def test_given_plan_output_when_formatting_then_contains_expected_fragments(
         full_refresh=test_case.full_refresh,
         use_color=False,
         display_options=test_case.display_options,
-        include_standard_freshness_diagnostics=(test_case.include_standard_freshness_diagnostics),
+        include_direct_freshness_diagnostics=(test_case.include_direct_freshness_diagnostics),
         python_plan_entries=test_case.python_plan_entries,
     )
 
@@ -1326,7 +1326,7 @@ def test_given_plan_output_when_formatting_then_contains_expected_fragments(
                     ),
                 ),
                 metadata={
-                    "standard_source_freshness": {
+                    "direct_source_freshness": {
                         "observed_source_names": ("raw_orders",),
                         "changed_source_names": ("raw_orders",),
                         "unchanged_source_names": (),

--- a/tests/unit/src/sqlbuild/compiler/pipeline/main/test_plan_work.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/main/test_plan_work.py
@@ -25,7 +25,7 @@ from tests.unit.src.sqlbuild.compiler.pipeline.main.helpers import build_plan_ou
         ),
         PlanWorkTestCase(
             description="pruned metadata alone has no executable work",
-            plan_output=PlanOutput(metadata={"standard_pruned_model_names": ("orders",)}),
+            plan_output=PlanOutput(metadata={"direct_pruned_model_names": ("orders",)}),
             python_plan_entries=(),
             expected_has_work=False,
         ),

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/helpers.py
@@ -69,9 +69,9 @@ from sqlbuild.compiler.planner.types import (
 )
 from sqlbuild.compiler.references.types import SqlReferenceKind
 from sqlbuild.compiler.source_freshness.models import (
+    DirectSourceFreshnessPlanningResult,
     SourceFreshnessIdentity,
     SourceFreshnessRecord,
-    StandardSourceFreshnessPlanningResult,
 )
 from sqlbuild.spec.contracts.models import (
     SchemaColumn,
@@ -251,7 +251,7 @@ def build_run_despite_unchanged_model(
 
 def build_run_despite_unchanged_source_freshness(
     *, data_version: str | None, value_kind: str, observed_at: datetime
-) -> StandardSourceFreshnessPlanningResult:
+) -> DirectSourceFreshnessPlanningResult:
     """Build source freshness state for run_despite_unchanged helper tests."""
 
     record: SourceFreshnessRecord = SourceFreshnessRecord(
@@ -266,7 +266,7 @@ def build_run_despite_unchanged_source_freshness(
         data_version_hash="hash",
         observed_at=observed_at,
     )
-    populated_result: StandardSourceFreshnessPlanningResult = StandardSourceFreshnessPlanningResult(
+    populated_result: DirectSourceFreshnessPlanningResult = DirectSourceFreshnessPlanningResult(
         observed_records=(record,),
         unchanged_identities=frozenset(
             {
@@ -279,7 +279,7 @@ def build_run_despite_unchanged_source_freshness(
             }
         ),
     )
-    return (StandardSourceFreshnessPlanningResult(), populated_result)[data_version is not None]
+    return (DirectSourceFreshnessPlanningResult(), populated_result)[data_version is not None]
 
 
 def source_key(name: str) -> CompiledObjectKey:

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_run_despite_unchanged.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_run_despite_unchanged.py
@@ -9,7 +9,7 @@ from sqlbuild.compiler.planner._helpers.pruning.run_despite_unchanged import (
 )
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.models import PlannerScope, RunDespiteUnchangedPlanningResult
-from sqlbuild.compiler.source_freshness.models import StandardSourceFreshnessPlanningResult
+from sqlbuild.compiler.source_freshness.models import DirectSourceFreshnessPlanningResult
 from sqlbuild.spec.contracts.types import SourceFreshnessValueKind
 from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
     RunDespiteUnchangedPlanningTestCase,
@@ -62,7 +62,7 @@ def test_given_valid_run_despite_unchanged_config_when_planning_then_returns_exp
         run_despite_unchanged=test_case.run_despite_unchanged,
         materialized=test_case.materialized,
     )
-    source_freshness: StandardSourceFreshnessPlanningResult = (
+    source_freshness: DirectSourceFreshnessPlanningResult = (
         build_run_despite_unchanged_source_freshness(
             data_version=test_case.data_version,
             value_kind=test_case.value_kind,
@@ -124,7 +124,7 @@ def test_given_invalid_run_despite_unchanged_config_when_planning_then_raises_er
         run_despite_unchanged=test_case.run_despite_unchanged,
         materialized=test_case.materialized,
     )
-    source_freshness: StandardSourceFreshnessPlanningResult = (
+    source_freshness: DirectSourceFreshnessPlanningResult = (
         build_run_despite_unchanged_source_freshness(
             data_version=test_case.data_version,
             value_kind=test_case.value_kind,

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_selection_staleness.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_selection_staleness.py
@@ -18,20 +18,20 @@ from sqlbuild.compiler.planner._helpers.pruning.selection_staleness import (
 )
 from sqlbuild.compiler.planner.models import (
     ChangeDetectionResult,
+    DirectModelVersionIdentities,
     PlannerChangeResults,
     PlannerPolicies,
     PlannerScope,
     PlannerScopeResolution,
     PlannerSelection,
     PlanWarning,
-    StandardModelVersionIdentities,
     WarehouseFingerprints,
     WarehouseSnapshot,
 )
 from sqlbuild.compiler.planner.types import ChangeKind
 from sqlbuild.compiler.source_freshness.models import (
+    DirectSourceFreshnessPlanningResult,
     SourceFreshnessIdentity,
-    StandardSourceFreshnessPlanningResult,
 )
 from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
     PlannerStaleWarningScopeTestCase,
@@ -240,7 +240,7 @@ def test_given_seed_or_source_change_when_classifying_then_warns_only_if_unselec
                 }
             )
         ),
-        version_identities=StandardModelVersionIdentities(
+        version_identities=DirectModelVersionIdentities(
             function_local_hashes={},
             seed_version_hashes={"orders_seed": "new_seed_hash"},
             seed_metadata_jsons={},
@@ -248,7 +248,7 @@ def test_given_seed_or_source_change_when_classifying_then_warns_only_if_unselec
             model_local_hashes={},
             model_version_hashes={},
         ),
-        source_freshness=StandardSourceFreshnessPlanningResult(
+        source_freshness=DirectSourceFreshnessPlanningResult(
             changed_identities=frozenset({SOURCE_IDENTITY})
         ),
     )
@@ -468,7 +468,7 @@ def test_given_stale_upstream_graph_when_classifying_then_reports_expected_trigg
             functions={},
         ),
         snapshot=WarehouseSnapshot(fingerprints=WarehouseFingerprints(seeds=seed_fingerprints)),
-        version_identities=StandardModelVersionIdentities(
+        version_identities=DirectModelVersionIdentities(
             function_local_hashes={},
             seed_version_hashes={
                 seed_name: "new_seed_hash" for seed_name in test_case.changed_seed_names
@@ -478,9 +478,7 @@ def test_given_stale_upstream_graph_when_classifying_then_reports_expected_trigg
             model_local_hashes={},
             model_version_hashes={},
         ),
-        source_freshness=StandardSourceFreshnessPlanningResult(
-            changed_identities=source_identities
-        ),
+        source_freshness=DirectSourceFreshnessPlanningResult(changed_identities=source_identities),
     )
     warning_text: str = "\n".join(warning.message for warning in warnings)
 

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_source_freshness.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_source_freshness.py
@@ -10,7 +10,7 @@ from sqlbuild.compiler.planner._helpers.warehouse.source_freshness import (
     build_planner_source_freshness_result,
 )
 from sqlbuild.compiler.planner.models import PlannerRelationsContext, PlannerScope
-from sqlbuild.compiler.source_freshness.models import StandardSourceFreshnessPlanningResult
+from sqlbuild.compiler.source_freshness.models import DirectSourceFreshnessPlanningResult
 from sqlbuild.spec.contracts.models import SourceEntry, SourceFreshnessConfig
 from sqlbuild.spec.contracts.types import SourceFreshnessStrategy, SourceFreshnessValueKind
 from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
@@ -34,7 +34,7 @@ def test_given_source_deferral_context_when_building_source_freshness_then_uses_
     adapter: DuckDbAdapter = DuckDbAdapter()
     connection: Any = adapter.connect({"database": ":memory:"})
     try:
-        result: StandardSourceFreshnessPlanningResult = build_planner_source_freshness_result(
+        result: DirectSourceFreshnessPlanningResult = build_planner_source_freshness_result(
             project=CompiledProject(
                 run_id="test_run",
                 effective_target_name=None,

--- a/tests/unit/src/sqlbuild/compiler/planner/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/main/_test_types.py
@@ -18,7 +18,7 @@ class CloneBoundaryTestCase:
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessPlanOutputTestCase:
+class DirectSourceFreshnessPlanOutputTestCase:
     description: str
     expected_has_source_freshness: bool
 
@@ -36,7 +36,7 @@ class ExternalBlockedPlanOutputTestCase:
 
 
 @dataclass(frozen=True)
-class StandardDirectInputBaselineTestCase:
+class DirectInputBaselineTestCase:
     description: str
     models_by_name: dict[str, str]
     origin_model_names: tuple[str, ...]

--- a/tests/unit/src/sqlbuild/compiler/planner/main/identity/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/main/identity/helpers.py
@@ -11,14 +11,14 @@ from sqlbuild.compiler.compile.models import (
 )
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner._helpers.graph.core import build_downstream_deps
-from sqlbuild.compiler.planner._helpers.identity.standard import (
-    build_standard_model_version_identities,
+from sqlbuild.compiler.planner._helpers.identity.direct import (
+    build_direct_model_version_identities,
 )
-from sqlbuild.compiler.planner.models import PlannerScope, StandardModelVersionIdentities
+from sqlbuild.compiler.planner.models import DirectModelVersionIdentities, PlannerScope
 from tests.unit.src.sqlbuild.compiler.planner._helpers.helpers import build_compiled_function
 
 
-def build_table_function_graph_identities(*, base_query: str) -> StandardModelVersionIdentities:
+def build_table_function_graph_identities(*, base_query: str) -> DirectModelVersionIdentities:
     base_key: CompiledObjectKey = CompiledObjectKey(
         resource_type=CompiledResourceType.MODEL,
         name="orders",
@@ -65,7 +65,7 @@ def build_table_function_graph_identities(*, base_query: str) -> StandardModelVe
         selected_keys=frozenset(upstream),
         execution_order=(base_key, function_key, consumer_key),
     )
-    return build_standard_model_version_identities(functions=(function,), scope=scope)
+    return build_direct_model_version_identities(functions=(function,), scope=scope)
 
 
 def _build_model(

--- a/tests/unit/src/sqlbuild/compiler/planner/main/identity/test_version_identity_function_hashes.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/main/identity/test_version_identity_function_hashes.py
@@ -13,7 +13,7 @@ from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.main.identity.version_identity_function_hashes import (
     build_function_local_hashes,
 )
-from sqlbuild.compiler.planner.models import StandardModelVersionIdentities
+from sqlbuild.compiler.planner.models import DirectModelVersionIdentities
 from tests.unit.src.sqlbuild.compiler.planner._helpers.helpers import build_compiled_function
 from tests.unit.src.sqlbuild.compiler.planner.main.identity._test_types import (
     FunctionReturnContractIdentityTestCase,
@@ -77,10 +77,10 @@ def test_given_table_function_return_contract_change_when_hashing_then_identity_
 def test_given_function_upstream_change_when_hashing_then_consumer_identity_changes(
     test_case: FunctionUpstreamIdentityTestCase,
 ) -> None:
-    original: StandardModelVersionIdentities = build_table_function_graph_identities(
+    original: DirectModelVersionIdentities = build_table_function_graph_identities(
         base_query=test_case.original_query
     )
-    changed: StandardModelVersionIdentities = build_table_function_graph_identities(
+    changed: DirectModelVersionIdentities = build_table_function_graph_identities(
         base_query=test_case.changed_query
     )
 

--- a/tests/unit/src/sqlbuild/compiler/planner/main/test_execution.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/main/test_execution.py
@@ -17,9 +17,9 @@ from sqlbuild.compiler.planner.types import (
     PlanReason,
 )
 from tests.unit.src.sqlbuild.compiler.planner.main._test_types import (
+    DirectSourceFreshnessPlanOutputTestCase,
     ExternalBlockedPlanOutputTestCase,
     HookFunctionPlanOutputTestCase,
-    StandardSourceFreshnessPlanOutputTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.planner.main.helpers import (
     build_execution_plan_from_kwargs,
@@ -30,15 +30,15 @@ from tests.unit.src.sqlbuild.integrations.dbt.helpers import build_compiled_proj
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardSourceFreshnessPlanOutputTestCase(
-            description="standard plan output carries source freshness result",
+        DirectSourceFreshnessPlanOutputTestCase(
+            description="direct plan output carries source freshness result",
             expected_has_source_freshness=True,
         ),
     ],
     ids=lambda case: case.description,
 )
 def test_given_direct_plan_when_building_execution_plan_then_source_freshness_is_available(
-    test_case: StandardSourceFreshnessPlanOutputTestCase,
+    test_case: DirectSourceFreshnessPlanOutputTestCase,
 ) -> None:
     adapter: DuckDbAdapter = DuckDbAdapter()
     connection: Any = adapter.connect({"database": ":memory:"})

--- a/tests/unit/src/sqlbuild/compiler/source_freshness/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/source_freshness/main/_test_types.py
@@ -68,7 +68,7 @@ class SharedSourceFreshnessHashTestCase:
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessPlanningTestCase:
+class DirectSourceFreshnessPlanningTestCase:
     description: str
     previous_data_version: str | None
     current_query: str
@@ -77,7 +77,7 @@ class StandardSourceFreshnessPlanningTestCase:
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessLagToleranceTestCase:
+class DirectSourceFreshnessLagToleranceTestCase:
     description: str
     current_query: str
     expected_changed_count: int
@@ -85,7 +85,7 @@ class StandardSourceFreshnessLagToleranceTestCase:
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessAgePolicyTestCase:
+class DirectSourceFreshnessAgePolicyTestCase:
     description: str
     current_query: str
     warn_after: str | None
@@ -96,13 +96,13 @@ class StandardSourceFreshnessAgePolicyTestCase:
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessUnknownTestCase:
+class DirectSourceFreshnessUnknownTestCase:
     description: str
     expected_unknown_source_names: tuple[str, ...]
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessAdapterDefaultTestCase:
+class DirectSourceFreshnessAdapterDefaultTestCase:
     description: str
     expected_changed_count: int
     expected_observed_count: int
@@ -110,28 +110,28 @@ class StandardSourceFreshnessAdapterDefaultTestCase:
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessManagedSkipTestCase:
+class DirectSourceFreshnessManagedSkipTestCase:
     description: str
     expected_observed_count: int
     expected_unknown_source_names: tuple[str, ...]
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessMultiSchemaTestCase:
+class DirectSourceFreshnessMultiSchemaTestCase:
     description: str
     expected_previous_count: int
     expected_unchanged_count: int
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessDuplicateSchemaTestCase:
+class DirectSourceFreshnessDuplicateSchemaTestCase:
     description: str
     expected_previous_data_version: str
     expected_changed_count: int
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessPropagationTestCase:
+class DirectSourceFreshnessPropagationTestCase:
     description: str
     changed_source_names: tuple[str, ...]
     unknown_source_names: tuple[str, ...]
@@ -153,7 +153,7 @@ class SharedSourceFreshnessExpressionSubqueryTestCase:
 
 
 @dataclass(frozen=True)
-class StandardSourceFreshnessExpressionTestCase:
+class DirectSourceFreshnessExpressionTestCase:
     description: str
     expression: str
     column: str

--- a/tests/unit/src/sqlbuild/compiler/source_freshness/main/test_planning.py
+++ b/tests/unit/src/sqlbuild/compiler/source_freshness/main/test_planning.py
@@ -10,16 +10,16 @@ from sqlbuild.adapter.contract.models import TableFreshnessMetadata, TableFreshn
 from sqlbuild.adapter.contract.types import FrameworkType
 from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
 from sqlbuild.compiler.source_freshness.main._planning import (
-    build_standard_source_freshness_planning_result,
+    build_direct_source_freshness_planning_result,
 )
 from sqlbuild.compiler.source_freshness.main.data_version_hash import (
     source_freshness_data_version_hash,
 )
 from sqlbuild.compiler.source_freshness.main.write import write_source_freshness_records
 from sqlbuild.compiler.source_freshness.models import (
+    DirectSourceFreshnessPlanningResult,
     SourceFreshnessRecord,
     SourceFreshnessRenderers,
-    StandardSourceFreshnessPlanningResult,
 )
 from sqlbuild.spec.contracts.models import (
     SourceEntry,
@@ -28,15 +28,15 @@ from sqlbuild.spec.contracts.models import (
 )
 from sqlbuild.spec.contracts.types import SourceFreshnessStrategy, SourceFreshnessValueKind
 from tests.unit.src.sqlbuild.compiler.source_freshness.main._test_types import (
-    StandardSourceFreshnessAdapterDefaultTestCase,
-    StandardSourceFreshnessAgePolicyTestCase,
-    StandardSourceFreshnessDuplicateSchemaTestCase,
-    StandardSourceFreshnessExpressionTestCase,
-    StandardSourceFreshnessLagToleranceTestCase,
-    StandardSourceFreshnessManagedSkipTestCase,
-    StandardSourceFreshnessMultiSchemaTestCase,
-    StandardSourceFreshnessPlanningTestCase,
-    StandardSourceFreshnessUnknownTestCase,
+    DirectSourceFreshnessAdapterDefaultTestCase,
+    DirectSourceFreshnessAgePolicyTestCase,
+    DirectSourceFreshnessDuplicateSchemaTestCase,
+    DirectSourceFreshnessExpressionTestCase,
+    DirectSourceFreshnessLagToleranceTestCase,
+    DirectSourceFreshnessManagedSkipTestCase,
+    DirectSourceFreshnessMultiSchemaTestCase,
+    DirectSourceFreshnessPlanningTestCase,
+    DirectSourceFreshnessUnknownTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.source_freshness.main.helpers import (
     state_table_exists_map,
@@ -93,22 +93,22 @@ class FreshnessMetadataDuckDbAdapter(DuckDbAdapter):
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardSourceFreshnessPlanningTestCase(
-            description="classifies first standard source freshness observation as changed",
+        DirectSourceFreshnessPlanningTestCase(
+            description="classifies first direct source freshness observation as changed",
             previous_data_version=None,
             current_query="SELECT 1 AS data_version",
             expected_changed_count=1,
             expected_unchanged_count=0,
         ),
-        StandardSourceFreshnessPlanningTestCase(
-            description="classifies matching previous standard source freshness as unchanged",
+        DirectSourceFreshnessPlanningTestCase(
+            description="classifies matching previous direct source freshness as unchanged",
             previous_data_version="1",
             current_query="SELECT 1 AS data_version",
             expected_changed_count=0,
             expected_unchanged_count=1,
         ),
-        StandardSourceFreshnessPlanningTestCase(
-            description="classifies different previous standard source freshness as changed",
+        DirectSourceFreshnessPlanningTestCase(
+            description="classifies different previous direct source freshness as changed",
             previous_data_version="1",
             current_query="SELECT 2 AS data_version",
             expected_changed_count=1,
@@ -117,8 +117,8 @@ class FreshnessMetadataDuckDbAdapter(DuckDbAdapter):
     ],
     ids=lambda case: case.description,
 )
-def test_given_standard_source_freshness_state_when_planning_then_classifies_hash_comparison(
-    test_case: StandardSourceFreshnessPlanningTestCase,
+def test_given_direct_source_freshness_state_when_planning_then_classifies_hash_comparison(
+    test_case: DirectSourceFreshnessPlanningTestCase,
 ) -> None:
     adapter: DuckDbAdapter = DuckDbAdapter()
     connection: Any = adapter.connect({"database": ":memory:"})
@@ -140,23 +140,21 @@ def test_given_standard_source_freshness_state_when_planning_then_classifies_has
             data_version=test_case.previous_data_version,
         )
 
-        result: StandardSourceFreshnessPlanningResult = (
-            build_standard_source_freshness_planning_result(
+        result: DirectSourceFreshnessPlanningResult = build_direct_source_freshness_planning_result(
+            adapter=adapter,
+            connection=connection,
+            sources=(source,),
+            state_database=None,
+            state_schemas=("state_schema",),
+            observed_at=datetime(2026, 1, 15, 12, 0, 0),
+            run_id="planning",
+            render_qualified_name=RENDER_QUALIFIED_NAME,
+            state_table_exists_by_schema=state_table_exists_map(
                 adapter=adapter,
                 connection=connection,
-                sources=(source,),
                 state_database=None,
                 state_schemas=("state_schema",),
-                observed_at=datetime(2026, 1, 15, 12, 0, 0),
-                run_id="planning",
-                render_qualified_name=RENDER_QUALIFIED_NAME,
-                state_table_exists_by_schema=state_table_exists_map(
-                    adapter=adapter,
-                    connection=connection,
-                    state_database=None,
-                    state_schemas=("state_schema",),
-                ),
-            )
+            ),
         )
     finally:
         adapter.close(connection)
@@ -169,7 +167,7 @@ def test_given_standard_source_freshness_state_when_planning_then_classifies_has
 @pytest.mark.parametrize(
     "test_case",
     (
-        StandardSourceFreshnessAgePolicyTestCase(
+        DirectSourceFreshnessAgePolicyTestCase(
             description="fresh timestamp passes age policy",
             current_query="SELECT CAST('2026-01-15 11:30:00' AS TIMESTAMP) AS data_version",
             warn_after="1h",
@@ -177,7 +175,7 @@ def test_given_standard_source_freshness_state_when_planning_then_classifies_has
             value_kind=SourceFreshnessValueKind.TIMESTAMP,
             expected_age_status="pass",
         ),
-        StandardSourceFreshnessAgePolicyTestCase(
+        DirectSourceFreshnessAgePolicyTestCase(
             description="older timestamp warns before error threshold",
             current_query="SELECT CAST('2026-01-15 10:30:00' AS TIMESTAMP) AS data_version",
             warn_after="1h",
@@ -185,7 +183,7 @@ def test_given_standard_source_freshness_state_when_planning_then_classifies_has
             value_kind=SourceFreshnessValueKind.TIMESTAMP,
             expected_age_status="warn",
         ),
-        StandardSourceFreshnessAgePolicyTestCase(
+        DirectSourceFreshnessAgePolicyTestCase(
             description="old timestamp errors after error threshold",
             current_query="SELECT CAST('2026-01-15 09:30:00' AS TIMESTAMP) AS data_version",
             warn_after="1h",
@@ -193,7 +191,7 @@ def test_given_standard_source_freshness_state_when_planning_then_classifies_has
             value_kind=SourceFreshnessValueKind.TIMESTAMP,
             expected_age_status="error",
         ),
-        StandardSourceFreshnessAgePolicyTestCase(
+        DirectSourceFreshnessAgePolicyTestCase(
             description="naive timestamp compares against aware observed timestamp",
             current_query="SELECT CAST('2026-01-15 09:30:00' AS TIMESTAMP) AS data_version",
             warn_after="1h",
@@ -202,7 +200,7 @@ def test_given_standard_source_freshness_state_when_planning_then_classifies_has
             expected_age_status="error",
             observed_at=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
         ),
-        StandardSourceFreshnessAgePolicyTestCase(
+        DirectSourceFreshnessAgePolicyTestCase(
             description="non timestamp observation is unknown for age policy",
             current_query="SELECT 42 AS data_version",
             warn_after="1h",
@@ -214,7 +212,7 @@ def test_given_standard_source_freshness_state_when_planning_then_classifies_has
     ids=lambda case: case.description,
 )
 def test_given_source_freshness_age_policy_when_planning_then_records_age_status(
-    test_case: StandardSourceFreshnessAgePolicyTestCase,
+    test_case: DirectSourceFreshnessAgePolicyTestCase,
 ) -> None:
     adapter: DuckDbAdapter = DuckDbAdapter()
     connection: Any = adapter.connect({"database": ":memory:"})
@@ -233,23 +231,21 @@ def test_given_source_freshness_age_policy_when_planning_then_records_age_status
             ),
         )
 
-        result: StandardSourceFreshnessPlanningResult = (
-            build_standard_source_freshness_planning_result(
+        result: DirectSourceFreshnessPlanningResult = build_direct_source_freshness_planning_result(
+            adapter=adapter,
+            connection=connection,
+            sources=(source,),
+            state_database=None,
+            state_schemas=("state_schema",),
+            observed_at=test_case.observed_at,
+            run_id="planning",
+            render_qualified_name=RENDER_QUALIFIED_NAME,
+            state_table_exists_by_schema=state_table_exists_map(
                 adapter=adapter,
                 connection=connection,
-                sources=(source,),
                 state_database=None,
                 state_schemas=("state_schema",),
-                observed_at=test_case.observed_at,
-                run_id="planning",
-                render_qualified_name=RENDER_QUALIFIED_NAME,
-                state_table_exists_by_schema=state_table_exists_map(
-                    adapter=adapter,
-                    connection=connection,
-                    state_database=None,
-                    state_schemas=("state_schema",),
-                ),
-            )
+            ),
         )
     finally:
         adapter.close(connection)
@@ -261,7 +257,7 @@ def test_given_source_freshness_age_policy_when_planning_then_records_age_status
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardSourceFreshnessAgePolicyTestCase(
+        DirectSourceFreshnessAgePolicyTestCase(
             description="adapter metadata timestamp can error age policy",
             current_query="",
             warn_after="1h",
@@ -273,7 +269,7 @@ def test_given_source_freshness_age_policy_when_planning_then_records_age_status
     ids=lambda case: case.description,
 )
 def test_given_adapter_metadata_age_policy_when_planning_then_records_age_status(
-    test_case: StandardSourceFreshnessAgePolicyTestCase,
+    test_case: DirectSourceFreshnessAgePolicyTestCase,
 ) -> None:
     adapter: FreshnessMetadataDuckDbAdapter = FreshnessMetadataDuckDbAdapter(
         data_version=datetime(2026, 1, 15, 9, 30, 0),
@@ -295,23 +291,21 @@ def test_given_adapter_metadata_age_policy_when_planning_then_records_age_status
             ),
         )
 
-        result: StandardSourceFreshnessPlanningResult = (
-            build_standard_source_freshness_planning_result(
+        result: DirectSourceFreshnessPlanningResult = build_direct_source_freshness_planning_result(
+            adapter=adapter,
+            connection=connection,
+            sources=(source,),
+            state_database=None,
+            state_schemas=("state_schema",),
+            observed_at=datetime(2026, 1, 15, 12, 0, 0),
+            run_id="planning",
+            render_qualified_name=RENDER_QUALIFIED_NAME,
+            state_table_exists_by_schema=state_table_exists_map(
                 adapter=adapter,
                 connection=connection,
-                sources=(source,),
                 state_database=None,
                 state_schemas=("state_schema",),
-                observed_at=datetime(2026, 1, 15, 12, 0, 0),
-                run_id="planning",
-                render_qualified_name=RENDER_QUALIFIED_NAME,
-                state_table_exists_by_schema=state_table_exists_map(
-                    adapter=adapter,
-                    connection=connection,
-                    state_database=None,
-                    state_schemas=("state_schema",),
-                ),
-            )
+            ),
         )
     finally:
         adapter.close(connection)
@@ -323,25 +317,25 @@ def test_given_adapter_metadata_age_policy_when_planning_then_records_age_status
 @pytest.mark.parametrize(
     "test_case",
     (
-        StandardSourceFreshnessLagToleranceTestCase(
+        DirectSourceFreshnessLagToleranceTestCase(
             description="within timestamp lag tolerance",
             current_query="SELECT CAST('2026-01-15 12:05:00' AS TIMESTAMP) AS data_version",
             expected_changed_count=0,
             expected_unchanged_count=1,
         ),
-        StandardSourceFreshnessLagToleranceTestCase(
+        DirectSourceFreshnessLagToleranceTestCase(
             description="exactly at timestamp lag tolerance boundary",
             current_query="SELECT CAST('2026-01-15 12:10:00' AS TIMESTAMP) AS data_version",
             expected_changed_count=0,
             expected_unchanged_count=1,
         ),
-        StandardSourceFreshnessLagToleranceTestCase(
+        DirectSourceFreshnessLagToleranceTestCase(
             description="beyond timestamp lag tolerance",
             current_query="SELECT CAST('2026-01-15 12:11:00' AS TIMESTAMP) AS data_version",
             expected_changed_count=1,
             expected_unchanged_count=0,
         ),
-        StandardSourceFreshnessLagToleranceTestCase(
+        DirectSourceFreshnessLagToleranceTestCase(
             description="backwards timestamp movement is conservative",
             current_query="SELECT CAST('2026-01-15 11:59:00' AS TIMESTAMP) AS data_version",
             expected_changed_count=1,
@@ -351,7 +345,7 @@ def test_given_adapter_metadata_age_policy_when_planning_then_records_age_status
     ids=lambda case: case.description,
 )
 def test_given_timestamp_lag_tolerance_when_planning_then_classifies_tolerated_movement(
-    test_case: StandardSourceFreshnessLagToleranceTestCase,
+    test_case: DirectSourceFreshnessLagToleranceTestCase,
 ) -> None:
     adapter: DuckDbAdapter = DuckDbAdapter()
     connection: Any = adapter.connect({"database": ":memory:"})
@@ -389,33 +383,31 @@ def test_given_timestamp_lag_tolerance_when_planning_then_classifies_tolerated_m
             ),
         )
 
-        result: StandardSourceFreshnessPlanningResult = (
-            build_standard_source_freshness_planning_result(
-                adapter=adapter,
-                connection=connection,
-                sources=(
-                    SourceEntry(
-                        name="raw.orders",
-                        freshness=SourceFreshnessConfig(
-                            strategy=SourceFreshnessStrategy.SQL,
-                            value_kind=SourceFreshnessValueKind.TIMESTAMP,
-                            query=test_case.current_query,
-                            lag_tolerance="10m",
-                        ),
+        result: DirectSourceFreshnessPlanningResult = build_direct_source_freshness_planning_result(
+            adapter=adapter,
+            connection=connection,
+            sources=(
+                SourceEntry(
+                    name="raw.orders",
+                    freshness=SourceFreshnessConfig(
+                        strategy=SourceFreshnessStrategy.SQL,
+                        value_kind=SourceFreshnessValueKind.TIMESTAMP,
+                        query=test_case.current_query,
+                        lag_tolerance="10m",
                     ),
                 ),
+            ),
+            state_database=None,
+            state_schemas=("state_schema",),
+            observed_at=datetime(2026, 1, 15, 12, 30, 0),
+            run_id="planning",
+            render_qualified_name=RENDER_QUALIFIED_NAME,
+            state_table_exists_by_schema=state_table_exists_map(
+                adapter=adapter,
+                connection=connection,
                 state_database=None,
                 state_schemas=("state_schema",),
-                observed_at=datetime(2026, 1, 15, 12, 30, 0),
-                run_id="planning",
-                render_qualified_name=RENDER_QUALIFIED_NAME,
-                state_table_exists_by_schema=state_table_exists_map(
-                    adapter=adapter,
-                    connection=connection,
-                    state_database=None,
-                    state_schemas=("state_schema",),
-                ),
-            )
+            ),
         )
     finally:
         adapter.close(connection)
@@ -427,7 +419,7 @@ def test_given_timestamp_lag_tolerance_when_planning_then_classifies_tolerated_m
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardSourceFreshnessUnknownTestCase(
+        DirectSourceFreshnessUnknownTestCase(
             description="classifies unsupported default source freshness as unknown",
             expected_unknown_source_names=("raw.orders",),
         )
@@ -435,28 +427,26 @@ def test_given_timestamp_lag_tolerance_when_planning_then_classifies_tolerated_m
     ids=lambda case: case.description,
 )
 def test_given_unconfigured_source_without_adapter_metadata_when_planning_then_marks_unknown(
-    test_case: StandardSourceFreshnessUnknownTestCase,
+    test_case: DirectSourceFreshnessUnknownTestCase,
 ) -> None:
     adapter: DuckDbAdapter = DuckDbAdapter()
     connection: Any = adapter.connect({"database": ":memory:"})
     try:
-        result: StandardSourceFreshnessPlanningResult = (
-            build_standard_source_freshness_planning_result(
+        result: DirectSourceFreshnessPlanningResult = build_direct_source_freshness_planning_result(
+            adapter=adapter,
+            connection=connection,
+            sources=(SourceEntry(name="raw.orders", table="orders"),),
+            state_database=None,
+            state_schemas=("state_schema",),
+            observed_at=datetime(2026, 1, 15, 12, 0, 0),
+            run_id="planning",
+            render_qualified_name=RENDER_QUALIFIED_NAME,
+            state_table_exists_by_schema=state_table_exists_map(
                 adapter=adapter,
                 connection=connection,
-                sources=(SourceEntry(name="raw.orders", table="orders"),),
                 state_database=None,
                 state_schemas=("state_schema",),
-                observed_at=datetime(2026, 1, 15, 12, 0, 0),
-                run_id="planning",
-                render_qualified_name=RENDER_QUALIFIED_NAME,
-                state_table_exists_by_schema=state_table_exists_map(
-                    adapter=adapter,
-                    connection=connection,
-                    state_database=None,
-                    state_schemas=("state_schema",),
-                ),
-            )
+            ),
         )
     finally:
         adapter.close(connection)
@@ -468,7 +458,7 @@ def test_given_unconfigured_source_without_adapter_metadata_when_planning_then_m
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardSourceFreshnessExpressionTestCase(
+        DirectSourceFreshnessExpressionTestCase(
             description="column freshness observes an expression source via subquery",
             expression="SELECT 1 AS id, 7 AS batch_id",
             column="batch_id",
@@ -478,38 +468,36 @@ def test_given_unconfigured_source_without_adapter_metadata_when_planning_then_m
     ids=lambda case: case.description,
 )
 def test_given_column_freshness_expression_when_planning_then_observes_subquery(
-    test_case: StandardSourceFreshnessExpressionTestCase,
+    test_case: DirectSourceFreshnessExpressionTestCase,
 ) -> None:
     adapter: DuckDbAdapter = DuckDbAdapter()
     connection: Any = adapter.connect({"database": ":memory:"})
     try:
-        result: StandardSourceFreshnessPlanningResult = (
-            build_standard_source_freshness_planning_result(
-                adapter=adapter,
-                connection=connection,
-                sources=(
-                    SourceEntry(
-                        name="raw_orders",
-                        expression=test_case.expression,
-                        freshness=SourceFreshnessConfig(
-                            strategy=SourceFreshnessStrategy.COLUMN,
-                            value_kind=SourceFreshnessValueKind.INTEGER,
-                            column=test_case.column,
-                        ),
+        result: DirectSourceFreshnessPlanningResult = build_direct_source_freshness_planning_result(
+            adapter=adapter,
+            connection=connection,
+            sources=(
+                SourceEntry(
+                    name="raw_orders",
+                    expression=test_case.expression,
+                    freshness=SourceFreshnessConfig(
+                        strategy=SourceFreshnessStrategy.COLUMN,
+                        value_kind=SourceFreshnessValueKind.INTEGER,
+                        column=test_case.column,
                     ),
                 ),
+            ),
+            state_database=None,
+            state_schemas=("state_schema",),
+            observed_at=datetime(2026, 1, 15, 12, 0, 0),
+            run_id="planning",
+            render_qualified_name=RENDER_QUALIFIED_NAME,
+            state_table_exists_by_schema=state_table_exists_map(
+                adapter=adapter,
+                connection=connection,
                 state_database=None,
                 state_schemas=("state_schema",),
-                observed_at=datetime(2026, 1, 15, 12, 0, 0),
-                run_id="planning",
-                render_qualified_name=RENDER_QUALIFIED_NAME,
-                state_table_exists_by_schema=state_table_exists_map(
-                    adapter=adapter,
-                    connection=connection,
-                    state_database=None,
-                    state_schemas=("state_schema",),
-                ),
-            )
+            ),
         )
     finally:
         adapter.close(connection)
@@ -522,7 +510,7 @@ def test_given_column_freshness_expression_when_planning_then_observes_subquery(
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardSourceFreshnessAdapterDefaultTestCase(
+        DirectSourceFreshnessAdapterDefaultTestCase(
             description="adapter default freshness observes unconfigured physical sources in batch",
             expected_changed_count=2,
             expected_observed_count=2,
@@ -532,31 +520,29 @@ def test_given_column_freshness_expression_when_planning_then_observes_subquery(
     ids=lambda case: case.description,
 )
 def test_given_adapter_metadata_support_when_planning_unconfigured_source_then_observes_default(
-    test_case: StandardSourceFreshnessAdapterDefaultTestCase,
+    test_case: DirectSourceFreshnessAdapterDefaultTestCase,
 ) -> None:
     adapter: FreshnessMetadataDuckDbAdapter = FreshnessMetadataDuckDbAdapter()
     connection: Any = adapter.connect({"database": ":memory:"})
     try:
-        result: StandardSourceFreshnessPlanningResult = (
-            build_standard_source_freshness_planning_result(
+        result: DirectSourceFreshnessPlanningResult = build_direct_source_freshness_planning_result(
+            adapter=adapter,
+            connection=connection,
+            sources=(
+                SourceEntry(name="raw.orders", schema="raw", table="orders"),
+                SourceEntry(name="raw.customers", schema="raw", table="customers"),
+            ),
+            state_database=None,
+            state_schemas=("state_schema",),
+            observed_at=datetime(2026, 1, 15, 12, 5, 0),
+            run_id="planning",
+            render_qualified_name=RENDER_QUALIFIED_NAME,
+            state_table_exists_by_schema=state_table_exists_map(
                 adapter=adapter,
                 connection=connection,
-                sources=(
-                    SourceEntry(name="raw.orders", schema="raw", table="orders"),
-                    SourceEntry(name="raw.customers", schema="raw", table="customers"),
-                ),
                 state_database=None,
                 state_schemas=("state_schema",),
-                observed_at=datetime(2026, 1, 15, 12, 5, 0),
-                run_id="planning",
-                render_qualified_name=RENDER_QUALIFIED_NAME,
-                state_table_exists_by_schema=state_table_exists_map(
-                    adapter=adapter,
-                    connection=connection,
-                    state_database=None,
-                    state_schemas=("state_schema",),
-                ),
-            )
+            ),
         )
     finally:
         adapter.close(connection)
@@ -570,8 +556,8 @@ def test_given_adapter_metadata_support_when_planning_unconfigured_source_then_o
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardSourceFreshnessManagedSkipTestCase(
-            description="managed sources are skipped during standard planning observation",
+        DirectSourceFreshnessManagedSkipTestCase(
+            description="managed sources are skipped during direct planning observation",
             expected_observed_count=0,
             expected_unknown_source_names=(),
         )
@@ -579,30 +565,26 @@ def test_given_adapter_metadata_support_when_planning_unconfigured_source_then_o
     ids=lambda case: case.description,
 )
 def test_given_managed_source_when_planning_source_freshness_then_skips_observation(
-    test_case: StandardSourceFreshnessManagedSkipTestCase,
+    test_case: DirectSourceFreshnessManagedSkipTestCase,
 ) -> None:
     adapter: FreshnessMetadataDuckDbAdapter = FreshnessMetadataDuckDbAdapter()
     connection: Any = adapter.connect({"database": ":memory:"})
     try:
-        result: StandardSourceFreshnessPlanningResult = (
-            build_standard_source_freshness_planning_result(
+        result: DirectSourceFreshnessPlanningResult = build_direct_source_freshness_planning_result(
+            adapter=adapter,
+            connection=connection,
+            sources=(SourceEntry(name="raw.orders", schema="raw", table="orders", managed=True),),
+            state_database=None,
+            state_schemas=("state_schema",),
+            observed_at=datetime(2026, 1, 15, 12, 5, 0),
+            run_id="planning",
+            render_qualified_name=RENDER_QUALIFIED_NAME,
+            state_table_exists_by_schema=state_table_exists_map(
                 adapter=adapter,
                 connection=connection,
-                sources=(
-                    SourceEntry(name="raw.orders", schema="raw", table="orders", managed=True),
-                ),
                 state_database=None,
                 state_schemas=("state_schema",),
-                observed_at=datetime(2026, 1, 15, 12, 5, 0),
-                run_id="planning",
-                render_qualified_name=RENDER_QUALIFIED_NAME,
-                state_table_exists_by_schema=state_table_exists_map(
-                    adapter=adapter,
-                    connection=connection,
-                    state_database=None,
-                    state_schemas=("state_schema",),
-                ),
-            )
+            ),
         )
     finally:
         adapter.close(connection)
@@ -614,8 +596,8 @@ def test_given_managed_source_when_planning_source_freshness_then_skips_observat
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardSourceFreshnessMultiSchemaTestCase(
-            description="reads previous standard source freshness across multiple state schemas",
+        DirectSourceFreshnessMultiSchemaTestCase(
+            description="reads previous direct source freshness across multiple state schemas",
             expected_previous_count=2,
             expected_unchanged_count=1,
         )
@@ -623,7 +605,7 @@ def test_given_managed_source_when_planning_source_freshness_then_skips_observat
     ids=lambda case: case.description,
 )
 def test_given_multiple_state_schemas_when_planning_then_merges_previous_records(
-    test_case: StandardSourceFreshnessMultiSchemaTestCase,
+    test_case: DirectSourceFreshnessMultiSchemaTestCase,
 ) -> None:
     adapter: DuckDbAdapter = DuckDbAdapter()
     connection: Any = adapter.connect({"database": ":memory:"})
@@ -648,32 +630,30 @@ def test_given_multiple_state_schemas_when_planning_then_merges_previous_records
             source_name="raw.customers",
             data_version="2",
         )
-        result: StandardSourceFreshnessPlanningResult = (
-            build_standard_source_freshness_planning_result(
-                adapter=adapter,
-                connection=connection,
-                sources=(
-                    SourceEntry(
-                        name="raw.orders",
-                        freshness=SourceFreshnessConfig(
-                            strategy=SourceFreshnessStrategy.SQL,
-                            value_kind=SourceFreshnessValueKind.INTEGER,
-                            query="SELECT 1 AS data_version",
-                        ),
+        result: DirectSourceFreshnessPlanningResult = build_direct_source_freshness_planning_result(
+            adapter=adapter,
+            connection=connection,
+            sources=(
+                SourceEntry(
+                    name="raw.orders",
+                    freshness=SourceFreshnessConfig(
+                        strategy=SourceFreshnessStrategy.SQL,
+                        value_kind=SourceFreshnessValueKind.INTEGER,
+                        query="SELECT 1 AS data_version",
                     ),
                 ),
+            ),
+            state_database=None,
+            state_schemas=("state_a", "state_b"),
+            observed_at=datetime(2026, 1, 15, 12, 5, 0),
+            run_id="planning",
+            render_qualified_name=RENDER_QUALIFIED_NAME,
+            state_table_exists_by_schema=state_table_exists_map(
+                adapter=adapter,
+                connection=connection,
                 state_database=None,
                 state_schemas=("state_a", "state_b"),
-                observed_at=datetime(2026, 1, 15, 12, 5, 0),
-                run_id="planning",
-                render_qualified_name=RENDER_QUALIFIED_NAME,
-                state_table_exists_by_schema=state_table_exists_map(
-                    adapter=adapter,
-                    connection=connection,
-                    state_database=None,
-                    state_schemas=("state_a", "state_b"),
-                ),
-            )
+            ),
         )
     finally:
         adapter.close(connection)
@@ -685,7 +665,7 @@ def test_given_multiple_state_schemas_when_planning_then_merges_previous_records
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardSourceFreshnessDuplicateSchemaTestCase(
+        DirectSourceFreshnessDuplicateSchemaTestCase(
             description="uses newest duplicate source freshness record across state schemas",
             expected_previous_data_version="2",
             expected_changed_count=0,
@@ -694,7 +674,7 @@ def test_given_multiple_state_schemas_when_planning_then_merges_previous_records
     ids=lambda case: case.description,
 )
 def test_given_duplicate_state_schema_records_when_planning_then_uses_newest_observation(
-    test_case: StandardSourceFreshnessDuplicateSchemaTestCase,
+    test_case: DirectSourceFreshnessDuplicateSchemaTestCase,
 ) -> None:
     adapter: DuckDbAdapter = DuckDbAdapter()
     connection: Any = adapter.connect({"database": ":memory:"})
@@ -722,32 +702,30 @@ def test_given_duplicate_state_schema_records_when_planning_then_uses_newest_obs
             observed_at=datetime(2026, 1, 15, 10, 0, 0),
         )
 
-        result: StandardSourceFreshnessPlanningResult = (
-            build_standard_source_freshness_planning_result(
-                adapter=adapter,
-                connection=connection,
-                sources=(
-                    SourceEntry(
-                        name="raw.orders",
-                        freshness=SourceFreshnessConfig(
-                            strategy=SourceFreshnessStrategy.SQL,
-                            value_kind=SourceFreshnessValueKind.INTEGER,
-                            query="SELECT 2 AS data_version",
-                        ),
+        result: DirectSourceFreshnessPlanningResult = build_direct_source_freshness_planning_result(
+            adapter=adapter,
+            connection=connection,
+            sources=(
+                SourceEntry(
+                    name="raw.orders",
+                    freshness=SourceFreshnessConfig(
+                        strategy=SourceFreshnessStrategy.SQL,
+                        value_kind=SourceFreshnessValueKind.INTEGER,
+                        query="SELECT 2 AS data_version",
                     ),
                 ),
+            ),
+            state_database=None,
+            state_schemas=("state_a", "state_b"),
+            observed_at=datetime(2026, 1, 15, 12, 5, 0),
+            run_id="planning",
+            render_qualified_name=RENDER_QUALIFIED_NAME,
+            state_table_exists_by_schema=state_table_exists_map(
+                adapter=adapter,
+                connection=connection,
                 state_database=None,
                 state_schemas=("state_a", "state_b"),
-                observed_at=datetime(2026, 1, 15, 12, 5, 0),
-                run_id="planning",
-                render_qualified_name=RENDER_QUALIFIED_NAME,
-                state_table_exists_by_schema=state_table_exists_map(
-                    adapter=adapter,
-                    connection=connection,
-                    state_database=None,
-                    state_schemas=("state_a", "state_b"),
-                ),
-            )
+            ),
         )
     finally:
         adapter.close(connection)

--- a/tests/unit/src/sqlbuild/compiler/source_freshness/main/test_propagation.py
+++ b/tests/unit/src/sqlbuild/compiler/source_freshness/main/test_propagation.py
@@ -4,15 +4,15 @@ import pytest
 
 from sqlbuild.compiler.planner.models import PlannerScope
 from sqlbuild.compiler.source_freshness.main._propagation import (
-    build_standard_source_freshness_propagation_result,
+    build_direct_source_freshness_propagation_result,
 )
 from sqlbuild.compiler.source_freshness.models import (
-    StandardSourceFreshnessPlanningResult,
-    StandardSourceFreshnessPropagationResult,
+    DirectSourceFreshnessPlanningResult,
+    DirectSourceFreshnessPropagationResult,
 )
 from sqlbuild.compiler.source_freshness.types import SourceFreshnessAgeStatus
 from tests.unit.src.sqlbuild.compiler.source_freshness.main._test_types import (
-    StandardSourceFreshnessPropagationTestCase,
+    DirectSourceFreshnessPropagationTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.source_freshness.main.helpers import (
     downstream_deps_from_edges,
@@ -23,7 +23,7 @@ from tests.unit.src.sqlbuild.compiler.source_freshness.main.helpers import (
 @pytest.mark.parametrize(
     "test_case",
     [
-        StandardSourceFreshnessPropagationTestCase(
+        DirectSourceFreshnessPropagationTestCase(
             description="propagates changed source to direct downstream model",
             changed_source_names=("raw.orders",),
             unknown_source_names=(),
@@ -32,7 +32,7 @@ from tests.unit.src.sqlbuild.compiler.source_freshness.main.helpers import (
             expected_changed_source_model_names={"raw.orders": frozenset({"orders"})},
             expected_unknown_source_model_names={},
         ),
-        StandardSourceFreshnessPropagationTestCase(
+        DirectSourceFreshnessPropagationTestCase(
             description="propagates changed source through view to downstream table",
             changed_source_names=("raw.orders",),
             unknown_source_names=(),
@@ -46,7 +46,7 @@ from tests.unit.src.sqlbuild.compiler.source_freshness.main.helpers import (
             },
             expected_unknown_source_model_names={},
         ),
-        StandardSourceFreshnessPropagationTestCase(
+        DirectSourceFreshnessPropagationTestCase(
             description="preserves shared downstream for multiple changed sources",
             changed_source_names=("raw.orders", "raw.payments"),
             unknown_source_names=(),
@@ -61,7 +61,7 @@ from tests.unit.src.sqlbuild.compiler.source_freshness.main.helpers import (
             },
             expected_unknown_source_model_names={},
         ),
-        StandardSourceFreshnessPropagationTestCase(
+        DirectSourceFreshnessPropagationTestCase(
             description="propagates unknown source conservatively to downstream models",
             changed_source_names=(),
             unknown_source_names=("raw.orders",),
@@ -70,7 +70,7 @@ from tests.unit.src.sqlbuild.compiler.source_freshness.main.helpers import (
             expected_changed_source_model_names={},
             expected_unknown_source_model_names={"raw.orders": frozenset({"orders"})},
         ),
-        StandardSourceFreshnessPropagationTestCase(
+        DirectSourceFreshnessPropagationTestCase(
             description="propagates source age errors to blocked downstream models",
             changed_source_names=(),
             unknown_source_names=(),
@@ -91,11 +91,11 @@ from tests.unit.src.sqlbuild.compiler.source_freshness.main.helpers import (
     ids=lambda case: case.description,
 )
 def test_given_source_freshness_roots_when_propagating_then_returns_downstream_models(
-    test_case: StandardSourceFreshnessPropagationTestCase,
+    test_case: DirectSourceFreshnessPropagationTestCase,
 ) -> None:
-    propagation: StandardSourceFreshnessPropagationResult = (
-        build_standard_source_freshness_propagation_result(
-            source_freshness=StandardSourceFreshnessPlanningResult(
+    propagation: DirectSourceFreshnessPropagationResult = (
+        build_direct_source_freshness_propagation_result(
+            source_freshness=DirectSourceFreshnessPlanningResult(
                 changed_identities=frozenset(
                     source_freshness_identity(source_name)
                     for source_name in test_case.changed_source_names

--- a/tests/unit/src/sqlbuild/executor/build/_helpers/test_scheduler.py
+++ b/tests/unit/src/sqlbuild/executor/build/_helpers/test_scheduler.py
@@ -115,7 +115,7 @@ def test_given_managed_source_node_when_build_runs_then_records_loader_and_block
             connections=(connection,),
             scheduler_connection=connection,
             runtime=BuildRuntimeParams(
-                promotion_mode=TablePromotionMode.DIRECT,
+                promotion_mode=TablePromotionMode.IMMEDIATE,
                 run_id="run-1",
                 run_audits=False,
                 run_tests=False,
@@ -196,7 +196,7 @@ def test_given_model_materialize_hook_when_build_runs_then_it_prepares_or_fails_
             connections=(connection,),
             scheduler_connection=connection,
             runtime=BuildRuntimeParams(
-                promotion_mode=TablePromotionMode.DIRECT,
+                promotion_mode=TablePromotionMode.IMMEDIATE,
                 run_id="run-1",
                 run_audits=False,
                 run_tests=False,
@@ -289,7 +289,7 @@ def test_given_model_pre_hook_skips_when_build_runs_then_downstream_model_is_ski
             connections=(connection,),
             scheduler_connection=connection,
             runtime=BuildRuntimeParams(
-                promotion_mode=TablePromotionMode.DIRECT,
+                promotion_mode=TablePromotionMode.IMMEDIATE,
                 run_id="run-1",
                 run_audits=False,
                 run_tests=False,
@@ -363,7 +363,7 @@ def test_given_model_plan_action_skip_when_build_runs_then_downstream_model_is_s
             connections=(connection,),
             scheduler_connection=connection,
             runtime=BuildRuntimeParams(
-                promotion_mode=TablePromotionMode.DIRECT,
+                promotion_mode=TablePromotionMode.IMMEDIATE,
                 run_id="run-1",
                 run_audits=False,
                 run_tests=False,

--- a/tests/unit/src/sqlbuild/executor/python_nodes/_helpers/test_execution.py
+++ b/tests/unit/src/sqlbuild/executor/python_nodes/_helpers/test_execution.py
@@ -12,8 +12,8 @@ from sqlbuild.compiler.discovery.models import DiscoveredAssetFunction, Discover
 from sqlbuild.compiler.python_nodes.types import PythonNodeStatus
 from sqlbuild.cost.classes.cost_context import CostContext
 from sqlbuild.cost.models import CostResourceContext
-from sqlbuild.executor.node_results.classes.standard_store import StandardNodeResultStore
-from sqlbuild.executor.node_results.main._standard_store import build_standard_node_result_store
+from sqlbuild.executor.node_results.classes.direct_store import DirectNodeResultStore
+from sqlbuild.executor.node_results.main._direct_store import build_direct_node_result_store
 from sqlbuild.executor.python_nodes._helpers.execution import (
     execute_python_nodes,
     execute_ready_python_node,
@@ -383,7 +383,7 @@ def test_given_ready_python_node_when_executing_then_uses_existing_run_state(
     )
 
     adapter: PythonNodeContextTestAdapter = PythonNodeContextTestAdapter()
-    result_store: StandardNodeResultStore = build_standard_node_result_store(
+    result_store: DirectNodeResultStore = build_direct_node_result_store(
         adapter=adapter,
         connection=object(),
         database=None,

--- a/tests/unit/src/sqlbuild/integrations/dbt/test_mode.py
+++ b/tests/unit/src/sqlbuild/integrations/dbt/test_mode.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
-from sqlbuild.integrations.dbt._helpers.cli.mode import enforce_dbt_interop_standard_mode
+from sqlbuild.integrations.dbt._helpers.cli.mode import enforce_dbt_interop_direct_mode
 from sqlbuild.integrations.dbt.exceptions import DbtInteropConfigError
 from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig, SettingsConfig
 from tests.unit.src.sqlbuild.integrations.dbt._test_types import DbtModeGuardTestCase
@@ -13,7 +13,7 @@ from tests.unit.src.sqlbuild.integrations.dbt._test_types import DbtModeGuardTes
     "test_case",
     [
         DbtModeGuardTestCase(
-            description="allows dbt interop in standard mode",
+            description="allows dbt interop in direct mode",
             virtual_environments=False,
             expected_error_fragment=None,
             expected_code=None,
@@ -22,7 +22,7 @@ from tests.unit.src.sqlbuild.integrations.dbt._test_types import DbtModeGuardTes
     ],
     ids=lambda case: case.description,
 )
-def test_given_standard_project_mode_when_enforcing_dbt_interop_support_then_allows_execution(
+def test_given_direct_project_mode_when_enforcing_dbt_interop_support_then_allows_execution(
     test_case: DbtModeGuardTestCase,
 ) -> None:
     discovered_inputs: DiscoveredProjectInputs = DiscoveredProjectInputs(
@@ -34,7 +34,7 @@ def test_given_standard_project_mode_when_enforcing_dbt_interop_support_then_all
         local_config=LocalConfig(),
     )
 
-    enforce_dbt_interop_standard_mode(discovered_inputs=discovered_inputs)
+    enforce_dbt_interop_direct_mode(discovered_inputs=discovered_inputs)
 
     assert test_case.expected_code is None
 
@@ -65,7 +65,7 @@ def test_given_virtual_project_mode_when_enforcing_dbt_interop_support_then_rais
     )
 
     with pytest.raises(DbtInteropConfigError) as exc_info:
-        enforce_dbt_interop_standard_mode(discovered_inputs=discovered_inputs)
+        enforce_dbt_interop_direct_mode(discovered_inputs=discovered_inputs)
 
     error: DbtInteropConfigError = exc_info.value
     assert test_case.expected_error_fragment is not None

--- a/tests/unit/src/sqlbuild/microbatches/_test_types.py
+++ b/tests/unit/src/sqlbuild/microbatches/_test_types.py
@@ -37,7 +37,7 @@ class MicrobatchReplayProjectionTestCase:
 
 @dataclass(frozen=True)
 class MicrobatchDdlAdapterTestCase:
-    """One adapter expected to render the complete standard state table."""
+    """One adapter expected to render the complete direct state table."""
 
     description: str
     adapter: BaseAdapter
@@ -46,7 +46,7 @@ class MicrobatchDdlAdapterTestCase:
 
 @dataclass(frozen=True)
 class MicrobatchSqlBehaviorTestCase:
-    """Expected SQL shape for one standard-state behavior test."""
+    """Expected SQL shape for one direct-state behavior test."""
 
     description: str
     expected_statement_count: int

--- a/tests/unit/src/sqlbuild/microbatches/helpers.py
+++ b/tests/unit/src/sqlbuild/microbatches/helpers.py
@@ -14,7 +14,7 @@ from sqlbuild.microbatches.types import (
 
 CREATED_AT: datetime = datetime(2026, 1, 1, tzinfo=UTC)
 SCOPE: MicrobatchScope = MicrobatchScope(
-    scope_kind="standard_logical",
+    scope_kind="direct_logical",
     scope_key="duckdb:main.orders",
     model_name="orders",
     target_database=None,
@@ -117,7 +117,7 @@ def timestamp_completion(
     """Build one timestamp completion for overlap projection tests."""
 
     scope: MicrobatchScope = MicrobatchScope(
-        scope_kind="standard_logical",
+        scope_kind="direct_logical",
         scope_key="duckdb:main.events",
         model_name="events",
         target_database=None,
@@ -154,7 +154,7 @@ def completion_for_sql() -> MicrobatchEvent:
         event_id="event-1",
         record_type=MicrobatchRecordType.PARTITION_COMPLETION,
         scope=MicrobatchScope(
-            scope_kind="standard_logical",
+            scope_kind="direct_logical",
             scope_key="duckdb:analytics.orders",
             model_name="orders",
             target_database=None,

--- a/tests/unit/src/sqlbuild/microbatches/test_sql.py
+++ b/tests/unit/src/sqlbuild/microbatches/test_sql.py
@@ -1,4 +1,4 @@
-"""Adapter contract tests for standard microbatch state SQL."""
+"""Adapter contract tests for direct microbatch state SQL."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Why

Direct mode more clearly describes SQLBuild's default path, which writes ordinary relations and state directly to configured warehouse targets, and it matches StreamBuild terminology. The previous standard-mode rename was motivated by a naming collision with direct table promotion; that smaller concept can instead use the clearer immediate name.

## Changes

- Rename standard execution symbols, modules, metadata, persisted microbatch scope, tests, and user-facing text to direct.
- Rename `TablePromotionMode.DIRECT` and `table_promotion_mode = "direct"` to `IMMEDIATE` / `"immediate"`.
- Preserve staged promotion behavior and the existing immediate publish-then-audit behavior.
- Align Fensu policy paths, CLI previews, all adapter coverage, and the generated SQLBuild skill.
- Keep unrelated direct terminology for dependencies, lineage transforms, direct-logic tests, and warehouse-direct scenarios.
- Add companion published documentation in [sqlbuild-docs PR #6](https://github.com/chio-labs/sqlbuild-docs/pull/6).

## Verification

- Full unit/integration: 4,223 passed, 89 skipped.
- Complete DuckDB E2E: 572 passed in 11m21s.
- Performance gates: 6 passed in 36.66s.
- Focused mode/planner/store/lifecycle: 181 passed; focused direct/microbatch E2E: 37 passed.
- Post-review lifecycle, lineage, and skill checks: 74 passed.
- `make check-ci`, `make rust-check`, and `git diff --check` passed; Fensu found zero faults.
- Independent review findings were resolved; changelog history remains unchanged.
