### PR TITLE
feat(sql): unify native resource headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ test-virtual:
 
 
 skills:
-	uv run python scripts/generate_docs_skill.py
+	uv run python -m scripts.generate_docs_skill
 	uv run sqb skills update --global --target opencode
 	uv run fensu skills
 

--- a/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
+++ b/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
@@ -256,8 +256,8 @@ Beyond the multi-model tests shown above, SQLBuild runs end-to-end scenario test
 
 ```sql
 SCENARIO (
-  description: "Daily revenue includes only successful payments",
-  tags: ["revenue"]
+  description "Daily revenue includes only successful payments",
+  tags ["revenue"]
 );
 
 WITH
@@ -624,7 +624,7 @@ SQLBuild, dbt, and SQLMesh are all SQL pipeline frameworks. They share common gr
 | Macros as test helpers | Tests are SQL - macros work as reusable fixture generators | No (YAML stubs) | No |
 | E2E scenario tests | Fixture worlds with real graph execution | No | No |
 | Local E2E replay | Capture from warehouse, replay in DuckDB | No | No |
-| Macro / UDF / table function tests | `TEST(mode: macro/udf/table_fn)` | No | No |
+| Macro / UDF / table function tests | `TEST(mode macro)`, `TEST(mode udf)`, or `TEST(mode table_fn)` | No | No |
 | Zero-row assertions | `__assert__` CTEs in tests and scenarios | No | No |
 
 #### Audits
@@ -2867,7 +2867,7 @@ SQLBuild discovers `.sql` files recursively under `hooks/sql/`. Each file define
 
 ```sql
 HOOK (
-  description: "Grant a warehouse role access to the model relation"
+  description "Grant a warehouse role access to the model relation"
 );
 
 GRANT SELECT ON @relation TO @role
@@ -2900,6 +2900,8 @@ MODEL (
 SELECT 1 AS id
 ```
 
+SQLBuild resource-header fields use native `key value` syntax, as in `TEST (mode macro)`, `SCENARIO (tags ["revenue"])`, `AUDIT (severity error)`, and `HOOK (description "...")`. The `relation: ...` and `role: ...` entries above intentionally retain `key: value` syntax because they are nested named arguments to the `sql(...)` hook call, not resource-header fields. The same distinction applies to named arguments passed to `python(...)`.
+
 ### SQL hook arguments
 
 Named SQL hooks declare parameters by using them in the SQL body. Arguments are supplied as named values in `sql("name", args...)`:
@@ -2913,7 +2915,7 @@ Named SQL hooks declare parameters by using them in the SQL body. Arguments are 
 
 ```sql
 HOOK (
-  description: "Record access configuration"
+  description "Record access configuration"
 );
 
 INSERT INTO audit.access_log (relation_name, role_name)
@@ -5247,7 +5249,10 @@ Singular audits are standalone SQL files under `audits/` (outside the `generic/`
 
 ```sql
 -- audits/orders_have_payments.sql
-AUDIT ();
+AUDIT (
+  name "completed orders have payments",
+  severity error
+);
 
 SELECT o.order_id
 FROM __ref("fact_orders") o
@@ -5605,7 +5610,7 @@ By default, `TEST()` runs in model mode - mocking sources/refs and comparing mod
 Test macro output by calling the macro in `__macro_actual__` and comparing against `__macro_expected__`:
 
 ```sql
-TEST (mode: macro, name: "calculates line total cents");
+TEST (mode macro, name "calculates line total cents");
 
 WITH
 input_values AS (
@@ -5628,7 +5633,7 @@ Macros are compile-time code, so macro tests expand the macro at compile time an
 Test scalar UDFs by calling them in `__udf_actual__` and comparing against `__udf_expected__`:
 
 ```sql
-TEST (mode: udf, name: "detects completed orders");
+TEST (mode udf, name "detects completed orders");
 
 WITH
 input_values AS (
@@ -5657,7 +5662,7 @@ UDFs are warehouse objects, so the function is created before the test runs. Dur
 Test table functions by calling them in `__table_fn_actual__` and comparing against `__table_fn_expected__`:
 
 ```sql
-TEST (mode: table_fn, name: "returns customer orders");
+TEST (mode table_fn, name "returns customer orders");
 
 WITH
 __table_fn_actual__ AS (
@@ -5692,7 +5697,7 @@ CTE prefixes from other modes are not allowed. For example, `__source__` in a ma
 A single test file can contain multiple `TEST()` blocks. Each block must have a unique `name`:
 
 ```sql
-TEST (name: "completed orders only");
+TEST (name "completed orders only");
 
 WITH
 __source__raw__orders AS (
@@ -5703,7 +5708,7 @@ __expected__stg_orders AS (
 )
 SELECT 1
 
-TEST (name: "cancelled orders excluded");
+TEST (name "cancelled orders excluded");
 
 WITH
 __source__raw__orders AS (
@@ -5793,8 +5798,8 @@ Each file has a `SCENARIO()` header followed by CTEs that define inputs, expecte
 
 ```sql
 SCENARIO (
-  description: "Daily revenue includes only successful payments",
-  tags: ["revenue", "example"]
+  description "Daily revenue includes only successful payments",
+  tags ["revenue", "example"]
 );
 
 WITH

--- a/src/sqlbuild/cli/commands/_helpers/playground/copy.py
+++ b/src/sqlbuild/cli/commands/_helpers/playground/copy.py
@@ -271,8 +271,8 @@ SELECT 1
 """
 
 _VIRTUAL_SCENARIO_CUSTOMER_REVENUE_SQL: str = """SCENARIO (
-  description: "Customer revenue includes seed-backed waffle categories",
-  tags: ["virtual", "example"]
+  description "Customer revenue includes seed-backed waffle categories",
+  tags ["virtual", "example"]
 );
 
 WITH

--- a/src/sqlbuild/cli/commands/_helpers/playground/templates/waffle_shop/tests/scenarios/daily_revenue_minimal.sql
+++ b/src/sqlbuild/cli/commands/_helpers/playground/templates/waffle_shop/tests/scenarios/daily_revenue_minimal.sql
@@ -1,6 +1,6 @@
 SCENARIO (
-  description: "Daily revenue includes only successful payments",
-  tags: ["revenue", "example"]
+  description "Daily revenue includes only successful payments",
+  tags ["revenue", "example"]
 );
 
 WITH

--- a/src/sqlbuild/cli/commands/_helpers/playground/templates/waffle_shop/tests/scenarios/daily_revenue_multi_order.sql
+++ b/src/sqlbuild/cli/commands/_helpers/playground/templates/waffle_shop/tests/scenarios/daily_revenue_multi_order.sql
@@ -1,6 +1,6 @@
 SCENARIO (
-  description: "Daily revenue aggregates multiple successful orders",
-  tags: ["revenue", "example"]
+  description "Daily revenue aggregates multiple successful orders",
+  tags ["revenue", "example"]
 );
 
 WITH

--- a/src/sqlbuild/cli/commands/_helpers/playground/templates/waffle_shop/tests/unit/test_line_total_cents_macro.sql
+++ b/src/sqlbuild/cli/commands/_helpers/playground/templates/waffle_shop/tests/unit/test_line_total_cents_macro.sql
@@ -1,4 +1,4 @@
-TEST (mode: macro, name: "calculates line total cents");
+TEST (mode macro, name "calculates line total cents");
 
 WITH
 input_values AS (

--- a/src/sqlbuild/compiler/compile/_helpers/sql_tests/core.py
+++ b/src/sqlbuild/compiler/compile/_helpers/sql_tests/core.py
@@ -323,17 +323,17 @@ def _classify_model_sql_test_ctes(
         if cte.name in {MACRO_ACTUAL_TEST_CTE_NAME, MACRO_EXPECTED_TEST_CTE_NAME}:
             raise CompileInputError(
                 f"SQL test '{file_label}' is mode '{DEFAULT_SQL_TEST_MODE.value}' but defines "
-                f"macro-test CTE '{cte.name}'; use TEST (mode: {SqlTestMode.MACRO.value})"
+                f"macro-test CTE '{cte.name}'; use TEST (mode {SqlTestMode.MACRO.value})"
             )
         if cte.name in {UDF_ACTUAL_TEST_CTE_NAME, UDF_EXPECTED_TEST_CTE_NAME}:
             raise CompileInputError(
                 f"SQL test '{file_label}' is mode '{DEFAULT_SQL_TEST_MODE.value}' but defines "
-                f"UDF-test CTE '{cte.name}'; use TEST (mode: {SqlTestMode.UDF.value})"
+                f"UDF-test CTE '{cte.name}'; use TEST (mode {SqlTestMode.UDF.value})"
             )
         if cte.name in {TABLE_FN_ACTUAL_TEST_CTE_NAME, TABLE_FN_EXPECTED_TEST_CTE_NAME}:
             raise CompileInputError(
                 f"SQL test '{file_label}' is mode '{DEFAULT_SQL_TEST_MODE.value}' but defines "
-                f"table_fn-test CTE '{cte.name}'; use TEST (mode: {SqlTestMode.TABLE_FN.value})"
+                f"table_fn-test CTE '{cte.name}'; use TEST (mode {SqlTestMode.TABLE_FN.value})"
             )
         if cte.name.startswith(MACRO_TEST_CTE_PREFIX):
             macro_name: str = _require_prefixed_name(

--- a/src/sqlbuild/compiler/discovery/_helpers/sql/audits.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/sql/audits.py
@@ -7,9 +7,7 @@ from inspect import cleandoc
 from pathlib import Path
 from typing import cast
 
-import yaml
-from yaml import YAMLError
-
+from sqlbuild.compiler.discovery._helpers.sql.model_files import parse_header_values
 from sqlbuild.compiler.discovery.exceptions import SqlAuditParseError
 from sqlbuild.compiler.discovery.models import DiscoveredAuditBlock
 
@@ -21,8 +19,17 @@ _AUDIT_HEADER_ONLY_PATTERN: re.Pattern[str] = re.compile(
     r"^\s*AUDIT\s*\((?P<header>.*?)\)\s*;\s*",
     re.DOTALL | re.MULTILINE,
 )
+_AUDIT_NAME_HEADER_KEY: str = "name"
+_AUDIT_SEVERITY_HEADER_KEY: str = "severity"
+_AUDIT_RUN_SCOPE_HEADER_KEY: str = "run_scope"
+_AUDIT_ALWAYS_RUN_HEADER_KEY: str = "always_run"
 _SUPPORTED_AUDIT_HEADER_KEYS: frozenset[str] = frozenset(
-    {"name", "severity", "run_scope", "always_run"}
+    {
+        _AUDIT_NAME_HEADER_KEY,
+        _AUDIT_SEVERITY_HEADER_KEY,
+        _AUDIT_RUN_SCOPE_HEADER_KEY,
+        _AUDIT_ALWAYS_RUN_HEADER_KEY,
+    }
 )
 
 
@@ -96,7 +103,7 @@ def _parse_single_sql_audit_block(
     if not sql_body:
         raise SqlAuditParseError(f"SQL audit '{file_path}' must define SQL after AUDIT(...)")
 
-    name_value: object | None = header_values.get("name")
+    name_value: object | None = header_values.get(_AUDIT_NAME_HEADER_KEY)
     audit_name: str | None = cast(str | None, name_value)
     return DiscoveredAuditBlock(
         audit_index=audit_index,
@@ -107,22 +114,12 @@ def _parse_single_sql_audit_block(
 
 
 def _parse_audit_header(*, header: str, file_path: Path) -> dict[str, object]:
-    stripped_header: str = header.strip()
-    if not stripped_header:
-        return {}
-
-    try:
-        parsed_header: object = yaml.safe_load(f"{{{stripped_header}}}")
-    except YAMLError as error:
-        raise SqlAuditParseError(
-            f"AUDIT() header in '{file_path}' could not be parsed: {error}"
-        ) from error
-    if not isinstance(parsed_header, dict) or not all(
-        isinstance(key, str) for key in parsed_header
-    ):
-        raise SqlAuditParseError(
-            f"AUDIT() header in '{file_path}' must be a mapping like `AUDIT (name: \"...\");`"
-        )
+    parsed_header: dict[str, object] = parse_header_values(
+        header=header,
+        file_path=file_path,
+        statement_name="AUDIT",
+        error_class=SqlAuditParseError,
+    )
 
     unsupported_keys: tuple[str, ...] = tuple(
         str(key) for key in parsed_header if key not in _SUPPORTED_AUDIT_HEADER_KEYS
@@ -132,11 +129,20 @@ def _parse_audit_header(*, header: str, file_path: Path) -> dict[str, object]:
             f"AUDIT() in '{file_path}' has unsupported keys: {', '.join(unsupported_keys)}"
         )
 
-    name_value: object | None = parsed_header.get("name")
-    if name_value is not None and (not isinstance(name_value, str) or not name_value.strip()):
+    name_value: object | None = parsed_header.get(_AUDIT_NAME_HEADER_KEY)
+    if _AUDIT_NAME_HEADER_KEY in parsed_header and (
+        not isinstance(name_value, str) or not name_value.strip()
+    ):
         raise SqlAuditParseError(f"AUDIT() name in '{file_path}' must be a non-empty string")
+    for key in (_AUDIT_SEVERITY_HEADER_KEY, _AUDIT_RUN_SCOPE_HEADER_KEY):
+        value: object | None = parsed_header.get(key)
+        if key in parsed_header and (not isinstance(value, str) or not value.strip()):
+            raise SqlAuditParseError(f"AUDIT() {key} in '{file_path}' must be a non-empty string")
+    always_run: object | None = parsed_header.get(_AUDIT_ALWAYS_RUN_HEADER_KEY)
+    if _AUDIT_ALWAYS_RUN_HEADER_KEY in parsed_header and not isinstance(always_run, bool):
+        raise SqlAuditParseError(f"AUDIT() always_run in '{file_path}' must be a boolean")
 
-    return cast(dict[str, object], parsed_header)
+    return parsed_header
 
 
 def _validate_audit_names(*, file_path: Path, blocks: tuple[DiscoveredAuditBlock, ...]) -> None:

--- a/src/sqlbuild/compiler/discovery/_helpers/sql/hooks.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/sql/hooks.py
@@ -6,13 +6,12 @@ from inspect import cleandoc
 from pathlib import Path
 from typing import cast
 
-import yaml
-from yaml import YAMLError
-
+from sqlbuild.compiler.discovery._helpers.sql.model_files import parse_header_values
 from sqlbuild.compiler.discovery.exceptions import SqlHookParseError
 from sqlbuild.compiler.discovery.models import DiscoveredSqlHookFile
 
-_SUPPORTED_HOOK_HEADER_KEYS: frozenset[str] = frozenset({"description"})
+_HOOK_DESCRIPTION_HEADER_KEY: str = "description"
+_SUPPORTED_HOOK_HEADER_KEYS: frozenset[str] = frozenset({_HOOK_DESCRIPTION_HEADER_KEY})
 _SQL_ESCAPE_CHARACTER: str = "\\"
 _SQL_QUOTE_CHARACTERS: frozenset[str] = frozenset({"'", '"', "`"})
 _SQL_STATEMENT_TERMINATOR: str = ";"
@@ -98,21 +97,12 @@ def _split_hook_file(*, contents: str, file_path: Path) -> tuple[str, str]:
 
 
 def _parse_hook_header(*, header: str, file_path: Path) -> dict[str, object]:
-    stripped_header: str = header.strip()
-    if not stripped_header:
-        return {}
-    try:
-        parsed_header: object = yaml.safe_load(f"{{{stripped_header}}}")
-    except YAMLError as error:
-        raise SqlHookParseError(
-            f"HOOK() header in '{file_path}' could not be parsed: {error}"
-        ) from error
-    if not isinstance(parsed_header, dict) or not all(
-        isinstance(key, str) for key in parsed_header
-    ):
-        raise SqlHookParseError(
-            f"HOOK() header in '{file_path}' must be a mapping like `HOOK (description: \"...\");`"
-        )
+    parsed_header: dict[str, object] = parse_header_values(
+        header=header,
+        file_path=file_path,
+        statement_name="HOOK",
+        error_class=SqlHookParseError,
+    )
     unsupported_keys: tuple[str, ...] = tuple(
         str(key) for key in parsed_header if key not in _SUPPORTED_HOOK_HEADER_KEYS
     )
@@ -120,7 +110,9 @@ def _parse_hook_header(*, header: str, file_path: Path) -> dict[str, object]:
         raise SqlHookParseError(
             f"HOOK() in '{file_path}' has unsupported keys: {', '.join(unsupported_keys)}"
         )
-    description: object | None = parsed_header.get("description")
-    if description is not None and (not isinstance(description, str) or not description.strip()):
+    description: object | None = parsed_header.get(_HOOK_DESCRIPTION_HEADER_KEY)
+    if _HOOK_DESCRIPTION_HEADER_KEY in parsed_header and (
+        not isinstance(description, str) or not description.strip()
+    ):
         raise SqlHookParseError(f"HOOK() description in '{file_path}' must be a non-empty string")
-    return cast(dict[str, object], parsed_header)
+    return parsed_header

--- a/src/sqlbuild/compiler/discovery/_helpers/sql/model_files.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/sql/model_files.py
@@ -7,7 +7,11 @@ from bisect import bisect_right
 from dataclasses import dataclass
 from pathlib import Path
 
-from sqlbuild.compiler.discovery.exceptions import ModelHeaderSyntaxError, ModelSqlParseError
+from sqlbuild.compiler.discovery.exceptions import (
+    DiscoveryError,
+    ModelHeaderSyntaxError,
+    ModelSqlParseError,
+)
 from sqlbuild.compiler.discovery.models import NamedSqlHookEntry, PythonHookEntry, SqlHookEntry
 from sqlbuild.compiler.references.types import SqlReferenceKind
 from sqlbuild.spec.contracts.models import SourceLocation
@@ -461,7 +465,13 @@ def _keyword_at(*, sql: str, keyword: str, index: int) -> bool:
     )
 
 
-def parse_header_values(*, header: str, file_path: Path, statement_name: str) -> dict[str, object]:
+def parse_header_values(
+    *,
+    header: str,
+    file_path: Path,
+    statement_name: str,
+    error_class: type[DiscoveryError] = ModelSqlParseError,
+) -> dict[str, object]:
     """Parse one SQLBuild parenthesized header into nested Python values."""
 
     try:
@@ -470,7 +480,7 @@ def parse_header_values(*, header: str, file_path: Path, statement_name: str) ->
     except ModelSqlParseError:
         raise
     except ModelHeaderSyntaxError as error:
-        raise ModelSqlParseError(
+        raise error_class(
             f"{statement_name}(...) in '{file_path}' contains invalid SQLBuild header syntax: "
             f"{error}"
         ) from error

--- a/src/sqlbuild/compiler/discovery/_helpers/sql/scenarios.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/sql/scenarios.py
@@ -5,11 +5,8 @@ from __future__ import annotations
 import re
 from inspect import cleandoc
 from pathlib import Path
-from typing import cast
 
-import yaml
-from yaml import YAMLError
-
+from sqlbuild.compiler.discovery._helpers.sql.model_files import parse_header_values
 from sqlbuild.compiler.discovery.exceptions import SqlScenarioParseError
 from sqlbuild.compiler.discovery.models import DiscoveredSqlScenarioFile
 
@@ -17,6 +14,8 @@ _SCENARIO_HEADER_PATTERN: re.Pattern[str] = re.compile(
     r"^\s*SCENARIO\s*\((?P<header>.*?)\)\s*;\s*(?P<sql>.*)\Z",
     re.DOTALL,
 )
+_SCENARIO_DESCRIPTION_HEADER_KEY: str = "description"
+_SCENARIO_TAGS_HEADER_KEY: str = "tags"
 
 
 def parse_sql_scenario_file(
@@ -52,25 +51,17 @@ def parse_sql_scenario_file(
 
 
 def _parse_scenario_header(*, header: str, file_path: Path) -> dict[str, object]:
-    stripped_header: str = header.strip()
-    if not stripped_header:
-        return {}
+    parsed_header: dict[str, object] = parse_header_values(
+        header=header,
+        file_path=file_path,
+        statement_name="SCENARIO",
+        error_class=SqlScenarioParseError,
+    )
 
-    try:
-        parsed_header: object = yaml.safe_load(f"{{{stripped_header}}}")
-    except YAMLError as error:
-        raise SqlScenarioParseError(
-            f"SCENARIO() header in '{file_path}' could not be parsed: {error}"
-        ) from error
-    if not isinstance(parsed_header, dict) or not all(
-        isinstance(key, str) for key in parsed_header
-    ):
-        raise SqlScenarioParseError(
-            f"SCENARIO() header in '{file_path}' must be a mapping like "
-            '`SCENARIO (description: "...");`'
-        )
-
-    supported_keys: set[str] = {"description", "tags"}
+    supported_keys: set[str] = {
+        _SCENARIO_DESCRIPTION_HEADER_KEY,
+        _SCENARIO_TAGS_HEADER_KEY,
+    }
     unsupported_keys: tuple[str, ...] = tuple(
         str(key) for key in parsed_header if key not in supported_keys
     )
@@ -80,13 +71,13 @@ def _parse_scenario_header(*, header: str, file_path: Path) -> dict[str, object]
             f"unsupported keys: {', '.join(unsupported_keys)}"
         )
 
-    description_value: object | None = parsed_header.get("description")
-    if description_value is not None and not isinstance(description_value, str):
+    description_value: object | None = parsed_header.get(_SCENARIO_DESCRIPTION_HEADER_KEY)
+    if _SCENARIO_DESCRIPTION_HEADER_KEY in parsed_header and not isinstance(description_value, str):
         raise SqlScenarioParseError(f"SCENARIO() description in '{file_path}' must be a string")
-    tags_value: object | None = parsed_header.get("tags")
-    if tags_value is not None and (
+    tags_value: object | None = parsed_header.get(_SCENARIO_TAGS_HEADER_KEY)
+    if _SCENARIO_TAGS_HEADER_KEY in parsed_header and (
         not isinstance(tags_value, list) or not all(isinstance(tag, str) for tag in tags_value)
     ):
         raise SqlScenarioParseError(f"SCENARIO() tags in '{file_path}' must be a list of strings")
 
-    return cast(dict[str, object], parsed_header)
+    return parsed_header

--- a/src/sqlbuild/compiler/discovery/_helpers/sql/tests.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/sql/tests.py
@@ -7,11 +7,9 @@ from inspect import cleandoc
 from pathlib import Path
 from typing import cast
 
-import yaml
-from yaml import YAMLError
-
 from sqlbuild.compiler.compile.constants import DEFAULT_SQL_TEST_MODE
 from sqlbuild.compiler.compile.types import SqlTestMode
+from sqlbuild.compiler.discovery._helpers.sql.model_files import parse_header_values
 from sqlbuild.compiler.discovery.exceptions import SqlTestParseError
 from sqlbuild.compiler.discovery.models import DiscoveredSqlTestBlock
 
@@ -23,6 +21,8 @@ _TEST_HEADER_ONLY_PATTERN: re.Pattern[str] = re.compile(
     r"^\s*TEST\s*\((?P<header>.*?)\)\s*;\s*",
     re.DOTALL | re.MULTILINE,
 )
+_TEST_NAME_HEADER_KEY: str = "name"
+_TEST_MODE_HEADER_KEY: str = "mode"
 
 
 def parse_sql_test_file(*, contents: str, file_path: Path) -> tuple[DiscoveredSqlTestBlock, ...]:
@@ -109,24 +109,14 @@ def _parse_single_sql_test_block(
 
 
 def _parse_test_header(*, header: str, file_path: Path) -> dict[str, object]:
-    stripped_header: str = header.strip()
-    if not stripped_header:
-        return {}
+    parsed_header: dict[str, object] = parse_header_values(
+        header=header,
+        file_path=file_path,
+        statement_name="TEST",
+        error_class=SqlTestParseError,
+    )
 
-    try:
-        parsed_header: object = yaml.safe_load(f"{{{stripped_header}}}")
-    except YAMLError as error:
-        raise SqlTestParseError(
-            f"TEST() header in '{file_path}' could not be parsed: {error}"
-        ) from error
-    if not isinstance(parsed_header, dict) or not all(
-        isinstance(key, str) for key in parsed_header
-    ):
-        raise SqlTestParseError(
-            f"TEST() header in '{file_path}' must be a mapping like `TEST (name: \"...\");`"
-        )
-
-    supported_keys: frozenset[str] = frozenset({"name", "mode"})
+    supported_keys: frozenset[str] = frozenset({_TEST_NAME_HEADER_KEY, _TEST_MODE_HEADER_KEY})
     unsupported_keys: tuple[str, ...] = tuple(
         str(key) for key in parsed_header if key not in supported_keys
     )
@@ -136,22 +126,20 @@ def _parse_test_header(*, header: str, file_path: Path) -> dict[str, object]:
             f"{', '.join(unsupported_keys)}"
         )
 
-    _validate_test_name(name_value=parsed_header.get("name"), file_path=file_path)
-    _validate_test_mode(mode_value=parsed_header.get("mode"), file_path=file_path)
+    if _TEST_NAME_HEADER_KEY in parsed_header:
+        _validate_test_name(name_value=parsed_header[_TEST_NAME_HEADER_KEY], file_path=file_path)
+    if _TEST_MODE_HEADER_KEY in parsed_header:
+        _validate_test_mode(mode_value=parsed_header[_TEST_MODE_HEADER_KEY], file_path=file_path)
 
-    return cast(dict[str, object], parsed_header)
+    return parsed_header
 
 
-def _validate_test_name(*, name_value: object | None, file_path: Path) -> None:
-    if name_value is None:
-        return
+def _validate_test_name(*, name_value: object, file_path: Path) -> None:
     if not isinstance(name_value, str) or not name_value.strip():
         raise SqlTestParseError(f"TEST() name in '{file_path}' must be a non-empty string")
 
 
-def _validate_test_mode(*, mode_value: object | None, file_path: Path) -> None:
-    if mode_value is None:
-        return
+def _validate_test_mode(*, mode_value: object, file_path: Path) -> None:
     if not isinstance(mode_value, str):
         raise SqlTestParseError(f"TEST() mode in '{file_path}' must be a string")
 

--- a/src/sqlbuild/lint/_helpers/native.py
+++ b/src/sqlbuild/lint/_helpers/native.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from sqlbuild.compiler.discovery._helpers.sql.model_files import (
-    parse_header_values,  # noqa: FFL102 - lint owns header rules and reuses the compiler's header parser
+    parse_header_values,  # noqa: FFL102 - the compiler owns the canonical native header grammar
 )
 from sqlbuild.lint.constants import (
     DESCRIPTION_HEADER_KINDS,
@@ -20,7 +20,6 @@ from sqlbuild.lint.constants import (
     RULE_LEADING_COMMENT_DESCRIPTION,
     VIOLATION_SEVERITY_FAULT,
 )
-from sqlbuild.lint.exceptions import LintError
 from sqlbuild.lint.models import HeaderSpan, LintConfig, LintViolation
 
 _QUOTE_CHARACTERS: frozenset[str] = frozenset({"'", '"'})
@@ -32,7 +31,6 @@ _LINE_COMMENT_PREFIX: str = "--"
 _DESCRIPTION_KEY: str = "description"
 _DESCRIPTION_SENTINEL_PATH: str = "<lint>"
 _HEADER_INDENT: str = "  "
-_FUNCTION_KIND: str = "FUNCTION"
 
 
 @dataclass(frozen=True)
@@ -154,21 +152,11 @@ def _lint_header_values(
 
 def _parse_header_values(*, kind: str, header_text: str) -> dict[str, object]:
     inner: str = _inner_header_text(header_text=header_text)
-    if kind in (HEADER_KIND_MODEL, _FUNCTION_KIND):
-        return parse_header_values(
-            header=inner,
-            file_path=Path(_DESCRIPTION_SENTINEL_PATH),
-            statement_name=kind,
-        )
-    import yaml
-
-    stripped: str = inner.strip()
-    if not stripped:
-        return {}
-    parsed: object = yaml.safe_load(f"{{{stripped}}}")
-    if not isinstance(parsed, dict):
-        raise LintError("header must be a mapping")
-    return dict(parsed)
+    return parse_header_values(
+        header=inner,
+        file_path=Path(_DESCRIPTION_SENTINEL_PATH),
+        statement_name=kind,
+    )
 
 
 def _lint_header_whitespace(

--- a/src/sqlbuild/lint/constants.py
+++ b/src/sqlbuild/lint/constants.py
@@ -16,6 +16,7 @@ HEADER_KIND_FUNCTION: str = "FUNCTION"
 HEADER_KIND_ENUM: str = "ENUM"
 HEADER_KIND_CONSTANT: str = "CONSTANT"
 HEADER_KIND_HOOK: str = "HOOK"
+HEADER_KIND_SCHEMA: str = "SCHEMA"
 
 DSL_HEADER_KINDS: frozenset[str] = frozenset(
     {
@@ -27,6 +28,7 @@ DSL_HEADER_KINDS: frozenset[str] = frozenset(
         HEADER_KIND_ENUM,
         HEADER_KIND_CONSTANT,
         HEADER_KIND_HOOK,
+        HEADER_KIND_SCHEMA,
     }
 )
 
@@ -46,6 +48,7 @@ LINT_DIRECTORY_NAMES: tuple[str, ...] = (
     "enums",
     "constants",
     "hooks",
+    "schemas",
 )
 
 DEFAULT_SQRUFF_CONFIG_CONTENT: str = """\

--- a/tests/e2e/fixtures/dbt_interop/sqlbuild_project/tests/scenarios/downstream_orders.sql
+++ b/tests/e2e/fixtures/dbt_interop/sqlbuild_project/tests/scenarios/downstream_orders.sql
@@ -1,4 +1,4 @@
-SCENARIO (description: "Mocked dbt ref scenario", tags: ["dbt_ref"]);
+SCENARIO (description "Mocked dbt ref scenario", tags ["dbt_ref"]);
 
 WITH
 __dbt_ref__analytics__fact_orders AS (

--- a/tests/e2e/fixtures/waffle_shop/tests/scenarios/daily_revenue_minimal.sql
+++ b/tests/e2e/fixtures/waffle_shop/tests/scenarios/daily_revenue_minimal.sql
@@ -1,6 +1,6 @@
 SCENARIO (
-  description: "Daily revenue includes only successful payments",
-  tags: ["revenue", "example"]
+  description "Daily revenue includes only successful payments",
+  tags ["revenue", "example"]
 );
 
 WITH

--- a/tests/e2e/fixtures/waffle_shop/tests/scenarios/daily_revenue_multi_order.sql
+++ b/tests/e2e/fixtures/waffle_shop/tests/scenarios/daily_revenue_multi_order.sql
@@ -1,6 +1,6 @@
 SCENARIO (
-  description: "Daily revenue aggregates multiple successful orders",
-  tags: ["revenue", "example"]
+  description "Daily revenue aggregates multiple successful orders",
+  tags ["revenue", "example"]
 );
 
 WITH

--- a/tests/e2e/fixtures/waffle_shop/tests/scenarios/fact_order_retained_artifacts.sql
+++ b/tests/e2e/fixtures/waffle_shop/tests/scenarios/fact_order_retained_artifacts.sql
@@ -1,6 +1,6 @@
 SCENARIO (
-  description: "Retained scenario artifacts include source ref seed and model relations",
-  tags: ["retention", "example"]
+  description "Retained scenario artifacts include source ref seed and model relations",
+  tags ["retention", "example"]
 );
 
 WITH

--- a/tests/e2e/fixtures/waffle_shop/tests/unit/test_customer_orders_table_fn.sql
+++ b/tests/e2e/fixtures/waffle_shop/tests/unit/test_customer_orders_table_fn.sql
@@ -1,4 +1,4 @@
-TEST (mode: table_fn, name: "returns customer orders");
+TEST (mode table_fn, name "returns customer orders");
 
 WITH
 __table_fn_actual__ AS (

--- a/tests/e2e/fixtures/waffle_shop/tests/unit/test_is_completed_order_udf.sql
+++ b/tests/e2e/fixtures/waffle_shop/tests/unit/test_is_completed_order_udf.sql
@@ -1,4 +1,4 @@
-TEST (mode: udf, name: "detects completed orders");
+TEST (mode udf, name "detects completed orders");
 
 WITH
 input_values AS (

--- a/tests/e2e/fixtures/waffle_shop/tests/unit/test_line_total_cents_macro.sql
+++ b/tests/e2e/fixtures/waffle_shop/tests/unit/test_line_total_cents_macro.sql
@@ -1,4 +1,4 @@
-TEST (mode: macro, name: "calculates line total cents");
+TEST (mode macro, name "calculates line total cents");
 
 WITH
 input_values AS (

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_python_hooks.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_python_hooks.py
@@ -256,7 +256,7 @@ def test_given_project_with_python_hooks_when_building_then_hooks_execute(
             + "\n",
             "hooks/sql/select_one.sql": dedent(
                 """
-                HOOK (description: "Execute a parameterized SQL payload");
+                HOOK (description "Execute a parameterized SQL payload");
 
                 SELECT @value;
                 SELECT @value + 1

--- a/tests/e2e/src/sqlbuild/cli/commands/main/scenario/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/scenario/helpers.py
@@ -40,7 +40,7 @@ def build_scenario_project_files() -> dict[str, str]:
             'FROM __ref("orders")\n'
         ),
         "tests/scenarios/order_totals_pass.sql": (
-            'SCENARIO (description: "Order totals scenario", tags: ["scenario"]);\n\n'
+            'SCENARIO (description "Order totals scenario", tags ["scenario"]);\n\n'
             "WITH\n"
             "__source__raw_orders AS (\n"
             "  SELECT 1 AS id, 10 AS amount\n"
@@ -365,7 +365,7 @@ def write_stale_order_totals_scenario(*, project_dir: Path) -> None:
 
     scenario_path: Path = project_dir / "tests" / "scenarios" / "order_totals_pass.sql"
     scenario_path.write_text(
-        'SCENARIO (description: "Order totals scenario", tags: ["scenario"]);\n\n'
+        'SCENARIO (description "Order totals scenario", tags ["scenario"]);\n\n'
         "WITH\n"
         "__source__raw_orders AS (\n"
         "  SELECT 1 AS id, 10 AS amount\n"

--- a/tests/e2e/src/sqlbuild/cli/commands/main/scenario/test_capture.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/scenario/test_capture.py
@@ -217,7 +217,7 @@ def test_given_local_type_override_when_running_capture_then_manifest_uses_overr
         '"DECIMAL(*,*)" = "DECIMAL({1}, {2})"\n'
     )
     repo_files["tests/scenarios/order_totals_pass.sql"] = (
-        'SCENARIO (description: "Order totals scenario", tags: ["scenario"]);\n\n'
+        'SCENARIO (description "Order totals scenario", tags ["scenario"]);\n\n'
         "WITH\n"
         "__source__raw_orders AS (\n"
         "  SELECT\n"

--- a/tests/e2e/src/sqlbuild/cli/commands/main/snowflake/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/snowflake/helpers.py
@@ -484,7 +484,7 @@ def write_snowflake_dbt_scenario_date_trunc_model(*, sqlbuild_project_dir: Path)
     scenarios_dir: Path = sqlbuild_project_dir / "tests" / "scenarios"
     scenarios_dir.mkdir(parents=True, exist_ok=True)
     scenarios_dir.joinpath("dbt_event_rollup.sql").write_text(
-        'SCENARIO (description: "dbt date_trunc scenario", tags: ["dbt"]);\n\n'
+        'SCENARIO (description "dbt date_trunc scenario", tags ["dbt"]);\n\n'
         "WITH\n"
         "__source__raw__events AS (\n"
         "  SELECT 10 AS customer_id,"

--- a/tests/e2e/src/sqlbuild/cli/commands/main/test/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/test/helpers.py
@@ -121,7 +121,7 @@ def build_macro_test_project_files() -> dict[str, str]:
             "MODEL (materialized table);\n\nSELECT @normalize_status(\"'  PAID  '\") AS status\n"
         ),
         "tests/unit/test_normalize_status.sql": (
-            'TEST (mode: macro, name: "normalizes status");\n\n'
+            'TEST (mode macro, name "normalizes status");\n\n'
             "WITH\n"
             "input_values AS (SELECT '  PAID  ' AS raw_status),\n"
             "__macro_actual__ AS (\n"

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_assembly.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_assembly.py
@@ -128,7 +128,7 @@ SELECT 1
                 "sqlbuild_project.toml": 'name = "demo"\nadapter = "duckdb"\n',
                 "models/orders.sql": "MODEL ();\n\nSELECT 1 AS order_id\n",
                 "audits/orders.sql": """
-AUDIT (always_run: true);
+AUDIT (always_run true);
 
 SELECT order_id FROM __ref("orders") WHERE order_id IS NULL
 """.strip()
@@ -276,7 +276,7 @@ seeds:
                 ),
                 "models/customers.sql": "MODEL ();\n\nSELECT 'active' AS status\n",
                 "tests/unit/test_normalize_status.sql": """
-TEST (mode: macro, name: "normalizes status");
+TEST (mode macro, name "normalizes status");
 
 WITH
 input_values AS (SELECT '  PAID  ' AS raw_status),
@@ -372,7 +372,7 @@ FUNCTION (
                 ),
                 "models/customers.sql": "MODEL ();\n\nSELECT 'active' AS status\n",
                 "tests/unit/test_format_cents.sql": """
-TEST (mode: udf, name: "formats cents");
+TEST (mode udf, name "formats cents");
 
 WITH
 input_values AS (SELECT 1250 AS amount_cents),
@@ -426,7 +426,7 @@ SELECT p_customer_id AS customer_id, 1 AS order_id
                     'FROM __table_fn("customer_orders")(42)\n'
                 ),
                 "tests/unit/test_customer_orders.sql": """
-TEST (mode: table_fn, name: "returns customer orders");
+TEST (mode table_fn, name "returns customer orders");
 
 WITH
 __table_fn_actual__ AS (

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_tests.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_tests.py
@@ -537,7 +537,7 @@ def test_given_direct_logic_sql_test_cte_variants_when_extracting_then_it_return
         __macro_expected__ AS (SELECT 'paid' AS status)
         SELECT 1
         """.strip(),
-            expected_error_fragment=r"use TEST \(mode: macro\)",
+            expected_error_fragment=r"use TEST \(mode macro\)",
         ),
         ExtractSqlTestCtesErrorTestCase(
             description="raises when model mode includes udf actual cte",
@@ -546,7 +546,7 @@ def test_given_direct_logic_sql_test_cte_variants_when_extracting_then_it_return
         __udf_expected__ AS (SELECT '$12.50' AS formatted)
         SELECT 1
         """.strip(),
-            expected_error_fragment=r"use TEST \(mode: udf\)",
+            expected_error_fragment=r"use TEST \(mode udf\)",
         ),
         ExtractSqlTestCtesErrorTestCase(
             description="raises when model mode includes table function actual cte",
@@ -555,7 +555,7 @@ def test_given_direct_logic_sql_test_cte_variants_when_extracting_then_it_return
         __table_fn_expected__ AS (SELECT 42 AS customer_id)
         SELECT 1
         """.strip(),
-            expected_error_fragment=r"use TEST \(mode: table_fn\)",
+            expected_error_fragment=r"use TEST \(mode table_fn\)",
         ),
         ExtractSqlTestCtesErrorTestCase(
             description="raises when macro mode includes model test cte",

--- a/tests/unit/src/sqlbuild/compiler/compile/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_main.py
@@ -1653,7 +1653,7 @@ SELECT 1 AS id
 """.strip()
                 + "\n",
                 "hooks/sql/record_access.sql": """
-HOOK (description: "Record model access");
+HOOK (description "Record model access");
 
 SELECT @'role' AS role, '@@CTX:destination.qualified' AS relation_name
 """.strip()
@@ -1960,7 +1960,7 @@ def project_columns() -> str:
                 + "\n",
                 "models/staging/orders.sql": "MODEL ();\n\nselect 1\n",
                 "tests/unit/orders.sql": """
-TEST (name: "first");
+TEST (name "first");
 
 WITH
 __ref__orders AS (
@@ -1971,7 +1971,7 @@ __expected__orders AS (
 )
 SELECT 1;
 
-TEST (name: "second");
+TEST (name "second");
 
 WITH
 __ref__orders AS (
@@ -1984,11 +1984,11 @@ SELECT 1
 """.strip()
                 + "\n",
                 "audits/orders.sql": """
-AUDIT (name: "first");
+AUDIT (name "first");
 
 SELECT @project_columns() FROM raw_orders;
 
-AUDIT (name: "second");
+AUDIT (name "second");
 
 SELECT @project_columns() FROM raw_customers
 """.strip()
@@ -2964,7 +2964,7 @@ SELECT customer_id AS order_id
 """.strip()
                 + "\n",
                 "tests/unit/test_customer_orders.sql": """
-TEST (mode: table_fn, name: "customer orders arity");
+TEST (mode table_fn, name "customer orders arity");
 
 WITH
 __table_fn_actual__ AS (

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
@@ -276,6 +276,7 @@ class ParseSqlTestFileTestCase:
     expected_names: tuple[str | None, ...]
     expected_sql_bodies: tuple[str, ...]
     expected_test_indexes: tuple[int, ...]
+    expected_header_values: tuple[dict[str, object], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -320,6 +321,7 @@ class ParseSqlAuditFileTestCase:
     expected_names: tuple[str | None, ...]
     expected_sql_bodies: tuple[str, ...]
     expected_audit_indexes: tuple[int, ...]
+    expected_header_values: tuple[dict[str, object], ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_audits.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_audits.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from sqlbuild.compiler.discovery._helpers.sql.audits import parse_sql_audit_file
+from sqlbuild.compiler.discovery.exceptions import SqlAuditParseError
 from sqlbuild.compiler.discovery.models import DiscoveredAuditBlock
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
     ParseSqlAuditFileErrorTestCase,
@@ -27,17 +28,18 @@ from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
             expected_names=(None,),
             expected_sql_bodies=('SELECT order_id\nFROM __ref("orders")\nWHERE order_total < 0',),
             expected_audit_indexes=(1,),
+            expected_header_values=({},),
         ),
         ParseSqlAuditFileTestCase(
             description="discovers multiple named audit blocks from one file",
             contents="""
-        AUDIT (name: "negative totals");
+        AUDIT (name "negative totals");
 
         SELECT order_id
         FROM __ref("orders")
         WHERE order_total < 0;
 
-        AUDIT (name: "missing customers");
+        AUDIT (name "missing customers");
 
         SELECT customer_id
         FROM __ref("orders")
@@ -49,17 +51,34 @@ from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
                 'SELECT customer_id\nFROM __ref("orders")\nWHERE customer_id IS NULL',
             ),
             expected_audit_indexes=(1, 2),
+            expected_header_values=(
+                {"name": "negative totals"},
+                {"name": "missing customers"},
+            ),
         ),
         ParseSqlAuditFileTestCase(
-            description="parses a single named audit block",
+            description="parses all supported audit fields",
             contents="""
-        AUDIT (name: "negative totals");
+        AUDIT (
+          name "negative: totals",
+          severity warn,
+          run_scope delta_and_final,
+          always_run true
+        );
 
         SELECT 1
         """,
-            expected_names=("negative totals",),
+            expected_names=("negative: totals",),
             expected_sql_bodies=("SELECT 1",),
             expected_audit_indexes=(1,),
+            expected_header_values=(
+                {
+                    "name": "negative: totals",
+                    "severity": "warn",
+                    "run_scope": "delta_and_final",
+                    "always_run": True,
+                },
+            ),
         ),
     ],
     ids=lambda case: case.description,
@@ -75,6 +94,9 @@ def test_given_sql_audit_file_variants_when_parsing_then_it_returns_expected_raw
     assert tuple(block.sql_body for block in discovered_blocks) == test_case.expected_sql_bodies
     assert (
         tuple(block.audit_index for block in discovered_blocks) == test_case.expected_audit_indexes
+    )
+    assert tuple(block.header_values for block in discovered_blocks) == (
+        test_case.expected_header_values
     )
 
 
@@ -97,18 +119,18 @@ def test_given_sql_audit_file_variants_when_parsing_then_it_returns_expected_raw
             expected_error_fragment="must define SQL after AUDIT(...)",
         ),
         ParseSqlAuditFileErrorTestCase(
-            description="raises when the audit header contains malformed yaml",
+            description="rejects the old colon syntax",
             contents="""
-        AUDIT (name: [broken);
+        AUDIT (name: "legacy");
 
         SELECT 1
         """,
-            expected_error_fragment="could not be parsed",
+            expected_error_fragment="unexpected ':' after key 'name'",
         ),
         ParseSqlAuditFileErrorTestCase(
             description="raises when the audit header includes unsupported keys",
             contents="""
-        AUDIT (name: "negative totals", unsupported: true);
+        AUDIT (name "negative totals", unsupported true);
 
         SELECT 1
         """,
@@ -117,7 +139,7 @@ def test_given_sql_audit_file_variants_when_parsing_then_it_returns_expected_raw
         ParseSqlAuditFileErrorTestCase(
             description="raises when the audit name is blank",
             contents="""
-        AUDIT (name: "   ");
+        AUDIT (name "   ");
 
         SELECT 1
         """,
@@ -126,16 +148,36 @@ def test_given_sql_audit_file_variants_when_parsing_then_it_returns_expected_raw
         ParseSqlAuditFileErrorTestCase(
             description="raises when the audit name is not a string",
             contents="""
-        AUDIT (name: 123);
+        AUDIT (name 123);
 
         SELECT 1
         """,
             expected_error_fragment="must be a non-empty string",
         ),
         ParseSqlAuditFileErrorTestCase(
+            description="rejects an explicit null audit name",
+            contents="AUDIT (name null);\n\nSELECT 1\n",
+            expected_error_fragment="name.*must be a non-empty string",
+        ),
+        ParseSqlAuditFileErrorTestCase(
+            description="rejects an explicit null audit severity",
+            contents="AUDIT (severity null);\n\nSELECT 1\n",
+            expected_error_fragment="severity.*must be a non-empty string",
+        ),
+        ParseSqlAuditFileErrorTestCase(
+            description="rejects an explicit null audit run scope",
+            contents="AUDIT (run_scope null);\n\nSELECT 1\n",
+            expected_error_fragment="run_scope.*must be a non-empty string",
+        ),
+        ParseSqlAuditFileErrorTestCase(
+            description="rejects an explicit null audit always run flag",
+            contents="AUDIT (always_run null);\n\nSELECT 1\n",
+            expected_error_fragment="always_run.*must be a boolean",
+        ),
+        ParseSqlAuditFileErrorTestCase(
             description="raises when a multi-block file leaves one audit unnamed",
             contents="""
-        AUDIT (name: "negative totals");
+        AUDIT (name "negative totals");
 
         SELECT 1;
 
@@ -148,15 +190,20 @@ def test_given_sql_audit_file_variants_when_parsing_then_it_returns_expected_raw
         ParseSqlAuditFileErrorTestCase(
             description="raises when a multi-block file repeats an audit name",
             contents="""
-        AUDIT (name: "shared");
+        AUDIT (name "shared");
 
         SELECT 1;
 
-        AUDIT (name: "shared");
+        AUDIT (name "shared");
 
         SELECT 1
         """,
             expected_error_fragment=r"defines duplicate AUDIT\(\) name 'shared'",
+        ),
+        ParseSqlAuditFileErrorTestCase(
+            description="rejects duplicate audit keys",
+            contents='AUDIT (name "first", name "second");\n\nSELECT 1\n',
+            expected_error_fragment="duplicate.*name",
         ),
     ],
     ids=lambda case: case.description,
@@ -164,5 +211,5 @@ def test_given_sql_audit_file_variants_when_parsing_then_it_returns_expected_raw
 def test_given_invalid_sql_audit_file_contents_when_parsing_then_it_raises_clear_errors(
     test_case: ParseSqlAuditFileErrorTestCase,
 ) -> None:
-    with pytest.raises(ValueError, match=test_case.expected_error_fragment):
+    with pytest.raises(SqlAuditParseError, match=test_case.expected_error_fragment):
         parse_sql_audit_file(contents=test_case.contents, file_path=Path("audits/orders.sql"))

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_hooks.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_hooks.py
@@ -21,12 +21,10 @@ from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
     [
         ParseSqlHookTestCase(
             description="parses hook description and SQL body",
-            contents=(
-                "HOOK (description: \"Grant access\");\n\nGRANT SELECT ON @relation TO @'role'\n"
-            ),
+            contents=('HOOK (description "Grant: access");\n\n@grant(role: "analyst:read")\n'),
             expected_name="grant_access",
-            expected_description="Grant access",
-            expected_sql_body="GRANT SELECT ON @relation TO @'role'",
+            expected_description="Grant: access",
+            expected_sql_body='@grant(role: "analyst:read")',
         ),
         ParseSqlHookTestCase(
             description="allows header-like text inside strings and comments",
@@ -37,7 +35,7 @@ from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
         ),
         ParseSqlHookTestCase(
             description="allows header terminator text inside quoted descriptions",
-            contents='HOOK (description: "Run cleanup(); safely");\n\nSELECT 1\n',
+            contents='HOOK (description "Run cleanup(); safely");\n\nSELECT 1\n',
             expected_name="grant_access",
             expected_description="Run cleanup(); safely",
             expected_sql_body="SELECT 1",
@@ -245,13 +243,33 @@ def test_given_nested_sql_hook_files_when_discovering_then_names_come_from_stems
         ),
         ParseSqlHookErrorTestCase(
             description="rejects unsupported hook header key",
-            contents='HOOK (name: "override");\nSELECT 1\n',
+            contents='HOOK (name "override");\nSELECT 1\n',
             expected_error_fragment="unsupported keys: name",
         ),
         ParseSqlHookErrorTestCase(
             description="rejects a missing hook header",
             contents="SELECT 1\n",
             expected_error_fragment="must start with a HOOK",
+        ),
+        ParseSqlHookErrorTestCase(
+            description="rejects the old colon syntax",
+            contents='HOOK (description: "legacy");\nSELECT 1\n',
+            expected_error_fragment="unexpected ':' after key 'description'",
+        ),
+        ParseSqlHookErrorTestCase(
+            description="rejects duplicate hook keys",
+            contents='HOOK (description "first", description "second");\nSELECT 1\n',
+            expected_error_fragment="duplicate.*description",
+        ),
+        ParseSqlHookErrorTestCase(
+            description="rejects a non-string description",
+            contents="HOOK (description 123);\nSELECT 1\n",
+            expected_error_fragment="description.*non-empty string",
+        ),
+        ParseSqlHookErrorTestCase(
+            description="rejects an explicit null description",
+            contents="HOOK (description null);\nSELECT 1\n",
+            expected_error_fragment="description.*non-empty string",
         ),
     ],
     ids=lambda case: case.description,

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_scenarios.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_scenarios.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from sqlbuild.compiler.discovery._helpers.sql.scenarios import parse_sql_scenario_file
+from sqlbuild.compiler.discovery.exceptions import SqlScenarioParseError
 from sqlbuild.compiler.discovery.models import DiscoveredSqlScenarioFile
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
     ParseSqlScenarioFileErrorTestCase,
@@ -18,7 +19,7 @@ from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
         ParseSqlScenarioFileTestCase(
             description="parses scenario metadata and sql body",
             contents="""
-        SCENARIO (description: "Customer refund case", tags: ["revenue", "refunds"]);
+        SCENARIO (description "Customer: refund case", tags [revenue, refunds, yes]);
 
         WITH
         __source__raw__orders AS (
@@ -31,8 +32,8 @@ from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
         """,
             expected_name="revenue__customer_refund",
             expected_header_values={
-                "description": "Customer refund case",
-                "tags": ["revenue", "refunds"],
+                "description": "Customer: refund case",
+                "tags": ["revenue", "refunds", "yes"],
             },
             expected_sql_body=(
                 "WITH\n"
@@ -94,7 +95,7 @@ def test_given_sql_scenario_file_variants_when_parsing_then_it_returns_expected_
         ParseSqlScenarioFileErrorTestCase(
             description="raises when scenario header includes unsupported name",
             contents="""
-        SCENARIO (name: "customer_refund");
+        SCENARIO (name "customer_refund");
 
         SELECT 1
         """,
@@ -103,19 +104,29 @@ def test_given_sql_scenario_file_variants_when_parsing_then_it_returns_expected_
         ParseSqlScenarioFileErrorTestCase(
             description="raises when description is not a string",
             contents="""
-        SCENARIO (description: 123);
+        SCENARIO (description 123);
 
         SELECT 1
         """,
             expected_error_fragment="description.*must be a string",
         ),
         ParseSqlScenarioFileErrorTestCase(
+            description="rejects an explicit null description",
+            contents="SCENARIO (description null);\n\nSELECT 1\n",
+            expected_error_fragment="description.*must be a string",
+        ),
+        ParseSqlScenarioFileErrorTestCase(
             description="raises when tags is not a list of strings",
             contents="""
-        SCENARIO (tags: [revenue, 123]);
+        SCENARIO (tags [revenue, 123]);
 
         SELECT 1
         """,
+            expected_error_fragment="tags.*must be a list of strings",
+        ),
+        ParseSqlScenarioFileErrorTestCase(
+            description="rejects explicit null tags",
+            contents="SCENARIO (tags null);\n\nSELECT 1\n",
             expected_error_fragment="tags.*must be a list of strings",
         ),
         ParseSqlScenarioFileErrorTestCase(
@@ -123,13 +134,23 @@ def test_given_sql_scenario_file_variants_when_parsing_then_it_returns_expected_
             contents="SCENARIO ();\n",
             expected_error_fragment="must define SQL after SCENARIO",
         ),
+        ParseSqlScenarioFileErrorTestCase(
+            description="rejects the old colon syntax",
+            contents='SCENARIO (description: "legacy");\n\nSELECT 1\n',
+            expected_error_fragment="unexpected ':' after key 'description'",
+        ),
+        ParseSqlScenarioFileErrorTestCase(
+            description="rejects duplicate scenario keys",
+            contents='SCENARIO (description "first", description "second");\n\nSELECT 1\n',
+            expected_error_fragment="duplicate.*description",
+        ),
     ],
     ids=lambda case: case.description,
 )
 def test_given_invalid_sql_scenario_file_contents_when_parsing_then_it_raises_clear_errors(
     test_case: ParseSqlScenarioFileErrorTestCase,
 ) -> None:
-    with pytest.raises(ValueError, match=test_case.expected_error_fragment):
+    with pytest.raises(SqlScenarioParseError, match=test_case.expected_error_fragment):
         parse_sql_scenario_file(
             contents=test_case.contents,
             file_path=Path("tests/scenarios/revenue/revenue__customer_refund.sql"),

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_tests.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_tests.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from sqlbuild.compiler.discovery._helpers.sql.tests import parse_sql_test_file
+from sqlbuild.compiler.discovery.exceptions import SqlTestParseError
 from sqlbuild.compiler.discovery.models import DiscoveredSqlTestBlock
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
     ParseSqlTestFileErrorTestCase,
@@ -31,11 +32,12 @@ from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
                 "WITH\n__source__orders AS (\n  SELECT 1 AS order_id\n)\nSELECT 1",
             ),
             expected_test_indexes=(1,),
+            expected_header_values=({},),
         ),
         ParseSqlTestFileTestCase(
             description="discovers multiple named test blocks from one file",
             contents="""
-        TEST (name: "first");
+        TEST (name "first");
 
         WITH
         __source__orders AS (
@@ -43,7 +45,7 @@ from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
         )
         SELECT 1;
 
-        TEST (name: "second");
+        TEST (name "second");
 
         WITH
         __ref__orders AS (
@@ -57,17 +59,19 @@ from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
                 "WITH\n__ref__orders AS (\n  SELECT 2 AS order_id\n)\nSELECT 1",
             ),
             expected_test_indexes=(1, 2),
+            expected_header_values=({"name": "first"}, {"name": "second"}),
         ),
         ParseSqlTestFileTestCase(
             description="parses a single named test block",
             contents="""
-        TEST (name: "orders logic");
+        TEST (name "orders logic", mode macro);
 
         SELECT 1
         """,
             expected_names=("orders logic",),
             expected_sql_bodies=("SELECT 1",),
             expected_test_indexes=(1,),
+            expected_header_values=({"name": "orders logic", "mode": "macro"},),
         ),
     ],
     ids=lambda case: case.description,
@@ -82,6 +86,9 @@ def test_given_sql_test_file_variants_when_parsing_then_it_returns_expected_raw_
     assert tuple(block.name for block in discovered_blocks) == test_case.expected_names
     assert tuple(block.sql_body for block in discovered_blocks) == test_case.expected_sql_bodies
     assert tuple(block.test_index for block in discovered_blocks) == test_case.expected_test_indexes
+    assert tuple(block.header_values for block in discovered_blocks) == (
+        test_case.expected_header_values
+    )
 
 
 @pytest.mark.parametrize(
@@ -103,18 +110,18 @@ def test_given_sql_test_file_variants_when_parsing_then_it_returns_expected_raw_
             expected_error_fragment="must define SQL after TEST(...)",
         ),
         ParseSqlTestFileErrorTestCase(
-            description="raises when the test header contains malformed yaml",
+            description="rejects the old colon syntax",
             contents="""
-        TEST (name: [broken);
+        TEST (name: "orders");
 
         SELECT 1
         """,
-            expected_error_fragment="could not be parsed",
+            expected_error_fragment="unexpected ':' after key 'name'",
         ),
         ParseSqlTestFileErrorTestCase(
             description="raises when the test header includes unsupported keys",
             contents="""
-        TEST (name: "orders", chain: true);
+        TEST (name "orders", chain true);
 
         SELECT 1
         """,
@@ -123,7 +130,7 @@ def test_given_sql_test_file_variants_when_parsing_then_it_returns_expected_raw_
         ParseSqlTestFileErrorTestCase(
             description="raises when the test name is blank",
             contents="""
-        TEST (name: "   ");
+        TEST (name "   ");
 
         SELECT 1
         """,
@@ -132,16 +139,26 @@ def test_given_sql_test_file_variants_when_parsing_then_it_returns_expected_raw_
         ParseSqlTestFileErrorTestCase(
             description="raises when the test name is not a string",
             contents="""
-        TEST (name: 123);
+        TEST (name 123);
 
         SELECT 1
         """,
             expected_error_fragment="must be a non-empty string",
         ),
         ParseSqlTestFileErrorTestCase(
+            description="rejects an explicit null test name",
+            contents="TEST (name null);\n\nSELECT 1\n",
+            expected_error_fragment="name.*must be a non-empty string",
+        ),
+        ParseSqlTestFileErrorTestCase(
+            description="rejects an explicit null test mode with a discovery error",
+            contents="TEST (mode null);\n\nSELECT 1\n",
+            expected_error_fragment="mode.*must be a string",
+        ),
+        ParseSqlTestFileErrorTestCase(
             description="raises when a multi-block file leaves one block unnamed",
             contents="""
-        TEST (name: "first");
+        TEST (name "first");
 
         SELECT 1;
 
@@ -154,15 +171,25 @@ def test_given_sql_test_file_variants_when_parsing_then_it_returns_expected_raw_
         ParseSqlTestFileErrorTestCase(
             description="raises when a multi-block file repeats a test name",
             contents="""
-        TEST (name: "shared");
+        TEST (name "shared");
 
         SELECT 1;
 
-        TEST (name: "shared");
+        TEST (name "shared");
 
         SELECT 1
         """,
             expected_error_fragment=r"defines duplicate TEST\(\) name 'shared'",
+        ),
+        ParseSqlTestFileErrorTestCase(
+            description="rejects duplicate header keys",
+            contents='TEST (name "first", name "second");\n\nSELECT 1\n',
+            expected_error_fragment="duplicate.*name",
+        ),
+        ParseSqlTestFileErrorTestCase(
+            description="rejects an unknown test mode",
+            contents="TEST (mode integration);\n\nSELECT 1\n",
+            expected_error_fragment="mode.*must be one of",
         ),
     ],
     ids=lambda case: case.description,
@@ -170,5 +197,5 @@ def test_given_sql_test_file_variants_when_parsing_then_it_returns_expected_raw_
 def test_given_invalid_sql_test_file_contents_when_parsing_then_it_raises_clear_errors(
     test_case: ParseSqlTestFileErrorTestCase,
 ) -> None:
-    with pytest.raises(ValueError, match=test_case.expected_error_fragment):
+    with pytest.raises(SqlTestParseError, match=test_case.expected_error_fragment):
         parse_sql_test_file(contents=test_case.contents, file_path=Path("tests/unit/orders.sql"))

--- a/tests/unit/src/sqlbuild/compiler/discovery/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/test_main.py
@@ -48,7 +48,7 @@ seeds:
                 "tests/unit/orders.sql": "TEST ();\nSELECT 1\n",
                 "tests/legacy_orders.sql": "TEST ();\nSELECT 2\n",
                 "tests/scenarios/revenue/revenue__customer_refund.sql": """
-SCENARIO (description: "Customer refund", tags: ["revenue"]);
+SCENARIO (description "Customer refund", tags ["revenue"]);
 
 WITH
 __expected__daily_revenue AS (

--- a/tests/unit/src/sqlbuild/lint/_helpers/test_headers.py
+++ b/tests/unit/src/sqlbuild/lint/_helpers/test_headers.py
@@ -23,9 +23,9 @@ from tests.unit.src.sqlbuild.lint._helpers._test_types import (
         ScanHeadersTestCase(
             description="finds scenario test and audit headers in one file",
             contents=(
-                'SCENARIO (description: "d");\nSELECT 1\n'
+                'SCENARIO (description "d");\nSELECT 1\n'
                 "TEST ();\nSELECT 2\n"
-                'AUDIT (name: "a");\nSELECT 3\n'
+                'AUDIT (name "a");\nSELECT 3\n'
             ),
             expected_kinds=("SCENARIO", "TEST", "AUDIT"),
         ),

--- a/tests/unit/src/sqlbuild/lint/_helpers/test_native.py
+++ b/tests/unit/src/sqlbuild/lint/_helpers/test_native.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import pytest
 
 from sqlbuild.compiler.discovery._helpers.sql.model_files import parse_model_sql
+from sqlbuild.compiler.discovery._helpers.sql.scenarios import parse_sql_scenario_file
+from sqlbuild.compiler.discovery.exceptions import SqlScenarioParseError
 from sqlbuild.lint._helpers.headers import scan_headers
 from sqlbuild.lint._helpers.native import format_native_headers, lint_native_headers
 from sqlbuild.lint.models import LintConfig
@@ -34,13 +36,13 @@ DEFAULT_CONFIG: LintConfig = LintConfig()
         ),
         LintNativeTestCase(
             description="scenario without description does not fault",
-            contents='SCENARIO (tags: ["x"]);\nSELECT 1\n',
+            contents='SCENARIO (tags ["x"]);\nSELECT 1\n',
             expected_codes=(),
         ),
         LintNativeTestCase(
             description="long single-line scenario description passes",
             contents=(
-                'SCENARIO (description: "'
+                'SCENARIO (description "'
                 + " ".join(f"word{index}" for index in range(400))
                 + '");\nSELECT 1\n'
             ),
@@ -49,8 +51,8 @@ DEFAULT_CONFIG: LintConfig = LintConfig()
         LintNativeTestCase(
             description="oversized multiline scenario description faults",
             contents=(
-                'SCENARIO (description: "'
-                + "\\n ".join(f"line {index}" for index in range(11))
+                'SCENARIO (description "'
+                + "\n ".join(f"line {index}" for index in range(11))
                 + '");\nSELECT 1\n'
             ),
             expected_codes=("description-length",),
@@ -58,6 +60,11 @@ DEFAULT_CONFIG: LintConfig = LintConfig()
         LintNativeTestCase(
             description="broken model header faults with parse error",
             contents="MODEL (\n  materialized table,\n  description\n);\nSELECT 1\n",
+            expected_codes=("header-parse",),
+        ),
+        LintNativeTestCase(
+            description="legacy scenario colon syntax faults with parse error",
+            contents='SCENARIO (description: "legacy");\nSELECT 1\n',
             expected_codes=("header-parse",),
         ),
     ],
@@ -74,6 +81,38 @@ def test_given_contents_when_linting_then_codes_match_expected(
         config=DEFAULT_CONFIG,
     )
     assert tuple(violation.code for violation in violations) == test_case.expected_codes
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        LintNativeTestCase(
+            description="legacy scenario header is rejected by lint and compile",
+            contents='SCENARIO (description: "legacy");\nSELECT 1\n',
+            expected_codes=("header-parse",),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_legacy_scenario_header_when_linting_and_compiling_then_both_reject_it(
+    test_case: LintNativeTestCase,
+) -> None:
+    headers: tuple = scan_headers(contents=test_case.contents)
+
+    violations: tuple = lint_native_headers(
+        contents=test_case.contents,
+        file_path=FILE_PATH,
+        headers=headers,
+        config=DEFAULT_CONFIG,
+    )
+
+    assert tuple(violation.code for violation in violations) == test_case.expected_codes
+    with pytest.raises(SqlScenarioParseError, match="unexpected ':' after key 'description'"):
+        parse_sql_scenario_file(
+            contents=test_case.contents,
+            file_path=Path("tests/scenarios/example.sql"),
+            relative_path=Path("tests/scenarios/example.sql"),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/lint/test_expanded_lint.py
+++ b/tests/unit/src/sqlbuild/lint/test_expanded_lint.py
@@ -12,6 +12,7 @@ from sqlbuild.lint.models import LintConfig, LintRunResult
 from tests.unit.src.sqlbuild.lint._test_types import (
     ExpandedLintTestCase,
     LintCompileFailureTestCase,
+    LintProjectTestCase,
 )
 
 PROJECT_TOML: str = 'name = "demo"\nadapter = "duckdb"\n'
@@ -122,3 +123,40 @@ def test_given_uncompilable_project_when_linting_then_it_fails_clearly(
     with pytest.raises(ProjectCompileError) as error:
         _ = run_lint(project_dir=tmp_path, config=LintConfig(sqruff_enabled=True))
     assert test_case.expected_message_fragment in str(error.value)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        LintProjectTestCase(
+            description="canonical scenario header is accepted by lint and compile",
+            files={
+                "sqlbuild_project.toml": PROJECT_TOML,
+                "tests/scenarios/example.sql": (
+                    'SCENARIO (description "Contains: a colon", tags [yes, on]);\nSELECT 1\n'
+                ),
+            },
+            sqruff_enabled=True,
+            expected_fault_codes=(),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_canonical_scenario_header_when_linting_and_compiling_then_both_accept_it(
+    tmp_path: Path,
+    test_case: LintProjectTestCase,
+) -> None:
+    for relative_path, contents in test_case.files.items():
+        target: Path = tmp_path / relative_path
+        _ = target.parent.mkdir(parents=True, exist_ok=True)
+        _ = target.write_text(contents, encoding="utf-8")
+
+    result: LintRunResult = run_lint(
+        project_dir=tmp_path,
+        config=LintConfig(sqruff_enabled=test_case.sqruff_enabled),
+    )
+
+    assert (
+        tuple((violation.file_path.as_posix(), violation.code) for violation in result.violations)
+        == test_case.expected_fault_codes
+    )

--- a/tests/unit/src/sqlbuild/lint/test_run_lint.py
+++ b/tests/unit/src/sqlbuild/lint/test_run_lint.py
@@ -34,6 +34,11 @@ PROJECT_TOML: str = 'name = "demo"\nadapter = "duckdb"\n'
             expected_fault_codes=(),
         ),
         LintProjectTestCase(
+            description="schema declarations are discovered for linting",
+            files={"schemas/order.sql": "SCHEMA (name order, columns (id (type INTEGER)));\n"},
+            expected_fault_codes=(),
+        ),
+        LintProjectTestCase(
             description="sqruff engine violations are reported when enabled",
             extra_files={"sqlbuild_project.toml": PROJECT_TOML},
             files={
@@ -62,7 +67,7 @@ def test_given_synthetic_project_when_linting_then_results_match_expected(
         project_dir=tmp_path,
         config=LintConfig(sqruff_enabled=test_case.sqruff_enabled),
     )
-    assert result.files_checked == len(test_case.files)
+    assert result.files_checked == test_case.expected_files_checked
     codes: set = {(violation.file_path.name, violation.code) for violation in result.violations}
     expected_code: tuple[str, str]
     for expected_code in test_case.expected_fault_codes:


### PR DESCRIPTION
## Why
TEST, SCENARIO, AUDIT, and HOOK still used independent YAML-backed header parsing while the rest of the native DSL used canonical `key value` syntax. This created compile/lint drift and omitted SCHEMA files from native lint discovery. Closes CHI-114.

## Changes
- route TEST, SCENARIO, AUDIT, and HOOK headers through the compiler-owned native parser
- reject legacy colon syntax and explicit nulls with resource-specific diagnostics
- preserve nested hook-call `key: value` arguments
- unify lint parsing, add SCHEMA discovery, and migrate fixtures/playground guidance
- regenerate the packaged SQLBuild skill and fix its module-based generation entry point

## Verification
- `make check-ci`
- `make rust-check`
- `make test` (4300 passed)
- `make test-e2e-duckdb` (572 passed; 6 performance checks passed)
- focused native resource parser/lint suite (140 passed before final null cases; 75 parser cases after final fix)
- generated skill is byte-for-byte reproducible from the docs worktree
- `uv lock --check --python 3.12`