### PR TITLE
feat(constants): support typed SQL values

### DIFF
--- a/crates/sqlbuild-kata-native/src/models.rs
+++ b/crates/sqlbuild-kata-native/src/models.rs
@@ -126,6 +126,9 @@ pub(crate) struct Declaration {
     pub name: String,
     pub relative_path: String,
     pub members: Vec<DeclarationMember>,
+    pub value: Option<Value>,
+    pub value_type: Option<String>,
+    pub render_as: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
+++ b/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
@@ -1047,6 +1047,9 @@ default_audit_severity = "warn"
 [defaults]
 materialized = "table"
 
+[constants]
+collection_rendering = "value_list"
+
 [targets.prod]
 schema = "prod"
 
@@ -1190,6 +1193,19 @@ tags = ["managed"]
 ```
 
 These apply to all models unless overridden by path defaults or the model's own `MODEL()` header.
+
+### Constants
+
+Collection constants default to parenthesized SQL value lists. Set a project-wide default when lists and sets should instead compile to first-class adapter-native arrays:
+
+```toml
+[constants]
+collection_rendering = "array"
+```
+
+`collection_rendering` accepts `value_list` (the SQLBuild default) or `array`. A public constant's `render_as` field or a model-local `constant(...)` wrapper overrides the project setting. The complete precedence order is declaration override, project setting, then `value_list`.
+
+This setting does not make unsupported adapter features portable. In particular, SQL Server rejects native arrays, and BigQuery rejects nested arrays. See [Enums and Constants](/concepts/enums-and-constants#rendering-configuration) for syntax, adapter output, and value-list usage constraints.
 
 ### Path defaults
 
@@ -1765,6 +1781,20 @@ project = "my-gcp-project"
 credentials_path = "/path/to/service-account.json"
 ```
 
+### Typed constants
+
+BigQuery renders typed constant arrays with bracket syntax, objects as native JSON expressions, and exact decimals as `NUMERIC` expressions. For example:
+
+```sql
+['GB', 'FR', 'HK']
+JSON '{"GB":"Great Britain"}'
+NUMERIC '2.4700'
+```
+
+BigQuery does not support arrays of arrays. A nested list or set requested with `render_as array` fails at compile time rather than producing invalid BigQuery SQL. Parenthesized `value_list` rendering remains available for ordinary scalar collections used with `IN`.
+
+See [Enums and Constants](/concepts/enums-and-constants#adapter-matrix) for declarations, rendering precedence, and the cross-adapter matrix.
+
 ## Databricks
 
 Source: `concepts/adapters/databricks.mdx`
@@ -1903,6 +1933,18 @@ database = "my_database"
 All fields in `connection` are passed to `pymssql.connect()`. See the [pymssql documentation](https://pymssql.readthedocs.io/en/stable/ref/pymssql.html) for all available options.
 
 SQL Server supports schema-only, full-row, and bounded `sqb diff` comparisons.
+
+### Typed constants
+
+SQL Server supports scalar and parenthesized `value_list` constants. Strings use Unicode literals where required, and objects render through a JSON expression such as:
+
+```sql
+JSON_QUERY(N'{"GB":"Great Britain"}')
+```
+
+SQL Server has no supported first-class native array expression. Any list or set that resolves to `render_as array`, whether through its declaration or `[constants].collection_rendering`, fails at compile time. SQLBuild does not silently substitute a value list or quoted JSON string.
+
+See [Enums and Constants](/concepts/enums-and-constants#adapter-matrix) for declarations, rendering precedence, and the cross-adapter matrix.
 
 ### Per-target connections
 
@@ -3121,7 +3163,7 @@ MODEL() header fields and SQL-validation controls.
 | `model_schema` | Reusable column schema name |
 | `audits` | Model-level audit instances |
 | `enums` | Model-local enum declarations; names must begin with `_` |
-| `constants` | Model-local scalar constants; names must begin with `_` |
+| `constants` | Model-local scalar, list, set, or object constants; names must begin with `_`. Use `constant(...)` for an explicit decimal type or collection rendering override. |
 | `schema` | Destination warehouse schema override |
 | `database` | Destination database override |
 | `alias` | Destination relation-name override |
@@ -3588,9 +3630,9 @@ exceptions.
 
 Source: `concepts/enums-and-constants.mdx`
 
-Declare compiler-validated domain values and scalar constants for use across SQLBuild SQL.
+Declare compiler-validated domain values and typed constants for use across SQLBuild SQL.
 
-Enums name a fixed domain of string or integer values. Constants name one string or integer value. SQLBuild validates references at compile time and renders them as SQL literals.
+Enums name a fixed domain of string or integer values. Constants name a compiler-validated SQL value: a scalar, list, set, or object. SQLBuild validates and normalizes declarations at compile time, then asks the active adapter to render them safely for its SQL dialect.
 
 ### Public declarations
 
@@ -3621,15 +3663,102 @@ ENUM (
 );
 ```
 
+Constants use canonical key-value fields. A file may contain multiple declarations:
+
 ```sql
 -- constants/market/thresholds.sql
 CONSTANT (name min_runners, value 7);
 CONSTANT (name fallback_source, value "centrum");
+CONSTANT (name enabled, value true);
+CONSTANT (name ratio, value 0.75);
+CONSTANT (name missing_value, value null);
 ```
 
-A file may contain multiple declarations. Public names must not start with `_`.
+Public names must not start with `_`.
 
-### References
+### Constant values
+
+#### Scalars
+
+Constants support strings, signed integers, booleans, finite floating-point numbers, exact decimals, and null. Integers use a portable signed 64-bit baseline. Non-finite floats such as NaN and positive or negative infinity are rejected.
+
+Use `type decimal` with a quoted value when decimal precision must be exact:
+
+```sql
+CONSTANT (
+  name usd_rate,
+  type decimal,
+  value "2.4700",
+);
+```
+
+SQLBuild parses the quoted representation directly as a decimal, without converting it through a binary float. An incompatible `type` and `value` fails compilation. Strings are otherwise kept as strings; SQLBuild never interprets a constant value as raw SQL.
+
+#### Lists
+
+Square brackets declare an ordered list. Lists preserve authored order and allow duplicates:
+
+```sql
+CONSTANT (
+  name supported_countries,
+  value ["GB", "FR", "HK"],
+);
+```
+
+#### Sets
+
+Curly braces declare a semantic set. Sets reject duplicate typed values and use a stable canonical order for rendering and identity:
+
+```sql
+CONSTANT (
+  name unique_countries,
+  value {"GB", "FR", "HK"},
+);
+```
+
+For example, `{true, 1}` does not contain a duplicate because boolean and integer are distinct logical types. By contrast, `{"GB", "FR", "GB"}` fails compilation rather than silently discarding the second `"GB"`.
+
+#### Objects
+
+Parenthesized key-value entries declare a string-keyed object. Object values may themselves be scalars, lists, sets, or objects:
+
+```sql
+CONSTANT (
+  name country_rules,
+  value (
+    GB (
+      label "Great Britain",
+      threshold 2.47,
+      enabled true,
+      regions ["ENG", "SCT", "WLS"],
+    ),
+    FR (
+      label "France",
+      threshold 2.5,
+      enabled true,
+      regions ["IDF", "NAQ"],
+    ),
+  ),
+);
+```
+
+Object keys must be unique strings accepted by header syntax. SQLBuild canonicalizes keys into a stable order. Objects are logical JSON values, not portable homogeneous SQL maps or structs.
+
+Nested numeric tokens are finite floating-point values. Exact decimal parsing currently applies to a top-level constant declared with `type decimal`; nested exact decimals require a future nested typed-value syntax.
+
+#### Collection restrictions
+
+Lists and sets must be non-empty and have one recursively compatible element type. Nullable elements are ignored while inferring that type, so `[1, null, 2]` is valid, but the following declarations fail:
+
+```sql
+CONSTANT (name empty_values, value []);          -- no element type
+CONSTANT (name unknown_values, value [null]);    -- no non-null element type
+CONSTANT (name mixed_values, value [1, "two"]); -- integer and string
+```
+
+The same empty, all-null, and mixed-type restrictions apply to sets. Objects may contain values of different types because each key has its own recursively validated value. SQLBuild also applies nesting-depth, element-count, and rendered-size safety limits; errors identify the declaration path and nested value path.
+
+### References and rendering
 
 Use `@enum("name").MEMBER` and `@const("name")` anywhere public declarations are supported:
 
@@ -3638,20 +3767,81 @@ SELECT *
 FROM prices
 WHERE market_type = @enum("market_type").WIN
   AND runner_count > @const("min_runners")
-```
-
-This compiles to:
-
-```sql
-WHERE market_type = 'WIN'
-  AND runner_count > 7
+  AND country_code IN @const("supported_countries")
 ```
 
 Public references work in model queries, SQL hooks, SQL functions, audits, unit tests, scenarios, and inline source expressions. Unknown declarations or enum members fail compilation.
 
+#### Value-list rendering
+
+Lists and sets render as `value_list` by default on every adapter. This targets the common `IN` use case:
+
+```sql
+WHERE country_code IN @const("supported_countries")
+```
+
+compiles to:
+
+```sql
+WHERE country_code IN ('GB', 'FR', 'HK')
+```
+
+Every element is escaped by the active adapter before SQLBuild constructs the parenthesized list.
+
+A `value_list` constant is a SQL fragment intended for a value-list position such as `IN (...)`. It is not a portable standalone projection or a first-class array value. For example, `SELECT @const("supported_countries")` does not have consistent meaning across adapters. Use `render_as array` when the constant must be an array expression.
+
+#### Array rendering
+
+Set `render_as array` to request a first-class adapter-native array. SQLBuild does not rewrite array membership operations, so use the operators and functions appropriate for your adapter.
+
+```sql
+CONSTANT (
+  name supported_countries_array,
+  value ["GB", "FR", "HK"],
+  render_as array,
+);
+```
+
+Sets support the same rendering modes after duplicate validation and canonical ordering. Scalars and objects reject `render_as` because value-list and array modes have no defined meaning for them.
+
+#### Adapter matrix
+
+The selected rendering mode has the same semantics on every adapter; only its SQL spelling changes.
+
+| Adapter | Native array expression | Object/JSON expression |
+|---------|-------------------------|------------------------|
+| DuckDB | `['GB', 'FR', 'HK']` | `json('{"GB":"Great Britain"}')` |
+| MotherDuck | `['GB', 'FR', 'HK']` | `json('{"GB":"Great Britain"}')` |
+| Snowflake | `ARRAY_CONSTRUCT('GB', 'FR', 'HK')` | `PARSE_JSON('{"GB":"Great Britain"}')` |
+| BigQuery | `['GB', 'FR', 'HK']` | `JSON '{"GB":"Great Britain"}'` |
+| Databricks | `array('GB', 'FR', 'HK')` | `parse_json('{"GB":"Great Britain"}')` |
+| PostgreSQL | `ARRAY['GB', 'FR', 'HK']` | `'{"GB":"Great Britain"}'::JSONB` |
+| SQL Server | Unsupported | `JSON_QUERY(N'{"GB":"Great Britain"}')` |
+
+Object constants always use the adapter's native JSON or semi-structured expression, or its validated JSON-text equivalent; they are not emitted as an ordinary quoted JSON string. Every nested scalar and key is escaped safely.
+
+BigQuery supports native arrays but does not support arrays whose elements are arrays. A nested-array constant requested with `render_as array` therefore fails during compilation. SQL Server has no native array representation, so any array request fails during compilation rather than falling back to a value list or string. See the [BigQuery](/concepts/adapters/bigquery#typed-constants) and [SQL Server](/concepts/adapters/sqlserver#typed-constants) adapter pages.
+
+### Rendering configuration
+
+Change the project default for list and set declarations in `sqlbuild_project.toml`:
+
+```toml
+[constants]
+collection_rendering = "array"
+```
+
+Allowed values are `value_list` and `array`. Rendering mode is resolved in this order:
+
+1. The declaration's `render_as` field
+2. Project `[constants].collection_rendering`
+3. SQLBuild's `value_list` default
+
+The project default applies to both public and model-local collection constants. There is no reference-site override: one declaration has one representation throughout a compilation. Changing the resolved mode changes dependent rendered SQL and query identity.
+
 ### Model-local declarations
 
-Use model-local declarations for values that should not enter the project-wide namespace:
+Use model-local declarations for values that should not enter the project-wide namespace. The shorthand accepts every scalar and collection form:
 
 ```sql
 MODEL (
@@ -3660,6 +3850,12 @@ MODEL (
   ),
   constants (
     _min_runners 7,
+    _supported_countries ["GB", "FR", "HK"],
+    _unique_countries {"GB", "FR", "HK"},
+    _country_labels (
+      GB "Great Britain",
+      FR "France",
+    ),
   ),
 );
 
@@ -3667,18 +3863,43 @@ SELECT *
 FROM runners
 WHERE state = @enum("_state").OPEN
   AND runner_count > @const("_min_runners")
+  AND country_code IN @const("_supported_countries")
 ```
 
-Model-local names must start with `_`. They are available only in that model's query and SQL hooks; another model cannot resolve them.
+Use the `constant(...)` wrapper when a local declaration needs an explicit type or rendering override:
 
-### Types and validation
+```sql
+MODEL (
+  constants (
+    _usd_rate constant(
+      type decimal,
+      value "2.4700",
+    ),
+    _supported_countries constant(
+      value ["GB", "FR", "HK"],
+      render_as array,
+    ),
+  ),
+);
+```
+
+The wrapper is distinct from object syntax, so an object with keys named `value` or `render_as` remains unambiguous. Model-local names must start with `_`. They are available only in that model's query and SQL hooks; another model cannot resolve them.
+
+### Determinism and identity
+
+SQLBuild normalizes constants before rendering and fingerprinting:
+
+- List order and duplicates are preserved, so changing either changes rendered SQL and query identity.
+- Set declaration order is ignored; membership is canonicalized, so reordering alone changes neither rendered SQL nor query identity.
+- Object key declaration order is ignored; keys are canonicalized, so reordering alone changes neither rendered SQL nor query identity.
+- Set membership, object values, rendering mode, and an applicable project rendering default all participate in dependent query identity.
+- An unused declaration does not invalidate unrelated models.
+
+### Enum validation
 
 Enums must contain at least one member and use one consistent scalar type. String and integer members cannot be mixed. Integer values use explicit member syntax.
 
-Names must be SQL identifiers. Enum member identifiers must be uppercase, even when an explicit
-member's stored value is lowercase. Member lookup is case-sensitive, so `.WIN` is valid for
-`WIN "win"` and `.win` is not. Duplicate declaration names, duplicate member names, invalid
-visibility prefixes, and malformed references all fail compilation.
+Names must be SQL identifiers. Enum member identifiers must be uppercase, even when an explicit member's stored value is lowercase. Member lookup is case-sensitive, so `.WIN` is valid for `WIN "win"` and `.win` is not. Duplicate declaration names, duplicate member names, invalid visibility prefixes, and malformed references all fail compilation.
 
 ### Enum-typed contracts
 
@@ -3739,7 +3960,7 @@ The rule is simple: if it's any SQL that will be executed, it uses `@`. If it's 
 | Syntax | Where | Resolved |
 |--------|-------|----------|
 | `@enum("name").MEMBER` | Executable SQL | Compile time - expands to the validated enum member value |
-| `@const("name")` | Executable SQL | Compile time - expands to the named scalar value |
+| `@const("name")` | Executable SQL | Compile time - expands to the named typed scalar, value list, native array, or object expression |
 | `@macro(args)` | Model SQL, SQL hooks, tests, audits, inline source expressions | Compile time - expands to macro return value |
 | `@@name` | Model SQL, SQL hooks, tests, audits, inline source expressions | Compile time - project variable substitution |
 | `@@ENV:NAME` | Model SQL, SQL hooks, tests, audits, inline source expressions | Compile time - environment variable |
@@ -3752,7 +3973,7 @@ The rule is simple: if it's any SQL that will be executed, it uses `@`. If it's 
 
 `@@CTX:` is intentionally SQL-hook-only. Model SQL describes a relation's data and should not reference its own destination identity. SQL hooks are the operational SQL layer where destination context is useful - grants, logging, post-materialization DDL. Python hooks access the same information through `ctx.destination` on the [`HookContext`](/concepts/models/hooks/python#hook-context) object.
 
-See [Enums and Constants](/concepts/enums-and-constants) for declaration syntax, visibility, and contract integration.
+See [Enums and Constants](/concepts/enums-and-constants) for scalar and collection syntax, visibility, collection-rendering precedence, adapter behavior, and contract integration.
 
 ### Project variables
 
@@ -3891,7 +4112,7 @@ SQLBuild processes authored SQL in this order:
 1. **Config templates** (`${CTX:...}`, `${ENV:...}`) in TOML/YAML config values are resolved during config compilation
 2. **Named SQL hook arguments** (`@name` and `@'name'`) are substituted into reusable hook bodies
 3. **Project variables** (`@@name`), **environment variables** (`@@ENV:NAME`), and **context variables** (`@@CTX:name` in SQL hooks) are substituted
-4. **Enum and constant references** are validated and expanded to scalar SQL literals
+4. **Enum and constant references** are validated, normalized, and expanded through the active adapter
 5. **Macro calls** (`@name(args)`) are expanded
 6. **SQL analysis validation** runs against the fully expanded SQL
 

--- a/src/sqlbuild/adapter/contract/classes/base_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/base_adapter.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from datetime import date, datetime
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
 from sqlbuild.adapter.contract.classes.strict_adapter import StrictAdapter
-from sqlbuild.adapter.contract.constants import INTEGER_TYPE_TOKEN
-from sqlbuild.adapter.contract.exceptions import AdapterUserError
+from sqlbuild.adapter.contract.constants import (
+    INTEGER_TYPE_TOKEN,
+    TYPED_OBJECT_ENTRY_PART_COUNT,
+)
+from sqlbuild.adapter.contract.exceptions import (
+    AdapterUserError,
+    UnsupportedTypedSqlRenderingError,
+)
 from sqlbuild.adapter.contract.models import (
     ColumnInfo,
     CursorValue,
@@ -44,6 +51,23 @@ from sqlbuild.compiler.planner.types import InitialValidFrom, SnapshotStrategy
 from sqlbuild.compiler.source_freshness.models import SourceFreshnessRecord
 from sqlbuild.spec.contracts.constants import DEFAULT_SEED_CSV_SETTINGS
 from sqlbuild.spec.contracts.models import SeedCsvSettings
+from sqlbuild.sql_values.exceptions import SqlValueRenderingError
+from sqlbuild.sql_values.models import SqlValue
+from sqlbuild.sql_values.types import SqlValueKind
+
+_SCALAR_SQL_VALUE_KINDS: frozenset[SqlValueKind] = frozenset(
+    {
+        SqlValueKind.STRING,
+        SqlValueKind.INTEGER,
+        SqlValueKind.BOOLEAN,
+        SqlValueKind.FLOAT,
+        SqlValueKind.DECIMAL,
+        SqlValueKind.NULL,
+    }
+)
+_COLLECTION_SQL_VALUE_KINDS: frozenset[SqlValueKind] = frozenset(
+    {SqlValueKind.LIST, SqlValueKind.SET}
+)
 
 
 class BaseAdapter(StrictAdapter):
@@ -1685,6 +1709,40 @@ class BaseAdapter(StrictAdapter):
             case LoaderLogicalType.JSON:
                 return "JSON"
 
+    def render_typed_scalar(self, *, value: SqlValue) -> str:
+        """Render a validated typed scalar using ANSI-compatible literals."""
+
+        return _render_ansi_typed_scalar(value=value)
+
+    def render_typed_value_list(self, *, value: SqlValue) -> str:
+        """Render scalar collection members as a parenthesized SQL value list."""
+
+        return _render_typed_value_list(value=value, render_scalar=self.render_typed_scalar)
+
+    def render_typed_array(self, *, value: SqlValue) -> str:
+        del value
+        raise UnsupportedTypedSqlRenderingError(adapter_name=self.adapter_name, rendering="array")
+
+    def render_typed_object(self, *, value: SqlValue) -> str:
+        del value
+        raise UnsupportedTypedSqlRenderingError(adapter_name=self.adapter_name, rendering="object")
+
+    def _render_typed_array_item(self, value: SqlValue) -> str:
+        if value.kind in _SCALAR_SQL_VALUE_KINDS:
+            return self.render_typed_scalar(value=value)
+        if value.kind in _COLLECTION_SQL_VALUE_KINDS:
+            return self.render_typed_array(value=value)
+        if value.kind == SqlValueKind.OBJECT:
+            return self.render_typed_object(value=value)
+        raise AdapterUserError(
+            message=f"unsupported trusted typed SQL value kind '{value.kind.value}'"
+        )
+
+    def _render_typed_array_items(self, value: SqlValue) -> str:
+        return ", ".join(
+            self._render_typed_array_item(item) for item in _typed_collection_items(value)
+        )
+
     def render_loader_value_literal(
         self, *, value: object, logical_type: LoaderLogicalType | None
     ) -> str:
@@ -2059,6 +2117,132 @@ def _build_names_filter(
         return ""
     quoted: str = ", ".join(_quote_sql_string(name) for name in names)
     return f" AND {column_name} IN ({quoted})"
+
+
+def _typed_collection_items(value: SqlValue) -> tuple[SqlValue, ...]:
+    if value.kind not in _COLLECTION_SQL_VALUE_KINDS or not isinstance(value.value, tuple):
+        raise AdapterUserError(
+            message=f"expected trusted typed SQL collection, received '{value.kind.value}'"
+        )
+    if not all(isinstance(item, SqlValue) for item in value.value):
+        raise AdapterUserError(message="typed SQL collection contains an untrusted child")
+    return cast(tuple[SqlValue, ...], value.value)
+
+
+def _typed_object_items(value: SqlValue) -> tuple[tuple[str, SqlValue], ...]:
+    if value.kind != SqlValueKind.OBJECT or not isinstance(value.value, tuple):
+        raise AdapterUserError(
+            message=f"expected trusted typed SQL object, received '{value.kind.value}'"
+        )
+    entries: list[tuple[str, SqlValue]] = []
+    for entry in value.value:
+        if (
+            not isinstance(entry, tuple)
+            or len(entry) != TYPED_OBJECT_ENTRY_PART_COUNT
+            or not isinstance(entry[0], str)
+            or not isinstance(entry[1], SqlValue)
+        ):
+            raise AdapterUserError(message="typed SQL object contains an untrusted entry")
+        entries.append(cast(tuple[str, SqlValue], entry))
+    return tuple(entries)
+
+
+def _typed_scalar_payload(value: SqlValue) -> str | int | bool | float | Decimal | None:
+    payload: object = value.value
+    valid: bool
+    match value.kind:
+        case SqlValueKind.STRING:
+            valid = isinstance(payload, str)
+        case SqlValueKind.INTEGER:
+            valid = isinstance(payload, int) and not isinstance(payload, bool)
+        case SqlValueKind.BOOLEAN:
+            valid = isinstance(payload, bool)
+        case SqlValueKind.FLOAT:
+            valid = isinstance(payload, float)
+        case SqlValueKind.DECIMAL:
+            valid = isinstance(payload, Decimal)
+        case SqlValueKind.NULL:
+            valid = payload is None
+        case _:
+            raise AdapterUserError(
+                message=f"expected trusted typed SQL scalar, received '{value.kind.value}'"
+            )
+    if not valid:
+        raise AdapterUserError(message=f"typed SQL {value.kind.value} contains an invalid payload")
+    return cast(str | int | bool | float | Decimal | None, payload)
+
+
+def _render_ansi_typed_scalar(*, value: SqlValue) -> str:
+    payload: str | int | bool | float | Decimal | None = _typed_scalar_payload(value)
+    match value.kind:
+        case SqlValueKind.STRING:
+            return _quote_sql_string(cast(str, payload))
+        case SqlValueKind.BOOLEAN:
+            return "TRUE" if payload else "FALSE"
+        case SqlValueKind.NULL:
+            return "NULL"
+        case _:
+            return str(payload)
+
+
+def _render_typed_value_list(*, value: SqlValue, render_scalar: Callable[..., str]) -> str:
+    items: tuple[SqlValue, ...] = _typed_collection_items(value)
+    if any(item.kind not in _SCALAR_SQL_VALUE_KINDS for item in items):
+        raise SqlValueRenderingError(
+            "typed SQL value-list rendering supports scalar collection members only"
+        )
+    return "(" + ", ".join(render_scalar(value=item) for item in items) + ")"
+
+
+def _encode_typed_json(value: SqlValue) -> str:
+    if value.kind in _SCALAR_SQL_VALUE_KINDS:
+        payload: str | int | bool | float | Decimal | None = _typed_scalar_payload(value)
+        if value.kind == SqlValueKind.NULL:
+            return "null"
+        if value.kind == SqlValueKind.BOOLEAN:
+            return "true" if payload else "false"
+        if value.kind == SqlValueKind.STRING:
+            return json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+        return str(payload)
+    if value.kind in _COLLECTION_SQL_VALUE_KINDS:
+        return (
+            "["
+            + ",".join(_encode_typed_json(item) for item in _typed_collection_items(value))
+            + "]"
+        )
+    if value.kind == SqlValueKind.OBJECT:
+        return (
+            "{"
+            + ",".join(
+                json.dumps(key, ensure_ascii=True, separators=(",", ":"))
+                + ":"
+                + _encode_typed_json(item)
+                for key, item in sorted(_typed_object_items(value), key=lambda entry: entry[0])
+            )
+            + "}"
+        )
+    raise AdapterUserError(message=f"unsupported trusted typed SQL value kind '{value.kind.value}'")
+
+
+def _validate_rectangular_typed_array(*, value: SqlValue, adapter_name: str) -> None:
+    def dimensions(node: SqlValue) -> tuple[int, ...] | None:
+        if node.kind == SqlValueKind.NULL:
+            return None
+        if node.kind not in _COLLECTION_SQL_VALUE_KINDS:
+            return ()
+        items: tuple[SqlValue, ...] = _typed_collection_items(node)
+        child_dimensions: tuple[tuple[int, ...], ...] = tuple(
+            child_shape for item in items if (child_shape := dimensions(item)) is not None
+        )
+        if child_dimensions and any(shape != child_dimensions[0] for shape in child_dimensions[1:]):
+            raise UnsupportedTypedSqlRenderingError(
+                adapter_name=adapter_name,
+                rendering="array",
+                reason="requires rectangular nested arrays",
+            )
+        return (len(items), *(child_dimensions[0] if child_dimensions else ()))
+
+    dimensions(value)
 
 
 def _quote_sql_string(value: str) -> str:

--- a/src/sqlbuild/adapter/contract/classes/duckdb_backed_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/duckdb_backed_adapter.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, ClassVar
 
-from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.adapter.contract.classes.base_adapter import (
+    BaseAdapter,
+    _encode_typed_json,
+    _render_ansi_typed_scalar,
+    _render_typed_value_list,
+)
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
 from sqlbuild.adapter.contract.constants import (
     DIFF_LEFT_SIDE,
@@ -58,6 +63,7 @@ from sqlbuild.compiler.source_freshness.models import SourceFreshnessRecord
 from sqlbuild.diagnostics.main.log_sql import log_sql
 from sqlbuild.spec.contracts.constants import DEFAULT_SEED_CSV_SETTINGS
 from sqlbuild.spec.contracts.models import SeedCsvSettings
+from sqlbuild.sql_values.models import SqlValue
 
 
 class DuckDbBackedAdapter(BaseAdapter):
@@ -282,6 +288,18 @@ class DuckDbBackedAdapter(BaseAdapter):
                 return "DATE"
             case LoaderLogicalType.JSON:
                 return "JSON"
+
+    def render_typed_scalar(self, *, value: SqlValue) -> str:
+        return _render_ansi_typed_scalar(value=value)
+
+    def render_typed_value_list(self, *, value: SqlValue) -> str:
+        return _render_typed_value_list(value=value, render_scalar=self.render_typed_scalar)
+
+    def render_typed_array(self, *, value: SqlValue) -> str:
+        return "[" + self._render_typed_array_items(value) + "]"
+
+    def render_typed_object(self, *, value: SqlValue) -> str:
+        return f"json({self._quote_sql_string(_encode_typed_json(value))})"
 
     def render_loader_value_literal(
         self, *, value: object, logical_type: LoaderLogicalType | None

--- a/src/sqlbuild/adapter/contract/classes/strict_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/strict_adapter.py
@@ -29,6 +29,7 @@ from sqlbuild.adapter.contract.types import (
 )
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.source_freshness.models import SourceFreshnessRecord
+from sqlbuild.sql_values.models import SqlValue
 
 
 class StrictAdapter(
@@ -670,6 +671,26 @@ class StrictAdapter(
     @abstractmethod
     def render_loader_logical_type(self, type_name: LoaderLogicalType) -> str:
         """Render one source-loader logical type for this adapter."""
+        ...
+
+    @abstractmethod
+    def render_typed_scalar(self, *, value: SqlValue) -> str:
+        """Render one validated typed SQL scalar."""
+        ...
+
+    @abstractmethod
+    def render_typed_value_list(self, *, value: SqlValue) -> str:
+        """Render one validated collection as a parenthesized SQL value list."""
+        ...
+
+    @abstractmethod
+    def render_typed_array(self, *, value: SqlValue) -> str:
+        """Render one validated collection as an adapter-native array."""
+        ...
+
+    @abstractmethod
+    def render_typed_object(self, *, value: SqlValue) -> str:
+        """Render one validated object as an adapter-native JSON expression."""
         ...
 
     @abstractmethod

--- a/src/sqlbuild/adapter/contract/constants.py
+++ b/src/sqlbuild/adapter/contract/constants.py
@@ -17,6 +17,7 @@ DATETIME_TYPE_NAME: str = "DATETIME"
 POLYGLOT_CUSTOM_TYPE_NAME: str = "CUSTOM"
 TIMESTAMP_TYPE_TOKEN: str = "TIMESTAMP"
 INTEGER_TYPE_TOKEN: str = "INT"
+TYPED_OBJECT_ENTRY_PART_COUNT: int = 2
 TABLE_RELATION_TYPE_NAMES: frozenset[str] = frozenset(
     {"base table", "table", "managed", "external"}
 )

--- a/src/sqlbuild/adapter/contract/exceptions.py
+++ b/src/sqlbuild/adapter/contract/exceptions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from sqlbuild.sql_values.exceptions import SqlValueRenderingError
+
 
 class AdapterUserError(ValueError):
     """Raised when adapter configuration or optional dependencies are invalid."""
@@ -13,3 +15,16 @@ class AdapterUserError(ValueError):
         self.message = message
         self.code = code if code is not None else self.code
         self.help = help
+
+
+class UnsupportedTypedSqlRenderingError(AdapterUserError, SqlValueRenderingError):
+    """Raised when an adapter cannot represent a requested typed SQL value."""
+
+    def __init__(self, *, adapter_name: str, rendering: str, reason: str | None = None) -> None:
+        reason_text: str = f": {reason}" if reason is not None else ""
+        super().__init__(
+            message=(
+                f"adapter '{adapter_name}' does not support typed SQL {rendering} rendering"
+                f"{reason_text}"
+            )
+        )

--- a/src/sqlbuild/adapter/discovery/main/resolve_adapter.py
+++ b/src/sqlbuild/adapter/discovery/main/resolve_adapter.py
@@ -1,0 +1,39 @@
+"""Public adapter resolution from built-in and project-local registrations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.adapter.contract.classes.strict_adapter import StrictAdapter
+from sqlbuild.adapter.contract.exceptions import AdapterUserError
+from sqlbuild.adapter.discovery.main.builtins import builtin_adapter_classes
+from sqlbuild.adapter.discovery.main.project_adapters import discover_project_adapters
+
+
+def resolve_adapter(*, adapter_name: str, project_dir: Path | None = None) -> BaseAdapter:
+    """Resolve one adapter without depending on CLI error types."""
+
+    builtins: dict[str, type[BaseAdapter]] = builtin_adapter_classes()
+    adapter_class: type[StrictAdapter] | None = None
+    if project_dir is not None:
+        adapter_class = discover_project_adapters(
+            project_dir=project_dir,
+            reserved_names=frozenset(builtins),
+        ).get(adapter_name)
+    if adapter_class is None:
+        adapter_class = builtins.get(adapter_name)
+    if adapter_class is None:
+        available: str = ", ".join(sorted(builtins))
+        local_text: str = (
+            " Project-local adapters are discovered from adapters/**/*.py."
+            if project_dir is not None
+            else ""
+        )
+        raise AdapterUserError(
+            f"unknown adapter '{adapter_name}'. Available built-in adapters: "
+            f"{available}.{local_text}",
+            code="A601",
+        )
+    return cast(BaseAdapter, adapter_class())

--- a/src/sqlbuild/adapters/bigquery/classes/bigquery_adapter.py
+++ b/src/sqlbuild/adapters/bigquery/classes/bigquery_adapter.py
@@ -9,11 +9,22 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any, ClassVar, cast
 
-from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.adapter.contract.classes.base_adapter import (
+    _COLLECTION_SQL_VALUE_KINDS,
+    BaseAdapter,
+    _encode_typed_json,
+    _render_ansi_typed_scalar,
+    _render_typed_value_list,
+    _typed_collection_items,
+    _typed_scalar_payload,
+)
 from sqlbuild.adapter.contract.classes.microbatch import MicrobatchMixin
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
 from sqlbuild.adapter.contract.constants import DIFF_LEFT_SIDE, DIFF_RIGHT_SIDE
-from sqlbuild.adapter.contract.exceptions import AdapterUserError
+from sqlbuild.adapter.contract.exceptions import (
+    AdapterUserError,
+    UnsupportedTypedSqlRenderingError,
+)
 from sqlbuild.adapter.contract.models import (
     ColumnInfo,
     CursorValue,
@@ -74,6 +85,8 @@ from sqlbuild.compiler.source_freshness.models import SourceFreshnessRecord
 from sqlbuild.diagnostics.main.log_sql import log_sql
 from sqlbuild.spec.contracts.constants import DEFAULT_SEED_CSV_SETTINGS
 from sqlbuild.spec.contracts.models import SeedCsvSettings
+from sqlbuild.sql_values.models import SqlValue
+from sqlbuild.sql_values.types import SqlValueKind
 
 
 class BigQueryAdapter(MicrobatchMixin, BaseAdapter):
@@ -746,6 +759,26 @@ class BigQueryAdapter(MicrobatchMixin, BaseAdapter):
                 return "DATE"
             case LoaderLogicalType.JSON:
                 return "JSON"
+
+    def render_typed_scalar(self, *, value: SqlValue) -> str:
+        if value.kind == SqlValueKind.DECIMAL:
+            return f"NUMERIC {self._quote_sql_string(str(_typed_scalar_payload(value)))}"
+        return _render_ansi_typed_scalar(value=value)
+
+    def render_typed_value_list(self, *, value: SqlValue) -> str:
+        return _render_typed_value_list(value=value, render_scalar=self.render_typed_scalar)
+
+    def render_typed_array(self, *, value: SqlValue) -> str:
+        if any(item.kind in _COLLECTION_SQL_VALUE_KINDS for item in _typed_collection_items(value)):
+            raise UnsupportedTypedSqlRenderingError(
+                adapter_name=self.adapter_name,
+                rendering="array",
+                reason="does not support nested arrays",
+            )
+        return "[" + self._render_typed_array_items(value) + "]"
+
+    def render_typed_object(self, *, value: SqlValue) -> str:
+        return f"JSON {self._quote_sql_string(_encode_typed_json(value))}"
 
     def render_loader_value_literal(
         self, *, value: object, logical_type: LoaderLogicalType | None

--- a/src/sqlbuild/adapters/databricks/classes/databricks_adapter.py
+++ b/src/sqlbuild/adapters/databricks/classes/databricks_adapter.py
@@ -11,7 +11,12 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any, ClassVar
 
-from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.adapter.contract.classes.base_adapter import (
+    BaseAdapter,
+    _encode_typed_json,
+    _render_ansi_typed_scalar,
+    _render_typed_value_list,
+)
 from sqlbuild.adapter.contract.classes.microbatch import MicrobatchMixin
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
 from sqlbuild.adapter.contract.constants import DIFF_LEFT_SIDE, DIFF_RIGHT_SIDE
@@ -64,6 +69,7 @@ from sqlbuild.compiler.source_freshness.models import SourceFreshnessRecord
 from sqlbuild.diagnostics.main.log_sql import log_sql
 from sqlbuild.spec.contracts.constants import DEFAULT_SEED_CSV_SETTINGS
 from sqlbuild.spec.contracts.models import SeedCsvSettings
+from sqlbuild.sql_values.models import SqlValue
 
 
 class DatabricksAdapter(MicrobatchMixin, BaseAdapter):
@@ -531,6 +537,18 @@ class DatabricksAdapter(MicrobatchMixin, BaseAdapter):
                 return "DATE"
             case LoaderLogicalType.JSON:
                 return "STRING"
+
+    def render_typed_scalar(self, *, value: SqlValue) -> str:
+        return _render_ansi_typed_scalar(value=value)
+
+    def render_typed_value_list(self, *, value: SqlValue) -> str:
+        return _render_typed_value_list(value=value, render_scalar=self.render_typed_scalar)
+
+    def render_typed_array(self, *, value: SqlValue) -> str:
+        return "array(" + self._render_typed_array_items(value) + ")"
+
+    def render_typed_object(self, *, value: SqlValue) -> str:
+        return f"parse_json({self._quote_sql_string(_encode_typed_json(value))})"
 
     def render_loader_value_literal(
         self, *, value: object, logical_type: LoaderLogicalType | None

--- a/src/sqlbuild/adapters/postgres/classes/postgres_adapter.py
+++ b/src/sqlbuild/adapters/postgres/classes/postgres_adapter.py
@@ -14,15 +14,19 @@ from sqlbuild.adapter.contract.classes.base_adapter import (
     BaseAdapter,
     _build_names_filter,
     _build_schemas_filter,
+    _encode_typed_json,
     _historical_check_snapshot_select_sql,
     _historical_hard_deleted_at_sql,
     _historical_snapshot_combined_close_sql,
     _historical_timestamp_changes_select_sql,
     _historical_timestamp_snapshot_select_sql,
     _quote_sql_string,
+    _render_ansi_typed_scalar,
+    _render_typed_value_list,
     _snapshot_hard_delete_close_sql,
     _snapshot_initial_valid_from_expr,
     _snapshot_key_condition,
+    _validate_rectangular_typed_array,
 )
 from sqlbuild.adapter.contract.classes.microbatch import MicrobatchMixin
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
@@ -71,6 +75,7 @@ from sqlbuild.compiler.source_freshness.models import SourceFreshnessRecord
 from sqlbuild.diagnostics.main.log_sql import log_sql
 from sqlbuild.spec.contracts.constants import DEFAULT_SEED_CSV_SETTINGS
 from sqlbuild.spec.contracts.models import SeedCsvSettings
+from sqlbuild.sql_values.models import SqlValue
 
 
 class PostgresAdapter(MicrobatchMixin, BaseAdapter):
@@ -1597,6 +1602,19 @@ class PostgresAdapter(MicrobatchMixin, BaseAdapter):
                 return "DATE"
             case LoaderLogicalType.JSON:
                 return "JSONB"
+
+    def render_typed_scalar(self, *, value: SqlValue) -> str:
+        return _render_ansi_typed_scalar(value=value)
+
+    def render_typed_value_list(self, *, value: SqlValue) -> str:
+        return _render_typed_value_list(value=value, render_scalar=self.render_typed_scalar)
+
+    def render_typed_array(self, *, value: SqlValue) -> str:
+        _validate_rectangular_typed_array(value=value, adapter_name=self.adapter_name)
+        return "ARRAY[" + self._render_typed_array_items(value) + "]"
+
+    def render_typed_object(self, *, value: SqlValue) -> str:
+        return f"{self._quote_sql_string(_encode_typed_json(value))}::JSONB"
 
     def render_loader_value_literal(
         self, *, value: object, logical_type: LoaderLogicalType | None

--- a/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
+++ b/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
@@ -11,7 +11,12 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any, ClassVar
 
-from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.adapter.contract.classes.base_adapter import (
+    BaseAdapter,
+    _encode_typed_json,
+    _render_ansi_typed_scalar,
+    _render_typed_value_list,
+)
 from sqlbuild.adapter.contract.classes.microbatch import MicrobatchMixin
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
 from sqlbuild.adapter.contract.constants import DIFF_LEFT_SIDE, DIFF_RIGHT_SIDE
@@ -71,6 +76,7 @@ from sqlbuild.cost.types import CostCapability, CostStatus
 from sqlbuild.diagnostics.main.log_sql import log_sql
 from sqlbuild.spec.contracts.constants import DEFAULT_SEED_CSV_SETTINGS
 from sqlbuild.spec.contracts.models import SeedCsvSettings
+from sqlbuild.sql_values.models import SqlValue
 
 
 class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
@@ -944,6 +950,18 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
                 return "DATE"
             case LoaderLogicalType.JSON:
                 return "VARIANT"
+
+    def render_typed_scalar(self, *, value: SqlValue) -> str:
+        return _render_ansi_typed_scalar(value=value)
+
+    def render_typed_value_list(self, *, value: SqlValue) -> str:
+        return _render_typed_value_list(value=value, render_scalar=self.render_typed_scalar)
+
+    def render_typed_array(self, *, value: SqlValue) -> str:
+        return "ARRAY_CONSTRUCT(" + self._render_typed_array_items(value) + ")"
+
+    def render_typed_object(self, *, value: SqlValue) -> str:
+        return f"PARSE_JSON({self._quote_sql_string(_encode_typed_json(value))})"
 
     def render_loader_value_literal(
         self, *, value: object, logical_type: LoaderLogicalType | None

--- a/src/sqlbuild/adapters/sqlserver/classes/sqlserver_adapter.py
+++ b/src/sqlbuild/adapters/sqlserver/classes/sqlserver_adapter.py
@@ -14,16 +14,23 @@ from sqlbuild.adapter.contract.classes.base_adapter import (
     BaseAdapter,
     _build_names_filter,
     _build_schemas_filter,
+    _encode_typed_json,
     _historical_hard_deleted_at_sql,
     _historical_timestamp_changes_new_records_cte_sql,
     _quote_sql_string,
+    _render_ansi_typed_scalar,
+    _render_typed_value_list,
     _snapshot_initial_valid_from_expr,
     _snapshot_key_condition,
+    _typed_scalar_payload,
 )
 from sqlbuild.adapter.contract.classes.microbatch import MicrobatchMixin
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
 from sqlbuild.adapter.contract.constants import DIFF_LEFT_SIDE, DIFF_RIGHT_SIDE
-from sqlbuild.adapter.contract.exceptions import AdapterUserError
+from sqlbuild.adapter.contract.exceptions import (
+    AdapterUserError,
+    UnsupportedTypedSqlRenderingError,
+)
 from sqlbuild.adapter.contract.models import (
     ColumnInfo,
     CursorValue,
@@ -70,6 +77,8 @@ from sqlbuild.compiler.source_freshness.models import SourceFreshnessRecord
 from sqlbuild.diagnostics.main.log_sql import log_sql
 from sqlbuild.spec.contracts.constants import DEFAULT_SEED_CSV_SETTINGS
 from sqlbuild.spec.contracts.models import SeedCsvSettings
+from sqlbuild.sql_values.models import SqlValue
+from sqlbuild.sql_values.types import SqlValueKind
 
 
 class SqlServerAdapter(MicrobatchMixin, BaseAdapter):
@@ -864,6 +873,24 @@ class SqlServerAdapter(MicrobatchMixin, BaseAdapter):
                 return "DATE"
             case LoaderLogicalType.JSON:
                 return "NVARCHAR(MAX)"
+
+    def render_typed_scalar(self, *, value: SqlValue) -> str:
+        if value.kind == SqlValueKind.STRING:
+            rendered: str = _render_ansi_typed_scalar(value=value)
+            return f"N{rendered}"
+        if value.kind == SqlValueKind.BOOLEAN:
+            return "1" if _typed_scalar_payload(value) else "0"
+        return _render_ansi_typed_scalar(value=value)
+
+    def render_typed_value_list(self, *, value: SqlValue) -> str:
+        return _render_typed_value_list(value=value, render_scalar=self.render_typed_scalar)
+
+    def render_typed_array(self, *, value: SqlValue) -> str:
+        del value
+        raise UnsupportedTypedSqlRenderingError(adapter_name=self.adapter_name, rendering="array")
+
+    def render_typed_object(self, *, value: SqlValue) -> str:
+        return f"JSON_QUERY(N{self._quote_sql_string(_encode_typed_json(value))})"
 
     def render_loader_value_literal(
         self, *, value: object, logical_type: LoaderLogicalType | None

--- a/src/sqlbuild/cli/commands/_helpers/lint/runs.py
+++ b/src/sqlbuild/cli/commands/_helpers/lint/runs.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
+from sqlbuild.cli.commands._helpers.runtime.adapters import resolve_adapter
+from sqlbuild.compiler.compile.types import TypedSqlValueRenderer
+from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.lint.constants import (
     DEFAULT_MAX_DESCRIPTION_LINES,
     DEFAULT_SQRUFF_CONFIG_PATH,
@@ -16,6 +20,9 @@ from sqlbuild.lint.constants import (
 )
 from sqlbuild.lint.main.ensure_config import ensure_sqruff_config
 from sqlbuild.lint.models import LintConfig, LintRunResult
+from sqlbuild.spec.contracts.main.resolve_effective_adapter_name import (
+    resolve_effective_adapter_name,
+)
 
 
 def resolve_lint_config(*, project_dir: Path, no_sqruff: bool) -> LintConfig:
@@ -62,6 +69,24 @@ def prepare_lint_run(*, project_dir: Path, no_sqruff: bool) -> tuple[LintConfig,
         sqruff_enabled=config.sqruff_enabled,
     )
     return config, warning
+
+
+def resolve_lint_value_renderer(
+    *, project_dir: Path, config: LintConfig
+) -> TypedSqlValueRenderer | None:
+    """Resolve typed SQL rendering only when expanded-SQL lint is enabled."""
+
+    if not config.sqruff_enabled:
+        return None
+    discovered: DiscoveredProjectInputs = discover_project_inputs(
+        project_dir=project_dir,
+        sql_analysis_enabled_override=False,
+    )
+    adapter_name: str = resolve_effective_adapter_name(
+        project_config=discovered.project_config,
+        local_config=discovered.local_config,
+    )
+    return resolve_adapter(adapter_name=adapter_name, project_dir=project_dir)
 
 
 def render_lint_result(*, result: LintRunResult, show_formatted: bool) -> None:

--- a/src/sqlbuild/cli/commands/_helpers/runtime/adapters.py
+++ b/src/sqlbuild/cli/commands/_helpers/runtime/adapters.py
@@ -3,36 +3,19 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
-from sqlbuild.adapter.contract.classes.strict_adapter import StrictAdapter
-from sqlbuild.adapter.discovery.main.builtins import builtin_adapter_classes
-from sqlbuild.adapter.discovery.main.project_adapters import discover_project_adapters
+from sqlbuild.adapter.contract.exceptions import AdapterUserError
+from sqlbuild.adapter.discovery.main.resolve_adapter import (
+    resolve_adapter as resolve_registered_adapter,
+)
 from sqlbuild.cli.commands.exceptions import CliUserError
 
 
 def resolve_adapter(*, adapter_name: str, project_dir: Path | None = None) -> BaseAdapter:
     """Resolve an adapter name from project config to an adapter instance."""
 
-    builtin_adapters: dict[str, type[BaseAdapter]] = builtin_adapter_classes()
-    adapter_class: type[StrictAdapter] | None = None
-    if project_dir is not None:
-        local_adapters: dict[str, type[StrictAdapter]] = discover_project_adapters(
-            project_dir=project_dir,
-            reserved_names=frozenset(builtin_adapters),
-        )
-        adapter_class = local_adapters.get(adapter_name)
-    if adapter_class is None:
-        adapter_class = builtin_adapters.get(adapter_name)
-    if adapter_class is None:
-        available: tuple[str, ...] = tuple(sorted(builtin_adapters))
-        local_text: str = ""
-        if project_dir is not None:
-            local_text = " Project-local adapters are discovered from adapters/**/*.py."
-        raise CliUserError(
-            f"unknown adapter '{adapter_name}'. Available built-in adapters: "
-            f"{', '.join(available)}.{local_text}",
-            code="C601",
-        )
-    return cast(BaseAdapter, adapter_class())
+    try:
+        return resolve_registered_adapter(adapter_name=adapter_name, project_dir=project_dir)
+    except AdapterUserError as error:
+        raise CliUserError(error.message, code="C601", help=error.help) from error

--- a/src/sqlbuild/cli/commands/main/project/_format.py
+++ b/src/sqlbuild/cli/commands/main/project/_format.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sqlbuild.cli.commands._helpers.lint.runs import prepare_lint_run, render_lint_result
+from sqlbuild.cli.commands._helpers.lint.runs import (
+    prepare_lint_run,
+    render_lint_result,
+    resolve_lint_value_renderer,
+)
 from sqlbuild.lint.main.run_format import run_format
 from sqlbuild.lint.models import LintConfig, LintRunResult
 
@@ -18,6 +22,13 @@ def run_format_command(*, project_dir: Path | None, no_sqruff: bool = False) -> 
     )
     if prepared[1] is not None:
         print(f"WARN  {prepared[1]}")
-    result: LintRunResult = run_format(project_dir=base_dir, config=prepared[0])
+    result: LintRunResult = run_format(
+        project_dir=base_dir,
+        config=prepared[0],
+        value_renderer=resolve_lint_value_renderer(
+            project_dir=base_dir,
+            config=prepared[0],
+        ),
+    )
     _ = render_lint_result(result=result, show_formatted=True)
     return 1 if result.violations else 0

--- a/src/sqlbuild/cli/commands/main/project/_lint.py
+++ b/src/sqlbuild/cli/commands/main/project/_lint.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sqlbuild.cli.commands._helpers.lint.runs import prepare_lint_run, render_lint_result
+from sqlbuild.cli.commands._helpers.lint.runs import (
+    prepare_lint_run,
+    render_lint_result,
+    resolve_lint_value_renderer,
+)
 from sqlbuild.lint.main.run_lint import run_lint
 from sqlbuild.lint.models import LintConfig, LintRunResult
 
@@ -18,6 +22,13 @@ def run_lint_command(*, project_dir: Path | None, no_sqruff: bool = False) -> in
     )
     if prepared[1] is not None:
         print(f"WARN  {prepared[1]}")
-    result: LintRunResult = run_lint(project_dir=base_dir, config=prepared[0])
+    result: LintRunResult = run_lint(
+        project_dir=base_dir,
+        config=prepared[0],
+        value_renderer=resolve_lint_value_renderer(
+            project_dir=base_dir,
+            config=prepared[0],
+        ),
+    )
     _ = render_lint_result(result=result, show_formatted=False)
     return 1 if result.violations else 0

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/audits.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/audits.py
@@ -30,6 +30,7 @@ from sqlbuild.compiler.compile.models import (
     CompileModelInput,
     CompileSourceInput,
     CompileSqlReference,
+    DeclarationExpansionContext,
     LoadedMacro,
     MacroContext,
 )
@@ -37,11 +38,9 @@ from sqlbuild.compiler.compile.types import (
     AttachedAuditTargetKind,
 )
 from sqlbuild.compiler.discovery.models import (
-    ConstantDeclaration,
     DiscoveredAuditBlock,
     DiscoveredAuditFile,
     DiscoveredProjectInputs,
-    EnumDeclaration,
 )
 from sqlbuild.compiler.references.types import SqlReferenceKind
 from sqlbuild.spec.contracts.models import (
@@ -65,8 +64,7 @@ class _AuditAttachmentContext:
     default_audit_run_scope: str | None
     effective_vars: dict[str, object]
     macro_context: MacroContext
-    public_enums: dict[str, EnumDeclaration]
-    public_constants: dict[str, ConstantDeclaration]
+    declaration_expansion: DeclarationExpansionContext
 
 
 _LEGACY_MODEL_HOOK_KEYS: frozenset[str] = frozenset({"pre_hook", "post_hook"})
@@ -85,8 +83,7 @@ def build_audit_inputs(
     effective_vars: dict[str, object],
     macro_context: MacroContext,
     loaded_macros: dict[str, LoadedMacro],
-    public_enums: dict[str, EnumDeclaration] | None = None,
-    public_constants: dict[str, ConstantDeclaration] | None = None,
+    declaration_expansion: DeclarationExpansionContext,
     generic_audit_definitions: dict[str, tuple[DiscoveredAuditFile, DiscoveredAuditBlock]]
     | None = None,
 ) -> tuple[CompileAuditInput, ...]:
@@ -109,8 +106,7 @@ def build_audit_inputs(
         default_audit_run_scope=default_audit_run_scope,
         effective_vars=effective_vars,
         macro_context=macro_context,
-        public_enums=public_enums or {},
-        public_constants=public_constants or {},
+        declaration_expansion=declaration_expansion,
     )
     audit_inputs: list[CompileAuditInput] = []
     audit_file: DiscoveredAuditFile
@@ -125,8 +121,10 @@ def build_audit_inputs(
                 effective_vars=effective_vars,
                 loaded_macros=loaded_macros,
                 macro_context=macro_context,
-                enums=public_enums,
-                constants=public_constants,
+                enums=declaration_expansion.declarations.enums,
+                constants=declaration_expansion.declarations.constants,
+                value_renderer=declaration_expansion.value_renderer,
+                collection_rendering=declaration_expansion.collection_rendering,
             )
             reject_cursor_intrinsics(
                 sql=expanded_sql_body,
@@ -347,8 +345,10 @@ def build_attached_audit_input(
         effective_vars=context.effective_vars,
         loaded_macros=context.loaded_macros,
         macro_context=context.macro_context,
-        enums=context.public_enums,
-        constants=context.public_constants,
+        enums=context.declaration_expansion.declarations.enums,
+        constants=context.declaration_expansion.declarations.constants,
+        value_renderer=context.declaration_expansion.value_renderer,
+        collection_rendering=context.declaration_expansion.collection_rendering,
     )
     reject_cursor_intrinsics(
         sql=expanded_sql_body,

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
@@ -66,6 +66,8 @@ from sqlbuild.compiler.compile.models import (
     CompileModelInput,
     CompileSeedInput,
     CompileSqlReference,
+    DeclarationExpansionContext,
+    DeclarationResolutionContext,
     LoadedMacro,
     MacroContext,
     ModelInputBuildContext,
@@ -125,8 +127,7 @@ class _HookExpansionContext:
     context_values: dict[str, str | None]
     loaded_macros: dict[str, LoadedMacro]
     macro_context: MacroContext
-    enums: dict[str, EnumDeclaration]
-    constants: dict[str, ConstantDeclaration]
+    declaration_expansion: DeclarationExpansionContext
     sql_hook_definitions: dict[str, DiscoveredSqlHookFile]
 
 
@@ -228,6 +229,8 @@ def _build_model_inputs(
             file_path=model_file.file_path,
             enums=declarations.enums,
             constants=declarations.constants,
+            value_renderer=context.value_renderer,
+            collection_rendering=context.collection_rendering,
         )
         expanded_query_sql: str = expand_sql_macros(
             sql=declaration_expanded_sql,
@@ -322,8 +325,14 @@ def _build_model_inputs(
                 ),
                 loaded_macros=loaded_macros,
                 macro_context=macro_context,
-                enums=declarations.enums,
-                constants=declarations.constants,
+                declaration_expansion=DeclarationExpansionContext(
+                    declarations=DeclarationResolutionContext(
+                        enums=declarations.enums,
+                        constants=declarations.constants,
+                    ),
+                    value_renderer=context.value_renderer,
+                    collection_rendering=context.collection_rendering,
+                ),
                 sql_hook_definitions=sql_hook_definitions,
             ),
             matched_path_default=effective_config.matched_path_default,
@@ -599,8 +608,7 @@ def expand_model_hook_macros(
     context_values: dict[str, str | None],
     loaded_macros: dict[str, LoadedMacro],
     macro_context: MacroContext,
-    enums: dict[str, EnumDeclaration],
-    constants: dict[str, ConstantDeclaration],
+    declaration_expansion: DeclarationExpansionContext,
     sql_hook_definitions: dict[str, DiscoveredSqlHookFile] | None = None,
 ) -> dict[str, object]:
     """Expand SQL interpolation and macros within executable hook SQL strings."""
@@ -619,8 +627,7 @@ def expand_model_hook_macros(
                 context_values=context_values,
                 loaded_macros=loaded_macros,
                 macro_context=macro_context,
-                enums=enums,
-                constants=constants,
+                declaration_expansion=declaration_expansion,
                 sql_hook_definitions=sql_hook_definitions or {},
             ),
             hook_key=hook_key,
@@ -820,8 +827,10 @@ def expand_sql_macros_in_value(
             context_values=context.context_values,
             loaded_macros=context.loaded_macros,
             macro_context=context.macro_context,
-            enums=context.enums,
-            constants=context.constants,
+            enums=context.declaration_expansion.declarations.enums,
+            constants=context.declaration_expansion.declarations.constants,
+            value_renderer=context.declaration_expansion.value_renderer,
+            collection_rendering=context.declaration_expansion.collection_rendering,
         )
     if isinstance(value, SqlHookEntry):
         expanded_statement: object = expand_sql_macros_in_value(

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/functions.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/functions.py
@@ -35,7 +35,7 @@ from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.models import (
     CompileSqlFunctionInput,
     CompileSqlReference,
-    DeclarationResolutionContext,
+    DeclarationExpansionContext,
     FunctionArgument,
     FunctionReturnColumn,
     InferredColumn,
@@ -88,7 +88,7 @@ def build_sql_function_inputs(
     adapter_name: str,
     macro_context: MacroContext,
     loaded_macros: dict[str, LoadedMacro],
-    declarations: DeclarationResolutionContext | None = None,
+    declaration_expansion: DeclarationExpansionContext,
     no_sql_validation: bool = False,
     python_functions_inherit_default_namespace: bool = True,
 ) -> tuple[CompileSqlFunctionInput, ...]:
@@ -155,8 +155,10 @@ def build_sql_function_inputs(
             effective_vars=effective_vars,
             loaded_macros=loaded_macros,
             macro_context=macro_context,
-            enums=declarations.enums if declarations is not None else None,
-            constants=declarations.constants if declarations is not None else None,
+            enums=declaration_expansion.declarations.enums,
+            constants=declaration_expansion.declarations.constants,
+            value_renderer=declaration_expansion.value_renderer,
+            collection_rendering=declaration_expansion.collection_rendering,
         )
         reject_cursor_intrinsics(
             sql=expanded_body_sql,

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/sources.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/sources.py
@@ -19,14 +19,13 @@ from sqlbuild.compiler.compile._helpers.render.templating import (
 )
 from sqlbuild.compiler.compile.models import (
     CompileSourceInput,
+    DeclarationExpansionContext,
     LoadedMacro,
     MacroContext,
 )
 from sqlbuild.compiler.discovery.models import (
-    ConstantDeclaration,
     DiscoveredProjectInputs,
     DiscoveredSourceFile,
-    EnumDeclaration,
 )
 from sqlbuild.spec.contracts.models import (
     SchemaAuditInstance,
@@ -50,8 +49,7 @@ def build_source_inputs(
     effective_settings: SettingsConfig,
     macro_context: MacroContext,
     loaded_macros: dict[str, LoadedMacro],
-    public_enums: dict[str, EnumDeclaration] | None = None,
-    public_constants: dict[str, ConstantDeclaration] | None = None,
+    declaration_expansion: DeclarationExpansionContext,
     no_sql_validation: bool = False,
 ) -> tuple[CompileSourceInput, ...]:
     """Normalize discovered source declarations into one collection."""
@@ -72,8 +70,7 @@ def build_source_inputs(
                 effective_vars=effective_vars,
                 loaded_macros=loaded_macros,
                 macro_context=macro_context,
-                public_enums=public_enums,
-                public_constants=public_constants,
+                declaration_expansion=declaration_expansion,
             )
             source_expression: str | None = source_entry.expression
             if source_expression is not None:
@@ -106,8 +103,7 @@ def expand_source_entry_templates(
     effective_vars: dict[str, object],
     loaded_macros: dict[str, LoadedMacro],
     macro_context: MacroContext,
-    public_enums: dict[str, EnumDeclaration] | None = None,
-    public_constants: dict[str, ConstantDeclaration] | None = None,
+    declaration_expansion: DeclarationExpansionContext,
 ) -> SourceEntry:
     """Apply config templating and SQL interpolation to source metadata."""
 
@@ -119,8 +115,10 @@ def expand_source_entry_templates(
             effective_vars=effective_vars,
             loaded_macros=loaded_macros,
             macro_context=macro_context,
-            enums=public_enums,
-            constants=public_constants,
+            enums=declaration_expansion.declarations.enums,
+            constants=declaration_expansion.declarations.constants,
+            value_renderer=declaration_expansion.value_renderer,
+            collection_rendering=declaration_expansion.collection_rendering,
         )
     return replace(
         source_entry,

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
@@ -36,6 +36,7 @@ from sqlbuild.compiler.compile.models import (
     CompileSqlTestCte,
     CompileSqlTestCtes,
     CompileSqlTestInput,
+    DeclarationExpansionContext,
     LoadedMacro,
     MacroContext,
 )
@@ -66,8 +67,7 @@ def build_test_inputs(
     effective_vars: dict[str, object] | None = None,
     macro_context: MacroContext,
     loaded_macros: dict[str, LoadedMacro],
-    public_enums: dict[str, EnumDeclaration] | None = None,
-    public_constants: dict[str, ConstantDeclaration] | None = None,
+    declaration_expansion: DeclarationExpansionContext,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
     sql_function_inputs: tuple[CompileSqlFunctionInput, ...] = (),
 ) -> tuple[CompileSqlTestInput, ...]:
@@ -128,8 +128,10 @@ def build_test_inputs(
                 effective_vars=vars_for_substitution,
                 loaded_macros=loaded_macros,
                 macro_context=macro_context,
-                enums=public_enums,
-                constants=public_constants,
+                enums=declaration_expansion.declarations.enums,
+                constants=declaration_expansion.declarations.constants,
+                value_renderer=declaration_expansion.value_renderer,
+                collection_rendering=declaration_expansion.collection_rendering,
             )
             reject_cursor_intrinsics(
                 sql=expanded_sql_body,
@@ -353,8 +355,7 @@ def build_scenario_inputs(
     effective_vars: dict[str, object] | None = None,
     macro_context: MacroContext,
     loaded_macros: dict[str, LoadedMacro],
-    public_enums: dict[str, EnumDeclaration] | None = None,
-    public_constants: dict[str, ConstantDeclaration] | None = None,
+    declaration_expansion: DeclarationExpansionContext,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
 ) -> tuple[CompileSqlScenarioInput, ...]:
     """Build compile-time scenario inputs from discovered SQL-native scenario files."""
@@ -376,8 +377,10 @@ def build_scenario_inputs(
             effective_vars=vars_for_substitution,
             loaded_macros=loaded_macros,
             macro_context=macro_context,
-            enums=public_enums,
-            constants=public_constants,
+            enums=declaration_expansion.declarations.enums,
+            constants=declaration_expansion.declarations.constants,
+            value_renderer=declaration_expansion.value_renderer,
+            collection_rendering=declaration_expansion.collection_rendering,
         )
         reject_cursor_intrinsics(
             sql=expanded_sql_body,

--- a/src/sqlbuild/compiler/compile/_helpers/render/declarations.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/declarations.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from sqlbuild.compiler.compile.constants import MACRO_TOKEN, SQL_QUOTE_TOKENS
 from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.models import ExpansionSpan
+from sqlbuild.compiler.compile.types import TypedSqlValueRenderer
 from sqlbuild.compiler.discovery.models import (
     ConstantDeclaration,
     DiscoveredConstantFile,
@@ -25,6 +26,9 @@ from sqlbuild.compiler.sql_analysis.main._skip_block_comment import skip_block_c
 from sqlbuild.compiler.sql_analysis.main._skip_line_comment import skip_line_comment
 from sqlbuild.compiler.sql_analysis.main._skip_quoted_text import skip_quoted_text
 from sqlbuild.spec.contracts.models import SchemaAuditInstance, SchemaColumn, SchemaModelEntry
+from sqlbuild.sql_values.exceptions import SqlValueRenderingError, SqlValueValidationError
+from sqlbuild.sql_values.main.validate_rendered_size import validate_rendered_sql_value_size
+from sqlbuild.sql_values.types import CollectionRendering, SqlValueKind
 
 _ENUM_REFERENCE_PATTERN: re.Pattern[str] = re.compile(
     r"@enum\s*\(\s*(?P<quote>['\"])(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
@@ -182,12 +186,19 @@ def expand_declaration_references(
     file_path: Path,
     enums: dict[str, EnumDeclaration],
     constants: dict[str, ConstantDeclaration],
+    value_renderer: TypedSqlValueRenderer,
+    collection_rendering: CollectionRendering,
 ) -> str:
     """Resolve enum-member and constant references to SQL scalar literals."""
 
     rendered_sql: str
     rendered_sql, _spans = expand_declaration_references_with_spans(
-        sql=sql, file_path=file_path, enums=enums, constants=constants
+        sql=sql,
+        file_path=file_path,
+        enums=enums,
+        constants=constants,
+        value_renderer=value_renderer,
+        collection_rendering=collection_rendering,
     )
     return rendered_sql
 
@@ -198,6 +209,8 @@ def expand_declaration_references_with_spans(
     file_path: Path,
     enums: dict[str, EnumDeclaration],
     constants: dict[str, ConstantDeclaration],
+    value_renderer: TypedSqlValueRenderer,
+    collection_rendering: CollectionRendering,
 ) -> tuple[str, tuple[ExpansionSpan, ...]]:
     """Resolve declaration references, returning the span of every substitution."""
 
@@ -234,6 +247,8 @@ def expand_declaration_references_with_spans(
                 reference_start=reference_start,
                 file_path=file_path,
                 constants=constants,
+                value_renderer=value_renderer,
+                collection_rendering=collection_rendering,
             )
         rendered_parts.append(replacement)
         spans.append(
@@ -330,6 +345,8 @@ def _resolve_constant_reference(
     reference_start: int,
     file_path: Path,
     constants: dict[str, ConstantDeclaration],
+    value_renderer: TypedSqlValueRenderer,
+    collection_rendering: CollectionRendering,
 ) -> tuple[str, int]:
     match: re.Match[str] | None = _CONSTANT_REFERENCE_PATTERN.match(sql, reference_start)
     if match is None:
@@ -341,7 +358,36 @@ def _resolve_constant_reference(
     if declaration is None:
         scope_help: str = " in this model" if name.startswith("_") else ""
         raise CompileInputError(f"Unknown constant '{name}'{scope_help} in '{file_path}'")
-    return _render_scalar(value=declaration.value), match.end()
+    selected_rendering: CollectionRendering = declaration.render_as or collection_rendering
+    try:
+        if declaration.value.kind in {
+            SqlValueKind.STRING,
+            SqlValueKind.INTEGER,
+            SqlValueKind.BOOLEAN,
+            SqlValueKind.FLOAT,
+            SqlValueKind.DECIMAL,
+            SqlValueKind.NULL,
+        }:
+            rendered: str = value_renderer.render_typed_scalar(value=declaration.value)
+        elif declaration.value.kind in {SqlValueKind.LIST, SqlValueKind.SET}:
+            rendered = (
+                value_renderer.render_typed_array(value=declaration.value)
+                if selected_rendering == CollectionRendering.ARRAY
+                else value_renderer.render_typed_value_list(value=declaration.value)
+            )
+        else:
+            rendered = value_renderer.render_typed_object(value=declaration.value)
+        validate_rendered_sql_value_size(
+            rendered_sql=rendered,
+            context=f"{declaration.relative_path} constant '{declaration.name}'",
+        )
+    except (SqlValueRenderingError, SqlValueValidationError) as error:
+        raise CompileInputError(
+            f"{declaration.relative_path} constant '{declaration.name}' could not be rendered "
+            f"in '{file_path}' by adapter '{value_renderer.adapter_name}' as "
+            f"{selected_rendering.value}: {error}"
+        ) from error
+    return rendered, match.end()
 
 
 def _render_scalar(*, value: str | int) -> str:

--- a/src/sqlbuild/compiler/compile/_helpers/render/sql_vars.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/sql_vars.py
@@ -27,6 +27,7 @@ from sqlbuild.compiler.compile.models import (
     LoadedMacro,
     MacroContext,
 )
+from sqlbuild.compiler.compile.types import TypedSqlValueRenderer
 from sqlbuild.compiler.discovery.models import ConstantDeclaration, EnumDeclaration
 from sqlbuild.compiler.sql_analysis.main._is_identifier_character import (
     is_identifier_character as _is_identifier_continue,
@@ -37,6 +38,7 @@ from sqlbuild.compiler.sql_analysis.main._is_identifier_start import (
 from sqlbuild.compiler.sql_analysis.main._skip_block_comment import skip_block_comment
 from sqlbuild.compiler.sql_analysis.main._skip_line_comment import skip_line_comment
 from sqlbuild.compiler.sql_analysis.main._skip_quoted_text import skip_quoted_text
+from sqlbuild.sql_values.types import CollectionRendering
 
 _CONTEXT: str = "SQL interpolation"
 
@@ -64,6 +66,8 @@ def expand_authored_sql(
     effective_vars: dict[str, object],
     loaded_macros: dict[str, LoadedMacro],
     macro_context: MacroContext,
+    value_renderer: TypedSqlValueRenderer,
+    collection_rendering: CollectionRendering,
     context_values: Mapping[str, str | None] | None = None,
     enums: dict[str, EnumDeclaration] | None = None,
     constants: dict[str, ConstantDeclaration] | None = None,
@@ -81,6 +85,8 @@ def expand_authored_sql(
         file_path=file_path,
         enums=enums or {},
         constants=constants or {},
+        value_renderer=value_renderer,
+        collection_rendering=collection_rendering,
     )
     return expand_sql_macros(
         sql=declaration_expanded_sql,
@@ -97,6 +103,8 @@ def expand_authored_sql_with_spans(
     effective_vars: dict[str, object],
     loaded_macros: dict[str, LoadedMacro],
     macro_context: MacroContext,
+    value_renderer: TypedSqlValueRenderer,
+    collection_rendering: CollectionRendering,
     context_values: Mapping[str, str | None] | None = None,
     enums: dict[str, EnumDeclaration] | None = None,
     constants: dict[str, ConstantDeclaration] | None = None,
@@ -118,6 +126,8 @@ def expand_authored_sql_with_spans(
         file_path=file_path,
         enums=enums or {},
         constants=constants or {},
+        value_renderer=value_renderer,
+        collection_rendering=collection_rendering,
     )
     macro_expanded_sql: str
     macro_spans: tuple[ExpansionSpan, ...]

--- a/src/sqlbuild/compiler/compile/main/_build_compile_inputs.py
+++ b/src/sqlbuild/compiler/compile/main/_build_compile_inputs.py
@@ -34,6 +34,7 @@ from sqlbuild.compiler.compile._helpers.render.declarations import (
 )
 from sqlbuild.compiler.compile._helpers.render.macros import load_project_macros
 from sqlbuild.compiler.compile.models import (
+    CompileAdapterContext,
     CompileAuditInput,
     CompileModelInput,
     CompileProjectInputs,
@@ -43,6 +44,7 @@ from sqlbuild.compiler.compile.models import (
     CompileSqlFunctionInput,
     CompileSqlScenarioInput,
     CompileSqlTestInput,
+    DeclarationExpansionContext,
     DeclarationResolutionContext,
     LoadedMacro,
     MacroContext,
@@ -66,12 +68,12 @@ from sqlbuild.spec.contracts.models import SettingsConfig, TargetConfig
 def build_compile_inputs(
     *,
     discovered_inputs: DiscoveredProjectInputs,
+    adapter_context: CompileAdapterContext,
     selected_target: str | None = None,
     cli_vars: dict[str, object] | None = None,
     run_id: str | None = None,
     no_sql_validation: bool = False,
     defer_model_sql_validation: bool = False,
-    python_functions_inherit_default_namespace: bool = True,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
     resolved_connection: dict[str, object] | None = None,
     no_cache: bool = False,
@@ -116,6 +118,8 @@ def build_compile_inputs(
         run_id=resolved_run_id,
         macro_context=macro_context,
         loaded_macros=loaded_macros,
+        value_renderer=adapter_context.value_renderer,
+        collection_rendering=adapter_context.collection_rendering,
     )
     model_inputs: tuple[CompileModelInput, ...]
     declarations: DeclarationResolutionContext
@@ -127,14 +131,21 @@ def build_compile_inputs(
         external_sql_reference_resolver=external_sql_reference_resolver,
         reference_cache_dir=compile_cache_dir,
     )
+    model_context = replace(
+        model_context,
+        public_enums=declarations.enums,
+        public_constants=declarations.constants,
+    )
     seed_inputs: tuple[CompileSeedInput, ...] = build_seed_inputs(discovered_inputs)
     sql_function_inputs: tuple[CompileSqlFunctionInput, ...] = _build_sql_functions(
         discovered_inputs=discovered_inputs,
         context=model_context,
-        declarations=declarations,
+        declaration_expansion=model_context.declaration_expansion,
         model_inputs=model_inputs,
         no_sql_validation=no_sql_validation,
-        python_functions_inherit_default_namespace=(python_functions_inherit_default_namespace),
+        python_functions_inherit_default_namespace=(
+            adapter_context.python_functions_inherit_default_namespace
+        ),
     )
     source_inputs: tuple[CompileSourceInput, ...] = build_source_inputs(
         discovered_inputs=discovered_inputs,
@@ -142,8 +153,7 @@ def build_compile_inputs(
         effective_settings=effective_settings,
         macro_context=macro_context,
         loaded_macros=loaded_macros,
-        public_enums=declarations.enums,
-        public_constants=declarations.constants,
+        declaration_expansion=model_context.declaration_expansion,
         no_sql_validation=no_sql_validation,
     )
     test_inputs: tuple[CompileSqlTestInput, ...] = build_test_inputs(
@@ -151,8 +161,7 @@ def build_compile_inputs(
         effective_vars=effective_vars,
         macro_context=macro_context,
         loaded_macros=loaded_macros,
-        public_enums=declarations.enums,
-        public_constants=declarations.constants,
+        declaration_expansion=model_context.declaration_expansion,
         external_sql_reference_resolver=external_sql_reference_resolver,
         sql_function_inputs=sql_function_inputs,
     )
@@ -161,8 +170,7 @@ def build_compile_inputs(
         effective_vars=effective_vars,
         macro_context=macro_context,
         loaded_macros=loaded_macros,
-        public_enums=declarations.enums,
-        public_constants=declarations.constants,
+        declaration_expansion=model_context.declaration_expansion,
         external_sql_reference_resolver=external_sql_reference_resolver,
     )
     project_audit_definitions: dict[str, tuple[DiscoveredAuditFile, DiscoveredAuditBlock]] = (
@@ -181,8 +189,7 @@ def build_compile_inputs(
         effective_vars=effective_vars,
         macro_context=macro_context,
         loaded_macros=loaded_macros,
-        public_enums=declarations.enums,
-        public_constants=declarations.constants,
+        declaration_expansion=model_context.declaration_expansion,
         generic_audit_definitions=generic_audit_definitions,
     )
     return CompileProjectInputs(
@@ -224,7 +231,7 @@ def _build_sql_functions(
     *,
     discovered_inputs: DiscoveredProjectInputs,
     context: ModelInputBuildContext,
-    declarations: DeclarationResolutionContext,
+    declaration_expansion: DeclarationExpansionContext,
     model_inputs: tuple[CompileModelInput, ...],
     no_sql_validation: bool,
     python_functions_inherit_default_namespace: bool,
@@ -237,7 +244,7 @@ def _build_sql_functions(
         adapter_name=context.macro_context.adapter_name,
         macro_context=context.macro_context,
         loaded_macros=context.loaded_macros,
-        declarations=declarations,
+        declaration_expansion=declaration_expansion,
         no_sql_validation=no_sql_validation,
         python_functions_inherit_default_namespace=python_functions_inherit_default_namespace,
     )

--- a/src/sqlbuild/compiler/compile/main/expand_sql_with_spans.py
+++ b/src/sqlbuild/compiler/compile/main/expand_sql_with_spans.py
@@ -35,4 +35,6 @@ def expand_sql_with_spans(
         macro_context=context.macro_context,
         enums=enums,
         constants=constants,
+        value_renderer=context.value_renderer,
+        collection_rendering=context.collection_rendering,
     )

--- a/src/sqlbuild/compiler/compile/main/sql_expansion_context.py
+++ b/src/sqlbuild/compiler/compile/main/sql_expansion_context.py
@@ -18,12 +18,22 @@ from sqlbuild.compiler.compile.models import (
     MacroContext,
     SqlExpansionContext,
 )
+from sqlbuild.compiler.compile.types import TypedSqlValueRenderer
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.spec.contracts.main.resolve_effective_adapter_name import (
+    resolve_effective_adapter_name,
+)
+from sqlbuild.spec.contracts.main.resolve_effective_collection_rendering import (
+    resolve_effective_collection_rendering,
+)
 
 
 def build_sql_expansion_context(
-    *, project_dir: Path, cli_vars: dict[str, object] | None = None
+    *,
+    project_dir: Path,
+    value_renderer: TypedSqlValueRenderer,
+    cli_vars: dict[str, object] | None = None,
 ) -> SqlExpansionContext:
     """Assemble project vars, macros and declarations for SQL expansion."""
 
@@ -53,12 +63,20 @@ def build_sql_expansion_context(
         effective_vars=effective_vars,
         loaded_macros=loaded_macros,
         macro_context=MacroContext(
-            adapter_name=discovered_inputs.project_config.adapter,
+            adapter_name=resolve_effective_adapter_name(
+                project_config=discovered_inputs.project_config,
+                local_config=discovered_inputs.local_config,
+            ),
             sql_analysis_enabled=False,
             target_name=discovered_inputs.project_config.default_target,
             vars=effective_vars,
         ),
         enums=enums,
         constants=constants,
+        value_renderer=value_renderer,
+        collection_rendering=resolve_effective_collection_rendering(
+            project_config=discovered_inputs.project_config,
+            declaration_override=None,
+        ),
         local_declarations=local_declarations,
     )

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -14,6 +14,7 @@ from sqlbuild.compiler.compile.types import (
     DiagnosticSeverity,
     FunctionLanguage,
     SqlTestMode,
+    TypedSqlValueRenderer,
 )
 from sqlbuild.compiler.discovery.models import (
     ConstantDeclaration,
@@ -53,6 +54,7 @@ from sqlbuild.spec.contracts.models import (
     SourceLocation,
     TargetConfig,
 )
+from sqlbuild.sql_values.types import CollectionRendering
 
 
 @dataclass(frozen=True)
@@ -163,6 +165,24 @@ class DeclarationResolutionContext:
 
 
 @dataclass(frozen=True)
+class DeclarationExpansionContext:
+    """Declarations and adapter rendering used by one authored SQL owner."""
+
+    declarations: DeclarationResolutionContext
+    value_renderer: TypedSqlValueRenderer
+    collection_rendering: CollectionRendering
+
+
+@dataclass(frozen=True)
+class CompileAdapterContext:
+    """Cycle-free adapter behavior required while building compile inputs."""
+
+    value_renderer: TypedSqlValueRenderer
+    collection_rendering: CollectionRendering
+    python_functions_inherit_default_namespace: bool
+
+
+@dataclass(frozen=True)
 class ModelInputBuildContext:
     """Run-constant config and macros for building model compile inputs."""
 
@@ -173,9 +193,24 @@ class ModelInputBuildContext:
     run_id: str
     macro_context: MacroContext
     loaded_macros: dict[str, LoadedMacro]
+    value_renderer: TypedSqlValueRenderer
+    collection_rendering: CollectionRendering
     public_enums: dict[str, EnumDeclaration] = field(default_factory=dict)
     public_constants: dict[str, ConstantDeclaration] = field(default_factory=dict)
     public_model_schemas: dict[str, ModelSchemaDeclaration] = field(default_factory=dict)
+
+    @property
+    def declaration_expansion(self) -> DeclarationExpansionContext:
+        """Build the public declaration expansion context for non-model resources."""
+
+        return DeclarationExpansionContext(
+            declarations=DeclarationResolutionContext(
+                enums=self.public_enums,
+                constants=self.public_constants,
+            ),
+            value_renderer=self.value_renderer,
+            collection_rendering=self.collection_rendering,
+        )
 
 
 @dataclass(frozen=True)
@@ -673,6 +708,8 @@ class SqlExpansionContext:
     macro_context: MacroContext
     enums: dict[str, EnumDeclaration]
     constants: dict[str, ConstantDeclaration]
+    value_renderer: TypedSqlValueRenderer
+    collection_rendering: CollectionRendering
     local_declarations: dict[Path, DeclarationResolutionContext] = field(default_factory=dict)
 
 

--- a/src/sqlbuild/compiler/compile/types.py
+++ b/src/sqlbuild/compiler/compile/types.py
@@ -3,6 +3,23 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Protocol
+
+from sqlbuild.sql_values.models import SqlValue
+
+
+class TypedSqlValueRenderer(Protocol):
+    """Adapter rendering operations consumed by authored SQL expansion."""
+
+    adapter_name: str
+
+    def render_typed_scalar(self, *, value: SqlValue) -> str: ...
+
+    def render_typed_value_list(self, *, value: SqlValue) -> str: ...
+
+    def render_typed_array(self, *, value: SqlValue) -> str: ...
+
+    def render_typed_object(self, *, value: SqlValue) -> str: ...
 
 
 class AttachedAuditTargetKind(StrEnum):

--- a/src/sqlbuild/compiler/discovery/_helpers/sql/declarations.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/sql/declarations.py
@@ -20,6 +20,11 @@ from sqlbuild.compiler.discovery.models import (
     EnumMember,
     ModelSchemaDeclaration,
 )
+from sqlbuild.sql_values.constants import MISSING_SQL_VALUE
+from sqlbuild.sql_values.exceptions import SqlValueValidationError
+from sqlbuild.sql_values.main.normalize import normalize_sql_value
+from sqlbuild.sql_values.models import AuthoredSqlValueCall, SqlValue
+from sqlbuild.sql_values.types import CollectionRendering, SqlValueKind
 
 _IDENTIFIER_PATTERN: re.Pattern[str] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _DECLARATION_START_PATTERN: re.Pattern[str] = re.compile(r"(?P<kind>ENUM|CONSTANT|SCHEMA)\s*\(")
@@ -67,11 +72,13 @@ def parse_constant_declaration_file(
     return tuple(
         _parse_constant_declaration(
             name=parsed_header.values.get("name"),
-            value=parsed_header.values.get("value"),
+            value=parsed_header.values.get("value", MISSING_SQL_VALUE),
+            explicit_type=parsed_header.values.get("type", MISSING_SQL_VALUE),
+            raw_render_as=parsed_header.values.get("render_as", MISSING_SQL_VALUE),
             file_path=file_path,
             relative_path=relative_path,
             model_name=None,
-            unknown_keys=set(parsed_header.values) - {"name", "value"},
+            unknown_keys=set(parsed_header.values) - {"name", "value", "type", "render_as"},
         )
         for parsed_header in _parse_declaration_headers(
             contents=contents,
@@ -203,6 +210,8 @@ def parse_model_constant_declarations(
             _parse_constant_declaration(
                 name=raw_name,
                 value=raw_value_item,
+                explicit_type=MISSING_SQL_VALUE,
+                raw_render_as=MISSING_SQL_VALUE,
                 file_path=relative_path,
                 relative_path=relative_path,
                 model_name=model_name,
@@ -365,6 +374,8 @@ def _parse_constant_declaration(
     *,
     name: object | None,
     value: object | None,
+    explicit_type: object | None,
+    raw_render_as: object | None,
     file_path: Path,
     relative_path: Path,
     model_name: str | None,
@@ -380,18 +391,72 @@ def _parse_constant_declaration(
         kind="constant",
         model_name=model_name,
     )
-    scalar_value: str | int = _parse_scalar(
-        raw_value=value,
+    if isinstance(value, AuthoredSqlValueCall):
+        if explicit_type is not MISSING_SQL_VALUE or raw_render_as is not MISSING_SQL_VALUE:
+            raise DeclarationParseError(
+                f"{file_path} constant '{parsed_name}' cannot combine wrapper and outer options"
+            )
+        wrapper_values: dict[str, object] = dict(value.arguments)
+        wrapper_unknown_keys: set[str] = set(wrapper_values) - {"value", "type", "render_as"}
+        if wrapper_unknown_keys:
+            raise DeclarationParseError(
+                f"{file_path} constant '{parsed_name}' wrapper has unknown keys: "
+                f"{', '.join(sorted(wrapper_unknown_keys))}"
+            )
+        value = wrapper_values.get("value", MISSING_SQL_VALUE)
+        explicit_type = wrapper_values.get("type", MISSING_SQL_VALUE)
+        raw_render_as = wrapper_values.get("render_as", MISSING_SQL_VALUE)
+    if value is MISSING_SQL_VALUE:
+        raise DeclarationParseError(
+            f"{file_path} constant '{parsed_name}' is missing required value"
+        )
+    parsed_explicit_type: str | None = _parse_constant_option(
+        raw_value=explicit_type,
         file_path=file_path,
-        label=f"constant '{parsed_name}'",
+        label=f"constant '{parsed_name}' type",
     )
+    render_as_text: str | None = _parse_constant_option(
+        raw_value=raw_render_as,
+        file_path=file_path,
+        label=f"constant '{parsed_name}' render_as",
+    )
+    try:
+        render_as: CollectionRendering | None = (
+            CollectionRendering(render_as_text) if render_as_text is not None else None
+        )
+    except ValueError as error:
+        raise DeclarationParseError(
+            f"{file_path} constant '{parsed_name}' render_as must be value_list or array"
+        ) from error
+    try:
+        typed_value: SqlValue = normalize_sql_value(
+            raw_value=value,
+            explicit_type=parsed_explicit_type,
+            context=f"{file_path} constant '{parsed_name}'",
+        )
+    except SqlValueValidationError as error:
+        raise DeclarationParseError(str(error)) from error
+    if render_as is not None and typed_value.kind not in {SqlValueKind.LIST, SqlValueKind.SET}:
+        raise DeclarationParseError(
+            f"{file_path} constant '{parsed_name}' is {typed_value.kind.value} and does not "
+            "support "
+            f"render_as {render_as.value}"
+        )
     return ConstantDeclaration(
         name=parsed_name,
-        value=scalar_value,
-        scalar_type=_scalar_type(value=scalar_value),
+        value=typed_value,
         relative_path=relative_path,
         model_name=model_name,
+        render_as=render_as,
     )
+
+
+def _parse_constant_option(*, raw_value: object, file_path: Path, label: str) -> str | None:
+    if raw_value is MISSING_SQL_VALUE:
+        return None
+    if not isinstance(raw_value, str) or not raw_value:
+        raise DeclarationParseError(f"{file_path} {label} must be an identifier")
+    return raw_value
 
 
 def _parse_declaration_name(

--- a/src/sqlbuild/compiler/discovery/_helpers/sql/model_files.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/sql/model_files.py
@@ -15,16 +15,19 @@ from sqlbuild.compiler.discovery.exceptions import (
 from sqlbuild.compiler.discovery.models import NamedSqlHookEntry, PythonHookEntry, SqlHookEntry
 from sqlbuild.compiler.references.types import SqlReferenceKind
 from sqlbuild.spec.contracts.models import SourceLocation
+from sqlbuild.sql_values.models import AuthoredSqlSet, AuthoredSqlValueCall
 
 _MODEL_HEADER_END_TOKEN: str = "end"
 _MODEL_HEADER_WORD_TOKEN: str = "word"
 _MODEL_HEADER_STRING_TOKEN: str = "string"
 _MODEL_HEADER_SYMBOL_TOKEN: str = "symbol"
-_MODEL_HEADER_SYMBOLS: frozenset[str] = frozenset({"(", ")", "[", "]", ","})
+_MODEL_HEADER_SYMBOLS: frozenset[str] = frozenset({"(", ")", "[", "]", "{", "}", ","})
 _MODEL_HEADER_OPEN_PAREN: str = "("
 _MODEL_HEADER_CLOSE_PAREN: str = ")"
 _MODEL_HEADER_OPEN_BRACKET: str = "["
 _MODEL_HEADER_CLOSE_BRACKET: str = "]"
+_MODEL_HEADER_OPEN_BRACE: str = "{"
+_MODEL_HEADER_CLOSE_BRACE: str = "}"
 _MODEL_HEADER_COMMA: str = ","
 _MODEL_HEADER_KEY_VALUE_SEPARATOR: str = ":"
 _MODEL_HEADER_QUOTE_NAMES: dict[str, str] = {"'": "single", '"': "double"}
@@ -51,6 +54,7 @@ _MODEL_HEADER_HOOK_FIELD_NAMES: frozenset[str] = frozenset({"pre_hooks", "post_h
 _MODEL_HEADER_TRUE_VALUE: str = "true"
 _MODEL_HEADER_FALSE_VALUE: str = "false"
 _MODEL_HEADER_NULL_VALUE: str = "null"
+_MODEL_HEADER_TYPED_CONSTANT_CALL: str = "constant"
 _SQL_IDENTIFIER_SEPARATOR: str = "_"
 _SQL_SELECT_KEYWORD: str = "SELECT"
 _SQL_UNION_KEYWORD: str = "UNION"
@@ -540,22 +544,33 @@ class _ModelHeaderParser:
                     return self._parse_relation_call(token.value)
                 if token.value in _MODEL_HEADER_HOOK_CALL_NAMES:
                     return self._parse_hook_call(token.value)
+                if token.value == _MODEL_HEADER_TYPED_CONSTANT_CALL:
+                    return AuthoredSqlValueCall(
+                        arguments=tuple(
+                            self._parse_map(end_symbol=_MODEL_HEADER_CLOSE_PAREN).items()
+                        )
+                    )
                 return {token.value: self._parse_map(end_symbol=_MODEL_HEADER_CLOSE_PAREN)}
             return _parse_word_value(token.value)
         if self._match_symbol(_MODEL_HEADER_OPEN_BRACKET):
             return self._parse_list()
+        if self._match_symbol(_MODEL_HEADER_OPEN_BRACE):
+            return AuthoredSqlSet(values=tuple(self._parse_sequence(_MODEL_HEADER_CLOSE_BRACE)))
         if self._match_symbol(_MODEL_HEADER_OPEN_PAREN):
             return self._parse_map(end_symbol=_MODEL_HEADER_CLOSE_PAREN)
         raise ModelHeaderSyntaxError(f"expected value at position {token.position}")
 
     def _parse_list(self) -> list[object]:
+        return self._parse_sequence(_MODEL_HEADER_CLOSE_BRACKET)
+
+    def _parse_sequence(self, end_symbol: str) -> list[object]:
         values: list[object] = []
-        while not self._is_at_end_symbol(_MODEL_HEADER_CLOSE_BRACKET):
+        while not self._is_at_end_symbol(end_symbol):
             if self._match_symbol(_MODEL_HEADER_COMMA):
                 continue
             values.append(self._parse_value())
             self._match_symbol(_MODEL_HEADER_COMMA)
-        self._consume_symbol(_MODEL_HEADER_CLOSE_BRACKET)
+        self._consume_symbol(end_symbol)
         return values
 
     def _parse_hook_field_value(self, field_name: str) -> list[object]:
@@ -580,7 +595,7 @@ class _ModelHeaderParser:
         if token.kind == _MODEL_HEADER_STRING_TOKEN:
             self._advance()
             return token.value
-        if token.kind != _MODEL_HEADER_WORD_TOKEN:
+        if token.kind not in {_MODEL_HEADER_WORD_TOKEN, _MODEL_HEADER_STRING_TOKEN}:
             raise ModelHeaderSyntaxError(
                 f"{field_name} entries must use typed inline_sql(...), sql(...), or "
                 "python(...) hook syntax"
@@ -696,6 +711,19 @@ def _tokenize_model_header(header: str) -> list[_ModelHeaderToken]:
         if character.isspace():
             index += 1
             continue
+        if header.startswith("${", index):
+            template_end: int = header.find("}", index + 2)
+            if template_end < 0:
+                raise ModelHeaderSyntaxError(f"unterminated template value at position {index}")
+            tokens.append(
+                _ModelHeaderToken(
+                    kind=_MODEL_HEADER_WORD_TOKEN,
+                    value=header[index : template_end + 1],
+                    position=index,
+                )
+            )
+            index = template_end + 1
+            continue
         if character in _MODEL_HEADER_SYMBOLS:
             tokens.append(
                 _ModelHeaderToken(kind=_MODEL_HEADER_SYMBOL_TOKEN, value=character, position=index)
@@ -722,6 +750,14 @@ def _tokenize_model_header(header: str) -> list[_ModelHeaderToken]:
         value: str
         next_index = index
         while next_index < len(header):
+            if header.startswith("${", next_index):
+                embedded_template_end: int = header.find("}", next_index + 2)
+                if embedded_template_end < 0:
+                    raise ModelHeaderSyntaxError(
+                        f"unterminated template value at position {next_index}"
+                    )
+                next_index = embedded_template_end + 1
+                continue
             next_character: str = header[next_index]
             if (
                 next_character.isspace()

--- a/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
@@ -31,6 +31,7 @@ from sqlbuild.compiler.planner.types import ContractPolicy
 from sqlbuild.cost.constants import USD_PER_CREDIT_CONFIG_KEY
 from sqlbuild.spec.contracts.models import (
     ClonePolicy,
+    ConstantsConfig,
     CostConfig,
     DbtConfig,
     DefaultsConfig,
@@ -48,6 +49,7 @@ from sqlbuild.spec.contracts.models import (
     StateConfig,
     TargetConfig,
 )
+from sqlbuild.sql_values.types import CollectionRendering
 
 _SNAPSHOT_FULL_REFRESH_POLICIES: frozenset[str] = frozenset(
     {"allow", "deny", "require_confirmation"}
@@ -74,6 +76,9 @@ def load_project_config(*, project_dir: Path) -> ProjectConfig:
     connection: dict[str, object] = _optional_mapping(payload=payload, key="connection")
     settings: SettingsConfig = _load_settings(payload=payload.get("settings"), file_path=file_path)
     cost: CostConfig = _load_cost(payload=payload.get("cost"), file_path=file_path)
+    constants: ConstantsConfig = _load_constants(
+        payload=payload.get("constants"), file_path=file_path
+    )
     defaults: DefaultsConfig = _load_defaults(payload=payload.get("defaults"), file_path=file_path)
     path_defaults: dict[str, dict[str, object]] = _load_path_defaults(
         payload=payload.get("path_defaults"),
@@ -105,6 +110,7 @@ def load_project_config(*, project_dir: Path) -> ProjectConfig:
         connection=connection,
         settings=settings,
         cost=cost,
+        constants=constants,
         defaults=defaults,
         path_defaults=path_defaults,
         vars=vars_map,
@@ -339,6 +345,30 @@ def _load_cost(*, payload: object, file_path: Path) -> CostConfig:
             f"{file_path} cost.usd_per_credit must be a finite number greater than zero"
         )
     return CostConfig(usd_per_credit=value, usd_per_credit_is_default=False)
+
+
+def _load_constants(*, payload: object, file_path: Path) -> ConstantsConfig:
+    mapping: dict[str, object] = _coerce_mapping(
+        payload=payload, label="constants", file_path=file_path
+    )
+    key: str = "collection_rendering"
+    _validate_allowed_keys(
+        mapping=mapping,
+        allowed_keys=frozenset({key}),
+        label="constants",
+        file_path=file_path,
+    )
+    raw_value: object = mapping.get(key, CollectionRendering.VALUE_LIST.value)
+    if not isinstance(raw_value, str):
+        raise ProjectConfigError(f"{file_path} constants.{key} must be a string")
+    try:
+        collection_rendering: CollectionRendering = CollectionRendering(raw_value)
+    except ValueError as error:
+        valid_values: str = ", ".join(rendering.value for rendering in CollectionRendering)
+        raise ProjectConfigError(
+            f"{file_path} constants.{key} must be one of: {valid_values}"
+        ) from error
+    return ConstantsConfig(collection_rendering=collection_rendering)
 
 
 def _load_local_settings(

--- a/src/sqlbuild/compiler/discovery/models.py
+++ b/src/sqlbuild/compiler/discovery/models.py
@@ -23,6 +23,8 @@ from sqlbuild.spec.contracts.models import (
     SourceLocation,
 )
 from sqlbuild.spec.contracts.types import SourceWriteStrategy
+from sqlbuild.sql_values.models import SqlLogicalType, SqlValue
+from sqlbuild.sql_values.types import CollectionRendering, SqlValueKind
 
 
 @dataclass(frozen=True)
@@ -118,10 +120,30 @@ class ConstantDeclaration:
     """One validated public or model-local constant declaration."""
 
     name: str
-    value: str | int
-    scalar_type: str
+    value: SqlValue
     relative_path: Path
     model_name: str | None = None
+    render_as: CollectionRendering | None = None
+
+    @property
+    def logical_type(self) -> SqlLogicalType:
+        """Return the normalized logical type."""
+
+        return self.value.logical_type
+
+    @property
+    def scalar_type(self) -> str:
+        """Retain the existing SQL scalar type label for scalar declarations."""
+
+        names: dict[SqlValueKind, str] = {
+            SqlValueKind.STRING: "VARCHAR",
+            SqlValueKind.INTEGER: "INTEGER",
+            SqlValueKind.BOOLEAN: "BOOLEAN",
+            SqlValueKind.FLOAT: "FLOAT",
+            SqlValueKind.DECIMAL: "DECIMAL",
+            SqlValueKind.NULL: "NULL",
+        }
+        return names.get(self.value.kind, self.value.logical_type.display_name.upper())
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -7,6 +7,7 @@ from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
 from sqlbuild.compiler.compile.main._assemble_project import assemble_project
 from sqlbuild.compiler.compile.main._build_compile_inputs import build_compile_inputs
 from sqlbuild.compiler.compile.models import (
+    CompileAdapterContext,
     CompileAnalysisSelection,
     CompiledProject,
     CompileProjectInputs,
@@ -29,6 +30,9 @@ from sqlbuild.compiler.planner.models import (
 from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.contracts.main.resolve_effective_adapter_name import (
     resolve_effective_adapter_name,
+)
+from sqlbuild.spec.contracts.main.resolve_effective_collection_rendering import (
+    resolve_effective_collection_rendering,
 )
 
 
@@ -54,14 +58,21 @@ def build_compiled_project(
     no_cache: bool = analysis_selection is not None and analysis_selection.no_cache
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs=discovered_inputs,
+        adapter_context=CompileAdapterContext(
+            value_renderer=adapter,
+            collection_rendering=resolve_effective_collection_rendering(
+                project_config=discovered_inputs.project_config,
+                declaration_override=None,
+            ),
+            python_functions_inherit_default_namespace=(
+                adapter.python_functions_inherit_default_namespace()
+            ),
+        ),
         selected_target=selected_target,
         no_sql_validation=no_sql_validation,
         defer_model_sql_validation=True,
         cli_vars=cli_vars,
         resolved_connection=resolved_connection,
-        python_functions_inherit_default_namespace=(
-            adapter.python_functions_inherit_default_namespace()
-        ),
         external_sql_reference_resolver=external_sql_reference_resolver,
         no_cache=no_cache,
     )

--- a/src/sqlbuild/kata_engine/_helpers/engine/native.py
+++ b/src/sqlbuild/kata_engine/_helpers/engine/native.py
@@ -8,8 +8,9 @@ import json
 import pickle
 import sys
 from dataclasses import asdict
+from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import sqlbuild._kata_native as _kata_native
 from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject
@@ -30,6 +31,8 @@ from sqlbuild.kata_engine.models import (
     KataResult,
     KataRule,
 )
+from sqlbuild.sql_values.models import SqlValue
+from sqlbuild.sql_values.types import SqlValueKind
 
 
 def evaluate_native(
@@ -258,6 +261,28 @@ def _constant_payload(declaration: ConstantDeclaration) -> dict[str, object]:
         "name": declaration.name,
         "relative_path": declaration.relative_path.as_posix(),
         "members": [],
+        "value": _typed_value_payload(declaration.value),
+        "value_type": declaration.logical_type.display_name,
+        "render_as": declaration.render_as.value if declaration.render_as is not None else None,
+    }
+
+
+def _typed_value_payload(value: SqlValue) -> object:
+    if value.kind == SqlValueKind.DECIMAL:
+        return str(cast(Decimal, value.value))
+    if value.kind in {
+        SqlValueKind.STRING,
+        SqlValueKind.INTEGER,
+        SqlValueKind.BOOLEAN,
+        SqlValueKind.FLOAT,
+        SqlValueKind.NULL,
+    }:
+        return value.value
+    if value.kind in {SqlValueKind.LIST, SqlValueKind.SET}:
+        return [_typed_value_payload(item) for item in cast(tuple[SqlValue, ...], value.value)]
+    return {
+        key: _typed_value_payload(item)
+        for key, item in cast(tuple[tuple[str, SqlValue], ...], value.value)
     }
 
 

--- a/src/sqlbuild/lint/_helpers/expansion.py
+++ b/src/sqlbuild/lint/_helpers/expansion.py
@@ -4,26 +4,56 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from sqlbuild.adapter.contract.exceptions import AdapterUserError
+from sqlbuild.adapter.discovery.main.resolve_adapter import resolve_adapter
 from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.main.expand_sql_with_spans import expand_sql_with_spans
 from sqlbuild.compiler.compile.main.sql_expansion_context import build_sql_expansion_context
 from sqlbuild.compiler.compile.models import ExpansionSpan, SqlExpansionContext
+from sqlbuild.compiler.compile.types import TypedSqlValueRenderer
 from sqlbuild.compiler.discovery.exceptions import DiscoveryError
+from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.lint._helpers.sqlbuild_tokens import neutralize_interpolation, sentinel_spans
 from sqlbuild.lint.exceptions import ProjectCompileError
 from sqlbuild.lint.models import InterpolationSite, LintBody
+from sqlbuild.spec.contracts.main.resolve_effective_adapter_name import (
+    resolve_effective_adapter_name,
+)
 
 
-def build_lint_expansion_context(*, project_dir: Path) -> SqlExpansionContext:
+def build_lint_expansion_context(
+    *, project_dir: Path, value_renderer: TypedSqlValueRenderer | None = None
+) -> SqlExpansionContext:
     """Build the expansion context, reporting compile failures as lint failures."""
 
     try:
-        return build_sql_expansion_context(project_dir=project_dir)
-    except (CompileInputError, DiscoveryError) as error:
+        effective_renderer: TypedSqlValueRenderer = value_renderer or _resolve_value_renderer(
+            project_dir=project_dir
+        )
+        return build_sql_expansion_context(
+            project_dir=project_dir,
+            value_renderer=effective_renderer,
+        )
+    except (AdapterUserError, CompileInputError, DiscoveryError) as error:
         raise ProjectCompileError(
             f"sqb lint checks the SQL your project actually produces, so the project must "
             f"compile first: {error}"
         ) from error
+
+
+def _resolve_value_renderer(*, project_dir: Path) -> TypedSqlValueRenderer:
+    discovered: DiscoveredProjectInputs = discover_project_inputs(
+        project_dir=project_dir,
+        sql_analysis_enabled_override=False,
+    )
+    return resolve_adapter(
+        adapter_name=resolve_effective_adapter_name(
+            project_config=discovered.project_config,
+            local_config=discovered.local_config,
+        ),
+        project_dir=project_dir,
+    )
 
 
 def prepare_lint_body(

--- a/src/sqlbuild/lint/main/run_format.py
+++ b/src/sqlbuild/lint/main/run_format.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from sqlbuild.compiler.compile.models import SqlExpansionContext
+from sqlbuild.compiler.compile.types import TypedSqlValueRenderer
 from sqlbuild.lint._helpers.expansion import build_lint_expansion_context, prepare_lint_body
 from sqlbuild.lint._helpers.headers import scan_headers, sql_body_ranges
 from sqlbuild.lint._helpers.native import format_native_headers, lint_native_headers
@@ -20,7 +21,12 @@ from sqlbuild.lint.models import (
 )
 
 
-def run_format(*, project_dir: Path, config: LintConfig) -> LintRunResult:
+def run_format(
+    *,
+    project_dir: Path,
+    config: LintConfig,
+    value_renderer: TypedSqlValueRenderer | None = None,
+) -> LintRunResult:
     """Format all DSL files in place and report the violations that remain."""
 
     files: dict[Path, str] = collect_project_files(project_dir=project_dir)
@@ -40,7 +46,11 @@ def run_format(*, project_dir: Path, config: LintConfig) -> LintRunResult:
             )
         formatted.append(file_path)
     violations: list[LintViolation] = _lint_final_contents(
-        files=files, updated_contents=updated_contents, config=config, project_dir=project_dir
+        files=files,
+        updated_contents=updated_contents,
+        config=config,
+        project_dir=project_dir,
+        value_renderer=value_renderer,
     )
     return LintRunResult(
         files_checked=len(files),
@@ -90,6 +100,7 @@ def _lint_final_contents(
     updated_contents: dict[Path, str],
     config: LintConfig,
     project_dir: Path,
+    value_renderer: TypedSqlValueRenderer | None,
 ) -> list[LintViolation]:
     """Lint final contents so reported violations match a follow-up lint run."""
 
@@ -98,7 +109,10 @@ def _lint_final_contents(
     bodies: list[LintBody] = []
     context: SqlExpansionContext | None = None
     if config.sqruff_enabled:
-        context = build_lint_expansion_context(project_dir=project_dir)
+        context = build_lint_expansion_context(
+            project_dir=project_dir,
+            value_renderer=value_renderer,
+        )
     file_path: Path
     contents: str
     for file_path, contents in sorted(files.items()):

--- a/src/sqlbuild/lint/main/run_lint.py
+++ b/src/sqlbuild/lint/main/run_lint.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from sqlbuild.compiler.compile.models import SqlExpansionContext
+from sqlbuild.compiler.compile.types import TypedSqlValueRenderer
 from sqlbuild.lint._helpers.expansion import build_lint_expansion_context, prepare_lint_body
 from sqlbuild.lint._helpers.headers import scan_headers, sql_body_ranges
 from sqlbuild.lint._helpers.native import lint_native_headers
@@ -13,14 +14,21 @@ from sqlbuild.lint._helpers.sqruff_engine import run_sqruff_lint
 from sqlbuild.lint.models import HeaderSpan, LintBody, LintConfig, LintRunResult, LintViolation
 
 
-def run_lint(*, project_dir: Path, config: LintConfig) -> LintRunResult:
+def run_lint(
+    *,
+    project_dir: Path,
+    config: LintConfig,
+    value_renderer: TypedSqlValueRenderer | None = None,
+) -> LintRunResult:
     """Lint all DSL files in the project without modifying anything."""
 
     files: dict[Path, str] = collect_project_files(project_dir=project_dir)
     violations: list[LintViolation] = []
     bodies: list[LintBody] = []
     context: SqlExpansionContext | None = _expansion_context(
-        project_dir=project_dir, sqruff_enabled=config.sqruff_enabled
+        project_dir=project_dir,
+        sqruff_enabled=config.sqruff_enabled,
+        value_renderer=value_renderer,
     )
     file_path: Path
     contents: str
@@ -62,10 +70,18 @@ def run_lint(*, project_dir: Path, config: LintConfig) -> LintRunResult:
     )
 
 
-def _expansion_context(*, project_dir: Path, sqruff_enabled: bool) -> SqlExpansionContext | None:
+def _expansion_context(
+    *,
+    project_dir: Path,
+    sqruff_enabled: bool,
+    value_renderer: TypedSqlValueRenderer | None,
+) -> SqlExpansionContext | None:
     if not sqruff_enabled:
         return None
-    return build_lint_expansion_context(project_dir=project_dir)
+    return build_lint_expansion_context(
+        project_dir=project_dir,
+        value_renderer=value_renderer,
+    )
 
 
 def _prepared_bodies(

--- a/src/sqlbuild/spec/contracts/_helpers/project_config.py
+++ b/src/sqlbuild/spec/contracts/_helpers/project_config.py
@@ -8,6 +8,19 @@ from sqlbuild.spec.contracts.models import (
     ScenarioConfig,
     ScenarioSnapshotLimitsConfig,
 )
+from sqlbuild.sql_values.types import CollectionRendering
+
+
+def resolve_effective_collection_rendering(
+    *,
+    project_config: ProjectConfig,
+    declaration_override: CollectionRendering | None,
+) -> CollectionRendering:
+    """Resolve declaration rendering over project configuration."""
+
+    if declaration_override is not None:
+        return declaration_override
+    return project_config.constants.collection_rendering
 
 
 def resolve_effective_adapter_name(

--- a/src/sqlbuild/spec/contracts/main/resolve_effective_collection_rendering.py
+++ b/src/sqlbuild/spec/contracts/main/resolve_effective_collection_rendering.py
@@ -1,0 +1,20 @@
+"""Public effective collection rendering resolution operation."""
+
+from sqlbuild.spec.contracts._helpers.project_config import (
+    resolve_effective_collection_rendering as _resolve_effective_collection_rendering,
+)
+from sqlbuild.spec.contracts.models import ProjectConfig
+from sqlbuild.sql_values.types import CollectionRendering
+
+
+def resolve_effective_collection_rendering(
+    *,
+    project_config: ProjectConfig,
+    declaration_override: CollectionRendering | None,
+) -> CollectionRendering:
+    """Resolve declaration rendering over project configuration."""
+
+    return _resolve_effective_collection_rendering(
+        project_config=project_config,
+        declaration_override=declaration_override,
+    )

--- a/src/sqlbuild/spec/contracts/models.py
+++ b/src/sqlbuild/spec/contracts/models.py
@@ -12,6 +12,7 @@ from sqlbuild.spec.contracts.types import (
     SourceFreshnessValueKind,
     SourceWriteStrategy,
 )
+from sqlbuild.sql_values.types import CollectionRendering
 
 
 @dataclass(frozen=True)
@@ -113,6 +114,13 @@ class CostConfig:
 
 
 @dataclass(frozen=True)
+class ConstantsConfig:
+    """Project-wide constant rendering configuration."""
+
+    collection_rendering: CollectionRendering = CollectionRendering.VALUE_LIST
+
+
+@dataclass(frozen=True)
 class DefaultsConfig:
     """Project-wide model defaults."""
 
@@ -210,6 +218,7 @@ class ProjectConfig:
     connection: dict[str, object] = field(default_factory=dict)
     settings: SettingsConfig = field(default_factory=SettingsConfig)
     cost: CostConfig = field(default_factory=CostConfig)
+    constants: ConstantsConfig = field(default_factory=ConstantsConfig)
     defaults: DefaultsConfig = field(default_factory=DefaultsConfig)
     path_defaults: dict[str, dict[str, object]] = field(default_factory=dict)
     vars: dict[str, str] = field(default_factory=dict)

--- a/src/sqlbuild/sql_values/_helpers/normalization.py
+++ b/src/sqlbuild/sql_values/_helpers/normalization.py
@@ -1,0 +1,296 @@
+"""Recursive implementation for typed SQL value normalization."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import cast
+
+from sqlbuild.sql_values.constants import (
+    MAX_SIGNED_64_BIT_INTEGER,
+    MIN_SIGNED_64_BIT_INTEGER,
+)
+from sqlbuild.sql_values.exceptions import SqlValueValidationError
+from sqlbuild.sql_values.models import AuthoredSqlSet, SqlLogicalType, SqlValue, SqlValueLimits
+from sqlbuild.sql_values.types import SqlScalar, SqlValueKind
+
+_SCALAR_KINDS: frozenset[SqlValueKind] = frozenset(
+    {
+        SqlValueKind.STRING,
+        SqlValueKind.INTEGER,
+        SqlValueKind.BOOLEAN,
+        SqlValueKind.FLOAT,
+        SqlValueKind.DECIMAL,
+        SqlValueKind.NULL,
+    }
+)
+_DEFAULT_SQL_VALUE_LIMITS: SqlValueLimits = SqlValueLimits()
+
+
+@dataclass
+class _NormalizationState:
+    context: str
+    limits: SqlValueLimits
+    elements: int = 0
+    size: int = 0
+
+    def account(self, *, path: str, elements: int = 0, size: int = 0) -> None:
+        self.elements += elements
+        self.size += size
+        if self.elements > self.limits.max_elements:
+            raise SqlValueValidationError(
+                f"{self.context}{path} exceeds the maximum element count "
+                f"of {self.limits.max_elements}"
+            )
+        if self.size > self.limits.max_size:
+            raise SqlValueValidationError(
+                f"{self.context}{path} exceeds the maximum value size of "
+                f"{self.limits.max_size} bytes"
+            )
+
+
+def normalize_sql_value(
+    *,
+    raw_value: object,
+    context: str,
+    explicit_type: str | None = None,
+    limits: SqlValueLimits = _DEFAULT_SQL_VALUE_LIMITS,
+) -> SqlValue:
+    """Validate and normalize one authored value with contextual diagnostics."""
+
+    state: _NormalizationState = _NormalizationState(context=context, limits=limits)
+    return _normalize(
+        raw_value=raw_value,
+        path="",
+        depth=1,
+        state=state,
+        explicit_type=explicit_type,
+    )
+
+
+def sql_value_identity(*, value: SqlValue) -> tuple[object, ...]:
+    """Return typed canonical identity without Python's cross-type equality."""
+
+    kind: SqlValueKind = value.kind
+    if kind == SqlValueKind.DECIMAL:
+        decimal_value: object = value.value
+        if not isinstance(decimal_value, Decimal):
+            raise SqlValueValidationError("typed decimal contains an invalid payload")
+        return kind.value, decimal_value.normalize().as_tuple()
+    if kind in _SCALAR_KINDS:
+        return kind.value, value.value
+    if kind in {SqlValueKind.LIST, SqlValueKind.SET}:
+        items: tuple[SqlValue, ...] = cast(tuple[SqlValue, ...], value.value)
+        return kind.value, tuple(sql_value_identity(value=item) for item in items)
+    entries: tuple[tuple[str, SqlValue], ...] = cast(tuple[tuple[str, SqlValue], ...], value.value)
+    return kind.value, tuple((key, sql_value_identity(value=item)) for key, item in entries)
+
+
+def _normalize(
+    *,
+    raw_value: object,
+    path: str,
+    depth: int,
+    state: _NormalizationState,
+    explicit_type: str | None,
+) -> SqlValue:
+    if depth > state.limits.max_depth:
+        raise SqlValueValidationError(
+            f"{state.context}{path} exceeds the maximum nesting depth of {state.limits.max_depth}"
+        )
+    if explicit_type is not None:
+        return _normalize_explicit_scalar(
+            raw_value=raw_value, path=path, explicit_type=explicit_type, state=state
+        )
+    if raw_value is None:
+        state.account(path=path, size=4)
+        return _scalar(kind=SqlValueKind.NULL, value=None)
+    if type(raw_value) is bool:
+        state.account(path=path, size=5)
+        return _scalar(kind=SqlValueKind.BOOLEAN, value=raw_value)
+    if type(raw_value) is int:
+        if not MIN_SIGNED_64_BIT_INTEGER <= raw_value <= MAX_SIGNED_64_BIT_INTEGER:
+            raise SqlValueValidationError(
+                f"{state.context}{path} integer {raw_value} is outside the signed 64-bit range"
+            )
+        state.account(path=path, size=len(str(raw_value)))
+        return _scalar(kind=SqlValueKind.INTEGER, value=raw_value)
+    if type(raw_value) is float:
+        if not math.isfinite(raw_value):
+            raise SqlValueValidationError(
+                f"{state.context}{path} float must be finite; received {raw_value!r}"
+            )
+        normalized_float: float = 0.0 if raw_value == 0.0 else raw_value
+        state.account(path=path, size=len(repr(normalized_float)))
+        return _scalar(kind=SqlValueKind.FLOAT, value=normalized_float)
+    if type(raw_value) is Decimal:
+        if not raw_value.is_finite():
+            raise SqlValueValidationError(
+                f"{state.context}{path} decimal must be finite; received {raw_value!r}"
+            )
+        state.account(path=path, size=len(str(raw_value)))
+        return _scalar(kind=SqlValueKind.DECIMAL, value=raw_value)
+    if type(raw_value) is str:
+        state.account(path=path, size=len(raw_value.encode("utf-8")) + 2)
+        return _scalar(kind=SqlValueKind.STRING, value=raw_value)
+    if type(raw_value) is list:
+        return _normalize_collection(
+            raw_values=tuple(raw_value), kind=SqlValueKind.LIST, path=path, depth=depth, state=state
+        )
+    if isinstance(raw_value, AuthoredSqlSet):
+        return _normalize_collection(
+            raw_values=raw_value.values,
+            kind=SqlValueKind.SET,
+            path=path,
+            depth=depth,
+            state=state,
+        )
+    if type(raw_value) is dict:
+        return _normalize_object(
+            raw_value=cast(dict[object, object], raw_value), path=path, depth=depth, state=state
+        )
+    raise SqlValueValidationError(
+        f"{state.context}{path} has unsupported type {type(raw_value).__name__}; "
+        "expected a scalar, list, set, or object"
+    )
+
+
+def _normalize_explicit_scalar(
+    *, raw_value: object, path: str, explicit_type: str, state: _NormalizationState
+) -> SqlValue:
+    try:
+        kind: SqlValueKind = SqlValueKind(explicit_type.lower())
+    except ValueError as error:
+        allowed: str = ", ".join(item.value for item in SqlValueKind if item in _SCALAR_KINDS)
+        raise SqlValueValidationError(
+            f"{state.context}{path} has unsupported explicit type '{explicit_type}'; "
+            f"expected {allowed}"
+        ) from error
+    if kind not in _SCALAR_KINDS:
+        raise SqlValueValidationError(
+            f"{state.context}{path} explicit type '{explicit_type}' is not a scalar type"
+        )
+    if kind == SqlValueKind.DECIMAL:
+        if type(raw_value) is not str:
+            raise SqlValueValidationError(
+                f"{state.context}{path} with type decimal requires a quoted decimal string; "
+                f"received {type(raw_value).__name__}"
+            )
+        try:
+            decimal_value: Decimal = Decimal(raw_value)
+        except InvalidOperation as error:
+            raise SqlValueValidationError(
+                f"{state.context}{path} has invalid decimal value {raw_value!r}"
+            ) from error
+        if not decimal_value.is_finite():
+            raise SqlValueValidationError(
+                f"{state.context}{path} decimal must be finite; received {raw_value!r}"
+            )
+        state.account(path=path, size=len(raw_value))
+        return _scalar(kind=kind, value=decimal_value)
+    expected_types: dict[SqlValueKind, type[object]] = {
+        SqlValueKind.STRING: str,
+        SqlValueKind.INTEGER: int,
+        SqlValueKind.BOOLEAN: bool,
+        SqlValueKind.FLOAT: float,
+        SqlValueKind.NULL: type(None),
+    }
+    expected_type: type[object] = expected_types[kind]
+    valid: bool = type(raw_value) is expected_type
+    if not valid:
+        raise SqlValueValidationError(
+            f"{state.context}{path} has type {type(raw_value).__name__}; expected {kind.value}"
+        )
+    return _normalize(raw_value=raw_value, path=path, depth=1, state=state, explicit_type=None)
+
+
+def _normalize_collection(
+    *,
+    raw_values: tuple[object, ...],
+    kind: SqlValueKind,
+    path: str,
+    depth: int,
+    state: _NormalizationState,
+) -> SqlValue:
+    if not raw_values:
+        raise SqlValueValidationError(
+            f"{state.context}{path} {kind.value} must contain at least one value"
+        )
+    state.account(path=path, elements=len(raw_values), size=2 + len(raw_values))
+    values: tuple[SqlValue, ...] = tuple(
+        _normalize(
+            raw_value=raw_value,
+            path=f"{path}[{index}]",
+            depth=depth + 1,
+            state=state,
+            explicit_type=None,
+        )
+        for index, raw_value in enumerate(raw_values)
+    )
+    element_type: SqlLogicalType = _infer_element_type(
+        values=values, path=path, kind=kind, state=state
+    )
+    if kind == SqlValueKind.SET:
+        seen: set[tuple[object, ...]] = set()
+        for index, value in enumerate(values):
+            identity: tuple[object, ...] = sql_value_identity(value=value)
+            if identity in seen:
+                raise SqlValueValidationError(
+                    f"{state.context}{path} contains duplicate set value {value.value!r} "
+                    f"at {path}[{index}]"
+                )
+            seen.add(identity)
+        values = tuple(sorted(values, key=lambda value: repr(sql_value_identity(value=value))))
+    return SqlValue(logical_type=SqlLogicalType(kind, element_type), value=values)
+
+
+def _infer_element_type(
+    *, values: tuple[SqlValue, ...], path: str, kind: SqlValueKind, state: _NormalizationState
+) -> SqlLogicalType:
+    expected: SqlLogicalType | None = next(
+        (value.logical_type for value in values if value.kind != SqlValueKind.NULL), None
+    )
+    if expected is None:
+        raise SqlValueValidationError(
+            f"{state.context}{path} {kind.value} cannot infer an element type from only null values"
+        )
+    for index, value in enumerate(values):
+        if value.kind != SqlValueKind.NULL and value.logical_type != expected:
+            raise SqlValueValidationError(
+                f"{state.context}{path}[{index}] has type {value.logical_type.display_name}; "
+                f"expected {expected.display_name}"
+            )
+    return expected
+
+
+def _normalize_object(
+    *, raw_value: dict[object, object], path: str, depth: int, state: _NormalizationState
+) -> SqlValue:
+    state.account(path=path, elements=len(raw_value), size=2 + len(raw_value))
+    entries: list[tuple[str, SqlValue]] = []
+    for raw_key, item in raw_value.items():
+        if type(raw_key) is not str:
+            raise SqlValueValidationError(
+                f"{state.context}{path} object key {raw_key!r} must be a string"
+            )
+        state.account(path=path, size=len(raw_key.encode("utf-8")) + 2)
+        item_path: str = f"{path}.{raw_key}" if path else f".{raw_key}"
+        entries.append(
+            (
+                raw_key,
+                _normalize(
+                    raw_value=item,
+                    path=item_path,
+                    depth=depth + 1,
+                    state=state,
+                    explicit_type=None,
+                ),
+            )
+        )
+    entries.sort(key=lambda entry: entry[0])
+    return SqlValue(logical_type=SqlLogicalType(SqlValueKind.OBJECT), value=tuple(entries))
+
+
+def _scalar(*, kind: SqlValueKind, value: SqlScalar) -> SqlValue:
+    return SqlValue(logical_type=SqlLogicalType(kind), value=value)

--- a/src/sqlbuild/sql_values/constants.py
+++ b/src/sqlbuild/sql_values/constants.py
@@ -1,0 +1,8 @@
+"""Constants for typed SQL value validation."""
+
+MIN_SIGNED_64_BIT_INTEGER: int = -(2**63)
+MAX_SIGNED_64_BIT_INTEGER: int = 2**63 - 1
+DEFAULT_MAX_SQL_VALUE_DEPTH: int = 32
+DEFAULT_MAX_SQL_VALUE_ELEMENTS: int = 10_000
+DEFAULT_MAX_SQL_VALUE_SIZE: int = 1_000_000
+MISSING_SQL_VALUE: object = object()

--- a/src/sqlbuild/sql_values/exceptions.py
+++ b/src/sqlbuild/sql_values/exceptions.py
@@ -1,0 +1,9 @@
+"""Typed SQL value errors."""
+
+
+class SqlValueValidationError(ValueError):
+    """An authored value cannot be represented by the typed SQL value domain."""
+
+
+class SqlValueRenderingError(ValueError):
+    """An adapter cannot represent a validated typed SQL value."""

--- a/src/sqlbuild/sql_values/main/normalize.py
+++ b/src/sqlbuild/sql_values/main/normalize.py
@@ -1,0 +1,22 @@
+"""Public entry point for typed SQL value normalization."""
+
+from sqlbuild.sql_values._helpers.normalization import normalize_sql_value as _normalize_sql_value
+from sqlbuild.sql_values.models import SqlValue, SqlValueLimits
+
+
+def normalize_sql_value(
+    *,
+    raw_value: object,
+    context: str,
+    explicit_type: str | None = None,
+    limits: SqlValueLimits | None = None,
+) -> SqlValue:
+    """Validate and normalize one authored value with contextual diagnostics."""
+
+    if limits is None:
+        return _normalize_sql_value(
+            raw_value=raw_value, context=context, explicit_type=explicit_type
+        )
+    return _normalize_sql_value(
+        raw_value=raw_value, context=context, explicit_type=explicit_type, limits=limits
+    )

--- a/src/sqlbuild/sql_values/main/validate_rendered_size.py
+++ b/src/sqlbuild/sql_values/main/validate_rendered_size.py
@@ -1,0 +1,19 @@
+"""Rendered typed SQL value size validation."""
+
+from sqlbuild.sql_values.constants import DEFAULT_MAX_SQL_VALUE_SIZE
+from sqlbuild.sql_values.exceptions import SqlValueValidationError
+
+
+def validate_rendered_sql_value_size(
+    *,
+    rendered_sql: str,
+    context: str,
+    max_size: int = DEFAULT_MAX_SQL_VALUE_SIZE,
+) -> None:
+    """Reject adapter SQL that exceeds the shared UTF-8 byte limit."""
+
+    rendered_size: int = len(rendered_sql.encode("utf-8"))
+    if rendered_size > max_size:
+        raise SqlValueValidationError(
+            f"{context} rendered value is {rendered_size} bytes; maximum is {max_size} bytes"
+        )

--- a/src/sqlbuild/sql_values/models.py
+++ b/src/sqlbuild/sql_values/models.py
@@ -1,0 +1,65 @@
+"""Immutable models for validated and authored typed SQL values."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlbuild.sql_values.constants import (
+    DEFAULT_MAX_SQL_VALUE_DEPTH,
+    DEFAULT_MAX_SQL_VALUE_ELEMENTS,
+    DEFAULT_MAX_SQL_VALUE_SIZE,
+)
+from sqlbuild.sql_values.types import SqlValueKind, SqlValuePayload
+
+
+@dataclass(frozen=True)
+class SqlLogicalType:
+    """Logical type inferred for a normalized SQL value."""
+
+    kind: SqlValueKind
+    element_type: SqlLogicalType | None = None
+
+    @property
+    def display_name(self) -> str:
+        """Return a stable human-readable type name."""
+
+        if self.element_type is None:
+            return self.kind.value
+        return f"{self.kind.value}<{self.element_type.display_name}>"
+
+
+@dataclass(frozen=True)
+class SqlValue:
+    """One validated, canonical SQL value."""
+
+    logical_type: SqlLogicalType
+    value: SqlValuePayload
+
+    @property
+    def kind(self) -> SqlValueKind:
+        """Return the outer logical kind."""
+
+        return self.logical_type.kind
+
+
+@dataclass(frozen=True)
+class AuthoredSqlSet:
+    """Set literal entries retained in authored order until validation."""
+
+    values: tuple[object, ...]
+
+
+@dataclass(frozen=True)
+class AuthoredSqlValueCall:
+    """Source-preserving representation of an authored ``constant(...)`` call."""
+
+    arguments: tuple[tuple[str, object], ...]
+
+
+@dataclass(frozen=True)
+class SqlValueLimits:
+    """Safety limits applied while normalizing recursively authored values."""
+
+    max_depth: int = DEFAULT_MAX_SQL_VALUE_DEPTH
+    max_elements: int = DEFAULT_MAX_SQL_VALUE_ELEMENTS
+    max_size: int = DEFAULT_MAX_SQL_VALUE_SIZE

--- a/src/sqlbuild/sql_values/types.py
+++ b/src/sqlbuild/sql_values/types.py
@@ -1,0 +1,32 @@
+"""Immutable logical values shared by SQLBuild-authored SQL features."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import StrEnum
+
+
+class SqlValueKind(StrEnum):
+    """Closed logical kinds accepted by the typed SQL value boundary."""
+
+    STRING = "string"
+    INTEGER = "integer"
+    BOOLEAN = "boolean"
+    FLOAT = "float"
+    DECIMAL = "decimal"
+    NULL = "null"
+    LIST = "list"
+    SET = "set"
+    OBJECT = "object"
+
+
+class CollectionRendering(StrEnum):
+    """Physical rendering choices for homogeneous SQL collections."""
+
+    VALUE_LIST = "value_list"
+    ARRAY = "array"
+
+
+type SqlScalar = str | int | bool | float | Decimal | None
+type SqlValuePayload = SqlScalar | tuple[object, ...]
+type SqlCollectionRendering = CollectionRendering

--- a/tests/integration/src/sqlbuild/adapters/duckdb/_test_types.py
+++ b/tests/integration/src/sqlbuild/adapters/duckdb/_test_types.py
@@ -13,6 +13,12 @@ from sqlbuild.spec.contracts.models import SeedCsvSettings
 
 
 @dataclass(frozen=True)
+class TypedSqlRenderingExecutionTestCase:
+    description: str
+    expected_row: tuple[object, ...]
+
+
+@dataclass(frozen=True)
 class PhysicalRelationGenerationTestCase:
     description: str
     expected_stable: bool

--- a/tests/integration/src/sqlbuild/adapters/duckdb/test_typed_sql_rendering.py
+++ b/tests/integration/src/sqlbuild/adapters/duckdb/test_typed_sql_rendering.py
@@ -1,0 +1,52 @@
+from decimal import Decimal
+
+import duckdb
+import pytest
+
+from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.sql_values.main.normalize import normalize_sql_value
+from tests.integration.src.sqlbuild.adapters.duckdb._test_types import (
+    TypedSqlRenderingExecutionTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TypedSqlRenderingExecutionTestCase(
+            description="value list array and object execute with typed semantics",
+            expected_row=(True, "FR", "O'Brien", Decimal("2.4700")),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_typed_values_when_executing_duckdb_rendering_then_values_round_trip(
+    test_case: TypedSqlRenderingExecutionTestCase,
+) -> None:
+    adapter: DuckDbAdapter = DuckDbAdapter()
+    value_list: str = adapter.render_typed_value_list(
+        value=normalize_sql_value(raw_value=["GB", "FR"], context="countries")
+    )
+    array: str = adapter.render_typed_array(
+        value=normalize_sql_value(raw_value=["GB", "FR"], context="countries")
+    )
+    object_value: str = adapter.render_typed_object(
+        value=normalize_sql_value(
+            raw_value={"label": "O'Brien", "rate": Decimal("2.4700")},
+            context="rules",
+        )
+    )
+    sql: str = (
+        f"SELECT 'GB' IN {value_list}, {array}[2], "
+        f"json_extract_string({object_value}, '$.label'), "
+        f"CAST(json_extract_string({object_value}, '$.rate') AS DECIMAL(10, 4))"
+    )
+
+    with duckdb.connect() as connection:
+        row: tuple[object, ...] | None = connection.execute(sql).fetchone()
+
+    assert row == test_case.expected_row
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/integration/src/sqlbuild/integrations/dbt/helpers.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/helpers.py
@@ -2,9 +2,18 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.compiler.compile.models import CompileAdapterContext
 from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver
 from sqlbuild.integrations.dbt.main.manifest.build_compile_reference_resolver import (
     build_compile_reference_resolver,
+)
+from sqlbuild.sql_values.types import CollectionRendering
+
+DUCKDB_COMPILE_ADAPTER_CONTEXT: CompileAdapterContext = CompileAdapterContext(
+    value_renderer=DuckDbAdapter(),
+    collection_rendering=CollectionRendering.VALUE_LIST,
+    python_functions_inherit_default_namespace=True,
 )
 
 

--- a/tests/integration/src/sqlbuild/integrations/dbt/test_graph.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/test_graph.py
@@ -30,6 +30,7 @@ from tests.integration.src.sqlbuild.integrations.dbt._test_types import (
     RealDbtCombinedGraphTestCase,
 )
 from tests.integration.src.sqlbuild.integrations.dbt.helpers import (
+    DUCKDB_COMPILE_ADAPTER_CONTEXT,
     build_external_sql_reference_resolver,
     build_sqlbuild_project_with_manifest,
 )
@@ -81,6 +82,7 @@ def test_given_real_dbt_manifest_and_sqlbuild_project_when_building_graph_then_e
     )
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs=discovered_inputs,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
         external_sql_reference_resolver=build_external_sql_reference_resolver(
             manifest_source=manifest_source
         ),

--- a/tests/integration/src/sqlbuild/integrations/dbt/test_manifest.py
+++ b/tests/integration/src/sqlbuild/integrations/dbt/test_manifest.py
@@ -14,6 +14,7 @@ from tests.integration.src.sqlbuild.integrations.dbt._test_types import (
     RealDbtManifestCompileTestCase,
 )
 from tests.integration.src.sqlbuild.integrations.dbt.helpers import (
+    DUCKDB_COMPILE_ADAPTER_CONTEXT,
     build_external_sql_reference_resolver,
 )
 
@@ -68,6 +69,7 @@ def test_given_real_dbt_manifest_when_compiling_sqlbuild_then_preserves_dbt_ref(
     )
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs=discovered_inputs,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
         external_sql_reference_resolver=build_external_sql_reference_resolver(
             manifest_source=manifest_source
         ),

--- a/tests/unit/src/sqlbuild/adapter/contract/typed_sql_rendering/_test_types.py
+++ b/tests/unit/src/sqlbuild/adapter/contract/typed_sql_rendering/_test_types.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from sqlbuild.adapter.contract.classes.strict_adapter import StrictAdapter
+
+
+@dataclass(frozen=True)
+class AdapterTypedSqlRenderingTestCase:
+    description: str
+    adapter_factory: Callable[[], StrictAdapter]
+    expected_string: str
+    expected_true: str
+    expected_false: str
+    expected_integer: str
+    expected_float: str
+    expected_decimal: str
+    expected_null: str
+    expected_value_list: str
+    expected_object: str
+
+
+@dataclass(frozen=True)
+class InvalidTypedArrayTestCase:
+    description: str
+    adapter_factory: Callable[[], StrictAdapter]
+    raw_value: object
+    expected_error: str
+
+
+@dataclass(frozen=True)
+class NativeArrayRenderingTestCase:
+    description: str
+    adapter_factory: Callable[[], StrictAdapter]
+    raw_value: object
+    expected_sql: str

--- a/tests/unit/src/sqlbuild/adapter/contract/typed_sql_rendering/helpers.py
+++ b/tests/unit/src/sqlbuild/adapter/contract/typed_sql_rendering/helpers.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from sqlbuild.sql_values.main.normalize import normalize_sql_value
+from sqlbuild.sql_values.models import SqlValue
+
+
+def typed_sql_value(raw_value: object) -> SqlValue:
+    return normalize_sql_value(raw_value=raw_value, context="test value")

--- a/tests/unit/src/sqlbuild/adapter/contract/typed_sql_rendering/test_typed_sql_rendering.py
+++ b/tests/unit/src/sqlbuild/adapter/contract/typed_sql_rendering/test_typed_sql_rendering.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from sqlbuild.adapter.contract.classes.strict_adapter import StrictAdapter
+from sqlbuild.adapter.contract.exceptions import AdapterUserError
+from sqlbuild.adapters.bigquery.classes.bigquery_adapter import BigQueryAdapter
+from sqlbuild.adapters.databricks.classes.databricks_adapter import DatabricksAdapter
+from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.adapters.motherduck.classes.motherduck_adapter import MotherDuckAdapter
+from sqlbuild.adapters.postgres.classes.postgres_adapter import PostgresAdapter
+from sqlbuild.adapters.snowflake.classes.snowflake_adapter import SnowflakeAdapter
+from sqlbuild.adapters.sqlserver.classes.sqlserver_adapter import SqlServerAdapter
+from sqlbuild.sql_values.models import SqlValue
+from tests.unit.src.sqlbuild.adapter.contract.typed_sql_rendering._test_types import (
+    AdapterTypedSqlRenderingTestCase,
+    InvalidTypedArrayTestCase,
+    NativeArrayRenderingTestCase,
+)
+from tests.unit.src.sqlbuild.adapter.contract.typed_sql_rendering.helpers import typed_sql_value
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AdapterTypedSqlRenderingTestCase(
+            description="duckdb",
+            adapter_factory=DuckDbAdapter,
+            expected_string="'O''Brien'",
+            expected_true="TRUE",
+            expected_false="FALSE",
+            expected_integer="-7",
+            expected_float="1.25",
+            expected_decimal="2.4700",
+            expected_null="NULL",
+            expected_value_list="('GB', 'FR')",
+            expected_object='json(\'{"amount":2.4700,"label":"O\'\'Brien"}\')',
+        ),
+        AdapterTypedSqlRenderingTestCase(
+            description="motherduck",
+            adapter_factory=MotherDuckAdapter,
+            expected_string="'O''Brien'",
+            expected_true="TRUE",
+            expected_false="FALSE",
+            expected_integer="-7",
+            expected_float="1.25",
+            expected_decimal="2.4700",
+            expected_null="NULL",
+            expected_value_list="('GB', 'FR')",
+            expected_object='json(\'{"amount":2.4700,"label":"O\'\'Brien"}\')',
+        ),
+        AdapterTypedSqlRenderingTestCase(
+            description="postgres",
+            adapter_factory=PostgresAdapter,
+            expected_string="'O''Brien'",
+            expected_true="TRUE",
+            expected_false="FALSE",
+            expected_integer="-7",
+            expected_float="1.25",
+            expected_decimal="2.4700",
+            expected_null="NULL",
+            expected_value_list="('GB', 'FR')",
+            expected_object='\'{"amount":2.4700,"label":"O\'\'Brien"}\'::JSONB',
+        ),
+        AdapterTypedSqlRenderingTestCase(
+            description="snowflake",
+            adapter_factory=SnowflakeAdapter,
+            expected_string="'O''Brien'",
+            expected_true="TRUE",
+            expected_false="FALSE",
+            expected_integer="-7",
+            expected_float="1.25",
+            expected_decimal="2.4700",
+            expected_null="NULL",
+            expected_value_list="('GB', 'FR')",
+            expected_object='PARSE_JSON(\'{"amount":2.4700,"label":"O\'\'Brien"}\')',
+        ),
+        AdapterTypedSqlRenderingTestCase(
+            description="bigquery",
+            adapter_factory=BigQueryAdapter,
+            expected_string="'O''Brien'",
+            expected_true="TRUE",
+            expected_false="FALSE",
+            expected_integer="-7",
+            expected_float="1.25",
+            expected_decimal="NUMERIC '2.4700'",
+            expected_null="NULL",
+            expected_value_list="('GB', 'FR')",
+            expected_object='JSON \'{"amount":2.4700,"label":"O\'\'Brien"}\'',
+        ),
+        AdapterTypedSqlRenderingTestCase(
+            description="databricks",
+            adapter_factory=DatabricksAdapter,
+            expected_string="'O''Brien'",
+            expected_true="TRUE",
+            expected_false="FALSE",
+            expected_integer="-7",
+            expected_float="1.25",
+            expected_decimal="2.4700",
+            expected_null="NULL",
+            expected_value_list="('GB', 'FR')",
+            expected_object='parse_json(\'{"amount":2.4700,"label":"O\'\'Brien"}\')',
+        ),
+        AdapterTypedSqlRenderingTestCase(
+            description="sqlserver",
+            adapter_factory=SqlServerAdapter,
+            expected_string="N'O''Brien'",
+            expected_true="1",
+            expected_false="0",
+            expected_integer="-7",
+            expected_float="1.25",
+            expected_decimal="2.4700",
+            expected_null="NULL",
+            expected_value_list="(N'GB', N'FR')",
+            expected_object='JSON_QUERY(N\'{"amount":2.4700,"label":"O\'\'Brien"}\')',
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_typed_values_when_rendering_then_adapter_uses_expected_dialect_sql(
+    test_case: AdapterTypedSqlRenderingTestCase,
+) -> None:
+    adapter: StrictAdapter = test_case.adapter_factory()
+
+    assert (
+        adapter.render_typed_scalar(value=typed_sql_value("O'Brien")) == test_case.expected_string
+    )
+    assert adapter.render_typed_scalar(value=typed_sql_value(True)) == test_case.expected_true
+    assert adapter.render_typed_scalar(value=typed_sql_value(False)) == test_case.expected_false
+    assert adapter.render_typed_scalar(value=typed_sql_value(-7)) == test_case.expected_integer
+    assert adapter.render_typed_scalar(value=typed_sql_value(1.25)) == test_case.expected_float
+    assert adapter.render_typed_scalar(value=typed_sql_value(Decimal("2.4700"))) == (
+        test_case.expected_decimal
+    )
+    assert adapter.render_typed_scalar(value=typed_sql_value(None)) == test_case.expected_null
+    assert adapter.render_typed_value_list(value=typed_sql_value(["GB", "FR"])) == (
+        test_case.expected_value_list
+    )
+    value: SqlValue = typed_sql_value({"label": "O'Brien", "amount": Decimal("2.4700")})
+    assert adapter.render_typed_object(value=value) == test_case.expected_object
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        NativeArrayRenderingTestCase(
+            description="duckdb",
+            adapter_factory=DuckDbAdapter,
+            raw_value=["GB", "FR"],
+            expected_sql="['GB', 'FR']",
+        ),
+        NativeArrayRenderingTestCase(
+            description="motherduck",
+            adapter_factory=MotherDuckAdapter,
+            raw_value=["GB", "FR"],
+            expected_sql="['GB', 'FR']",
+        ),
+        NativeArrayRenderingTestCase(
+            description="postgres",
+            adapter_factory=PostgresAdapter,
+            raw_value=["GB", "FR"],
+            expected_sql="ARRAY['GB', 'FR']",
+        ),
+        NativeArrayRenderingTestCase(
+            description="snowflake",
+            adapter_factory=SnowflakeAdapter,
+            raw_value=["GB", "FR"],
+            expected_sql="ARRAY_CONSTRUCT('GB', 'FR')",
+        ),
+        NativeArrayRenderingTestCase(
+            description="bigquery",
+            adapter_factory=BigQueryAdapter,
+            raw_value=["GB", "FR"],
+            expected_sql="['GB', 'FR']",
+        ),
+        NativeArrayRenderingTestCase(
+            description="databricks",
+            adapter_factory=DatabricksAdapter,
+            raw_value=["GB", "FR"],
+            expected_sql="array('GB', 'FR')",
+        ),
+        NativeArrayRenderingTestCase(
+            description="postgres nested rectangular",
+            adapter_factory=PostgresAdapter,
+            raw_value=[[1, 2], [3, 4]],
+            expected_sql="ARRAY[ARRAY[1, 2], ARRAY[3, 4]]",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_supported_typed_collection_when_rendering_then_uses_native_array(
+    test_case: NativeArrayRenderingTestCase,
+) -> None:
+    adapter: StrictAdapter = test_case.adapter_factory()
+
+    assert adapter.render_typed_array(value=typed_sql_value(test_case.raw_value)) == (
+        test_case.expected_sql
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        InvalidTypedArrayTestCase(
+            description="postgres rejects ragged nested arrays",
+            adapter_factory=PostgresAdapter,
+            raw_value=[[1, 2], [3]],
+            expected_error="requires rectangular nested arrays",
+        ),
+        InvalidTypedArrayTestCase(
+            description="bigquery rejects nested arrays",
+            adapter_factory=BigQueryAdapter,
+            raw_value=[[1, 2], [3, 4]],
+            expected_error="does not support nested arrays",
+        ),
+        InvalidTypedArrayTestCase(
+            description="sqlserver rejects arrays",
+            adapter_factory=SqlServerAdapter,
+            raw_value=["GB", "FR"],
+            expected_error="does not support typed SQL array rendering",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_unsupported_typed_array_when_rendering_then_raises_clear_error(
+    test_case: InvalidTypedArrayTestCase,
+) -> None:
+    adapter: StrictAdapter = test_case.adapter_factory()
+
+    with pytest.raises(AdapterUserError, match=test_case.expected_error):
+        adapter.render_typed_array(value=typed_sql_value(test_case.raw_value))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
@@ -64,6 +64,20 @@ class CompileDeclarationsTestCase:
 
 
 @dataclass(frozen=True)
+class CompileTypedConstantsTestCase:
+    description: str
+    expected_model_sql: str
+    expected_hook_sql: str
+    expected_named_hook_sql: str
+    expected_function_sql: str
+    expected_source_sql: str
+    expected_test_fragment: str
+    expected_scenario_fragment: str
+    expected_audit_sql: str
+    expected_attached_audit_sql: str
+
+
+@dataclass(frozen=True)
 class DeclarationFingerprintTestCase:
     description: str
     declaration_path: str

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/helpers.py
@@ -9,6 +9,7 @@ from sqlbuild.compiler.compile._helpers.render.macros import load_project_macros
 from sqlbuild.compiler.compile.main._assemble_project import assemble_project
 from sqlbuild.compiler.compile.main._build_compile_inputs import build_compile_inputs
 from sqlbuild.compiler.compile.models import (
+    CompileAdapterContext,
     CompileAnalysisSelection,
     CompiledDirectLogicSqlTestPayload,
     CompiledModel,
@@ -16,11 +17,30 @@ from sqlbuild.compiler.compile.models import (
     CompiledProject,
     CompiledSqlTest,
     CompileProjectInputs,
+    DeclarationExpansionContext,
+    DeclarationResolutionContext,
     LoadedMacro,
 )
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredMacroFile, DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
+from sqlbuild.sql_values.types import CollectionRendering
+
+DUCKDB_COMPILE_ADAPTER_CONTEXT: CompileAdapterContext = CompileAdapterContext(
+    value_renderer=DuckDbAdapter(),
+    collection_rendering=CollectionRendering.VALUE_LIST,
+    python_functions_inherit_default_namespace=True,
+)
+DUCKDB_ARRAY_COMPILE_ADAPTER_CONTEXT: CompileAdapterContext = CompileAdapterContext(
+    value_renderer=DUCKDB_COMPILE_ADAPTER_CONTEXT.value_renderer,
+    collection_rendering=CollectionRendering.ARRAY,
+    python_functions_inherit_default_namespace=True,
+)
+DUCKDB_DECLARATION_EXPANSION_CONTEXT: DeclarationExpansionContext = DeclarationExpansionContext(
+    declarations=DeclarationResolutionContext(),
+    value_renderer=DUCKDB_COMPILE_ADAPTER_CONTEXT.value_renderer,
+    collection_rendering=DUCKDB_COMPILE_ADAPTER_CONTEXT.collection_rendering,
+)
 
 
 def build_loaded_macros(tmp_path: Path, macro_file_contents: str) -> dict[str, LoadedMacro]:
@@ -45,6 +65,7 @@ def compile_first_model(*, project_dir: Path) -> CompiledModel:
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=project_dir)
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs=discovered_inputs,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
         run_id="test_run",
     )
     compiled_project: CompiledProject = assemble_project(

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_assembly.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_assembly.py
@@ -26,6 +26,7 @@ from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
     AssembleSqlHookValidationTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import (
+    DUCKDB_COMPILE_ADAPTER_CONTEXT,
     compiled_sql_test_expected_model_names,
     compiled_sql_test_tested_resource_names,
 )
@@ -480,7 +481,9 @@ def test_given_compile_inputs_when_assembling_compiled_project_then_returns_expe
     write_repo_files(tmp_path, test_case.repo_files)
     discovered: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
     compile_inputs: CompileProjectInputs = build_compile_inputs(
-        discovered_inputs=discovered, run_id="test_run_id"
+        discovered_inputs=discovered,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
+        run_id="test_run_id",
     )
     compiled: CompiledProject = assemble_compiled_project(inputs=compile_inputs)
 
@@ -601,7 +604,9 @@ def test_given_connection_location_when_assembling_project_then_sets_effective_t
     )
     discovered: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
     compile_inputs: CompileProjectInputs = build_compile_inputs(
-        discovered_inputs=discovered, run_id="test_run_id"
+        discovered_inputs=discovered,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
+        run_id="test_run_id",
     )
 
     compiled: CompiledProject = assemble_compiled_project(inputs=compile_inputs)
@@ -662,6 +667,7 @@ def test_given_sql_hooks_when_assembling_then_applies_adapter_aware_validation(
     discovered: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs=discovered,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
         run_id="test_run_id",
     )
 

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_declarations.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_declarations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -25,9 +26,14 @@ from sqlbuild.compiler.planner.main.identity.version_identity_model_metadata imp
 from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
     CompileDeclarationsErrorTestCase,
     CompileDeclarationsTestCase,
+    CompileTypedConstantsTestCase,
     DeclarationFingerprintTestCase,
 )
-from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import compile_first_model
+from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import (
+    DUCKDB_ARRAY_COMPILE_ADAPTER_CONTEXT,
+    DUCKDB_COMPILE_ADAPTER_CONTEXT,
+    compile_first_model,
+)
 
 _PROJECT_FILE: str = """
 name = "demo"
@@ -143,6 +149,7 @@ SELECT * FROM __ref("orders") WHERE threshold < @const("min_runners")
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs=discovered_inputs,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
         run_id="test_run",
     )
 
@@ -259,6 +266,131 @@ SELECT * FROM __ref("orders") WHERE threshold < @const("min_runners")
 @pytest.mark.parametrize(
     "test_case",
     [
+        CompileTypedConstantsTestCase(
+            description="typed constants expand through every authored SQL surface",
+            expected_model_sql=(
+                "SELECT TRUE AS enabled, 0.75 AS ratio,\n"
+                "  2.4700 AS rate, NULL AS missing,\n"
+                "  ('GB', 'FR') AS countries, ('FR', 'GB') AS unique_countries,\n"
+                "  ['project', 'default'] AS project_array, ['GB', 'FR'] AS country_array,\n"
+                '  json(\'{"FR":"France","GB":"Great Britain"}\') AS labels,\n'
+                "  ['local', 'values'] AS local_values"
+            ),
+            expected_hook_sql="SELECT 'GB' IN ('GB', 'FR')",
+            expected_named_hook_sql="SELECT 'FR' IN ('GB', 'FR')",
+            expected_function_sql="value IN ('GB', 'FR')",
+            expected_source_sql="SELECT * FROM entries WHERE country IN ('GB', 'FR')\n",
+            expected_test_fragment="SELECT 'GB' IN ('GB', 'FR') AS supported",
+            expected_scenario_fragment="SELECT ['GB', 'FR'] AS countries",
+            expected_audit_sql=("SELECT * FROM entries WHERE country NOT IN ('FR', 'GB')"),
+            expected_attached_audit_sql=(
+                "SELECT * FROM __ref(\"orders\") WHERE country NOT IN ('GB', 'FR')"
+            ),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_typed_constants_when_compiling_then_all_sql_surfaces_use_adapter_rendering(
+    test_case: CompileTypedConstantsTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(
+        tmp_path,
+        {
+            "sqlbuild_project.toml": (
+                _PROJECT_FILE + '\n[constants]\ncollection_rendering = "array"\n'
+            ),
+            "constants/typed.sql": """
+CONSTANT (name enabled, value true);
+CONSTANT (name ratio, value 0.75);
+CONSTANT (name rate, type decimal, value "2.4700");
+CONSTANT (name missing, value null);
+CONSTANT (name countries, value ["GB", "FR"], render_as value_list);
+CONSTANT (name unique_countries, value {"GB", "FR"}, render_as value_list);
+CONSTANT (name project_array, value ["project", "default"]);
+CONSTANT (name country_array, value ["GB", "FR"], render_as array);
+CONSTANT (name labels, value (GB "Great Britain", FR "France"));
+""",
+            "models/orders.sql": """
+MODEL (
+  pre_hooks [inline_sql("SELECT 'GB' IN @const('countries')")],
+  post_hooks [sql("typed_hook")],
+  audits [typed_audit],
+  constants (
+    _local_values constant(value ["local", "values"], render_as array),
+  ),
+);
+
+SELECT @const("enabled") AS enabled, @const("ratio") AS ratio,
+  @const("rate") AS rate, @const("missing") AS missing,
+  @const("countries") AS countries, @const("unique_countries") AS unique_countries,
+  @const("project_array") AS project_array, @const("country_array") AS country_array,
+  @const("labels") AS labels,
+  @const("_local_values") AS local_values
+""",
+            "functions/sql/is_supported.sql": """
+FUNCTION (arguments (value VARCHAR), returns BOOLEAN);
+value IN @const("countries")
+""",
+            "hooks/sql/typed_hook.sql": """
+HOOK (description "Typed constant hook");
+SELECT 'FR' IN @const("countries")
+""",
+            "sources/inline.yml": """
+sources:
+  - name: supported_entries
+    expression: |
+      SELECT * FROM entries WHERE country IN @const("countries")
+""",
+            "tests/unit/orders.sql": """
+TEST ();
+WITH __ref__orders AS (SELECT 'GB' IN @const("countries") AS supported),
+__expected__orders AS (SELECT true AS supported)
+SELECT 1
+""",
+            "tests/scenarios/orders.sql": """
+SCENARIO ();
+WITH __ref__orders AS (SELECT @const("country_array") AS countries),
+__expected__orders AS (SELECT @const("country_array") AS countries)
+SELECT 1
+""",
+            "audits/orders.sql": """
+AUDIT ();
+SELECT * FROM entries WHERE country NOT IN @const("unique_countries")
+""",
+            "audits/generic/typed_audit.sql": """
+AUDIT ();
+SELECT * FROM __ref("@model") WHERE country NOT IN @const("countries")
+""",
+        },
+    )
+
+    compile_inputs: CompileProjectInputs = build_compile_inputs(
+        discovered_inputs=discover_project_inputs(project_dir=tmp_path),
+        adapter_context=DUCKDB_ARRAY_COMPILE_ADAPTER_CONTEXT,
+        run_id="typed_constants",
+    )
+
+    assert compile_inputs.model_inputs[0].query_sql == test_case.expected_model_sql
+    assert compile_inputs.model_inputs[0].config.values["pre_hooks"] == [
+        SqlHookEntry(statement=test_case.expected_hook_sql)
+    ]
+    named_hook: SqlHookEntry = cast(
+        list[SqlHookEntry], compile_inputs.model_inputs[0].config.values["post_hooks"]
+    )[0]
+    assert named_hook.statement == test_case.expected_named_hook_sql
+    assert compile_inputs.sql_function_inputs[0].body_sql == test_case.expected_function_sql
+    assert compile_inputs.source_inputs[0].source_entry.expression == test_case.expected_source_sql
+    assert test_case.expected_test_fragment in compile_inputs.test_inputs[0].sql_body
+    assert test_case.expected_scenario_fragment in compile_inputs.scenario_inputs[0].sql_body
+    assert compile_inputs.audit_inputs[0].sql_body == test_case.expected_audit_sql
+    assert compile_inputs.audit_inputs[1].sql_body == test_case.expected_attached_audit_sql
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
         DeclarationFingerprintTestCase(
             description="constant value changes rendered query identity",
             declaration_path="constants/threshold.sql",
@@ -266,6 +398,84 @@ SELECT * FROM __ref("orders") WHERE threshold < @const("min_runners")
             changed_declaration="CONSTANT (name threshold, value 8);\n",
             model_sql='MODEL ();\nSELECT @const("threshold") AS threshold\n',
             expected_query_hash_changed=True,
+            expected_metadata_changed=False,
+        ),
+        DeclarationFingerprintTestCase(
+            description="list order changes rendered query identity",
+            declaration_path="constants/countries.sql",
+            initial_declaration='CONSTANT (name countries, value ["GB", "FR"]);\n',
+            changed_declaration='CONSTANT (name countries, value ["FR", "GB"]);\n',
+            model_sql='MODEL ();\nSELECT @const("countries") AS countries\n',
+            expected_query_hash_changed=True,
+            expected_metadata_changed=False,
+        ),
+        DeclarationFingerprintTestCase(
+            description="list duplicate changes rendered query identity",
+            declaration_path="constants/countries.sql",
+            initial_declaration='CONSTANT (name countries, value ["GB", "FR"]);\n',
+            changed_declaration='CONSTANT (name countries, value ["GB", "FR", "FR"]);\n',
+            model_sql='MODEL ();\nSELECT @const("countries") AS countries\n',
+            expected_query_hash_changed=True,
+            expected_metadata_changed=False,
+        ),
+        DeclarationFingerprintTestCase(
+            description="set order does not change rendered query identity",
+            declaration_path="constants/countries.sql",
+            initial_declaration='CONSTANT (name countries, value {"GB", "FR"});\n',
+            changed_declaration='CONSTANT (name countries, value {"FR", "GB"});\n',
+            model_sql='MODEL ();\nSELECT @const("countries") AS countries\n',
+            expected_query_hash_changed=False,
+            expected_metadata_changed=False,
+        ),
+        DeclarationFingerprintTestCase(
+            description="object key order does not change rendered query identity",
+            declaration_path="constants/labels.sql",
+            initial_declaration=(
+                'CONSTANT (name labels, value (GB "Great Britain", FR "France"));\n'
+            ),
+            changed_declaration=(
+                'CONSTANT (name labels, value (FR "France", GB "Great Britain"));\n'
+            ),
+            model_sql='MODEL ();\nSELECT @const("labels") AS labels\n',
+            expected_query_hash_changed=False,
+            expected_metadata_changed=False,
+        ),
+        DeclarationFingerprintTestCase(
+            description="set membership changes rendered query identity",
+            declaration_path="constants/countries.sql",
+            initial_declaration='CONSTANT (name countries, value {"GB", "FR"});\n',
+            changed_declaration='CONSTANT (name countries, value {"GB", "HK"});\n',
+            model_sql='MODEL ();\nSELECT @const("countries") AS countries\n',
+            expected_query_hash_changed=True,
+            expected_metadata_changed=False,
+        ),
+        DeclarationFingerprintTestCase(
+            description="object value changes rendered query identity",
+            declaration_path="constants/labels.sql",
+            initial_declaration='CONSTANT (name labels, value (GB "Great Britain"));\n',
+            changed_declaration='CONSTANT (name labels, value (GB "Britain"));\n',
+            model_sql='MODEL ();\nSELECT @const("labels") AS labels\n',
+            expected_query_hash_changed=True,
+            expected_metadata_changed=False,
+        ),
+        DeclarationFingerprintTestCase(
+            description="collection render mode changes rendered query identity",
+            declaration_path="constants/countries.sql",
+            initial_declaration='CONSTANT (name countries, value ["GB", "FR"]);\n',
+            changed_declaration=(
+                'CONSTANT (name countries, value ["GB", "FR"], render_as array);\n'
+            ),
+            model_sql='MODEL ();\nSELECT @const("countries") AS countries\n',
+            expected_query_hash_changed=True,
+            expected_metadata_changed=False,
+        ),
+        DeclarationFingerprintTestCase(
+            description="unused constant changes do not alter model identity",
+            declaration_path="constants/countries.sql",
+            initial_declaration='CONSTANT (name countries, value ["GB", "FR"]);\n',
+            changed_declaration='CONSTANT (name countries, value ["GB", "HK"]);\n',
+            model_sql="MODEL ();\nSELECT 1 AS value\n",
+            expected_query_hash_changed=False,
             expected_metadata_changed=False,
         ),
         DeclarationFingerprintTestCase(
@@ -367,6 +577,16 @@ def test_given_declaration_change_when_compiling_then_updates_dependent_identity
             },
             expected_error_fragment="Duplicate public enum 'state'",
         ),
+        CompileDeclarationsErrorTestCase(
+            description="nested collection cannot render as a portable value list",
+            repo_files={
+                "constants/groups.sql": "CONSTANT (name groups, value [[1], [2]]);",
+                "models/orders.sql": 'MODEL ();\nSELECT @const("groups") AS groups\n',
+            },
+            expected_error_fragment=(
+                "constants/groups.sql constant 'groups'.*adapter 'duckdb'.*value_list"
+            ),
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -384,7 +604,11 @@ def test_given_invalid_declaration_usage_when_compiling_then_raises_compile_erro
         match=test_case.expected_error_fragment,
     ):
         discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
-        build_compile_inputs(discovered_inputs=discovered_inputs, run_id="test_run")
+        build_compile_inputs(
+            discovered_inputs=discovered_inputs,
+            adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
+            run_id="test_run",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_expansion_spans.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_expansion_spans.py
@@ -10,7 +10,10 @@ from sqlbuild.compiler.compile._helpers.render.spans import map_through_passes
 from sqlbuild.compiler.compile._helpers.render.sql_vars import expand_authored_sql_with_spans
 from sqlbuild.compiler.compile.models import ExpansionSpan, LoadedMacro, MacroContext, MappedOffset
 from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import ExpandWithSpansTestCase
-from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import build_loaded_macros
+from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import (
+    DUCKDB_COMPILE_ADAPTER_CONTEXT,
+    build_loaded_macros,
+)
 
 _MACRO_CONTEXT: MacroContext = MacroContext(
     adapter_name="duckdb",
@@ -91,6 +94,8 @@ def test_given_expanded_offset_when_mapping_then_authored_position_matches(
         effective_vars=test_case.effective_vars,
         loaded_macros=loaded_macros,
         macro_context=_MACRO_CONTEXT,
+        value_renderer=DUCKDB_COMPILE_ADAPTER_CONTEXT.value_renderer,
+        collection_rendering=DUCKDB_COMPILE_ADAPTER_CONTEXT.collection_rendering,
     )
     assert expanded_sql == test_case.expected_expanded_sql
     resolved: MappedOffset = map_through_passes(

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_model_schemas.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_model_schemas.py
@@ -31,7 +31,10 @@ from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
     ModelSchemaErrorTestCase,
     ModelSchemaIdentityTestCase,
 )
-from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import compile_first_model
+from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import (
+    DUCKDB_COMPILE_ADAPTER_CONTEXT,
+    compile_first_model,
+)
 
 _PROJECT_FILE: str = """
 name = "demo"
@@ -164,6 +167,7 @@ SELECT
     )
     inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs=discovered,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
         run_id="test_run",
     )
     project: CompiledProject = assemble_project(inputs=inputs)
@@ -304,7 +308,11 @@ SELECT {test_case.projection}
 
     discovered: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
     project: CompiledProject = assemble_project(
-        inputs=build_compile_inputs(discovered_inputs=discovered, run_id="test_run")
+        inputs=build_compile_inputs(
+            discovered_inputs=discovered,
+            adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
+            run_id="test_run",
+        )
     )
 
     diagnostics: tuple[CompilerDiagnostic, ...] = evaluate_model_contracts(
@@ -535,7 +543,11 @@ def test_given_invalid_model_schema_when_compiling_then_fails_closed(
 
     with pytest.raises(CompileInputError, match=test_case.expected_error_fragment):
         discovered: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
-        build_compile_inputs(discovered_inputs=discovered, run_id="test_run")
+        build_compile_inputs(
+            discovered_inputs=discovered,
+            adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
+            run_id="test_run",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_scenarios.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_scenarios.py
@@ -23,6 +23,9 @@ from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
     ExtractSqlScenarioCtesErrorTestCase,
     ExtractSqlScenarioCtesTestCase,
 )
+from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import (
+    DUCKDB_DECLARATION_EXPANSION_CONTEXT,
+)
 
 
 @pytest.mark.parametrize(
@@ -310,6 +313,7 @@ def test_given_discovered_scenario_when_building_scenario_inputs_then_it_attache
             adapter_name="duckdb", sql_analysis_enabled=True, target_name=None
         ),
         loaded_macros={},
+        declaration_expansion=DUCKDB_DECLARATION_EXPANSION_CONTEXT,
     )
 
     assert len(scenario_inputs) == 1
@@ -383,4 +387,5 @@ def test_given_invalid_scenario_source_refs_when_building_inputs_then_it_raises_
                 adapter_name="duckdb", sql_analysis_enabled=True, target_name=None
             ),
             loaded_macros={},
+            declaration_expansion=DUCKDB_DECLARATION_EXPANSION_CONTEXT,
         )

--- a/tests/unit/src/sqlbuild/compiler/compile/test_cursor_start.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_cursor_start.py
@@ -9,6 +9,9 @@ from sqlbuild.compiler.compile.main._build_compile_inputs import build_compile_i
 from sqlbuild.compiler.compile.models import CompileProjectInputs
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import (
+    DUCKDB_COMPILE_ADAPTER_CONTEXT,
+)
 from tests.unit.src.sqlbuild.compiler.compile._test_types import (
     CursorStartCompileErrorTestCase,
     CursorStartCompileInputsTestCase,
@@ -44,7 +47,10 @@ def test_given_cursor_start_layers_when_building_compile_inputs_then_model_uses_
     write_repo_files(tmp_path, test_case.repo_files)
 
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
-    compile_inputs: CompileProjectInputs = build_compile_inputs(discovered_inputs=discovered_inputs)
+    compile_inputs: CompileProjectInputs = build_compile_inputs(
+        discovered_inputs=discovered_inputs,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
+    )
 
     assert (
         test_case.expected_cursor_start
@@ -91,4 +97,7 @@ def test_given_invalid_cursor_start_when_building_compile_inputs_then_raises_cle
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
 
     with pytest.raises(ValueError, match=test_case.expected_error_fragment):
-        build_compile_inputs(discovered_inputs=discovered_inputs)
+        build_compile_inputs(
+            discovered_inputs=discovered_inputs,
+            adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
+        )

--- a/tests/unit/src/sqlbuild/compiler/compile/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_main.py
@@ -26,6 +26,9 @@ from sqlbuild.spec.contracts.models import (
     ProjectConfig,
     TargetConfig,
 )
+from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import (
+    DUCKDB_COMPILE_ADAPTER_CONTEXT,
+)
 from tests.unit.src.sqlbuild.compiler.compile._test_helpers import (
     base_repo_files,
     build_external_sql_reference_resolver,
@@ -2486,6 +2489,7 @@ def test_given_discovered_inputs_when_building_compile_inputs_then_it_attaches_m
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs=discovered_inputs,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
         selected_target=test_case.selected_target,
         cli_vars=test_case.cli_vars,
         run_id=test_case.run_id,
@@ -4053,6 +4057,7 @@ def test_given_attachment_conflicts_when_building_compile_inputs_then_it_raises_
     with pytest.raises(test_case.expected_error_type, match=test_case.expected_error_fragment):
         build_compile_inputs(
             discovered_inputs=discovered_inputs,
+            adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
             selected_target=test_case.selected_target,
             run_id=test_case.run_id,
             external_sql_reference_resolver=build_external_sql_reference_resolver(
@@ -4095,7 +4100,10 @@ def test_given_python_hook_when_building_compile_inputs_then_validation_does_not
     write_repo_files(tmp_path, test_case.repo_files)
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
 
-    build_compile_inputs(discovered_inputs=discovered_inputs)
+    build_compile_inputs(
+        discovered_inputs=discovered_inputs,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
+    )
 
     assert (
         tmp_path / "hooks" / "executed.marker"
@@ -4190,6 +4198,7 @@ def test_given_snapshot_contract_schema_change_conflict_when_building_then_error
     with pytest.raises(ValueError, match=test_case.expected_error_fragment) as exc_info:
         build_compile_inputs(
             discovered_inputs=discovered_inputs,
+            adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
             selected_target=test_case.selected_target,
             run_id=test_case.run_id,
             external_sql_reference_resolver=build_external_sql_reference_resolver(
@@ -4234,6 +4243,9 @@ def test_given_model_referencing_seed_when_building_compile_inputs_then_succeeds
     write_repo_files(tmp_path, test_case.repo_files)
 
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
-    compile_inputs: CompileProjectInputs = build_compile_inputs(discovered_inputs=discovered_inputs)
+    compile_inputs: CompileProjectInputs = build_compile_inputs(
+        discovered_inputs=discovered_inputs,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
+    )
 
     assert len(compile_inputs.model_inputs) == test_case.expected_model_count

--- a/tests/unit/src/sqlbuild/compiler/compile/test_resolved_connection.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_resolved_connection.py
@@ -9,6 +9,9 @@ from sqlbuild.compiler.compile.main._build_compile_inputs import build_compile_i
 from sqlbuild.compiler.compile.models import CompileProjectInputs
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import (
+    DUCKDB_COMPILE_ADAPTER_CONTEXT,
+)
 from tests.unit.src.sqlbuild.compiler.compile._test_types import (
     ResolvedConnectionCompileInputsTestCase,
 )
@@ -55,6 +58,7 @@ def test_given_resolved_connection_when_building_compile_inputs_then_uses_expect
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
     compile_inputs: CompileProjectInputs = build_compile_inputs(
         discovered_inputs=discovered_inputs,
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
         resolved_connection=test_case.resolved_connection,
     )
 

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
 
+from sqlbuild.sql_values.types import CollectionRendering
+
 
 @dataclass(frozen=True)
 class DeferredModelOutputLocationTestCase:
@@ -111,6 +113,20 @@ class LoadProjectCostConfigTestCase:
 class LoadProjectCostConfigErrorTestCase:
     description: str
     value: str
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
+class LoadProjectConstantsConfigTestCase:
+    description: str
+    constants_toml: str
+    expected_collection_rendering: CollectionRendering
+
+
+@dataclass(frozen=True)
+class LoadProjectConstantsConfigErrorTestCase:
+    description: str
+    constants_toml: str
     expected_error_fragment: str
 
 
@@ -239,6 +255,24 @@ class ParseDeclarationFileErrorTestCase:
     description: str
     contents: str
     expected_error_fragment: str
+
+
+@dataclass(frozen=True)
+class ParseTypedConstantsTestCase:
+    description: str
+    contents: str
+    expected_kinds: tuple[str, ...]
+    expected_decimal: Decimal
+    expected_rendering: str
+    expected_object_keys: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ParseLocalTypedConstantsTestCase:
+    description: str
+    raw_value: dict[str, object]
+    expected_kinds: tuple[str, ...]
+    expected_decimal: Decimal
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_declarations.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_declarations.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from pathlib import Path
+from typing import cast
 
 import pytest
 
 from sqlbuild.compiler.discovery._helpers.sql.declarations import (
     parse_constant_declaration_file,
     parse_enum_declaration_file,
+    parse_model_constant_declarations,
     parse_model_schema_declaration_file,
 )
 from sqlbuild.compiler.discovery.exceptions import DeclarationParseError
@@ -15,10 +18,13 @@ from sqlbuild.compiler.discovery.models import (
     EnumDeclaration,
     ModelSchemaDeclaration,
 )
+from sqlbuild.sql_values.models import AuthoredSqlValueCall, SqlValue
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
     ParseDeclarationFileErrorTestCase,
     ParseDeclarationFileTestCase,
+    ParseLocalTypedConstantsTestCase,
     ParseModelSchemaDeclarationTestCase,
+    ParseTypedConstantsTestCase,
 )
 
 
@@ -110,7 +116,138 @@ def test_given_constant_declarations_when_parsing_then_returns_typed_values(
         tuple(declaration.scalar_type for declaration in declarations)
         == test_case.expected_scalar_types
     )
-    assert tuple((declaration.value,) for declaration in declarations) == test_case.expected_values
+    assert (
+        tuple((declaration.value.value,) for declaration in declarations)
+        == test_case.expected_values
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ParseTypedConstantsTestCase(
+            description="all public typed value forms",
+            contents="""
+CONSTANT (name enabled, value true);
+CONSTANT (name ratio, value 0.75);
+CONSTANT (name missing_value, value null);
+CONSTANT (name usd_rate, type decimal, value "2.4700");
+CONSTANT (name countries, value ["GB", "FR", null]);
+CONSTANT (name unique_ids, value {2, 1}, render_as array);
+CONSTANT (name labels, value (FR "France", GB "Great Britain"));
+""",
+            expected_kinds=("boolean", "float", "null", "decimal", "list", "set", "object"),
+            expected_decimal=Decimal("2.4700"),
+            expected_rendering="array",
+            expected_object_keys=("FR", "GB"),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_typed_public_constants_when_parsing_then_returns_normalized_values(
+    test_case: ParseTypedConstantsTestCase,
+) -> None:
+    declarations: tuple[ConstantDeclaration, ...] = parse_constant_declaration_file(
+        contents=test_case.contents,
+        file_path=Path("constants/domain.sql"),
+        relative_path=Path("constants/domain.sql"),
+    )
+
+    assert (
+        tuple(declaration.value.kind.value for declaration in declarations)
+        == test_case.expected_kinds
+    )
+    assert declarations[3].value.value == test_case.expected_decimal
+    assert declarations[5].render_as is not None
+    assert declarations[5].render_as.value == test_case.expected_rendering
+    object_entries: tuple[tuple[str, SqlValue], ...] = cast(
+        tuple[tuple[str, SqlValue], ...], declarations[6].value.value
+    )
+    assert tuple(key for key, _ in object_entries) == test_case.expected_object_keys
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ParseLocalTypedConstantsTestCase(
+            description="local shorthand and exact decimal wrapper",
+            raw_value={
+                "_enabled": True,
+                "_countries": ["GB", "FR"],
+                "_rate": AuthoredSqlValueCall(arguments=(("value", "2.4700"), ("type", "decimal"))),
+            },
+            expected_kinds=("boolean", "list", "decimal"),
+            expected_decimal=Decimal("2.4700"),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_local_shorthand_and_wrapper_constants_when_parsing_then_honors_options(
+    test_case: ParseLocalTypedConstantsTestCase,
+) -> None:
+    declarations: tuple[ConstantDeclaration, ...] = parse_model_constant_declarations(
+        raw_value=test_case.raw_value,
+        model_name="orders",
+        relative_path=Path("models/orders.sql"),
+    )
+
+    assert (
+        tuple(declaration.value.kind.value for declaration in declarations)
+        == test_case.expected_kinds
+    )
+    assert declarations[2].value.value == test_case.expected_decimal
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ParseDeclarationFileErrorTestCase(
+            description="missing value",
+            contents="CONSTANT (name absent);",
+            expected_error_fragment="missing required value",
+        ),
+        ParseDeclarationFileErrorTestCase(
+            description="duplicate set value",
+            contents='CONSTANT (name countries, value {"GB", "FR", "GB"});',
+            expected_error_fragment="duplicate set value 'GB'",
+        ),
+        ParseDeclarationFileErrorTestCase(
+            description="mixed list types",
+            contents='CONSTANT (name countries, value ["GB", 2]);',
+            expected_error_fragment=r"constant 'countries'\[1\] has type integer; expected string",
+        ),
+        ParseDeclarationFileErrorTestCase(
+            description="empty list",
+            contents="CONSTANT (name countries, value []);",
+            expected_error_fragment="list must contain at least one value",
+        ),
+        ParseDeclarationFileErrorTestCase(
+            description="unquoted decimal",
+            contents="CONSTANT (name rate, type decimal, value 2.47);",
+            expected_error_fragment="requires a quoted decimal string",
+        ),
+        ParseDeclarationFileErrorTestCase(
+            description="scalar render mode",
+            contents='CONSTANT (name label, value "GB", render_as array);',
+            expected_error_fragment="is string and does not support render_as array",
+        ),
+        ParseDeclarationFileErrorTestCase(
+            description="null type option",
+            contents="CONSTANT (name label, value 1, type null);",
+            expected_error_fragment="type must be an identifier",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_invalid_typed_constant_when_parsing_then_raises_contextual_error(
+    test_case: ParseDeclarationFileErrorTestCase,
+) -> None:
+    with pytest.raises(DeclarationParseError, match=test_case.expected_error_fragment):
+        parse_constant_declaration_file(
+            contents=test_case.contents,
+            file_path=Path("constants/domain.sql"),
+            relative_path=Path("constants/domain.sql"),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_models.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_models.py
@@ -17,6 +17,7 @@ from sqlbuild.compiler.discovery.models import (
     SqlHookEntry,
 )
 from sqlbuild.spec.contracts.models import SourceLocation
+from sqlbuild.sql_values.models import AuthoredSqlSet, AuthoredSqlValueCall
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
     DeferredModelOutputLocationTestCase,
     ModelHeaderColumnLocationTestCase,
@@ -64,6 +65,28 @@ def test_given_deferred_output_locations_when_discovering_models_then_projection
 @pytest.mark.parametrize(
     "test_case",
     [
+        ParseModelSqlHeaderTestCase(
+            description="preserves authored set and typed constant calls",
+            contents="""
+        MODEL (
+          constants (
+            _countries {"FR", "GB", "FR"},
+            _array constant(value [1, 2], render_as array),
+          ),
+        );
+
+        SELECT 1
+        """,
+            expected_header_values={
+                "constants": {
+                    "_countries": AuthoredSqlSet(("FR", "GB", "FR")),
+                    "_array": AuthoredSqlValueCall(
+                        arguments=(("value", [1, 2]), ("render_as", "array"))
+                    ),
+                }
+            },
+            expected_query="SELECT 1",
+        ),
         ParseModelSqlHeaderTestCase(
             description="accepts an empty model header",
             contents="""

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
@@ -11,11 +11,14 @@ from sqlbuild.compiler.discovery._helpers.yml.project import (
 )
 from sqlbuild.compiler.discovery.exceptions import ProjectConfigError
 from sqlbuild.spec.contracts.models import ProjectConfig
+from sqlbuild.sql_values.types import CollectionRendering
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
     LoadLocalConfigErrorTestCase,
     LoadLocalConfigTestCase,
     LoadProjectConfigErrorTestCase,
     LoadProjectConfigTestCase,
+    LoadProjectConstantsConfigErrorTestCase,
+    LoadProjectConstantsConfigTestCase,
     LoadProjectCostConfigErrorTestCase,
     LoadProjectCostConfigTestCase,
 )
@@ -115,6 +118,68 @@ def test_given_invalid_cost_rate_when_loading_project_then_config_error_is_raise
 ) -> None:
     (tmp_path / "sqlbuild_project.toml").write_text(
         f'name = "demo"\nadapter = "snowflake"\n[cost]\nusd_per_credit = {test_case.value}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ProjectConfigError, match=test_case.expected_error_fragment):
+        load_project_config(project_dir=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        LoadProjectConstantsConfigTestCase(
+            description="omitted constants config uses value-list rendering",
+            constants_toml="",
+            expected_collection_rendering=CollectionRendering.VALUE_LIST,
+        ),
+        LoadProjectConstantsConfigTestCase(
+            description="array collection rendering is loaded",
+            constants_toml='[constants]\ncollection_rendering = "array"',
+            expected_collection_rendering=CollectionRendering.ARRAY,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_constants_config_when_loading_project_then_collection_rendering_is_typed(
+    test_case: LoadProjectConstantsConfigTestCase, tmp_path: Path
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        f'name = "demo"\nadapter = "duckdb"\n{test_case.constants_toml}\n',
+        encoding="utf-8",
+    )
+
+    config: ProjectConfig = load_project_config(project_dir=tmp_path)
+
+    assert config.constants.collection_rendering is test_case.expected_collection_rendering
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        LoadProjectConstantsConfigErrorTestCase(
+            description="non-string collection rendering is rejected",
+            constants_toml="[constants]\ncollection_rendering = true",
+            expected_error_fragment="constants.collection_rendering must be a string",
+        ),
+        LoadProjectConstantsConfigErrorTestCase(
+            description="unknown collection rendering is rejected",
+            constants_toml='[constants]\ncollection_rendering = "values"',
+            expected_error_fragment="constants.collection_rendering must be one of: value_list, array",
+        ),
+        LoadProjectConstantsConfigErrorTestCase(
+            description="unknown constants key is rejected",
+            constants_toml='[constants]\nrendering = "array"',
+            expected_error_fragment=r"constants contains unknown key\(s\): rendering",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_invalid_constants_config_when_loading_project_then_config_error_is_raised(
+    test_case: LoadProjectConstantsConfigErrorTestCase, tmp_path: Path
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        f'name = "demo"\nadapter = "duckdb"\n{test_case.constants_toml}\n',
         encoding="utf-8",
     )
 

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/_test_types.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/_test_types.py
@@ -54,3 +54,11 @@ class CustomRuleEvidenceTestCase:
     test_source: str
     expected_count: int
     test_path: str = "tests/test_custom.py"
+
+
+@dataclass(frozen=True)
+class TypedConstantPayloadTestCase:
+    description: str
+    raw_value: object
+    expected_value: object
+    expected_type: str

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_typed_constants.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_typed_constants.py
@@ -1,0 +1,45 @@
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from sqlbuild.compiler.discovery.models import ConstantDeclaration
+from sqlbuild.kata_engine._helpers.engine.native import (
+    _constant_payload,  # noqa: FFL102 - verifies the native protocol payload boundary
+)
+from sqlbuild.sql_values.main.normalize import normalize_sql_value
+from tests.unit.src.sqlbuild.kata_engine._helpers.engine._test_types import (
+    TypedConstantPayloadTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TypedConstantPayloadTestCase(
+            description="nested typed value is JSON-safe and type-bearing",
+            raw_value={"rate": Decimal("2.4700"), "countries": ["GB", "FR"]},
+            expected_value={"countries": ["GB", "FR"], "rate": "2.4700"},
+            expected_type="object",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_typed_constant_when_building_native_payload_then_value_and_type_are_preserved(
+    test_case: TypedConstantPayloadTestCase,
+) -> None:
+    declaration: ConstantDeclaration = ConstantDeclaration(
+        name="rules",
+        value=normalize_sql_value(raw_value=test_case.raw_value, context="constant 'rules'"),
+        relative_path=Path("constants/rules.sql"),
+    )
+
+    payload: dict[str, object] = _constant_payload(declaration)
+
+    assert payload["value"] == test_case.expected_value
+    assert payload["value_type"] == test_case.expected_type
+    assert payload["render_as"] is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/unit/src/sqlbuild/lint/_test_types.py
+++ b/tests/unit/src/sqlbuild/lint/_test_types.py
@@ -117,3 +117,12 @@ class LintCompileFailureTestCase:
     description: str
     project_files: dict[str, str]
     expected_message_fragment: str
+
+
+@dataclass(frozen=True)
+class ExpandedTypedConstantTestCase:
+    description: str
+    project_files: dict[str, str]
+    model_path: str
+    authored_sql: str
+    expected_sql: str

--- a/tests/unit/src/sqlbuild/lint/test_expanded_lint.py
+++ b/tests/unit/src/sqlbuild/lint/test_expanded_lint.py
@@ -6,11 +6,15 @@ from pathlib import Path
 
 import pytest
 
+from sqlbuild.compiler.compile.main.expand_sql_with_spans import expand_sql_with_spans
+from sqlbuild.compiler.compile.models import SqlExpansionContext
+from sqlbuild.lint._helpers.expansion import build_lint_expansion_context
 from sqlbuild.lint.exceptions import ProjectCompileError
 from sqlbuild.lint.main.run_lint import run_lint
 from sqlbuild.lint.models import LintConfig, LintRunResult
 from tests.unit.src.sqlbuild.lint._test_types import (
     ExpandedLintTestCase,
+    ExpandedTypedConstantTestCase,
     LintCompileFailureTestCase,
     LintProjectTestCase,
 )
@@ -18,6 +22,44 @@ from tests.unit.src.sqlbuild.lint._test_types import (
 PROJECT_TOML: str = 'name = "demo"\nadapter = "duckdb"\n'
 BAD_COLUMNS_MACRO: str = 'def bad_cols(ctx):\n    return "a,b"\n'
 HEADER: str = 'MODEL (\n  materialized table,\n  description "ok"\n);\n'
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ExpandedTypedConstantTestCase(
+            description="lint expansion uses configured adapter array rendering",
+            project_files={
+                "sqlbuild_project.toml": PROJECT_TOML,
+                "constants/countries.sql": (
+                    'CONSTANT (name countries, value ["GB", "FR"], render_as array);\n'
+                ),
+                "models/demo.sql": f'{HEADER}SELECT @const("countries") AS countries\n',
+            },
+            model_path="models/demo.sql",
+            authored_sql='SELECT @const("countries") AS countries',
+            expected_sql="SELECT ['GB', 'FR'] AS countries",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_typed_constant_when_building_lint_context_then_uses_adapter_rendering(
+    test_case: ExpandedTypedConstantTestCase,
+    tmp_path: Path,
+) -> None:
+    for relative_path, contents in test_case.project_files.items():
+        target: Path = tmp_path / relative_path
+        _ = target.parent.mkdir(parents=True, exist_ok=True)
+        _ = target.write_text(contents, encoding="utf-8")
+    context: SqlExpansionContext = build_lint_expansion_context(project_dir=tmp_path)
+
+    expanded_sql, _passes = expand_sql_with_spans(
+        sql=test_case.authored_sql,
+        file_path=tmp_path / test_case.model_path,
+        context=context,
+    )
+
+    assert expanded_sql == test_case.expected_sql
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/spec/contracts/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/spec/contracts/main/_test_types.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig
+from sqlbuild.sql_values.types import CollectionRendering
 
 
 @dataclass(frozen=True)
@@ -27,3 +28,11 @@ class EffectiveChangesOnlyResolutionTestCase:
     local_config: LocalConfig
     cli_changes_only: bool
     expected_changes_only: bool
+
+
+@dataclass(frozen=True)
+class EffectiveCollectionRenderingResolutionTestCase:
+    description: str
+    project_config: ProjectConfig
+    declaration_override: CollectionRendering | None
+    expected_collection_rendering: CollectionRendering

--- a/tests/unit/src/sqlbuild/spec/contracts/main/test_constants.py
+++ b/tests/unit/src/sqlbuild/spec/contracts/main/test_constants.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from sqlbuild.spec.contracts.main.resolve_effective_collection_rendering import (
+    resolve_effective_collection_rendering,
+)
+from sqlbuild.spec.contracts.models import ConstantsConfig, ProjectConfig
+from sqlbuild.sql_values.types import CollectionRendering
+from tests.unit.src.sqlbuild.spec.contracts.main._test_types import (
+    EffectiveCollectionRenderingResolutionTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        EffectiveCollectionRenderingResolutionTestCase(
+            description="uses value-list default when no values override it",
+            project_config=ProjectConfig(name="demo", adapter="duckdb"),
+            declaration_override=None,
+            expected_collection_rendering=CollectionRendering.VALUE_LIST,
+        ),
+        EffectiveCollectionRenderingResolutionTestCase(
+            description="uses project collection rendering without declaration override",
+            project_config=ProjectConfig(
+                name="demo",
+                adapter="duckdb",
+                constants=ConstantsConfig(collection_rendering=CollectionRendering.ARRAY),
+            ),
+            declaration_override=None,
+            expected_collection_rendering=CollectionRendering.ARRAY,
+        ),
+        EffectiveCollectionRenderingResolutionTestCase(
+            description="declaration collection rendering overrides project config",
+            project_config=ProjectConfig(
+                name="demo",
+                adapter="duckdb",
+                constants=ConstantsConfig(collection_rendering=CollectionRendering.ARRAY),
+            ),
+            declaration_override=CollectionRendering.VALUE_LIST,
+            expected_collection_rendering=CollectionRendering.VALUE_LIST,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_rendering_configuration_when_resolving_then_precedence_is_applied(
+    test_case: EffectiveCollectionRenderingResolutionTestCase,
+) -> None:
+    collection_rendering: CollectionRendering = resolve_effective_collection_rendering(
+        project_config=test_case.project_config,
+        declaration_override=test_case.declaration_override,
+    )
+
+    assert collection_rendering is test_case.expected_collection_rendering

--- a/tests/unit/src/sqlbuild/sql_values/_test_types.py
+++ b/tests/unit/src/sqlbuild/sql_values/_test_types.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+
+from sqlbuild.sql_values.models import SqlValueLimits
+
+
+@dataclass(frozen=True)
+class NormalizeSqlValueTestCase:
+    description: str
+    raw_value: object
+    expected_kind: str
+    expected_value: object
+    explicit_type: str | None = None
+
+
+@dataclass(frozen=True)
+class NormalizeSqlValueErrorTestCase:
+    description: str
+    raw_value: object
+    expected_error: str
+
+
+@dataclass(frozen=True)
+class SqlValueLimitTestCase:
+    description: str
+    raw_value: object
+    limits: SqlValueLimits
+    expected_error: str
+
+
+@dataclass(frozen=True)
+class SqlValueBehaviorTestCase:
+    description: str
+    expected_list_values: tuple[int, ...] = ()
+    expected_identities_equal: bool = False
+
+
+@dataclass(frozen=True)
+class RenderedSqlValueLimitTestCase:
+    description: str
+    rendered_sql: str
+    max_size: int
+    expected_size: int

--- a/tests/unit/src/sqlbuild/sql_values/test_normalization.py
+++ b/tests/unit/src/sqlbuild/sql_values/test_normalization.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import cast
+
+import pytest
+
+from sqlbuild.sql_values._helpers.normalization import sql_value_identity
+from sqlbuild.sql_values.exceptions import SqlValueValidationError
+from sqlbuild.sql_values.main.normalize import normalize_sql_value
+from sqlbuild.sql_values.main.validate_rendered_size import validate_rendered_sql_value_size
+from sqlbuild.sql_values.models import AuthoredSqlSet, SqlValue, SqlValueLimits
+from tests.unit.src.sqlbuild.sql_values._test_types import (
+    NormalizeSqlValueErrorTestCase,
+    NormalizeSqlValueTestCase,
+    RenderedSqlValueLimitTestCase,
+    SqlValueBehaviorTestCase,
+    SqlValueLimitTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        NormalizeSqlValueTestCase("string", "GB", "string", "GB"),
+        NormalizeSqlValueTestCase("integer", 7, "integer", 7),
+        NormalizeSqlValueTestCase("boolean", True, "boolean", True),
+        NormalizeSqlValueTestCase("float", 0.75, "float", 0.75),
+        NormalizeSqlValueTestCase(
+            "native decimal", Decimal("2.4700"), "decimal", Decimal("2.4700")
+        ),
+        NormalizeSqlValueTestCase("null", None, "null", None),
+        NormalizeSqlValueTestCase(
+            "quoted exact decimal", "2.4700", "decimal", Decimal("2.4700"), explicit_type="decimal"
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_supported_scalar_when_normalizing_then_preserves_typed_value(
+    test_case: NormalizeSqlValueTestCase,
+) -> None:
+    value: SqlValue = normalize_sql_value(
+        raw_value=test_case.raw_value,
+        explicit_type=test_case.explicit_type,
+        context="constant 'usd_rate'",
+    )
+
+    assert value.kind.value == test_case.expected_kind
+    assert value.value == test_case.expected_value
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SqlValueBehaviorTestCase(
+            description="canonical collections and objects",
+            expected_list_values=(2, 1, 2),
+            expected_identities_equal=True,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_lists_sets_and_objects_when_normalizing_then_canonicalizes_unordered_values(
+    test_case: SqlValueBehaviorTestCase,
+) -> None:
+    list_value: SqlValue = normalize_sql_value(raw_value=[2, 1, 2], context="constant 'ordered'")
+    first_set: SqlValue = normalize_sql_value(
+        raw_value=AuthoredSqlSet((2, 1)), context="constant 'unique'"
+    )
+    second_set: SqlValue = normalize_sql_value(
+        raw_value=AuthoredSqlSet((1, 2)), context="constant 'unique'"
+    )
+    first_object: SqlValue = normalize_sql_value(
+        raw_value={"z": 1, "a": [True, None]}, context="constant 'rules'"
+    )
+    second_object: SqlValue = normalize_sql_value(
+        raw_value={"a": [True, None], "z": 1}, context="constant 'rules'"
+    )
+
+    list_items: tuple[SqlValue, ...] = cast(tuple[SqlValue, ...], list_value.value)
+    assert tuple(item.value for item in list_items) == test_case.expected_list_values
+    assert (
+        sql_value_identity(value=first_set) == sql_value_identity(value=second_set)
+    ) is test_case.expected_identities_equal
+    assert (
+        sql_value_identity(value=first_object) == sql_value_identity(value=second_object)
+    ) is test_case.expected_identities_equal
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        NormalizeSqlValueErrorTestCase("empty list", [], "list must contain at least one value"),
+        NormalizeSqlValueErrorTestCase(
+            "all-null list", [None, None], "cannot infer an element type"
+        ),
+        NormalizeSqlValueErrorTestCase(
+            "mixed list", ["GB", 1], r"\[1\] has type integer; expected string"
+        ),
+        NormalizeSqlValueErrorTestCase(
+            "duplicate set", AuthoredSqlSet(("GB", "GB")), "duplicate set value 'GB'"
+        ),
+        NormalizeSqlValueErrorTestCase("large integer", 2**63, "outside the signed 64-bit range"),
+        NormalizeSqlValueErrorTestCase("infinite float", float("inf"), "float must be finite"),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_invalid_values_when_normalizing_then_raises_contextual_error(
+    test_case: NormalizeSqlValueErrorTestCase,
+) -> None:
+    with pytest.raises(
+        SqlValueValidationError,
+        match=rf"constant 'countries'.*{test_case.expected_error}",
+    ):
+        normalize_sql_value(raw_value=test_case.raw_value, context="constant 'countries'")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [SqlValueBehaviorTestCase(description="boolean and integer identities remain distinct")],
+    ids=lambda case: case.description,
+)
+def test_given_python_equal_cross_type_values_when_identifying_then_identity_remains_typed(
+    test_case: SqlValueBehaviorTestCase,
+) -> None:
+    boolean: SqlValue = normalize_sql_value(raw_value=True, context="constant 'value'")
+    integer: SqlValue = normalize_sql_value(raw_value=1, context="constant 'value'")
+
+    assert (
+        sql_value_identity(value=boolean) == sql_value_identity(value=integer)
+    ) is test_case.expected_identities_equal
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SqlValueLimitTestCase(
+            "depth", [[[1]]], SqlValueLimits(max_depth=2), "maximum nesting depth"
+        ),
+        SqlValueLimitTestCase(
+            "elements", [1, 2], SqlValueLimits(max_elements=1), "maximum element count"
+        ),
+        SqlValueLimitTestCase(
+            "size", "oversized", SqlValueLimits(max_size=3), "maximum value size"
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_safety_limit_is_exceeded_when_normalizing_then_rejects_value(
+    test_case: SqlValueLimitTestCase,
+) -> None:
+    with pytest.raises(SqlValueValidationError, match=test_case.expected_error):
+        normalize_sql_value(
+            raw_value=test_case.raw_value,
+            context="constant 'limited'",
+            limits=test_case.limits,
+        )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        RenderedSqlValueLimitTestCase(
+            description="multibyte rendered SQL uses UTF-8 byte length",
+            rendered_sql="é",
+            max_size=1,
+            expected_size=2,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_rendered_sql_exceeds_limit_when_validating_then_counts_utf8_bytes(
+    test_case: RenderedSqlValueLimitTestCase,
+) -> None:
+    with pytest.raises(
+        SqlValueValidationError,
+        match=rf"rendered value is {test_case.expected_size} bytes",
+    ):
+        validate_rendered_sql_value_size(
+            rendered_sql=test_case.rendered_sql,
+            context="constant 'limited'",
+            max_size=test_case.max_size,
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])


### PR DESCRIPTION
## Why
Constants were limited to string and integer substitution, preventing typed booleans, exact decimals, nulls, collections, and objects from being rendered safely for each active adapter. Compile and lint also needed one shared adapter-aware rendering boundary for future typed test parameters. Closes CHI-90.

## Changes
- add an immutable neutral typed SQL value domain with recursive validation, canonical identity, deterministic sets/objects, and safety limits
- parse scalar, list, set, object, exact-decimal, and model-local `constant(...)` declarations
- add declaration and project-level `value_list`/`array` rendering selection
- add typed scalar, value-list, native-array, and object renderers for every built-in adapter
- thread the active renderer through models, hooks, sources, functions, tests, scenarios, audits, lint, format, and Kata
- include normalized typed constant facts in the native Kata request
- regenerate the packaged SQLBuild skill from the matching docs worktree

## Verification
- `make check-ci`
- `make rust-check`
- `make test` (4376 passed)
- `make test-e2e-duckdb` (572 passed; 6 performance checks passed)
- focused typed-value/compiler/lint/adapter/Kata suite (1216 passed, 2 skipped)
- DuckDB execution coverage for value lists, arrays, objects, and exact decimals
- `uv lock --check --python 3.12`
- generated skill is byte-for-byte reproducible from the docs worktree