### PR TITLE
feat(kata): add SQL test policy rules

### DIFF
--- a/crates/sqlbuild-kata-native/src/configuration/_helpers/loading.rs
+++ b/crates/sqlbuild-kata-native/src/configuration/_helpers/loading.rs
@@ -56,6 +56,7 @@ fn validate_raw(value: &toml::Value) -> Result<(), String> {
         "retired_source_tokens",
         "cte_name_whitelist",
         "cte_name_denylist",
+        "sql_tests",
         "cache",
     ];
     let mut unknown: Vec<String> = table
@@ -99,6 +100,27 @@ pub(crate) fn validate(config: &KataConfig) -> Result<(), String> {
         "min_tests_per_model",
         "min_custom_rule_test_cases",
     ];
+    let pipeline = Path::new(&config.sql_tests.pipeline_directory);
+    if config.sql_tests.pipeline_directory.trim().is_empty()
+        || config.sql_tests.pipeline_directory.contains('\\')
+        || config.sql_tests.pipeline_directory.contains("//")
+        || config.sql_tests.pipeline_directory.ends_with('/')
+        || config
+            .sql_tests
+            .pipeline_directory
+            .split('/')
+            .next()
+            .is_some_and(|component| component.ends_with(':'))
+        || pipeline.is_absolute()
+        || pipeline
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(
+            "kata.sql_tests.pipeline_directory must be a normalized path relative to tests/unit"
+                .into(),
+        );
+    }
     if let Some(name) = config
         .thresholds
         .keys()

--- a/crates/sqlbuild-kata-native/src/constants.rs
+++ b/crates/sqlbuild-kata-native/src/constants.rs
@@ -1,6 +1,12 @@
 pub(crate) const API_VERSION: u32 = 1;
 pub(crate) const SCOPE_METADATA_SCHEMA_VERSION: u32 = 1;
 pub(crate) const BUILT_IN_RULE_NAMESPACE: &str = "SQBK";
+pub(crate) const PIPELINE_SUBJECT: &str = "pipeline";
+pub(crate) const GENERIC_TEST_NAME: &str = "test";
+pub(crate) const GENERIC_WORKS_NAME: &str = "works";
+pub(crate) const GENERIC_BASIC_NAME: &str = "basic";
+pub(crate) const GENERIC_SCENARIO_NAME: &str = "scenario";
+pub(crate) const GENERIC_CASE_NAME: &str = "case";
 pub(crate) const CUSTOM_RULE_NAMESPACE: &str = "XSQBK";
 pub(crate) const TARGET_DIRECTORY: &str = "target";
 pub(crate) const REFERENCE_KIND: &str = "ref";

--- a/crates/sqlbuild-kata-native/src/engine/_helpers/evaluation.rs
+++ b/crates/sqlbuild-kata-native/src/engine/_helpers/evaluation.rs
@@ -3,9 +3,10 @@ use crate::constants::{API_VERSION, TARGET_DIRECTORY};
 use crate::engine::_helpers::cache::Cache;
 use crate::models::{EvaluateRequest, EvaluateResponse, Fault, RuleMetadata};
 use crate::rules::main::{
-    assemble_catalogue, evaluate as rules, fingerprint, resolve_threshold_overrides, select,
+    assemble_catalogue, evaluate as rules, evaluate_project, fingerprint,
+    resolve_threshold_overrides, select,
 };
-use crate::rules::models::ModelEvaluationRequest;
+use crate::rules::models::{ModelEvaluationRequest, ProjectEvaluationRequest};
 use fensu_policy::lifecycle::constants::ANALYSIS_BATCH_SCHEMA_VERSION;
 use fensu_policy::lifecycle::errors::LifecycleError;
 use fensu_policy::lifecycle::models::{
@@ -63,7 +64,7 @@ pub(crate) fn evaluate_json(request_json: &str) -> Result<String, String> {
         .any(|rule| rule.project_wide || rule.code.starts_with("SQBKX") || rule.custom);
     let project_fingerprint = if project_aware {
         Some(match &request.project_fingerprint {
-            Some(value) => value.clone(),
+            Some(value) => fingerprint_request_facts(value.as_bytes(), &request)?,
             None => fingerprint_project(Path::new(&request.project_dir), &request)?,
         })
     } else {
@@ -74,7 +75,10 @@ pub(crate) fn evaluate_json(request_json: &str) -> Result<String, String> {
         .transpose()?;
     let mut models: Vec<_> = request.models.iter().collect();
     models.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    let mut raw_faults: Vec<Fault> = Vec::new();
+    let mut raw_faults = evaluate_project::evaluate_project(ProjectEvaluationRequest {
+        selected: &selected_by_code,
+        request: &request,
+    })?;
     let mut cache_hits = 0;
     let mut cache_misses = 0;
     for (model_index, model) in models.iter().enumerate() {
@@ -159,9 +163,20 @@ fn fingerprint_project(project_dir: &Path, request: &EvaluateRequest) -> Result<
             )
         })?);
     }
+    fingerprint_request_facts(&digest.finalize(), request)
+}
+
+fn fingerprint_request_facts(seed: &[u8], request: &EvaluateRequest) -> Result<String, String> {
+    let mut digest = Sha256::new();
+    digest.update(seed);
     digest.update(
-        serde_json::to_vec(&(&request.public_enums, &request.public_constants))
-            .map_err(|error| error.to_string())?,
+        serde_json::to_vec(&(
+            &request.public_enums,
+            &request.public_constants,
+            &request.sql_tests,
+            &request.sql_scenarios,
+        ))
+        .map_err(|error| error.to_string())?,
     );
     Ok(format!("{:x}", digest.finalize()))
 }

--- a/crates/sqlbuild-kata-native/src/engine/tests.rs
+++ b/crates/sqlbuild-kata-native/src/engine/tests.rs
@@ -4,5 +4,7 @@ mod evaluation;
 mod helpers;
 #[path = "tests/test_scope_facts.rs"]
 mod scope_facts;
+#[path = "tests/test_sql_test_policy.rs"]
+mod sql_test_policy;
 #[path = "tests/test_types.rs"]
 mod test_types;

--- a/crates/sqlbuild-kata-native/src/engine/tests/helpers.rs
+++ b/crates/sqlbuild-kata-native/src/engine/tests/helpers.rs
@@ -1,6 +1,8 @@
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
+use crate::engine::main::evaluate::evaluate_json;
+
 pub(crate) fn request(project_dir: &TempDir, config: &Value) -> String {
     json!({
         "version": 1,
@@ -133,4 +135,72 @@ pub(crate) fn request_with_scope(scope: Value) -> Value {
         "project_fingerprint": null,
         "scope_index": scope
     })
+}
+
+pub(crate) fn sql_test_policy_evaluation(
+    project_dir: &TempDir,
+    code: &str,
+    tests: Value,
+    scenarios: Value,
+    scope_index: Value,
+    extra_config: Value,
+) -> Result<Value, String> {
+    let mut config = json!({
+        "select": [code],
+        "cache": {"enabled": false}
+    });
+    config
+        .as_object_mut()
+        .expect("base policy config is an object")
+        .extend(
+            extra_config
+                .as_object()
+                .expect("extra policy config is an object")
+                .clone(),
+        );
+    let request = json!({
+        "version": 1,
+        "project_dir": project_dir.path(),
+        "config": config,
+        "models": [],
+        "sql_tests": tests,
+        "sql_scenarios": scenarios,
+        "scope_index": scope_index
+    });
+    serde_json::from_str(&evaluate_json(&request.to_string())?).map_err(|error| error.to_string())
+}
+
+pub(crate) fn sql_test_fact(path: &str, name: Option<&str>, targets: Value) -> Value {
+    json!({
+        "source_path": path,
+        "ownership_root": "tests/unit",
+        "block_index": 1,
+        "name": name.unwrap_or("test_orders"),
+        "explicit_name": name,
+        "mode": "model",
+        "expected_model_names": targets,
+        "assertion_names": [],
+        "assertion_target_model_names": [],
+        "target_model_names": targets,
+        "tested_resources": []
+    })
+}
+
+pub(crate) fn cached_sql_test_policy_request(project_dir: &TempDir, name: Option<&str>) -> String {
+    json!({
+        "version": 1,
+        "project_dir": project_dir.path(),
+        "project_fingerprint": "compiler-project-v1",
+        "config": {"select": ["SQBKT004"], "cache": {"enabled": true}},
+        "models": [{
+            "name": "orders", "relative_path": "models/orders.sql",
+            "query_sql": "SELECT 1", "authored_sql": "SELECT 1"
+        }],
+        "sql_tests": [sql_test_fact(
+            "tests/unit/test_orders__paid.sql", name, json!(["orders"])
+        )],
+        "sql_scenarios": [],
+        "scope_index": scope_index()
+    })
+    .to_string()
 }

--- a/crates/sqlbuild-kata-native/src/engine/tests/test_sql_test_policy.rs
+++ b/crates/sqlbuild-kata-native/src/engine/tests/test_sql_test_policy.rs
@@ -1,0 +1,261 @@
+use crate::engine::main::evaluate::evaluate_json;
+use crate::engine::tests::{helpers, test_types};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+#[test]
+fn given_sql_test_facts_when_evaluating_project_policy_then_returns_expected_faults()
+-> Result<(), String> {
+    let project_dir = TempDir::new().map_err(|error| error.to_string())?;
+    let mut misplaced_test = helpers::sql_test_fact(
+        "quality/test_orders__paid.sql",
+        Some("orders: keeps paid orders"),
+        json!([]),
+    );
+    misplaced_test["ownership_root"] = json!("quality");
+    let mut scope = helpers::scope_index();
+    scope["resources"] = json!([
+        {
+            "identity": "model:stg_orders", "kind": "model", "name": "stg_orders",
+            "path": "models/commerce/staging/stg_orders.sql", "ownership_root": "models",
+            "ownership_root_kind": "model"
+        },
+        {
+            "identity": "model:fact_orders", "kind": "model", "name": "fact_orders",
+            "path": "models/commerce/marts/fact_orders.sql", "ownership_root": "models",
+            "ownership_root_kind": "model"
+        },
+        {
+            "identity": "model:daily_revenue", "kind": "model", "name": "daily_revenue",
+            "path": "models/finance/marts/daily_revenue.sql", "ownership_root": "models",
+            "ownership_root_kind": "model"
+        }
+    ]);
+    let mut macro_test = helpers::sql_test_fact(
+        "tests/unit/macros/test_normalize__trims.sql",
+        Some("normalize: trims spaces"),
+        json!([]),
+    );
+    macro_test["mode"] = json!("macro");
+    macro_test["tested_resources"] = json!([{"kind": "macro", "name": "normalize_status"}]);
+    let test_cases = [
+        test_types::SqlTestPolicyTestCase {
+            description: "canonical roots run without a model anchor",
+            code: "SQBKT001",
+            tests: json!([misplaced_test]),
+            scenarios: json!([{
+                "source_path": "quality/orders__paid.sql", "ownership_root": "quality",
+                "name": "orders__paid", "description": "Paid orders remain visible",
+                "expected_model_names": [], "assertion_names": [],
+                "assertion_target_model_names": [], "target_model_names": []
+            }]),
+            scope_index: helpers::scope_index(),
+            config: json!({}),
+            expected_fault_count: 2,
+            expected_evaluated_models: 0,
+            expected_paths: &["quality/orders__paid.sql", "quality/test_orders__paid.sql"],
+        },
+        test_types::SqlTestPolicyTestCase {
+            description: "filename grammar checks unit and scenario paths",
+            code: "SQBKT002",
+            tests: json!([
+                helpers::sql_test_fact(
+                    "tests/unit/test_orders__keeps_paid.sql",
+                    Some("orders: keeps paid orders"),
+                    json!([])
+                ),
+                helpers::sql_test_fact(
+                    "tests/unit/orders.sql",
+                    Some("orders: excludes cancelled orders"),
+                    json!([])
+                )
+            ]),
+            scenarios: json!([{
+                "source_path": "tests/scenarios/daily_revenue.sql",
+                "ownership_root": "tests/scenarios", "name": "daily_revenue",
+                "description": "Daily revenue includes successful payments",
+                "expected_model_names": [], "assertion_names": [],
+                "assertion_target_model_names": [], "target_model_names": []
+            }]),
+            scope_index: helpers::scope_index(),
+            config: json!({}),
+            expected_fault_count: 2,
+            expected_evaluated_models: 0,
+            expected_paths: &["tests/scenarios/daily_revenue.sql", "tests/unit/orders.sql"],
+        },
+        test_types::SqlTestPolicyTestCase {
+            description: "resolved ownership uses LCA, pipeline, and direct resource paths",
+            code: "SQBKT003",
+            tests: json!([
+                helpers::sql_test_fact(
+                    "tests/unit/commerce/staging/test_stg_orders__paid.sql",
+                    Some("stg_orders: keeps paid orders"),
+                    json!(["stg_orders"])
+                ),
+                helpers::sql_test_fact(
+                    "tests/unit/commerce/test_order_pipeline__paid.sql",
+                    Some("commerce: keeps paid orders"),
+                    json!(["stg_orders", "fact_orders"])
+                ),
+                helpers::sql_test_fact(
+                    "tests/unit/wrong/test_pipeline__revenue.sql",
+                    Some("pipeline: calculates revenue"),
+                    json!(["stg_orders", "daily_revenue"])
+                ),
+                macro_test
+            ]),
+            scenarios: json!([]),
+            scope_index: scope,
+            config: json!({"sql_tests": {"pipeline_directory": "chains"}}),
+            expected_fault_count: 1,
+            expected_evaluated_models: 0,
+            expected_paths: &["tests/unit/wrong/test_pipeline__revenue.sql"],
+        },
+        test_types::SqlTestPolicyTestCase {
+            description: "structured names require explicit target-aware behavior",
+            code: "SQBKT004",
+            tests: json!([
+                helpers::sql_test_fact(
+                    "tests/unit/test_orders__paid.sql",
+                    Some("orders: keeps paid orders: after capture"),
+                    json!(["orders"])
+                ),
+                helpers::sql_test_fact(
+                    "tests/unit/test_orders__basic.sql",
+                    Some("orders: basic"),
+                    json!(["orders"])
+                ),
+                helpers::sql_test_fact("tests/unit/test_orders__paid.sql", None, json!(["orders"])),
+                helpers::sql_test_fact(
+                    "tests/unit/test_orders__paid.sql",
+                    Some("payments: keeps paid orders"),
+                    json!(["orders"])
+                )
+            ]),
+            scenarios: json!([]),
+            scope_index: helpers::scope_index(),
+            config: json!({}),
+            expected_fault_count: 3,
+            expected_evaluated_models: 0,
+            expected_paths: &[
+                "tests/unit/test_orders__basic.sql",
+                "tests/unit/test_orders__paid.sql",
+                "tests/unit/test_orders__paid.sql",
+            ],
+        },
+        test_types::SqlTestPolicyTestCase {
+            description: "scenario descriptions reject generic numbering",
+            code: "SQBKT101",
+            tests: json!([]),
+            scenarios: json!([
+                {
+                    "source_path": "tests/scenarios/orders__paid.sql",
+                    "ownership_root": "tests/scenarios", "name": "orders__paid",
+                    "description": "Paid orders remain visible", "expected_model_names": [],
+                    "assertion_names": [], "assertion_target_model_names": [],
+                    "target_model_names": []
+                },
+                {
+                    "source_path": "tests/scenarios/orders__case_1.sql",
+                    "ownership_root": "tests/scenarios", "name": "orders__case_1",
+                    "description": "case 1", "expected_model_names": [],
+                    "assertion_names": [], "assertion_target_model_names": [],
+                    "target_model_names": []
+                }
+            ]),
+            scope_index: helpers::scope_index(),
+            config: json!({}),
+            expected_fault_count: 1,
+            expected_evaluated_models: 0,
+            expected_paths: &["tests/scenarios/orders__case_1.sql"],
+        },
+        test_types::SqlTestPolicyTestCase {
+            description: "path-scoped ignore suppresses a test policy fault",
+            code: "SQBKT004",
+            tests: json!([helpers::sql_test_fact(
+                "tests/unit/test_orders__paid.sql",
+                None,
+                json!(["orders"])
+            )]),
+            scenarios: json!([]),
+            scope_index: helpers::scope_index(),
+            config: json!({"rule_ignores": [{
+                "rules": ["SQBKT004"], "paths": ["tests/unit/**"],
+                "reason": "tracked naming migration"
+            }]}),
+            expected_fault_count: 0,
+            expected_evaluated_models: 0,
+            expected_paths: &[],
+        },
+    ];
+
+    for test_case in test_cases {
+        let result = helpers::sql_test_policy_evaluation(
+            &project_dir,
+            test_case.code,
+            test_case.tests,
+            test_case.scenarios,
+            test_case.scope_index,
+            test_case.config,
+        )?;
+        let paths: Vec<&str> = result["faults"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|fault| fault["path"].as_str())
+            .collect();
+        assert_eq!(
+            result["faults"].as_array().map(Vec::len),
+            Some(test_case.expected_fault_count),
+            "{}",
+            test_case.description
+        );
+        assert_eq!(
+            result["evaluated_models"], test_case.expected_evaluated_models,
+            "{}",
+            test_case.description
+        );
+        assert_eq!(paths, test_case.expected_paths, "{}", test_case.description);
+    }
+    Ok(())
+}
+
+#[test]
+fn given_test_fact_change_when_evaluating_cached_project_rule_then_model_cache_is_invalidated()
+-> Result<(), String> {
+    let project_dir = TempDir::new().map_err(|error| error.to_string())?;
+    let test_cases = [test_types::SqlTestPolicyCacheTestCase {
+        description: "test fact change invalidates model cache identity",
+        expected_first_misses: 1,
+        expected_second_hits: 0,
+        expected_second_misses: 1,
+    }];
+    for test_case in &test_cases {
+        let first: Value = serde_json::from_str(&evaluate_json(
+            &helpers::cached_sql_test_policy_request(&project_dir, None),
+        )?)
+        .map_err(|error| error.to_string())?;
+        let second: Value =
+            serde_json::from_str(&evaluate_json(&helpers::cached_sql_test_policy_request(
+                &project_dir,
+                Some("orders: keeps paid orders"),
+            ))?)
+            .map_err(|error| error.to_string())?;
+        assert_eq!(
+            first["cache_misses"], test_case.expected_first_misses,
+            "{}",
+            test_case.description
+        );
+        assert_eq!(
+            second["cache_hits"], test_case.expected_second_hits,
+            "{}",
+            test_case.description
+        );
+        assert_eq!(
+            second["cache_misses"], test_case.expected_second_misses,
+            "{}",
+            test_case.description
+        );
+    }
+    Ok(())
+}

--- a/crates/sqlbuild-kata-native/src/engine/tests/test_types.rs
+++ b/crates/sqlbuild-kata-native/src/engine/tests/test_types.rs
@@ -41,3 +41,22 @@ pub(crate) struct MissingScopeFactsTestCase {
     pub(crate) expected_complete: bool,
     pub(crate) expected_runtime_usage: bool,
 }
+
+pub(crate) struct SqlTestPolicyTestCase {
+    pub(crate) description: &'static str,
+    pub(crate) code: &'static str,
+    pub(crate) tests: Value,
+    pub(crate) scenarios: Value,
+    pub(crate) scope_index: Value,
+    pub(crate) config: Value,
+    pub(crate) expected_fault_count: usize,
+    pub(crate) expected_evaluated_models: usize,
+    pub(crate) expected_paths: &'static [&'static str],
+}
+
+pub(crate) struct SqlTestPolicyCacheTestCase {
+    pub(crate) description: &'static str,
+    pub(crate) expected_first_misses: u64,
+    pub(crate) expected_second_hits: u64,
+    pub(crate) expected_second_misses: u64,
+}

--- a/crates/sqlbuild-kata-native/src/models.rs
+++ b/crates/sqlbuild-kata-native/src/models.rs
@@ -53,6 +53,20 @@ pub(crate) struct ThresholdOverride {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
+pub(crate) struct SqlTestPolicyConfig {
+    pub pipeline_directory: String,
+}
+
+impl Default for SqlTestPolicyConfig {
+    fn default() -> Self {
+        Self {
+            pipeline_directory: "pipelines".into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
 pub(crate) struct KataConfig {
     pub select: Vec<String>,
     pub ignore: Vec<String>,
@@ -69,6 +83,7 @@ pub(crate) struct KataConfig {
     pub retired_source_tokens: BTreeMap<String, String>,
     pub cte_name_whitelist: Vec<String>,
     pub cte_name_denylist: Vec<String>,
+    pub sql_tests: SqlTestPolicyConfig,
     pub cache: CacheConfig,
 }
 
@@ -90,6 +105,7 @@ impl Default for KataConfig {
             retired_source_tokens: BTreeMap::new(),
             cte_name_whitelist: vec![],
             cte_name_denylist: vec![],
+            sql_tests: SqlTestPolicyConfig::default(),
             cache: CacheConfig::enabled_by_default(),
         }
     }
@@ -422,6 +438,59 @@ pub(crate) struct Model {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SqlTestMode {
+    Model,
+    Macro,
+    Udf,
+    TableFn,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DirectTestResourceKind {
+    Macro,
+    Udf,
+    TableFn,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TestedResource {
+    pub kind: DirectTestResourceKind,
+    pub name: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SqlTestFact {
+    pub source_path: String,
+    pub ownership_root: String,
+    pub block_index: u64,
+    pub name: String,
+    pub explicit_name: Option<String>,
+    pub mode: SqlTestMode,
+    pub expected_model_names: Vec<String>,
+    pub assertion_names: Vec<String>,
+    pub assertion_target_model_names: Vec<String>,
+    pub target_model_names: Vec<String>,
+    pub tested_resources: Vec<TestedResource>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SqlScenarioFact {
+    pub source_path: String,
+    pub ownership_root: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub expected_model_names: Vec<String>,
+    pub assertion_names: Vec<String>,
+    pub assertion_target_model_names: Vec<String>,
+    pub target_model_names: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct CustomRule {
     pub code: String,
@@ -466,6 +535,8 @@ pub(crate) struct EvaluateRequest {
     pub project_dir: String,
     pub config: KataConfig,
     pub models: Vec<Model>,
+    pub sql_tests: Vec<SqlTestFact>,
+    pub sql_scenarios: Vec<SqlScenarioFact>,
     pub public_enums: Vec<Declaration>,
     pub public_constants: Vec<Declaration>,
     pub scope_index: ScopeIndexFacts,
@@ -499,6 +570,8 @@ impl Default for EvaluateRequest {
             project_dir: ".".into(),
             config: KataConfig::default(),
             models: vec![],
+            sql_tests: vec![],
+            sql_scenarios: vec![],
             public_enums: vec![],
             public_constants: vec![],
             scope_index: ScopeIndexFacts::default(),

--- a/crates/sqlbuild-kata-native/src/rules/_helpers/catalogue.rs
+++ b/crates/sqlbuild-kata-native/src/rules/_helpers/catalogue.rs
@@ -23,7 +23,8 @@ macro_rules! rule {
             guidance: None,
             implementation_fingerprint: env!("CARGO_PKG_VERSION").into(),
             enabled_by_default: true,
-            project_wide: matches!($code, "SQBKH101" | "SQBKH201" | "SQBKX201"),
+            project_wide: matches!($code, "SQBKH101" | "SQBKH201" | "SQBKX201")
+                || $code.starts_with("SQBKT"),
             custom: false,
         }
     };
@@ -219,6 +220,41 @@ pub(crate) fn catalogue() -> Vec<RuleMetadata> {
             "declaration-domain-placement",
             "public enum and constant files must live under a configured domain folder",
             "Move this declaration beneath enums/<domain>/ or constants/<domain>/.",
+        ),
+        rule!(
+            "SQBKT001",
+            "sql-tests",
+            "canonical-test-roots",
+            "SQL unit tests and scenarios must use their compiler-owned canonical roots",
+            "Move unit tests beneath tests/unit/ and scenarios beneath tests/scenarios/.",
+        ),
+        rule!(
+            "SQBKT002",
+            "sql-tests",
+            "test-filename-grammar",
+            "SQL test and scenario filenames must identify their subject and behavior",
+            "Use test_<subject>__<behavior>.sql for unit tests and <subject>__<behavior>.sql for scenarios.",
+        ),
+        rule!(
+            "SQBKT003",
+            "sql-tests",
+            "semantic-test-mirroring",
+            "SQL unit tests must mirror compiler-resolved resource ownership",
+            "Move the test to the reported directory derived from its resolved models or direct tested resource.",
+        ),
+        rule!(
+            "SQBKT004",
+            "sql-tests",
+            "structured-test-name",
+            "every SQL unit-test block must have a target-aware subject: expected behavior name",
+            "Add name \"<resolved subject>: <expected behavior>\" to this TEST header.",
+        ),
+        rule!(
+            "SQBKT101",
+            "sql-tests",
+            "scenario-business-description",
+            "scenario descriptions must identify a concrete business behavior",
+            "Write a non-generic SCENARIO description that states the business behavior under test.",
         ),
         rule!(
             "SQBKX001",

--- a/crates/sqlbuild-kata-native/src/rules/_helpers/mod.rs
+++ b/crates/sqlbuild-kata-native/src/rules/_helpers/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod catalogue;
 pub(crate) mod evaluation;
+pub(crate) mod sql_test_policy;

--- a/crates/sqlbuild-kata-native/src/rules/_helpers/sql_test_policy.rs
+++ b/crates/sqlbuild-kata-native/src/rules/_helpers/sql_test_policy.rs
@@ -1,0 +1,514 @@
+use crate::models::{
+    DeclarationKind, Fault, ResourceKind, RuleMetadata, ScopeResource, SqlScenarioFact,
+    SqlTestFact, SqlTestMode,
+};
+use crate::rules::models::ProjectEvaluationRequest;
+use std::path::Path;
+
+const UNIT_ROOT: &str = "tests/unit";
+const SCENARIO_ROOT: &str = "tests/scenarios";
+
+pub(crate) fn evaluate_project(
+    evaluation: ProjectEvaluationRequest<'_>,
+) -> Result<Vec<Fault>, String> {
+    let mut faults: Vec<Fault> = Vec::new();
+    let mut tests: Vec<&SqlTestFact> = evaluation.request.sql_tests.iter().collect();
+    tests.sort_by(|left, right| {
+        (&left.source_path, left.block_index).cmp(&(&right.source_path, right.block_index))
+    });
+    let mut scenarios: Vec<&SqlScenarioFact> = evaluation.request.sql_scenarios.iter().collect();
+    scenarios.sort_by(|left, right| left.source_path.cmp(&right.source_path));
+
+    if let Some(rule) = evaluation.selected.get("SQBKT001") {
+        faults.extend(canonical_roots(rule, &tests, &scenarios));
+    }
+    if let Some(rule) = evaluation.selected.get("SQBKT002") {
+        faults.extend(filenames(rule, &tests, &scenarios));
+    }
+    if let Some(rule) = evaluation.selected.get("SQBKT003") {
+        faults.extend(mirroring(rule, &evaluation, &tests));
+    }
+    if let Some(rule) = evaluation.selected.get("SQBKT004") {
+        faults.extend(structured_names(rule, &evaluation, &tests));
+    }
+    if let Some(rule) = evaluation.selected.get("SQBKT101") {
+        faults.extend(scenario_descriptions(rule, &scenarios));
+    }
+    Ok(faults)
+}
+
+fn canonical_roots(
+    rule: &RuleMetadata,
+    tests: &[&SqlTestFact],
+    scenarios: &[&SqlScenarioFact],
+) -> Vec<Fault> {
+    let mut faults: Vec<Fault> = Vec::new();
+    for test in tests {
+        if test.ownership_root != UNIT_ROOT || !is_beneath(&test.source_path, UNIT_ROOT) {
+            faults.push(path_fault(
+                rule,
+                &test.source_path,
+                format!(
+                    "unit test block {} is outside the canonical {UNIT_ROOT}/ root",
+                    test.block_index
+                ),
+                format!("Move this unit test beneath {UNIT_ROOT}/."),
+            ));
+        }
+    }
+    for scenario in scenarios {
+        if scenario.ownership_root != SCENARIO_ROOT
+            || !is_beneath(&scenario.source_path, SCENARIO_ROOT)
+        {
+            faults.push(path_fault(
+                rule,
+                &scenario.source_path,
+                format!("scenario is outside the canonical {SCENARIO_ROOT}/ root"),
+                format!("Move this scenario beneath {SCENARIO_ROOT}/."),
+            ));
+        }
+    }
+    faults
+}
+
+fn filenames(
+    rule: &RuleMetadata,
+    tests: &[&SqlTestFact],
+    scenarios: &[&SqlScenarioFact],
+) -> Vec<Fault> {
+    let mut faults: Vec<Fault> = Vec::new();
+    for test in tests {
+        let stem = file_stem(&test.source_path);
+        let valid = stem.strip_prefix("test_").is_some_and(valid_unit_filename);
+        let behavior_matches = test.explicit_name.as_deref().is_none_or(|name| {
+            filename_behavior(stem)
+                .zip(structured_name(name).map(|(_, behavior)| behavior))
+                .is_none_or(|(slug, behavior)| behavior_slug_matches(slug, behavior))
+        });
+        if !valid || !behavior_matches {
+            faults.push(path_fault(
+                rule,
+                &test.source_path,
+                format!(
+                    "unit test block {} filename does not follow test_<subject>__<behavior>.sql",
+                    test.block_index
+                ),
+                test.explicit_name
+                    .as_deref()
+                    .and_then(structured_name)
+                    .map_or_else(
+                        || "Rename this file to test_<subject>__<behavior>.sql.".to_owned(),
+                        |(subject, behavior)| {
+                            format!(
+                                "Rename this file to test_{}__{}.sql.",
+                                slug(subject),
+                                slug(behavior)
+                            )
+                        },
+                    ),
+            ));
+        }
+    }
+    for scenario in scenarios {
+        if !valid_filename_parts(file_stem(&scenario.source_path)) {
+            faults.push(path_fault(
+                rule,
+                &scenario.source_path,
+                "scenario filename does not follow <subject>__<behavior>.sql".into(),
+                "Rename this file to <business subject>__<behavior>.sql.".into(),
+            ));
+        }
+    }
+    faults
+}
+
+fn mirroring(
+    rule: &RuleMetadata,
+    evaluation: &ProjectEvaluationRequest<'_>,
+    tests: &[&SqlTestFact],
+) -> Vec<Fault> {
+    let mut faults: Vec<Fault> = Vec::new();
+    for test in tests {
+        let Some(expected_parent) = expected_parent(evaluation, test) else {
+            continue;
+        };
+        let actual_parent = Path::new(&test.source_path)
+            .parent()
+            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_default();
+        if actual_parent != expected_parent {
+            faults.push(path_fault(
+                rule,
+                &test.source_path,
+                format!(
+                    "unit test block {} resolves to resources mirrored by {expected_parent}/",
+                    test.block_index
+                ),
+                format!("Move this test file beneath {expected_parent}/."),
+            ));
+        }
+    }
+    faults
+}
+
+fn structured_names(
+    rule: &RuleMetadata,
+    evaluation: &ProjectEvaluationRequest<'_>,
+    tests: &[&SqlTestFact],
+) -> Vec<Fault> {
+    let mut faults: Vec<Fault> = Vec::new();
+    for test in tests {
+        let Some(name) = test.explicit_name.as_deref() else {
+            faults.push(name_fault(
+                rule,
+                test,
+                "the TEST block has no explicit name",
+                None,
+            ));
+            continue;
+        };
+        let Some((subject, behavior)) = structured_name(name) else {
+            faults.push(name_fault(
+                rule,
+                test,
+                "the TEST name must contain a nonempty subject and behavior separated by ':'",
+                None,
+            ));
+            continue;
+        };
+        if generic(subject) || generic(behavior) {
+            faults.push(name_fault(
+                rule,
+                test,
+                "the TEST name uses a generic subject or behavior",
+                None,
+            ));
+            continue;
+        }
+        let allowed = allowed_subjects(evaluation, test);
+        if !allowed.is_empty() && !subject_matches(subject, &allowed) {
+            faults.push(name_fault(
+                rule,
+                test,
+                &format!(
+                    "the TEST subject '{}' does not identify its resolved target; expected {}",
+                    subject,
+                    allowed.join(" or ")
+                ),
+                allowed.first().map(String::as_str),
+            ));
+        }
+    }
+    faults
+}
+
+fn scenario_descriptions(rule: &RuleMetadata, scenarios: &[&SqlScenarioFact]) -> Vec<Fault> {
+    let mut faults: Vec<Fault> = Vec::new();
+    for scenario in scenarios {
+        let description = scenario.description.as_deref().unwrap_or("").trim();
+        let behavior = file_stem(&scenario.source_path)
+            .split_once("__")
+            .map(|(_, value)| value)
+            .unwrap_or("");
+        if description.is_empty() || generic(description) || generic(behavior) {
+            faults.push(path_fault(
+                rule,
+                &scenario.source_path,
+                "scenario description or filename uses a generic case label".into(),
+                "Write a concrete business description and a <subject>__<behavior>.sql filename."
+                    .into(),
+            ));
+        }
+    }
+    faults
+}
+
+fn expected_parent(
+    evaluation: &ProjectEvaluationRequest<'_>,
+    test: &SqlTestFact,
+) -> Option<String> {
+    match test.mode {
+        SqlTestMode::Model => {
+            let mut directories: Vec<Vec<String>> = Vec::new();
+            for name in &test.target_model_names {
+                let resource = scope_resource(evaluation, ResourceKind::Model, name)?;
+                directories.push(relative_parent(resource)?);
+            }
+            if directories.is_empty() {
+                return None;
+            }
+            let common = common_components(&directories);
+            Some(if common.is_empty() {
+                format!(
+                    "{UNIT_ROOT}/{}",
+                    evaluation.request.config.sql_tests.pipeline_directory
+                )
+            } else {
+                format!("{UNIT_ROOT}/{}", common.join("/"))
+            })
+        }
+        SqlTestMode::Macro => direct_expected_parent(&macro_parent_components(evaluation, test)?),
+        SqlTestMode::Udf | SqlTestMode::TableFn => {
+            direct_expected_parent(&function_parent_components(evaluation, test)?)
+        }
+    }
+}
+
+fn macro_parent_components(
+    evaluation: &ProjectEvaluationRequest<'_>,
+    test: &SqlTestFact,
+) -> Option<Vec<Vec<String>>> {
+    let mut parents: Vec<Vec<String>> = Vec::new();
+    for resource in &test.tested_resources {
+        let declaration = evaluation
+            .request
+            .scope_index
+            .declarations
+            .iter()
+            .find(|item| {
+                matches!(item.kind, DeclarationKind::Macro) && item.name == resource.name
+            })?;
+        parents.push(direct_parent_components(
+            &declaration.path,
+            &declaration.ownership_root,
+        )?);
+    }
+    Some(parents)
+}
+
+fn function_parent_components(
+    evaluation: &ProjectEvaluationRequest<'_>,
+    test: &SqlTestFact,
+) -> Option<Vec<Vec<String>>> {
+    let mut parents: Vec<Vec<String>> = Vec::new();
+    for resource in &test.tested_resources {
+        let fact = scope_resource(evaluation, ResourceKind::Function, &resource.name)?;
+        parents.push(direct_parent_components(&fact.path, &fact.ownership_root)?);
+    }
+    Some(parents)
+}
+
+fn direct_parent_components(path: &str, root: &str) -> Option<Vec<String>> {
+    let path: Vec<&str> = path.split('/').collect();
+    let root: Vec<&str> = root.split('/').collect();
+    if path.len() <= root.len() || path.get(..root.len()) != Some(root.as_slice()) {
+        return None;
+    }
+    Some(
+        path[..path.len() - 1]
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect(),
+    )
+}
+
+fn direct_expected_parent(parents: &[Vec<String>]) -> Option<String> {
+    let common = common_components(parents);
+    (!common.is_empty()).then(|| format!("{UNIT_ROOT}/{}", common.join("/")))
+}
+
+fn allowed_subjects(evaluation: &ProjectEvaluationRequest<'_>, test: &SqlTestFact) -> Vec<String> {
+    if !matches!(test.mode, SqlTestMode::Model) {
+        return test
+            .tested_resources
+            .iter()
+            .map(|resource| resource.name.clone())
+            .collect();
+    }
+    if test.target_model_names.len() == 1 {
+        return test.target_model_names.clone();
+    }
+    if test.target_model_names.len() > 1 {
+        let mut directories: Vec<Vec<String>> = Vec::new();
+        for name in &test.target_model_names {
+            let Some(resource) = scope_resource(evaluation, ResourceKind::Model, name) else {
+                return Vec::new();
+            };
+            let Some(parent) = relative_parent(resource) else {
+                return Vec::new();
+            };
+            directories.push(parent);
+        }
+        let common = common_components(&directories);
+        return common
+            .last()
+            .map_or_else(|| vec!["pipeline".into()], |domain| vec![domain.clone()]);
+    }
+    Vec::new()
+}
+
+fn scope_resource<'a>(
+    evaluation: &'a ProjectEvaluationRequest<'_>,
+    kind: ResourceKind,
+    name: &str,
+) -> Option<&'a ScopeResource> {
+    evaluation
+        .request
+        .scope_index
+        .resources
+        .iter()
+        .find(|item| same_resource_kind(&item.kind, &kind) && item.name == name)
+}
+
+fn same_resource_kind(left: &ResourceKind, right: &ResourceKind) -> bool {
+    matches!(
+        (left, right),
+        (ResourceKind::Model, ResourceKind::Model)
+            | (ResourceKind::Function, ResourceKind::Function)
+    )
+}
+
+fn relative_parent(resource: &ScopeResource) -> Option<Vec<String>> {
+    let path: Vec<&str> = resource.path.split('/').collect();
+    let root: Vec<&str> = resource.ownership_root.split('/').collect();
+    if path.len() <= root.len() || path.get(..root.len()) != Some(root.as_slice()) {
+        return None;
+    }
+    Some(
+        path[root.len()..path.len() - 1]
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect(),
+    )
+}
+
+fn common_components(values: &[Vec<String>]) -> Vec<String> {
+    let Some(first) = values.first() else {
+        return Vec::new();
+    };
+    let mut common: Vec<String> = Vec::new();
+    for (index, value) in first.iter().enumerate() {
+        let mut shared = true;
+        for candidate in values {
+            if candidate.get(index) != Some(value) {
+                shared = false;
+                break;
+            }
+        }
+        if !shared {
+            break;
+        }
+        common.push(value.clone());
+    }
+    common
+}
+
+fn name_fault(
+    rule: &RuleMetadata,
+    test: &SqlTestFact,
+    detail: &str,
+    proposed_subject: Option<&str>,
+) -> Fault {
+    path_fault(
+        rule,
+        &test.source_path,
+        format!("unit test block {} {detail}", test.block_index),
+        format!(
+            "Add name \"{}: <expected behavior>\" to this TEST header.",
+            proposed_subject.unwrap_or("<resolved subject>")
+        ),
+    )
+}
+
+fn path_fault(rule: &RuleMetadata, path: &str, message: String, remediation: String) -> Fault {
+    Fault {
+        code: rule.code.clone(),
+        path: path.to_owned(),
+        line: 1,
+        column: 1,
+        message,
+        remediation,
+    }
+}
+
+fn is_beneath(path: &str, root: &str) -> bool {
+    path.strip_prefix(root)
+        .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn file_stem(path: &str) -> &str {
+    let filename = path.rsplit('/').next().unwrap_or(path);
+    filename.strip_suffix(".sql").unwrap_or(filename)
+}
+
+fn valid_filename_parts(value: &str) -> bool {
+    let Some((subject, behavior)) = value.split_once("__") else {
+        return false;
+    };
+    !subject.is_empty()
+        && !behavior.is_empty()
+        && slug(subject) == subject
+        && slug(behavior) == behavior
+}
+
+fn valid_unit_filename(value: &str) -> bool {
+    if value.contains("__") {
+        return valid_filename_parts(value);
+    }
+    !value.is_empty() && slug(value) == value
+}
+
+fn filename_behavior(stem: &str) -> Option<&str> {
+    stem.split_once("__").map(|(_, behavior)| behavior)
+}
+
+fn structured_name(name: &str) -> Option<(&str, &str)> {
+    let (subject, behavior) = name.split_once(':')?;
+    let subject = subject.trim();
+    let behavior = behavior.trim();
+    (!subject.is_empty() && !behavior.is_empty()).then_some((subject, behavior))
+}
+
+fn behavior_slug_matches(filename: &str, behavior: &str) -> bool {
+    let behavior = slug(behavior);
+    behavior == filename || behavior.starts_with(&format!("{filename}_"))
+}
+
+fn subject_matches(subject: &str, allowed: &[String]) -> bool {
+    let normalized = slug(subject);
+    for value in allowed {
+        let candidate = slug(value);
+        if normalized == candidate {
+            return true;
+        }
+        if candidate == crate::constants::PIPELINE_SUBJECT
+            && normalized
+                .split('_')
+                .any(|component| component == crate::constants::PIPELINE_SUBJECT)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn generic(value: &str) -> bool {
+    let normalized = slug(value);
+    matches!(
+        normalized.as_str(),
+        crate::constants::GENERIC_TEST_NAME
+            | crate::constants::GENERIC_WORKS_NAME
+            | crate::constants::GENERIC_BASIC_NAME
+            | crate::constants::GENERIC_SCENARIO_NAME
+            | crate::constants::GENERIC_CASE_NAME
+    ) || normalized
+        .strip_prefix("case_")
+        .is_some_and(|suffix| suffix.chars().all(|character| character.is_ascii_digit()))
+}
+
+fn slug(value: &str) -> String {
+    let mut output = String::new();
+    let mut separator = false;
+    for character in value.chars().flat_map(char::to_lowercase) {
+        if character.is_alphanumeric() {
+            if separator && !output.is_empty() {
+                output.push('_');
+            }
+            output.push(character);
+            separator = false;
+        } else {
+            separator = true;
+        }
+    }
+    output
+}

--- a/crates/sqlbuild-kata-native/src/rules/main/evaluate_project.rs
+++ b/crates/sqlbuild-kata-native/src/rules/main/evaluate_project.rs
@@ -1,0 +1,8 @@
+use crate::models::Fault;
+use crate::rules::models::ProjectEvaluationRequest;
+
+pub(crate) fn evaluate_project(
+    request: ProjectEvaluationRequest<'_>,
+) -> Result<Vec<Fault>, String> {
+    crate::rules::_helpers::sql_test_policy::evaluate_project(request)
+}

--- a/crates/sqlbuild-kata-native/src/rules/main/mod.rs
+++ b/crates/sqlbuild-kata-native/src/rules/main/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod assemble_catalogue;
 pub(crate) mod catalogue;
 pub(crate) mod evaluate;
+pub(crate) mod evaluate_project;
 pub(crate) mod fingerprint;
 pub(crate) mod resolve_threshold_overrides;
 pub(crate) mod select;

--- a/crates/sqlbuild-kata-native/src/rules/models.rs
+++ b/crates/sqlbuild-kata-native/src/rules/models.rs
@@ -20,6 +20,12 @@ pub(crate) struct ModelEvaluationRequest<'a> {
 }
 
 #[derive(Debug)]
+pub(crate) struct ProjectEvaluationRequest<'a> {
+    pub(crate) selected: &'a BTreeMap<String, &'a RuleMetadata>,
+    pub(crate) request: &'a EvaluateRequest,
+}
+
+#[derive(Debug)]
 pub(crate) struct ResolvedThresholdOverride {
     pub(crate) matcher: GlobSet,
     pub(crate) thresholds: BTreeMap<String, u32>,

--- a/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
+++ b/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
@@ -3399,6 +3399,70 @@ min_tests_per_model = 1
 min_custom_rule_test_cases = 1
 ```
 
+#### SQL tests and scenarios
+
+The `SQBKT` family governs SQL authored under `tests/unit/` and `tests/scenarios/`. It consumes
+compiler-resolved test targets and resource ownership; it does not infer ownership from filenames
+or repeat compiler diagnostics for malformed tests.
+
+| Code | Check |
+|------|-------|
+| `SQBKT001` | Unit tests and scenarios use their compiler-owned canonical roots |
+| `SQBKT002` | Unit and scenario filenames identify their subject and behavior |
+| `SQBKT003` | Unit tests mirror resolved model, macro, UDF, or table-function ownership |
+| `SQBKT004` | Every `TEST` block has an explicit target-aware `subject: expected behavior` name |
+| `SQBKT101` | Scenario descriptions identify a concrete business behavior rather than generic case numbering |
+
+Select the family independently when adopting these conventions:
+
+```toml
+[kata]
+select = ["SQBKT"]
+```
+
+Every unit-test block, including the only block in a file, has an explicit name:
+
+```sql
+TEST (
+  name "stg_orders: excludes cancelled orders",
+);
+```
+
+The first colon separates a nonempty subject from nonempty behavior. Later colons are ordinary
+behavior prose. Single-model subjects match the resolved expected model, direct-mode subjects match
+the tested macro, UDF, or table function, and multi-model subjects name the common domain or an
+explicit pipeline. Generic values such as `test`, `works`, `basic`, and `case 1` are rejected without
+maintaining a verb allowlist.
+
+Unit filenames use either `test_<subject>.sql` or `test_<subject>__<behavior>.sql`. When a behavior
+suffix is present, it corresponds to the normalized behavior text; concise prefixes such as
+`excludes_cancelled` for `excludes cancelled orders` are valid. Scenario filenames omit the
+redundant prefix and use `<subject>__<behavior>.sql`:
+
+```text
+tests/unit/staging/test_stg_orders__excludes_cancelled.sql
+tests/scenarios/daily_revenue__multiple_orders.sql
+```
+
+Mirroring uses compiled relationships:
+
+- A single-model test mirrors the model parent below its compiler-owned model root.
+- A multi-model test mirrors the nearest common model-domain parent.
+- Models with no meaningful common parent use the configured pipeline directory.
+- Macro, UDF, and table-function tests mirror all resolved direct resource owners.
+- When ownership cannot be proven from compiler facts, Kata skips mirroring rather than guessing.
+
+The pipeline directory is relative to `tests/unit/`, normalized, and included in cache and generated
+guidance identity. The default is `pipelines`:
+
+```toml
+[kata.sql_tests]
+pipeline_directory = "chains/commerce"
+```
+
+This maps cross-domain tests to `tests/unit/chains/commerce/`. Absolute paths, traversal, repeated
+separators, and backslash paths are invalid configuration.
+
 ### Naming policy
 
 Naming and layer rules can use a closed project vocabulary:
@@ -11008,6 +11072,18 @@ models/mart/orders.sql:1:1 [SQBKS001] model SQL must keep transformation logic i
 Found 1 kata faults
 ```
 
+Project-phase SQL test policy also reports the authored test or scenario path. A finding can name
+the compiler-resolved target and exact destination:
+
+```text
+tests/unit/test_stg_orders.sql:1:1 [SQBKT003] unit test block 1 resolves to resources mirrored by tests/unit/staging/
+  Remediation: Move this test file beneath tests/unit/staging/.
+Found 1 kata faults
+```
+
+`SQBKT` rules run once per project, including projects with direct-resource tests but no models.
+Path-scoped exceptions and ignores match the reported test or scenario path.
+
 ### JSON output
 
 ```bash
@@ -11057,10 +11133,17 @@ Remediation: Move each __ref(...) or __source(...) into one named top-level impo
 
 Custom rules also show their source and declared option defaults.
 
+Inspecting an `SQBKT` rule also prints the effective canonical roots and configured cross-domain
+pipeline directory:
+
+```bash
+sqb kata rule SQBKT003
+```
+
 ### Generate policy skills
 
-Generate agent guidance from the active rules, options, thresholds, naming vocabulary, and scoped
-deviations:
+Generate agent guidance from the active rules, options, thresholds, naming vocabulary, SQL test
+paths, and scoped deviations:
 
 ```bash
 sqb kata skills

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -43,6 +42,7 @@ from sqlbuild.compiler.compile._helpers.render.macros import (
     find_macro_call_names,
 )
 from sqlbuild.compiler.compile._helpers.render.templating import expand_template_data
+from sqlbuild.compiler.compile._helpers.sql_tests.core import extract_assertion_target_model_names
 from sqlbuild.compiler.compile.constants import NOT_NULL_AUDIT_NAME, PRESERVE_TARGET_VALUE
 from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.main._scope_index_with_compile_usages import (
@@ -66,6 +66,7 @@ from sqlbuild.compiler.compile.models import (
     CompiledSource,
     CompiledSqlScenario,
     CompiledSqlTest,
+    CompiledSqlTestResource,
     CompileModelInput,
     CompileModelSqlTestInputPayload,
     CompileProjectInputs,
@@ -73,7 +74,6 @@ from sqlbuild.compiler.compile.models import (
     CompileSourceInput,
     CompileSqlFunctionInput,
     CompileSqlScenarioInput,
-    CompileSqlTestCte,
     CompileSqlTestInput,
     InferredColumn,
     MacroContext,
@@ -960,8 +960,8 @@ def _assemble_compiled_sql_test(
         )
     else:
         model_payload: CompileModelSqlTestInputPayload = test_input.payload
-        assertion_target_model_names: tuple[str, ...] = _extract_sql_test_assertion_ref_targets(
-            assertion_ctes=model_payload.assertion_ctes
+        assertion_target_model_names: tuple[str, ...] = extract_assertion_target_model_names(
+            assertion_sql=tuple(cte.sql_body for cte in model_payload.assertion_ctes)
         )
         scope_deps = sql_test_scope_deps(
             expected_model_names=tuple(
@@ -993,6 +993,42 @@ def _assemble_compiled_sql_test(
         sql_body=test_input.sql_body,
         mode=test_input.mode,
         payload=compiled_payload,
+        source_path=test_input.test_file.relative_path,
+        ownership_root=test_input.test_file.ownership_root,
+        block_index=test_input.test_block.test_index,
+        explicit_name=test_input.test_block.name,
+        expected_model_names=(
+            test_input.payload.expected_model_names
+            if isinstance(test_input.payload, CompileModelSqlTestInputPayload)
+            else ()
+        ),
+        assertion_names=(
+            test_input.payload.assertion_names
+            if isinstance(test_input.payload, CompileModelSqlTestInputPayload)
+            else ()
+        ),
+        assertion_target_model_names=(
+            assertion_target_model_names
+            if isinstance(test_input.payload, CompileModelSqlTestInputPayload)
+            else ()
+        ),
+        target_model_names=(
+            tuple(
+                dict.fromkeys(
+                    (*test_input.payload.expected_model_names, *assertion_target_model_names)
+                )
+            )
+            if isinstance(test_input.payload, CompileModelSqlTestInputPayload)
+            else ()
+        ),
+        tested_resources=(
+            tuple(
+                CompiledSqlTestResource(kind=test_input.payload.mode, name=name)
+                for name in test_input.payload.tested_resource_names
+            )
+            if isinstance(test_input.payload, CompileDirectLogicSqlTestInputPayload)
+            else ()
+        ),
     )
 
 
@@ -1047,18 +1083,6 @@ def _function_sql_test_scope_deps(
         CompiledObjectKey(resource_type=CompiledResourceType.TABLE_FN, name=function_name)
         for function_name in tested_function_names
     )
-
-
-def _extract_sql_test_assertion_ref_targets(
-    *, assertion_ctes: tuple[CompileSqlTestCte, ...]
-) -> tuple[str, ...]:
-    targets: list[str] = []
-    cte: CompileSqlTestCte
-    for cte in assertion_ctes:
-        match: re.Match[str]
-        for match in re.finditer(r'__ref\("([^"]+)"\)', cte.sql_body):
-            targets.append(match.group(1))
-    return tuple(dict.fromkeys(targets))
 
 
 def _build_test_model_query_overrides(
@@ -1129,6 +1153,10 @@ def _assemble_compiled_sql_scenario(
         dbt_ref_fixture_names=scenario_input.dbt_ref_fixture_names,
         expected_model_names=scenario_input.expected_model_names,
         assertion_names=scenario_input.assertion_names,
+        assertion_target_model_names=scenario_input.assertion_target_model_names,
+        target_model_names=scenario_input.target_model_names,
+        source_path=scenario_input.scenario_file.relative_path,
+        ownership_root=scenario_input.scenario_file.ownership_root,
     )
 
 

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
@@ -26,7 +26,10 @@ from sqlbuild.compiler.compile._helpers.render.sql_vars import (
     expand_authored_sql_result,
 )
 from sqlbuild.compiler.compile._helpers.scenarios.core import extract_sql_scenario_ctes
-from sqlbuild.compiler.compile._helpers.sql_tests.core import extract_sql_test_ctes
+from sqlbuild.compiler.compile._helpers.sql_tests.core import (
+    extract_assertion_target_model_names,
+    extract_sql_test_ctes,
+)
 from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.models import (
     AuthoredSqlExpansionResult,
@@ -39,7 +42,6 @@ from sqlbuild.compiler.compile.models import (
     CompileSqlScenarioCte,
     CompileSqlScenarioCtes,
     CompileSqlScenarioInput,
-    CompileSqlTestCte,
     CompileSqlTestCtes,
     CompileSqlTestInput,
     DeclarationExpansionContext,
@@ -432,6 +434,9 @@ def build_scenario_inputs(
             scenario_file=scenario_file,
             known_source_names=known_source_names,
         )
+        assertion_target_model_names: tuple[str, ...] = extract_assertion_target_model_names(
+            assertion_sql=tuple(cte.sql_body for cte in scenario_ctes.assertion_ctes)
+        )
         scenario_inputs.append(
             CompileSqlScenarioInput(
                 scenario_file=scenario_file,
@@ -445,6 +450,12 @@ def build_scenario_inputs(
                 dbt_ref_fixture_names=scenario_ctes.dbt_ref_fixture_names,
                 expected_model_names=scenario_ctes.expected_model_names,
                 assertion_names=scenario_ctes.assertion_names,
+                assertion_target_model_names=assertion_target_model_names,
+                target_model_names=tuple(
+                    dict.fromkeys(
+                        (*scenario_ctes.expected_model_names, *assertion_target_model_names)
+                    )
+                ),
                 declaration_usages=expansion.usages,
             )
         )
@@ -533,23 +544,11 @@ def validate_test_ctes(
             )
 
     assertion_target_name: str
-    for assertion_target_name in _extract_sql_test_assertion_ref_targets(
-        assertion_ctes=model_payload.assertion_ctes
+    for assertion_target_name in extract_assertion_target_model_names(
+        assertion_sql=tuple(cte.sql_body for cte in model_payload.assertion_ctes)
     ):
         if assertion_target_name not in known_model_names:
             raise CompileInputError(
                 f"SQL test file {test_file.relative_path} assertion references unknown model "
                 f"'{assertion_target_name}'"
             )
-
-
-def _extract_sql_test_assertion_ref_targets(
-    *, assertion_ctes: tuple[CompileSqlTestCte, ...]
-) -> tuple[str, ...]:
-    targets: list[str] = []
-    cte: CompileSqlTestCte
-    for cte in assertion_ctes:
-        match: re.Match[str]
-        for match in re.finditer(r'__ref\("([^"]+)"\)', cte.sql_body):
-            targets.append(match.group(1))
-    return tuple(dict.fromkeys(targets))

--- a/src/sqlbuild/compiler/compile/_helpers/sql_tests/core.py
+++ b/src/sqlbuild/compiler/compile/_helpers/sql_tests/core.py
@@ -108,6 +108,19 @@ def extract_sql_test_expected_model_names(
     )
 
 
+def extract_assertion_target_model_names(*, assertion_sql: tuple[str, ...]) -> tuple[str, ...]:
+    """Extract assertion model targets in authored order using canonical references."""
+
+    targets: list[str] = []
+    for sql in assertion_sql:
+        targets.extend(
+            reference.ref_name
+            for reference in extract_sql_references(sql)
+            if reference.ref_kind == SqlReferenceKind.REF
+        )
+    return tuple(dict.fromkeys(targets))
+
+
 def _extract_sql_test_ctes_with_scanner(
     *, sql: str, file_label: str
 ) -> tuple[CompileSqlTestCte, ...]:

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -538,6 +538,8 @@ class CompileSqlScenarioInput:
     dbt_ref_fixture_names: tuple[str, ...] = field(default_factory=tuple)
     expected_model_names: tuple[str, ...] = field(default_factory=tuple)
     assertion_names: tuple[str, ...] = field(default_factory=tuple)
+    assertion_target_model_names: tuple[str, ...] = field(default_factory=tuple)
+    target_model_names: tuple[str, ...] = field(default_factory=tuple)
     declaration_usages: tuple[UsageRecord, ...] = field(default_factory=tuple)
 
 
@@ -715,6 +717,26 @@ class CompiledSqlScenario:
     dbt_ref_fixture_names: tuple[str, ...] = field(default_factory=tuple)
     expected_model_names: tuple[str, ...] = field(default_factory=tuple)
     assertion_names: tuple[str, ...] = field(default_factory=tuple)
+    assertion_target_model_names: tuple[str, ...] = field(default_factory=tuple)
+    target_model_names: tuple[str, ...] = field(default_factory=tuple)
+    source_path: Path | None = None
+    ownership_root: Path | None = None
+
+    def __post_init__(self) -> None:
+        if self.source_path is None:
+            object.__setattr__(self, "source_path", self.scenario_file.relative_path)
+        if self.ownership_root is None:
+            object.__setattr__(self, "ownership_root", self.scenario_file.ownership_root)
+        if not self.target_model_names:
+            object.__setattr__(
+                self,
+                "target_model_names",
+                tuple(
+                    dict.fromkeys(
+                        (*self.expected_model_names, *self.assertion_target_model_names)
+                    )
+                ),
+            )
 
 
 @dataclass(frozen=True)
@@ -890,6 +912,14 @@ class CompiledDirectLogicSqlTestPayload:
 
 
 @dataclass(frozen=True)
+class CompiledSqlTestResource:
+    """One direct SQL test resource with its authored resource kind."""
+
+    kind: SqlTestMode
+    name: str
+
+
+@dataclass(frozen=True)
 class CompiledSqlTest:
     """Compiled SQL-native unit test metadata selected by expected targets."""
 
@@ -903,3 +933,22 @@ class CompiledSqlTest:
     payload: CompiledModelSqlTestPayload | CompiledDirectLogicSqlTestPayload = field(
         default_factory=CompiledModelSqlTestPayload
     )
+    source_path: Path | None = None
+    ownership_root: Path | None = None
+    block_index: int | None = None
+    explicit_name: str | None = None
+    expected_model_names: tuple[str, ...] = field(default_factory=tuple)
+    assertion_names: tuple[str, ...] = field(default_factory=tuple)
+    assertion_target_model_names: tuple[str, ...] = field(default_factory=tuple)
+    target_model_names: tuple[str, ...] = field(default_factory=tuple)
+    tested_resources: tuple[CompiledSqlTestResource, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.source_path is None:
+            object.__setattr__(self, "source_path", self.test_file.relative_path)
+        if self.ownership_root is None:
+            object.__setattr__(self, "ownership_root", self.test_file.ownership_root)
+        if self.block_index is None:
+            object.__setattr__(self, "block_index", self.test_block.test_index)
+        if self.explicit_name is None and self.test_block.name is not None:
+            object.__setattr__(self, "explicit_name", self.test_block.name)

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -732,9 +732,7 @@ class CompiledSqlScenario:
                 self,
                 "target_model_names",
                 tuple(
-                    dict.fromkeys(
-                        (*self.expected_model_names, *self.assertion_target_model_names)
-                    )
+                    dict.fromkeys((*self.expected_model_names, *self.assertion_target_model_names))
                 ),
             )
 

--- a/src/sqlbuild/compiler/discovery/_helpers/filesystem/core.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/filesystem/core.py
@@ -43,6 +43,7 @@ from sqlbuild.compiler.discovery.constants import (
     PYTHON_NODE_KIND_VOWELS,
     SCHEMA_FILE_NAME,
     SEED_FILE_SUFFIX,
+    SQL_TESTS_OWNERSHIP_ROOT,
     YAML_FILE_SUFFIXES,
 )
 from sqlbuild.compiler.discovery.exceptions import (
@@ -646,6 +647,7 @@ def discover_test_files(
                 relative_path=file_path.relative_to(project_dir),
                 contents=contents,
                 blocks=blocks,
+                ownership_root=Path(SQL_TESTS_OWNERSHIP_ROOT),
             )
         )
     return tuple(discovered_test_files)

--- a/src/sqlbuild/compiler/discovery/_helpers/sql/scenarios.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/sql/scenarios.py
@@ -7,6 +7,7 @@ from inspect import cleandoc
 from pathlib import Path
 
 from sqlbuild.compiler.discovery._helpers.sql.model_files import parse_header_values
+from sqlbuild.compiler.discovery.constants import SQL_SCENARIOS_OWNERSHIP_ROOT
 from sqlbuild.compiler.discovery.exceptions import SqlScenarioParseError
 from sqlbuild.compiler.discovery.models import DiscoveredSqlScenarioFile
 
@@ -47,6 +48,7 @@ def parse_sql_scenario_file(
         header_values=header_values,
         sql_body=sql_body,
         name=file_path.stem,
+        ownership_root=Path(SQL_SCENARIOS_OWNERSHIP_ROOT),
     )
 
 

--- a/src/sqlbuild/compiler/discovery/constants.py
+++ b/src/sqlbuild/compiler/discovery/constants.py
@@ -44,6 +44,8 @@ MODELS_DIRECTORY_NAME: str = "models"
 MODEL_SCHEMAS_DIRECTORY_NAME: str = "schemas"
 SEEDS_DIRECTORY_NAME: str = "seeds"
 CURRENT_DIRECTORY_PATH: str = "."
+SQL_TESTS_OWNERSHIP_ROOT: str = "tests/unit"
+SQL_SCENARIOS_OWNERSHIP_ROOT: str = "tests/scenarios"
 
 CANONICAL_AUTHORED_ROOTS: tuple[tuple[str, ...], ...] = (
     ("models",),

--- a/src/sqlbuild/compiler/discovery/models.py
+++ b/src/sqlbuild/compiler/discovery/models.py
@@ -8,6 +8,10 @@ from pathlib import Path
 
 from sqlbuild.compiler.compile.constants import DEFAULT_SQL_TEST_MODE
 from sqlbuild.compiler.compile.types import SqlTestMode
+from sqlbuild.compiler.discovery.constants import (
+    SQL_SCENARIOS_OWNERSHIP_ROOT,
+    SQL_TESTS_OWNERSHIP_ROOT,
+)
 from sqlbuild.compiler.discovery.types import LoaderConnectionMode
 from sqlbuild.compiler.scopes.types import ScopeKind
 from sqlbuild.providers import Provider
@@ -245,6 +249,7 @@ class DiscoveredSqlTestFile:
     relative_path: Path
     contents: str
     blocks: tuple[DiscoveredSqlTestBlock, ...]
+    ownership_root: Path = Path(SQL_TESTS_OWNERSHIP_ROOT)
 
 
 @dataclass(frozen=True)
@@ -268,6 +273,7 @@ class DiscoveredSqlScenarioFile:
     header_values: dict[str, object]
     sql_body: str
     name: str
+    ownership_root: Path = Path(SQL_SCENARIOS_OWNERSHIP_ROOT)
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/planner/_helpers/scenario/graph.py
+++ b/src/sqlbuild/compiler/planner/_helpers/scenario/graph.py
@@ -2,35 +2,18 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
-from typing import Any
 
 from sqlbuild.compiler.compile.models import (
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,
     CompiledSqlScenario,
-    CompileSqlScenarioCte,
 )
 from sqlbuild.compiler.compile.types import CompiledResourceType
-from sqlbuild.compiler.planner.constants import (
-    SCENARIO_PLAN_GRAPH_VALIDATION,
-    SCENARIO_PLAN_SQLGLOT_PARSE,
-    SCENARIO_PLAN_SQLGLOT_UNAVAILABLE,
-)
+from sqlbuild.compiler.planner.constants import SCENARIO_PLAN_GRAPH_VALIDATION
 from sqlbuild.compiler.planner.models import PlanWarning, ScenarioGraphPlan
 from sqlbuild.compiler.planner.types import WarningSeverity
-from sqlbuild.compiler.references.main.reference_call_prefix_pattern_text import (
-    reference_call_prefix_pattern_text,
-)
-from sqlbuild.compiler.references.types import SqlReferenceKind
-from sqlbuild.compiler.sql_analysis.main.import_polyglot_sql import import_polyglot_sql
-
-_REF_PATTERN: re.Pattern[str] = re.compile(
-    rf"{reference_call_prefix_pattern_text(SqlReferenceKind.REF)}\s*"
-    r"[\"']?(?P<name>[A-Za-z_][A-Za-z0-9_.]*)[\"']?\s*\)"
-)
 
 
 @dataclass(frozen=True)
@@ -58,18 +41,11 @@ def plan_scenario_graph(
     model_map: dict[str, CompiledModel] = {model.name: model for model in project.models}
     source_names: frozenset[str] = frozenset(source.name for source in project.sources)
     seed_names: frozenset[str] = frozenset(seed.name for seed in project.seeds)
-    assertion_target_names, assertion_warnings = _extract_assertion_target_names(
-        assertion_ctes=scenario.assertion_ctes,
-        scenario_name=scenario.name,
-        sql_analysis_enabled=sql_analysis_enabled,
-        sql_analysis_dialect=sql_analysis_dialect,
-    )
-    target_model_names: tuple[str, ...] = _dedupe_names(
-        (*scenario.expected_model_names, *assertion_target_names)
-    )
+    del sql_analysis_enabled, sql_analysis_dialect
+    assertion_target_names: tuple[str, ...] = scenario.assertion_target_model_names
+    target_model_names: tuple[str, ...] = scenario.target_model_names
 
     warnings: list[PlanWarning] = []
-    warnings.extend(assertion_warnings)
     warnings.extend(
         _declared_name_warnings(
             scenario=scenario,
@@ -145,77 +121,6 @@ def plan_scenario_graph(
         function_deps=tuple(function_deps),
     )
     return plan, tuple(warnings)
-
-
-def _extract_assertion_target_names(
-    *,
-    assertion_ctes: tuple[CompileSqlScenarioCte, ...],
-    scenario_name: str,
-    sql_analysis_enabled: bool,
-    sql_analysis_dialect: str | None,
-) -> tuple[tuple[str, ...], tuple[PlanWarning, ...]]:
-    names: list[str] = []
-    warnings: list[PlanWarning] = []
-    cte: CompileSqlScenarioCte
-    for cte in assertion_ctes:
-        if sql_analysis_enabled:
-            try:
-                names.extend(
-                    _extract_assertion_target_names_with_sql_analysis(
-                        sql=cte.sql_body,
-                        sql_analysis_dialect=sql_analysis_dialect,
-                    )
-                )
-            except ValueError as error:
-                warnings.append(
-                    _error(
-                        message=(
-                            f"Scenario '{scenario_name}' assertion CTE '{cte.name}' could not be "
-                            f"parsed with Polyglot: {error}"
-                        ),
-                        code=str(getattr(error, "code", SCENARIO_PLAN_SQLGLOT_PARSE)),
-                    )
-                )
-            continue
-        match: re.Match[str]
-        for match in _REF_PATTERN.finditer(cte.sql_body):
-            names.append(match.group("name"))
-    return _dedupe_names(tuple(names)), tuple(warnings)
-
-
-def _extract_assertion_target_names_with_sql_analysis(
-    *, sql: str, sql_analysis_dialect: str | None
-) -> tuple[str, ...]:
-    polyglot_module: Any | None = import_polyglot_sql()
-    if polyglot_module is None:
-        error: ValueError = ValueError("Polyglot is enabled but unavailable")
-        object.__setattr__(error, "code", SCENARIO_PLAN_SQLGLOT_UNAVAILABLE)
-        raise error
-    try:
-        parsed: Any = (
-            polyglot_module.parse_one(sql, dialect=sql_analysis_dialect)
-            if sql_analysis_dialect is not None
-            else polyglot_module.parse_one(sql, dialect="generic")
-        )
-    except Exception as error:
-        value_error: ValueError = ValueError(str(error))
-        object.__setattr__(value_error, "code", SCENARIO_PLAN_SQLGLOT_PARSE)
-        raise value_error from None
-
-    names: list[str] = []
-    function: Any
-    for function in parsed.find_all(polyglot_module.Function):
-        function_name: str = str(function.name).lower()
-        if function_name != SqlReferenceKind.REF.function_name:
-            continue
-        expressions: list[Any] = list(function.expressions)
-        if len(expressions) != 1:
-            continue
-        argument: Any = expressions[0]
-        if not hasattr(argument, "name"):
-            continue
-        names.append(str(argument.name))
-    return tuple(names)
 
 
 def _declared_name_warnings(

--- a/src/sqlbuild/kata_engine/_helpers/engine/config.py
+++ b/src/sqlbuild/kata_engine/_helpers/engine/config.py
@@ -12,6 +12,7 @@ from sqlbuild.kata_engine.models import (
     RuleExemption,
     RuleIgnore,
     SelectStarAllow,
+    SqlTestPolicyConfig,
     ThresholdOverride,
 )
 from sqlbuild.kata_engine.types import RuleOptionValue
@@ -59,6 +60,7 @@ def load_kata_config(project_dir: Path) -> KataConfig:
         retired_source_tokens=_string_mapping(payload.get("retired_source_tokens")),
         cte_name_whitelist=_strings(payload.get("cte_name_whitelist")),
         cte_name_denylist=_strings(payload.get("cte_name_denylist")),
+        sql_tests=_sql_tests(payload.get("sql_tests")),
         cache=_cache(payload.get("cache")),
     )
 
@@ -113,4 +115,13 @@ def _cache(value: object) -> KataCacheConfig:
     return KataCacheConfig(
         enabled=bool(table.get("enabled", True)),
         require_cacheable=bool(table.get("require_cacheable", False)),
+    )
+
+
+def _sql_tests(value: object) -> SqlTestPolicyConfig:
+    table: dict[str, object] = (
+        {str(key): item for key, item in value.items()} if isinstance(value, dict) else {}
+    )
+    return SqlTestPolicyConfig(
+        pipeline_directory=str(table.get("pipeline_directory", "pipelines"))
     )

--- a/src/sqlbuild/kata_engine/_helpers/engine/config.py
+++ b/src/sqlbuild/kata_engine/_helpers/engine/config.py
@@ -122,6 +122,4 @@ def _sql_tests(value: object) -> SqlTestPolicyConfig:
     table: dict[str, object] = (
         {str(key): item for key, item in value.items()} if isinstance(value, dict) else {}
     )
-    return SqlTestPolicyConfig(
-        pipeline_directory=str(table.get("pipeline_directory", "pipelines"))
-    )
+    return SqlTestPolicyConfig(pipeline_directory=str(table.get("pipeline_directory", "pipelines")))

--- a/src/sqlbuild/kata_engine/_helpers/engine/native.py
+++ b/src/sqlbuild/kata_engine/_helpers/engine/native.py
@@ -13,8 +13,13 @@ from pathlib import Path
 from typing import Any, cast
 
 import sqlbuild._kata_native as _kata_native
-from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject
-from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.compile.models import (
+    CompiledModel,
+    CompiledProject,
+    CompiledSqlScenario,
+    CompiledSqlTest,
+)
+from sqlbuild.compiler.compile.types import SqlTestMode
 from sqlbuild.compiler.discovery.models import ConstantDeclaration, EnumDeclaration
 from sqlbuild.compiler.scopes.main.scope_metadata import scope_metadata_projection
 from sqlbuild.kata_engine._helpers.engine.custom_rule_evidence import (
@@ -50,6 +55,8 @@ def evaluate_native(
         "project_dir": str(project_dir.resolve()),
         "config": _config_payload(config),
         "models": _model_payloads(project),
+        "sql_tests": _sql_test_payloads(project),
+        "sql_scenarios": _sql_scenario_payloads(project),
         "public_enums": [
             _enum_payload(declaration) for declaration in project.public_enums.values()
         ],
@@ -188,12 +195,9 @@ def _model_payloads(project: CompiledProject) -> list[dict[str, object]]:
             )
     test_counts: dict[str, int] = {}
     for test in project.sql_tests:
-        names: frozenset[str] = frozenset(
-            dependency.name
-            for dependency in test.scope_deps
-            if dependency.resource_type == CompiledResourceType.MODEL
-        )
-        for name in names:
+        if test.mode is not SqlTestMode.MODEL:
+            continue
+        for name in test.target_model_names:
             test_counts[name] = test_counts.get(name, 0) + 1
     return [
         _model_payload(
@@ -203,6 +207,49 @@ def _model_payloads(project: CompiledProject) -> list[dict[str, object]]:
         )
         for model in project.models
     ]
+
+
+def _sql_test_payloads(project: CompiledProject) -> list[dict[str, object]]:
+    return [_sql_test_payload(test) for test in project.sql_tests]
+
+
+def _sql_test_payload(test: CompiledSqlTest) -> dict[str, object]:
+    return {
+        "source_path": (test.source_path or test.test_file.relative_path).as_posix(),
+        "ownership_root": (test.ownership_root or test.test_file.ownership_root).as_posix(),
+        "block_index": test.block_index or test.test_block.test_index,
+        "name": test.name,
+        "explicit_name": test.explicit_name,
+        "mode": test.mode.value,
+        "expected_model_names": list(test.expected_model_names),
+        "assertion_names": list(test.assertion_names),
+        "assertion_target_model_names": list(test.assertion_target_model_names),
+        "target_model_names": list(test.target_model_names),
+        "tested_resources": [
+            {"kind": resource.kind.value, "name": resource.name}
+            for resource in test.tested_resources
+        ],
+    }
+
+
+def _sql_scenario_payloads(project: CompiledProject) -> list[dict[str, object]]:
+    return [_sql_scenario_payload(scenario) for scenario in project.sql_scenarios]
+
+
+def _sql_scenario_payload(scenario: CompiledSqlScenario) -> dict[str, object]:
+    description: object | None = scenario.scenario_file.header_values.get("description")
+    return {
+        "source_path": (scenario.source_path or scenario.scenario_file.relative_path).as_posix(),
+        "ownership_root": (
+            scenario.ownership_root or scenario.scenario_file.ownership_root
+        ).as_posix(),
+        "name": scenario.name,
+        "description": description if isinstance(description, str) else None,
+        "expected_model_names": list(scenario.expected_model_names),
+        "assertion_names": list(scenario.assertion_names),
+        "assertion_target_model_names": list(scenario.assertion_target_model_names),
+        "target_model_names": list(scenario.target_model_names),
+    }
 
 
 def _model_payload(

--- a/src/sqlbuild/kata_engine/_helpers/engine/ruleset.py
+++ b/src/sqlbuild/kata_engine/_helpers/engine/ruleset.py
@@ -78,6 +78,7 @@ def resolve_ruleset(*, config: KataConfig, project_dir: Path) -> ResolvedRuleset
         "retired_source_tokens": config.retired_source_tokens,
         "cte_name_whitelist": config.cte_name_whitelist,
         "cte_name_denylist": config.cte_name_denylist,
+        "sql_tests": config.sql_tests,
         "exceptions": config.rule_exceptions,
         "ignores": config.rule_ignores,
     }

--- a/src/sqlbuild/kata_engine/_helpers/guidance/presentation.py
+++ b/src/sqlbuild/kata_engine/_helpers/guidance/presentation.py
@@ -66,4 +66,14 @@ def format_rule_text(*, rule: KataRule, config: KataConfig | None = None) -> str
             lines.append(f"- {option.name}: default={option.default!r} ({option.description})")
     if config is not None and rule.code.startswith("SQBKX"):
         lines.extend(("", "Effective thresholds:", *format_threshold_lines(config=config)))
+    if config is not None and rule.code.startswith("SQBKT"):
+        lines.extend(
+            (
+                "",
+                "Effective SQL test paths:",
+                "- Unit tests: tests/unit/",
+                "- Scenarios: tests/scenarios/",
+                f"- Cross-domain pipelines: tests/unit/{config.sql_tests.pipeline_directory}/",
+            )
+        )
     return "\n".join(lines)

--- a/src/sqlbuild/kata_engine/_helpers/guidance/skills.py
+++ b/src/sqlbuild/kata_engine/_helpers/guidance/skills.py
@@ -62,6 +62,13 @@ def render_skills(*, config: KataConfig, project_dir: Path) -> tuple[str, str]:
     if any(rule.code.startswith("SQBKX") for rule in rules):
         body.extend(("", "## Effective Thresholds", ""))
         body.extend(format_threshold_lines(config=config))
+    if any(rule.code.startswith("SQBKT") for rule in rules):
+        body.extend(("", "## SQL Test Paths", ""))
+        body.append("- Unit tests: `tests/unit/`")
+        body.append("- Scenarios: `tests/scenarios/`")
+        body.append(
+            f"- Cross-domain pipelines: `tests/unit/{config.sql_tests.pipeline_directory}/`"
+        )
     if config.domains or config.approved_source_tokens or config.retired_source_tokens:
         body.extend(("", "## Naming Vocabulary", ""))
         body.append(f"- Domains: `{', '.join(config.domains)}`")
@@ -82,6 +89,11 @@ def _rule_example(*, rule: KataRule) -> str:
         "SQBKL001": "stg -> int_clean -> int_enriched -> mart; skipping layers is valid.",
         "SQBKR001": "domain__int_clean__entity or domain__mart_v__entity.",
         "SQBKR401": "MODEL (contract enforced, columns (...)); declare authoritative columns.",
+        "SQBKT001": "Keep unit tests in tests/unit/ and scenarios in tests/scenarios/.",
+        "SQBKT002": "test_stg_orders__excludes_cancelled.sql and daily_revenue__minimal.sql.",
+        "SQBKT003": "models/staging/stg_orders.sql maps to tests/unit/staging/.",
+        "SQBKT004": 'TEST (name "stg_orders: excludes cancelled orders");',
+        "SQBKT101": 'SCENARIO (description "Daily revenue includes successful payments");',
         "SQBKX001": "Attach not_null/unique audits to the model key.",
     }
     if rule.guidance is not None:

--- a/src/sqlbuild/kata_engine/models.py
+++ b/src/sqlbuild/kata_engine/models.py
@@ -172,6 +172,11 @@ class KataCacheConfig:
 
 
 @dataclass(frozen=True)
+class SqlTestPolicyConfig:
+    pipeline_directory: str = "pipelines"
+
+
+@dataclass(frozen=True)
 class KataConfig:
     select: tuple[str, ...] = ()
     ignore: tuple[str, ...] = ()
@@ -188,6 +193,7 @@ class KataConfig:
     retired_source_tokens: dict[str, str] = field(default_factory=dict)
     cte_name_whitelist: tuple[str, ...] = ()
     cte_name_denylist: tuple[str, ...] = ()
+    sql_tests: SqlTestPolicyConfig = field(default_factory=SqlTestPolicyConfig)
     cache: KataCacheConfig = field(default_factory=KataCacheConfig)
 
 

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/helpers.py
@@ -11,6 +11,9 @@ from types import MappingProxyType
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.models import RelationInfo
+from sqlbuild.compiler.compile._helpers.sql_tests.core import (
+    extract_assertion_target_model_names,
+)
 from sqlbuild.compiler.compile.models import (
     CompiledAudit,
     CompiledDirectLogicSqlTestPayload,
@@ -605,6 +608,9 @@ def build_scenario_from_test_case(
         CompileSqlScenarioCte(name=f"__expected__{model_name}", sql_body="SELECT 1")
         for model_name in test_case.expected_model_names
     )
+    assertion_target_model_names: tuple[str, ...] = extract_assertion_target_model_names(
+        assertion_sql=test_case.assertion_sql_bodies
+    )
     return CompiledSqlScenario(
         key=scenario_key,
         name="revenue__customer_refund",
@@ -625,6 +631,10 @@ def build_scenario_from_test_case(
         dbt_ref_fixture_names=test_case.dbt_ref_fixture_names,
         expected_model_names=test_case.expected_model_names,
         assertion_names=tuple(cte.name.removeprefix("__assert__") for cte in assertion_ctes),
+        assertion_target_model_names=assertion_target_model_names,
+        target_model_names=tuple(
+            dict.fromkeys((*test_case.expected_model_names, *assertion_target_model_names))
+        ),
     )
 
 

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_scenario_graph.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_scenario_graph.py
@@ -216,14 +216,6 @@ def test_given_scenario_when_planning_graph_then_infers_expected_slice(
             expected_error_fragment="assertion references unknown model 'daily_revenue'",
         ),
         PlanScenarioGraphErrorTestCase(
-            description="polyglot assertion parse failure fails clearly without regex fallback",
-            model_deps={"daily_revenue": ()},
-            source_names=(),
-            seed_names=(),
-            assertion_sql_bodies=("SELECT * FROM __ref(daily_revenue) WHERE (",),
-            expected_error_fragment="could not be parsed with Polyglot",
-        ),
-        PlanScenarioGraphErrorTestCase(
             description="unknown ref fixture fails clearly",
             model_deps={"daily_revenue": ()},
             source_names=(),

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/_test_types.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/_test_types.py
@@ -68,3 +68,24 @@ class TypedConstantPayloadTestCase:
 class ScopePayloadTestCase:
     description: str
     expected_result: bool
+
+
+@dataclass(frozen=True)
+class NativeFactPayloadTestCase:
+    description: str
+    expected_test_count: int
+    expected_scenario_count: int
+
+
+@dataclass(frozen=True)
+class SqlTestPolicyConfigTestCase:
+    description: str
+    source: str
+    expected_pipeline_directory: str
+
+
+@dataclass(frozen=True)
+class SqlTestPolicyGuidanceTestCase:
+    description: str
+    pipeline_directory: str
+    expected_path: str

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/helpers.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/helpers.py
@@ -8,7 +8,17 @@ from typing import Any, cast
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models import (
+    CompiledDirectLogicSqlTestPayload,
+    CompiledModelSqlTestPayload,
+    CompiledObjectKey,
+    CompiledProject,
+    CompiledSqlTest,
+    CompiledSqlTestResource,
+    CompileSqlTestCte,
+)
+from sqlbuild.compiler.compile.types import CompiledResourceType, SqlTestMode
+from sqlbuild.compiler.discovery.models import DiscoveredSqlTestBlock, DiscoveredSqlTestFile
 from sqlbuild.compiler.scopes.models import ScopeIndex
 from sqlbuild.kata_engine._helpers.engine import native
 from sqlbuild.kata_engine._helpers.engine.catalogue import build_catalogue
@@ -59,6 +69,69 @@ def captured_native_request(
         catalogue=(),
     )
     return captured
+
+
+def direct_sql_test(*, mode: SqlTestMode, name: str, block_index: int) -> CompiledSqlTest:
+    test_file: DiscoveredSqlTestFile = DiscoveredSqlTestFile(
+        file_path=Path(f"/private/project/tests/unit/{name}.sql"),
+        relative_path=Path(f"tests/unit/{name}.sql"),
+        contents="secret fixture value",
+        blocks=(),
+    )
+    test_block: DiscoveredSqlTestBlock = DiscoveredSqlTestBlock(
+        test_index=block_index,
+        header_values={"name": name},
+        sql_body="SELECT 'secret fixture value'",
+        name=name,
+        mode=mode,
+    )
+    return CompiledSqlTest(
+        key=CompiledObjectKey(CompiledResourceType.SQL_TEST, name),
+        scope_deps=(CompiledObjectKey(CompiledResourceType.MODEL, "orders"),),
+        name=name,
+        test_file=test_file,
+        test_block=test_block,
+        sql_body=test_block.sql_body,
+        mode=mode,
+        payload=CompiledDirectLogicSqlTestPayload(
+            actual_cte=CompileSqlTestCte("__actual", "SELECT 1"),
+            expected_cte=CompileSqlTestCte("__expected", "SELECT 1"),
+            mode=mode,
+            tested_resource_names=(name,),
+        ),
+        tested_resources=(CompiledSqlTestResource(kind=mode, name=name),),
+    )
+
+
+def model_sql_test() -> CompiledSqlTest:
+    name: str = "orders: keeps paid orders"
+    test_file: DiscoveredSqlTestFile = DiscoveredSqlTestFile(
+        file_path=Path("/private/project/tests/unit/test_orders__keeps_paid.sql"),
+        relative_path=Path("tests/unit/test_orders__keeps_paid.sql"),
+        contents="secret model fixture",
+        blocks=(),
+    )
+    test_block: DiscoveredSqlTestBlock = DiscoveredSqlTestBlock(
+        test_index=1,
+        header_values={"name": name},
+        sql_body="SELECT 1",
+        name=name,
+        mode=SqlTestMode.MODEL,
+    )
+    return CompiledSqlTest(
+        key=CompiledObjectKey(CompiledResourceType.SQL_TEST, name),
+        scope_deps=(),
+        name=name,
+        test_file=test_file,
+        test_block=test_block,
+        sql_body=test_block.sql_body,
+        mode=SqlTestMode.MODEL,
+        payload=CompiledModelSqlTestPayload(),
+        expected_model_names=("orders",),
+        assertion_names=("paid",),
+        assertion_target_model_names=("orders",),
+        target_model_names=("orders",),
+    )
 
 
 def write_rule(

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_catalogue.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_catalogue.py
@@ -14,11 +14,13 @@ from sqlbuild.kata_engine.models import (
     KataConfig,
     KataResult,
     KataRule,
+    SqlTestPolicyConfig,
     ThresholdOverride,
 )
 from tests.unit.src.sqlbuild.kata_engine._helpers.engine._test_types import (
     KataGuidanceTestCase,
     KataSelectionTestCase,
+    SqlTestPolicyGuidanceTestCase,
 )
 from tests.unit.src.sqlbuild.kata_engine.main.evaluate.helpers import build_project
 
@@ -50,6 +52,11 @@ BUILT_IN_CODES: tuple[str, ...] = (
     "SQBKS302",
     "SQBKS401",
     "SQBKS501",
+    "SQBKT001",
+    "SQBKT002",
+    "SQBKT003",
+    "SQBKT004",
+    "SQBKT101",
     "SQBKX001",
     "SQBKX002",
     "SQBKX201",
@@ -65,6 +72,13 @@ STRUCTURE_CODES: tuple[str, ...] = (
     "SQBKS302",
     "SQBKS401",
     "SQBKS501",
+)
+SQL_TEST_CODES: tuple[str, ...] = (
+    "SQBKT001",
+    "SQBKT002",
+    "SQBKT003",
+    "SQBKT004",
+    "SQBKT101",
 )
 NON_STRUCTURE_CODES: tuple[str, ...] = (
     "SQBKH001",
@@ -84,6 +98,7 @@ NON_STRUCTURE_CODES: tuple[str, ...] = (
     "SQBKR201",
     "SQBKR301",
     "SQBKR401",
+    *SQL_TEST_CODES,
     "SQBKX001",
     "SQBKX002",
     "SQBKX201",
@@ -112,6 +127,12 @@ NON_STRUCTURE_CODES: tuple[str, ...] = (
             expected_codes=("SQBKS001",),
         ),
         KataSelectionTestCase(
+            description="SQL test family activates every SQL test policy rule",
+            select=("SQBKT",),
+            ignore=(),
+            expected_codes=SQL_TEST_CODES,
+        ),
+        KataSelectionTestCase(
             description="empty selection activates no rules",
             select=(),
             ignore=(),
@@ -138,6 +159,36 @@ def test_given_rule_selectors_when_resolving_then_returns_expected_codes(
     )
 
     assert tuple(rule.code for rule in selected) == test_case.expected_codes
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SqlTestPolicyGuidanceTestCase(
+            description="nested pipeline directory",
+            pipeline_directory="chains/commerce",
+            expected_path="tests/unit/chains/commerce/",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_sql_test_policy_when_inspecting_and_rendering_skills_then_effective_paths_match(
+    tmp_path: Path,
+    test_case: SqlTestPolicyGuidanceTestCase,
+) -> None:
+    config: KataConfig = KataConfig(
+        select=("SQBKT",),
+        sql_tests=SqlTestPolicyConfig(pipeline_directory=test_case.pipeline_directory),
+    )
+    catalogue: tuple[KataRule, ...] = build_catalogue(config=config, project_dir=tmp_path)
+    rules_by_code: dict[str, KataRule] = {item.code: item for item in catalogue}
+    rule: KataRule = rules_by_code["SQBKT003"]
+
+    inspection: str = format_rule(rule=rule, config=config)
+    skill, _ = render_skills(config=config, project_dir=tmp_path)
+
+    assert test_case.expected_path in inspection
+    assert test_case.expected_path in skill
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_config.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_config.py
@@ -6,8 +6,10 @@ import pytest
 
 from sqlbuild.kata_engine.exceptions import KataError
 from sqlbuild.kata_engine.main.load_config import load_kata_config
+from sqlbuild.kata_engine.models import KataConfig, SqlTestPolicyConfig
 from tests.unit.src.sqlbuild.kata_engine._helpers.engine._test_types import (
     KataConfigErrorTestCase,
+    SqlTestPolicyConfigTestCase,
 )
 
 
@@ -78,6 +80,26 @@ from tests.unit.src.sqlbuild.kata_engine._helpers.engine._test_types import (
             source='[kata]\nselect = ["KTS"]\n',
             expected_error_pattern="malformed kata rule selector: KTS",
         ),
+        KataConfigErrorTestCase(
+            description="absolute pipeline directory",
+            source='[kata.sql_tests]\npipeline_directory = "/pipelines"\n',
+            expected_error_pattern="must be a normalized path relative to tests/unit",
+        ),
+        KataConfigErrorTestCase(
+            description="traversing pipeline directory",
+            source='[kata.sql_tests]\npipeline_directory = "../pipelines"\n',
+            expected_error_pattern="must be a normalized path relative to tests/unit",
+        ),
+        KataConfigErrorTestCase(
+            description="unnormalized pipeline directory",
+            source='[kata.sql_tests]\npipeline_directory = "chains//commerce"\n',
+            expected_error_pattern="must be a normalized path relative to tests/unit",
+        ),
+        KataConfigErrorTestCase(
+            description="unknown SQL test policy key",
+            source='[kata.sql_tests]\npipeline_directory = "pipelines"\nroot = "tests"\n',
+            expected_error_pattern="unknown field `root`",
+        ),
     ),
     ids=lambda case: case.description,
 )
@@ -89,3 +111,29 @@ def test_given_invalid_kata_config_when_loading_then_raises_clear_error(
 
     with pytest.raises(KataError, match=test_case.expected_error_pattern):
         load_kata_config(project_dir=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SqlTestPolicyConfigTestCase(
+            description="nested pipeline directory",
+            source='[kata.sql_tests]\npipeline_directory = "chains/commerce"\n',
+            expected_pipeline_directory="chains/commerce",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_pipeline_directory_when_loading_then_returns_typed_relative_configuration(
+    tmp_path: Path,
+    test_case: SqlTestPolicyConfigTestCase,
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        test_case.source, encoding="utf-8"
+    )
+
+    config: KataConfig = load_kata_config(project_dir=tmp_path)
+
+    assert config.sql_tests == SqlTestPolicyConfig(
+        pipeline_directory=test_case.expected_pipeline_directory
+    )

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_config.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_config.py
@@ -128,9 +128,7 @@ def test_given_pipeline_directory_when_loading_then_returns_typed_relative_confi
     tmp_path: Path,
     test_case: SqlTestPolicyConfigTestCase,
 ) -> None:
-    (tmp_path / "sqlbuild_project.toml").write_text(
-        test_case.source, encoding="utf-8"
-    )
+    (tmp_path / "sqlbuild_project.toml").write_text(test_case.source, encoding="utf-8")
 
     config: KataConfig = load_kata_config(project_dir=tmp_path)
 

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_native_facts.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_native_facts.py
@@ -1,0 +1,130 @@
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sqlbuild.compiler.compile.models import (
+    CompiledObjectKey,
+    CompiledProject,
+    CompiledSqlScenario,
+    CompiledSqlTest,
+)
+from sqlbuild.compiler.compile.types import CompiledResourceType, SqlTestMode
+from sqlbuild.compiler.discovery.models import (
+    DiscoveredSqlScenarioFile,
+)
+from tests.unit.src.sqlbuild.kata_engine._helpers.engine._test_types import (
+    NativeFactPayloadTestCase,
+)
+from tests.unit.src.sqlbuild.kata_engine._helpers.engine.helpers import (
+    captured_native_request,
+    direct_sql_test,
+    model_sql_test,
+)
+from tests.unit.src.sqlbuild.kata_engine.main.evaluate.helpers import build_project
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        NativeFactPayloadTestCase(
+            description="complete deterministic safe SQL test and scenario facts",
+            expected_test_count=4,
+            expected_scenario_count=1,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_compiled_sql_facts_when_evaluating_native_then_exact_safe_rows_are_sent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    test_case: NativeFactPayloadTestCase,
+) -> None:
+    project: CompiledProject = build_project(
+        name="orders",
+        relative_path="models/orders.sql",
+        sql="SELECT 1",
+        config_values={},
+    )
+    direct_tests: tuple[CompiledSqlTest, ...] = tuple(
+        direct_sql_test(mode=mode, name=name, block_index=index)
+        for index, (mode, name) in enumerate(
+            ((SqlTestMode.MACRO, "normalize"), (SqlTestMode.UDF, "tax"), (SqlTestMode.TABLE_FN, "items")),
+            start=1,
+        )
+    )
+    sql_tests: tuple[CompiledSqlTest, ...] = (*direct_tests, model_sql_test())
+    scenario_file: DiscoveredSqlScenarioFile = DiscoveredSqlScenarioFile(
+        file_path=Path("/private/project/tests/scenarios/orders.sql"),
+        relative_path=Path("tests/scenarios/orders.sql"),
+        contents="secret scenario fixture",
+        header_values={"description": "orders remain valid", "tags": ["safe"]},
+        sql_body="SELECT 'secret scenario fixture'",
+        name="orders",
+    )
+    scenario: CompiledSqlScenario = CompiledSqlScenario(
+        key=CompiledObjectKey(CompiledResourceType.SQL_SCENARIO, "orders"),
+        name="orders",
+        scenario_file=scenario_file,
+        sql_body=scenario_file.sql_body,
+        expected_model_names=("orders",),
+        assertion_names=("positive",),
+        assertion_target_model_names=("payments",),
+        target_model_names=("orders", "payments"),
+    )
+
+    request: dict[str, Any] = captured_native_request(
+        monkeypatch=monkeypatch,
+        project=replace(project, sql_tests=sql_tests, sql_scenarios=(scenario,)),
+        project_dir=tmp_path,
+    )
+
+    assert len(request["sql_tests"]) == test_case.expected_test_count
+    assert request["sql_tests"][:3] == [
+        {
+            "source_path": f"tests/unit/{name}.sql",
+            "ownership_root": "tests/unit",
+            "block_index": index,
+            "name": name,
+            "explicit_name": name,
+            "mode": mode,
+            "expected_model_names": [],
+            "assertion_names": [],
+            "assertion_target_model_names": [],
+            "target_model_names": [],
+            "tested_resources": [{"kind": mode, "name": name}],
+        }
+        for index, (mode, name) in enumerate(
+            (("macro", "normalize"), ("udf", "tax"), ("table_fn", "items")), start=1
+        )
+    ]
+    assert request["sql_tests"][3] == {
+        "source_path": "tests/unit/test_orders__keeps_paid.sql",
+        "ownership_root": "tests/unit",
+        "block_index": 1,
+        "name": "orders: keeps paid orders",
+        "explicit_name": "orders: keeps paid orders",
+        "mode": "model",
+        "expected_model_names": ["orders"],
+        "assertion_names": ["paid"],
+        "assertion_target_model_names": ["orders"],
+        "target_model_names": ["orders"],
+        "tested_resources": [],
+    }
+    assert len(request["sql_scenarios"]) == test_case.expected_scenario_count
+    assert request["sql_scenarios"] == [
+        {
+            "source_path": "tests/scenarios/orders.sql",
+            "ownership_root": "tests/scenarios",
+            "name": "orders",
+            "description": "orders remain valid",
+            "expected_model_names": ["orders"],
+            "assertion_names": ["positive"],
+            "assertion_target_model_names": ["payments"],
+            "target_model_names": ["orders", "payments"],
+        }
+    ]
+    assert request["models"][0]["targeting_test_count"] == 1
+    assert "/private/project" not in str(request["sql_tests"] + request["sql_scenarios"])
+    assert "secret fixture value" not in str(request["sql_tests"] + request["sql_scenarios"])

--- a/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_native_facts.py
+++ b/tests/unit/src/sqlbuild/kata_engine/_helpers/engine/test_native_facts.py
@@ -50,7 +50,11 @@ def test_given_compiled_sql_facts_when_evaluating_native_then_exact_safe_rows_ar
     direct_tests: tuple[CompiledSqlTest, ...] = tuple(
         direct_sql_test(mode=mode, name=name, block_index=index)
         for index, (mode, name) in enumerate(
-            ((SqlTestMode.MACRO, "normalize"), (SqlTestMode.UDF, "tax"), (SqlTestMode.TABLE_FN, "items")),
+            (
+                (SqlTestMode.MACRO, "normalize"),
+                (SqlTestMode.UDF, "tax"),
+                (SqlTestMode.TABLE_FN, "items"),
+            ),
             start=1,
         )
     )


### PR DESCRIPTION
## Why

SQL projects need compiler-aware naming and layout policy for unit tests and scenarios without duplicating compiler validation or guessing ownership from filenames.

## Changes

- add compiler-owned structural and semantic facts for SQL unit tests and scenarios
- add independently selectable native `SQBKT001`-`SQBKT004` and `SQBKT101` project-phase rules
- add strict typed pipeline-directory configuration, semantic model/direct-resource mirroring, suppressions, cache invalidation, inspection, and generated guidance
- correct model test coverage counts to use semantic model targets rather than execution scope dependencies

## Verification

- `uv run pytest tests/unit/src/sqlbuild/compiler tests/unit/src/sqlbuild/kata_engine -n auto --dist loadfile` (`2081 passed`)
- `uv run ruff check src tests`
- `uv run ty check src tests`
- `uv run fensu check --no-cache` (`0 faults`)
- `make rust-check`
- generated SQLBuild skill byte reproducibility

Docs: chio-labs/sqlbuild-docs#13

Linear: CHI-115
