### PR TITLE
feat(tests): add typed SQL test parameterization

### DIFF
--- a/crates/sqlbuild-kata-native/src/models.rs
+++ b/crates/sqlbuild-kata-native/src/models.rs
@@ -463,12 +463,42 @@ pub(crate) struct TestedResource {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub(crate) struct SqlTestParameterFact {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub value_type: String,
+    pub nullable: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SqlTestParameterValueFact {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub value_type: String,
+    pub value: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SqlTestFact {
     pub source_path: String,
     pub ownership_root: String,
     pub block_index: u64,
     pub name: String,
     pub explicit_name: Option<String>,
+    #[serde(default)]
+    pub parent_name: Option<String>,
+    #[serde(default)]
+    pub case_name: Option<String>,
+    #[serde(default)]
+    pub case_index: Option<u64>,
+    #[serde(default)]
+    pub case_fingerprint: Option<String>,
+    #[serde(default)]
+    pub parameter_schema: Vec<SqlTestParameterFact>,
+    #[serde(default)]
+    pub parameters: Vec<SqlTestParameterValueFact>,
     pub mode: SqlTestMode,
     pub expected_model_names: Vec<String>,
     pub assertion_names: Vec<String>,

--- a/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
+++ b/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
@@ -623,6 +623,7 @@ SQLBuild, dbt, and SQLMesh are all SQL pipeline frameworks. They share common gr
 | Feature | SQLBuild | dbt | SQLMesh |
 |---------|----------|-----|---------|
 | Multi-model tests | Chain across multiple models | YAML-stub, single model | CTE-based, single model |
+| Typed parameterized unit tests | Independent named cases with adapter-rendered scalar values | No | No |
 | Macros as test helpers | Tests are SQL - macros work as reusable fixture generators | No (YAML stubs) | No |
 | E2E scenario tests | Fixture worlds with real graph execution | No | No |
 | Local E2E replay | Capture from warehouse, replay in DuckDB | No | No |
@@ -6217,6 +6218,108 @@ SELECT 1
 
 A file with a single test can omit the `name` field. Files with multiple tests require names on every block.
 
+### Repeating test logic
+
+SQLBuild supports three repetition patterns:
+
+| Pattern | Use when | Result identity |
+|---------|----------|-----------------|
+| Multiple `TEST` blocks | Cases need different SQL shapes | One result per block |
+| Macro or `VALUES` case table | One aggregate comparison is sufficient | One result for the table |
+| Native parameters and cases | Cases share a template but need independent status | One result per named case |
+
+#### Native independent cases
+
+Declare a typed schema and ordered named cases in one header:
+
+```sql
+TEST (
+  name "order status: maps source states",
+  parameters (
+    source_status string,
+    expected_status string,
+  ),
+  cases (
+    completed (source_status "completed", expected_status "completed"),
+    cancelled (source_status "cancelled", expected_status "excluded"),
+    pending (source_status "pending", expected_status "open"),
+  ),
+);
+
+WITH
+__source__raw__orders AS (
+  SELECT 1 AS id, @param("source_status") AS status
+),
+__expected__stg_orders AS (
+  SELECT 1 AS id, @param("expected_status") AS status
+)
+SELECT 1
+```
+
+The cases report independently as `order status: maps source states [completed]`, `[cancelled]`,
+and `[pending]`. Authored order controls display order. Selection remains at the parent test's
+resolved model or resource, so selecting `stg_orders` selects every case; there is no case selector.
+
+Supported scalar types are `string`, `integer`, `boolean`, `float`, and exact `decimal`. Decimal
+values are quoted, such as `tax_rate "0.2000"`, so they never pass through binary float. Boolean
+and integer remain distinct. Raw SQL and collection parameters are rejected.
+
+Nullable parameters use an expanded declaration and are valid where SQL can infer the null type:
+
+```sql
+parameters (
+  cancellation_reason (type string, nullable true),
+),
+cases (
+  completed (cancellation_reason null),
+)
+```
+
+Every case provides exactly the declared parameters, and every declaration must appear as
+`@param("name")` in the template. SQLBuild rejects missing, extra, incompatible, undeclared, and
+unused values before execution.
+
+Expansion is deterministic:
+
+```text
+parse TEST template and cases
+  -> render typed @param values with the active adapter
+  -> expand @const and @enum references
+  -> expand macros
+  -> validate SQL and compile expected models/assertions
+```
+
+Values can therefore feed macro arguments, for example
+`@order_fixture(@param("source_status"))`. Parameters work in model, macro, UDF, and table-function
+modes and preserve every expected model in multi-model tests.
+
+Text and JSON output include parent/case identity and safe typed values. Compile JSON, manifests,
+DAG checks, and compiled/runtime SQL artifacts retain source, block, case, and content-fingerprint
+provenance. Changing one case changes that case's fingerprint without reassigning another case's
+stable identity.
+
+Scenarios are intentionally not parameterized. Keep one scenario per coherent business world so
+capture and replay identity remains explicit.
+
+#### Aggregate SQL case tables
+
+When independent status is unnecessary, a normal SQL case table remains concise:
+
+```sql
+WITH cases(case_name, source_status, expected_status) AS (
+  VALUES
+    ('completed', 'completed', 'completed'),
+    ('cancelled', 'cancelled', 'excluded')
+),
+__expected__status_mapping AS (
+  SELECT case_name, expected_status FROM cases
+)
+SELECT 1
+```
+
+This produces one aggregate test result. Use native cases when each row must pass or fail
+independently.
+
 ### Test placement
 
 Place unit test files under `tests/unit/` in your project directory. SQLBuild discovers all `.sql` files in this directory recursively.
@@ -11529,7 +11632,8 @@ Run SQL unit tests and multi-model tests in isolation.
 
 ## sqb test
 
-Runs SQL unit tests and multi-model tests without building models. Useful for validating test logic independently.
+Runs SQL unit tests, independently reported parameterized cases, and multi-model tests without
+building models. Useful for validating test logic independently.
 
 ### Usage
 
@@ -11544,6 +11648,14 @@ sqb --project-dir <path> test [flags]
 | `--no-sql-validation` | Skip compile-time SQL syntax validation |
 | `--select`, `-s` | Select tests targeting specific models |
 | `--exclude` | Exclude tests targeting specific models |
+
+Parameterized cases use parent-level selection. Selecting a target model includes every case in
+each matching `TEST` template; case names are not model selectors.
+
+Text output identifies each case as `<parent> [<case>]` and includes its source path and safe typed
+parameters. Structured JSON emits one check per case with stable source/block/case identity,
+declared parameter types and nullability, typed values, and a content fingerprint. Exact decimals
+are strings in JSON so their scale is preserved.
 
 ### Examples
 

--- a/src/sqlbuild/cli/commands/_helpers/compile/output.py
+++ b/src/sqlbuild/cli/commands/_helpers/compile/output.py
@@ -34,6 +34,7 @@ from sqlbuild.presentation.main.status_cell import format_status_cell
 from sqlbuild.presentation.main.surface_header import format_surface_header
 from sqlbuild.presentation.main.tree_connector import tree_connector
 from sqlbuild.spec.contracts.models import SourceLocation
+from sqlbuild.sql_values.types import SqlValueKind
 
 _HUMAN_MODEL_LIMIT: int = 100
 _MIN_MODEL_NAME_WIDTH: int = 24
@@ -314,11 +315,44 @@ def _test_resource(test: CompiledSqlTest) -> dict[str, object]:
     expected_models: list[str] = []
     if isinstance(test.payload, CompiledModelSqlTestPayload):
         expected_models = list(test.payload.expected_model_names)
-    return {
+    item: dict[str, object] = {
         "name": test.name,
         "relative_path": str(test.test_file.relative_path),
         "expected_models": expected_models,
     }
+    if test.case_name is not None:
+        parameter_types: dict[str, str] = {
+            parameter.name: parameter.value_type.value for parameter in test.parameter_schema
+        }
+        item.update(
+            {
+                "source_path": (test.source_path or test.test_file.relative_path).as_posix(),
+                "block_index": test.block_index,
+                "parent_name": test.parent_name,
+                "case_name": test.case_name,
+                "case_index": test.case_index,
+                "case_fingerprint": test.case_fingerprint,
+                "parameter_schema": [
+                    {
+                        "name": parameter.name,
+                        "type": parameter.value_type.value,
+                        "nullable": parameter.nullable,
+                    }
+                    for parameter in test.parameter_schema
+                ],
+                "parameters": [
+                    {
+                        "name": name,
+                        "type": parameter_types[name],
+                        "value": (
+                            str(value.value) if value.kind == SqlValueKind.DECIMAL else value.value
+                        ),
+                    }
+                    for name, value in test.parameter_values
+                ],
+            }
+        )
+    return item
 
 
 def _lineage_summary(

--- a/src/sqlbuild/cli/commands/_helpers/compile/target_writer.py
+++ b/src/sqlbuild/cli/commands/_helpers/compile/target_writer.py
@@ -223,9 +223,7 @@ def _write_tests(
 
     managed_paths: set[Path] = set()
     for entry in plan_output.test_entries:
-        test_path: Path = (
-            target_dir / _COMPILED_DIR / _TESTS_DIR / _test_folder(entry) / f"{entry.name}.sql"
-        )
+        test_path: Path = target_dir / _COMPILED_DIR / _TESTS_DIR / _test_output_path(entry)
         _write_sql(
             path=test_path,
             sql=build_sql_test_comparison_sql(
@@ -254,9 +252,7 @@ def _write_static_tests(
             adapter=adapter,
             sql_analysis_enabled=project.settings.sql_analysis,
         )
-        test_path: Path = (
-            target_dir / _COMPILED_DIR / _TESTS_DIR / _test_folder(entry) / f"{entry.name}.sql"
-        )
+        test_path: Path = target_dir / _COMPILED_DIR / _TESTS_DIR / _test_output_path(entry)
         _write_sql(
             path=test_path,
             sql=build_sql_test_comparison_sql(
@@ -373,3 +369,10 @@ def _test_folder(entry: SqlTestPlanEntry) -> Path:
     if len(unique_names) <= 1:
         return Path(unique_names[0] if unique_names else entry.name)
     return Path(_CHAIN_DIR) / "__".join(unique_names)
+
+
+def _test_output_path(entry: SqlTestPlanEntry) -> Path:
+    if entry.case_name is None or entry.source_path is None:
+        return _test_folder(entry) / f"{entry.name}{_SQL_FILE_SUFFIX}"
+    source_path: Path = entry.source_path.with_suffix("")
+    return source_path / f"block_{entry.block_index}__{entry.case_name}{_SQL_FILE_SUFFIX}"

--- a/src/sqlbuild/cli/commands/_helpers/test/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/test/execution.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 from sqlbuild.cli.commands._helpers.test.sql_progress import (
     build_test_expectation_rows,
+    format_parameterized_test_label,
     resolve_test_name_width,
     test_outcome_status,
 )
@@ -101,7 +102,12 @@ def execute_test_plan(
         on_progress=preparation.preflight_progress.report_preflight_progress,
         on_test_start=lambda entry: preparation.progress.on_item_start(
             group_name=_test_group_name_from_entry(entry),
-            item_name=entry.name,
+            item_name=format_parameterized_test_label(
+                name=entry.name,
+                source_path=entry.source_path,
+                parameter_schema=entry.parameter_schema,
+                parameter_values=entry.parameter_values,
+            ),
         ),
         on_test_complete=on_complete,
     )
@@ -118,7 +124,12 @@ def _build_on_complete(
         status_text: str = test_outcome_status(outcome=result.outcome)
         progress.on_item_complete(
             group_name=group_name,
-            item_name=result.test_name,
+            item_name=format_parameterized_test_label(
+                name=result.test_name,
+                source_path=result.source_path,
+                parameter_schema=result.parameter_schema,
+                parameter_values=result.parameter_values,
+            ),
             status_text=status_text,
             child_rows=build_test_expectation_rows(result),
             error_code=result.error_code,

--- a/src/sqlbuild/cli/commands/_helpers/test/outputs.py
+++ b/src/sqlbuild/cli/commands/_helpers/test/outputs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from sqlbuild.cli.commands._helpers.test.sql_progress import format_parameterized_test_label
 from sqlbuild.cli.commands.models import TestCommandRequest, TestInvocation
 from sqlbuild.cli.output.main._sql_test_execution_json import format_test_execution_json
 from sqlbuild.cli.output.main._write_execution_json_output import write_execution_json_output
@@ -67,7 +68,15 @@ def _format_test_failure_details(
     lines: list[str] = [style.error_strong("Failures:"), ""]
     result: SqlTestExecutionResult
     for result in failed_results:
-        lines.append(f"  {result.test_name}")
+        lines.append(
+            "  "
+            + format_parameterized_test_label(
+                name=result.test_name,
+                source_path=result.source_path,
+                parameter_schema=result.parameter_schema,
+                parameter_values=result.parameter_values,
+            )
+        )
         error_message: str = result.error_message or "test failed"
         rendered_error: str = error_message
         if result.error_code is not None:

--- a/src/sqlbuild/cli/commands/_helpers/test/sql_progress.py
+++ b/src/sqlbuild/cli/commands/_helpers/test/sql_progress.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from sqlbuild.cli.progress.main._expectation_detail import format_expectation_detail
 from sqlbuild.cli.progress.main._expectation_name import format_expectation_name
 from sqlbuild.cli.progress.models import NestedProgressChildRow
+from sqlbuild.compiler.discovery.models import SqlTestParameterDeclaration
 from sqlbuild.compiler.planner.models import SqlTestPlanEntry
 from sqlbuild.executor.testing.models import SqlTestExecutionResult, StepResult
 from sqlbuild.executor.testing.types import SqlTestOutcome
 from sqlbuild.presentation.main.resolve_name_column_width import resolve_name_column_width
+from sqlbuild.sql_values.models import SqlValue
+from sqlbuild.sql_values.types import SqlValueKind
 
 
 def resolve_test_name_width(test_entries: tuple[SqlTestPlanEntry, ...]) -> int:
@@ -17,7 +23,14 @@ def resolve_test_name_width(test_entries: tuple[SqlTestPlanEntry, ...]) -> int:
     names: list[str] = []
     entry: SqlTestPlanEntry
     for entry in test_entries:
-        names.append(entry.name)
+        names.append(
+            format_parameterized_test_label(
+                name=entry.name,
+                source_path=entry.source_path,
+                parameter_schema=entry.parameter_schema,
+                parameter_values=entry.parameter_values,
+            )
+        )
         names.extend(f"expected {step.model_name}" for step in entry.chain if step.expected_cte_sql)
         names.extend(f"assertion {assertion.name}" for assertion in entry.assertions)
     return resolve_name_column_width(names=names, min_width=50)
@@ -42,6 +55,32 @@ def build_test_expectation_rows(
             )
         )
     return tuple(rows)
+
+
+def format_parameterized_test_label(
+    *,
+    name: str,
+    source_path: Path | None,
+    parameter_schema: tuple[SqlTestParameterDeclaration, ...],
+    parameter_values: tuple[tuple[str, SqlValue], ...],
+) -> str:
+    """Add source and safe typed values only for parameterized test rows."""
+
+    if source_path is None or not parameter_values:
+        return name
+    schema_by_name: dict[str, SqlTestParameterDeclaration] = {
+        parameter.name: parameter for parameter in parameter_schema
+    }
+    rendered_values: list[str] = []
+    value_name: str
+    value: SqlValue
+    for value_name, value in parameter_values:
+        declaration: SqlTestParameterDeclaration = schema_by_name[value_name]
+        payload: object = str(value.value) if value.kind == SqlValueKind.DECIMAL else value.value
+        rendered: str = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+        nullable: str = "?" if declaration.nullable else ""
+        rendered_values.append(f"{value_name}:{declaration.value_type.value}{nullable}={rendered}")
+    return f"{name} ({source_path.as_posix()}; {', '.join(rendered_values)})"
 
 
 def test_outcome_status(*, outcome: SqlTestOutcome) -> str:

--- a/src/sqlbuild/cli/commands/classes/build_progress_callbacks.py
+++ b/src/sqlbuild/cli/commands/classes/build_progress_callbacks.py
@@ -8,6 +8,7 @@ import time
 
 from sqlbuild.adapter.contract.models import LifeCycleEvent
 from sqlbuild.adapter.contract.types import LifeCycleEventKind
+from sqlbuild.cli.commands._helpers.test.sql_progress import format_parameterized_test_label
 from sqlbuild.cli.progress.main._expectation_detail import format_expectation_detail
 from sqlbuild.cli.progress.main._expectation_name import format_expectation_name
 from sqlbuild.compiler.auditing.types import AuditOutcome, AuditRunScope
@@ -90,7 +91,7 @@ class BuildProgressCallbacks:
         self._model_entry_map: dict[str, ModelPlanEntry] = {
             entry.name: entry for entry in plan.model_entries
         }
-        self._test_results_by_model: dict[str, SqlTestExecutionResult] = {}
+        self._test_results_by_model: dict[str, list[SqlTestExecutionResult]] = {}
         self._total: int = (
             len(plan.model_entries)
             + len(plan.seed_entries)
@@ -264,7 +265,7 @@ class BuildProgressCallbacks:
             step: object
             for step in node_result.step_results:
                 if hasattr(step, "model_name"):
-                    self._test_results_by_model[step.model_name] = node_result
+                    self._test_results_by_model.setdefault(step.model_name, []).append(node_result)
             return
 
         self._stop_spinner_loop()
@@ -403,12 +404,15 @@ class BuildProgressCallbacks:
             label_width=hook_label_width,
         )
 
-        test_result: SqlTestExecutionResult | None = self._test_results_by_model.get(
-            model_result.model_name
-        )
-        if test_result is not None:
+        test_result: SqlTestExecutionResult
+        for test_result in self._test_results_by_model.get(model_result.model_name, []):
             test_status: str = self._style.status(status=_test_outcome_display(test_result.outcome))
-            test_name: str = test_result.test_name
+            test_name: str = format_parameterized_test_label(
+                name=test_result.test_name,
+                source_path=test_result.source_path,
+                parameter_schema=test_result.parameter_schema,
+                parameter_values=test_result.parameter_values,
+            )
             self._stream.write(
                 f"{sub_pad}{self._style.muted(f'{"test":<{_TYPE_WIDTH}}')}"
                 f"{test_name:<{sub_nw}} {test_status}\n"
@@ -479,7 +483,15 @@ class BuildProgressCallbacks:
             self._show_cursor()
         blank_ctr: str = " " * (len(str(self._total)) * 2 + 1)
         test_status: str = self._style.status(status=_test_outcome_display(test_result.outcome))
-        test_name: str = _truncate_name(name=test_result.test_name, width=self._name_width)
+        test_name: str = _truncate_name(
+            name=format_parameterized_test_label(
+                name=test_result.test_name,
+                source_path=test_result.source_path,
+                parameter_schema=test_result.parameter_schema,
+                parameter_values=test_result.parameter_values,
+            ),
+            width=self._name_width,
+        )
         self._stream.write(
             f"  {blank_ctr}  {self._style.muted(f'{"test":<{_TYPE_WIDTH}}')}"
             f"{test_name:<{self._name_width}} {test_status}\n"
@@ -896,7 +908,13 @@ def _format_failure_details(*, result: BuildExecutionResult, style: CliStyle) ->
             lines.append(style.error_strong("Failures:"))
             lines.append("")
             has_failures = True
-        lines.append(f"  {test_r.test_name}  (test)")
+        test_label: str = format_parameterized_test_label(
+            name=test_r.test_name,
+            source_path=test_r.source_path,
+            parameter_schema=test_r.parameter_schema,
+            parameter_values=test_r.parameter_values,
+        )
+        lines.append(f"  {test_label}  (test)")
         if test_r.error_message is not None:
             lines.extend(
                 _format_failure_error_block(

--- a/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
+++ b/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import cast
 
 from sqlbuild.compiler.auditing.types import AuditOutcome
 from sqlbuild.compiler.compile.types import CompiledResourceType
@@ -35,6 +36,8 @@ from sqlbuild.executor.scenario.models import (
 from sqlbuild.executor.scenario.types import ScenarioLocalRunStatus
 from sqlbuild.executor.testing.models import SqlTestExecutionResult, StepResult
 from sqlbuild.executor.testing.types import SqlTestOutcome
+from sqlbuild.sql_values.models import SqlValue
+from sqlbuild.sql_values.types import SqlValueKind
 
 _JSON_VERSION: int = 1
 
@@ -486,7 +489,8 @@ def _format_sql_test_checks(
                 {
                     "kind": "sql_test",
                     "name": result.test_name,
-                    "check_id": f"sql_test:{result.test_name}",
+                    "check_id": _sql_test_check_id(result),
+                    **_sql_test_case_metadata(result),
                     "passed": result.outcome == SqlTestOutcome.PASS,
                     "status": result.outcome.value,
                     "asset_name": _sql_test_asset_name(result),
@@ -498,6 +502,63 @@ def _format_sql_test_checks(
             )
         )
     return tuple(checks)
+
+
+def _sql_test_check_id(result: SqlTestExecutionResult) -> str:
+    if result.case_name is None or result.source_path is None or result.block_index is None:
+        return f"sql_test:{result.test_name}"
+    return f"sql_test:{result.source_path.as_posix()}:{result.block_index}:{result.case_name}"
+
+
+def _sql_test_case_metadata(result: SqlTestExecutionResult) -> dict[str, object]:
+    if result.case_name is None or result.source_path is None:
+        return {}
+    parameter_types: dict[str, str] = {
+        parameter.name: parameter.value_type.value for parameter in result.parameter_schema
+    }
+    return {
+        "source_path": result.source_path.as_posix(),
+        "block_index": result.block_index,
+        "parent_name": result.parent_name,
+        "case_name": result.case_name,
+        "case_index": result.case_index,
+        "case_fingerprint": result.case_fingerprint,
+        "parameter_schema": tuple(
+            {
+                "name": parameter.name,
+                "type": parameter.value_type.value,
+                "nullable": parameter.nullable,
+            }
+            for parameter in result.parameter_schema
+        ),
+        "parameters": tuple(
+            {
+                "name": name,
+                "type": parameter_types[name],
+                "value": _sql_value_json(value),
+            }
+            for name, value in result.parameter_values
+        ),
+    }
+
+
+def _sql_value_json(value: SqlValue) -> object:
+    if value.kind == SqlValueKind.DECIMAL:
+        return str(value.value)
+    if value.kind in {
+        SqlValueKind.STRING,
+        SqlValueKind.INTEGER,
+        SqlValueKind.BOOLEAN,
+        SqlValueKind.FLOAT,
+        SqlValueKind.NULL,
+    }:
+        return value.value
+    if value.kind in {SqlValueKind.LIST, SqlValueKind.SET}:
+        return [_sql_value_json(item) for item in cast(tuple[SqlValue, ...], value.value)]
+    return {
+        name: _sql_value_json(item)
+        for name, item in cast(tuple[tuple[str, SqlValue], ...], value.value)
+    }
 
 
 def _format_python_check_results(

--- a/src/sqlbuild/cli/target_artifacts/_helpers/runtime.py
+++ b/src/sqlbuild/cli/target_artifacts/_helpers/runtime.py
@@ -99,12 +99,26 @@ def write_test_runtime_target(
     """Write executed SQL unit-test statements under target/run/tests."""
 
     run_dir: Path = target_dir / _RUN_DIR
-    result_names: frozenset[str] = frozenset(result.test_name for result in results)
+    result_keys: frozenset[tuple[str, str | None, int | None, str | None]] = frozenset(
+        (
+            result.test_name,
+            result.source_path.as_posix() if result.source_path is not None else None,
+            result.block_index,
+            result.case_name,
+        )
+        for result in results
+    )
     entry: SqlTestPlanEntry
     for entry in plan_output.test_entries:
-        if entry.name not in result_names:
+        entry_key: tuple[str, str | None, int | None, str | None] = (
+            entry.name,
+            entry.source_path.as_posix() if entry.source_path is not None else None,
+            entry.block_index,
+            entry.case_name,
+        )
+        if entry_key not in result_keys:
             continue
-        test_run_path: Path = run_dir / _TESTS_DIR / _test_folder(entry) / f"{entry.name}.sql"
+        test_run_path: Path = run_dir / _TESTS_DIR / _test_output_path(entry)
         _write_sql(
             path=test_run_path,
             sql=build_sql_test_comparison_sql(
@@ -167,6 +181,13 @@ def _function_output_path(*, relative_path: Path, language: FunctionLanguage) ->
     ):
         return Path(*parts).with_suffix(_SQL_FILE_SUFFIX)
     return (Path(_FUNCTIONS_DIR) / language_dir / relative_path).with_suffix(_SQL_FILE_SUFFIX)
+
+
+def _test_output_path(entry: SqlTestPlanEntry) -> Path:
+    if entry.case_name is None or entry.source_path is None:
+        return _test_folder(entry) / f"{entry.name}{_SQL_FILE_SUFFIX}"
+    source_path: Path = entry.source_path.with_suffix("")
+    return source_path / f"block_{entry.block_index}__{entry.case_name}{_SQL_FILE_SUFFIX}"
 
 
 def _test_folder(entry: SqlTestPlanEntry) -> Path:

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -43,6 +43,9 @@ from sqlbuild.compiler.compile._helpers.render.macros import (
 )
 from sqlbuild.compiler.compile._helpers.render.templating import expand_template_data
 from sqlbuild.compiler.compile._helpers.sql_tests.core import extract_assertion_target_model_names
+from sqlbuild.compiler.compile._helpers.sql_tests.identity import (
+    build_sql_test_case_fingerprint,
+)
 from sqlbuild.compiler.compile.constants import NOT_NULL_AUDIT_NAME, PRESERVE_TARGET_VALUE
 from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.main._scope_index_with_compile_usages import (
@@ -984,6 +987,28 @@ def _assemble_compiled_sql_test(
             assertion_ctes=model_payload.assertion_ctes,
             assertion_names=model_payload.assertion_names,
         )
+    tested_resources: tuple[CompiledSqlTestResource, ...] = (
+        tuple(
+            CompiledSqlTestResource(kind=test_input.payload.mode, name=name)
+            for name in test_input.payload.tested_resource_names
+        )
+        if isinstance(test_input.payload, CompileDirectLogicSqlTestInputPayload)
+        else ()
+    )
+    case_fingerprint: str | None = (
+        build_sql_test_case_fingerprint(
+            source_path=test_input.test_file.relative_path,
+            block_index=test_input.test_block.test_index,
+            case_name=test_input.case_name,
+            parameter_schema=test_input.parameter_schema,
+            parameter_values=test_input.parameter_values,
+            expanded_sql=test_input.sql_body,
+            scope_deps=scope_deps,
+            tested_resources=tested_resources,
+        )
+        if test_input.case_name is not None
+        else None
+    )
     return CompiledSqlTest(
         key=CompiledObjectKey(resource_type=CompiledResourceType.SQL_TEST, name=test_name),
         scope_deps=scope_deps,
@@ -997,6 +1022,12 @@ def _assemble_compiled_sql_test(
         ownership_root=test_input.test_file.ownership_root,
         block_index=test_input.test_block.test_index,
         explicit_name=test_input.test_block.name,
+        parent_name=test_input.parent_name,
+        case_name=test_input.case_name,
+        case_index=test_input.case_index,
+        case_fingerprint=case_fingerprint,
+        parameter_schema=test_input.parameter_schema,
+        parameter_values=test_input.parameter_values,
         expected_model_names=(
             test_input.payload.expected_model_names
             if isinstance(test_input.payload, CompileModelSqlTestInputPayload)
@@ -1021,14 +1052,7 @@ def _assemble_compiled_sql_test(
             if isinstance(test_input.payload, CompileModelSqlTestInputPayload)
             else ()
         ),
-        tested_resources=(
-            tuple(
-                CompiledSqlTestResource(kind=test_input.payload.mode, name=name)
-                for name in test_input.payload.tested_resource_names
-            )
-            if isinstance(test_input.payload, CompileDirectLogicSqlTestInputPayload)
-            else ()
-        ),
+        tested_resources=tested_resources,
     )
 
 
@@ -1167,9 +1191,10 @@ def _resolve_audit_name(audit_input: CompileAuditInput) -> str:
 
 
 def _resolve_test_name(test_input: CompileSqlTestInput) -> str:
-    if test_input.test_block.name is not None:
-        return test_input.test_block.name
-    return test_input.test_file.file_path.stem
+    parent_name: str = test_input.test_block.name or test_input.test_file.file_path.stem
+    if test_input.case_name is not None:
+        return f"{parent_name} [{test_input.case_name}]"
+    return parent_name
 
 
 def _build_model_relation_target(

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
@@ -22,6 +22,7 @@ from sqlbuild.compiler.compile._helpers.render.declarations import (
 from sqlbuild.compiler.compile._helpers.render.macros import (
     find_macro_call_names,
 )
+from sqlbuild.compiler.compile._helpers.render.parameters import expand_test_parameters
 from sqlbuild.compiler.compile._helpers.render.sql_vars import (
     expand_authored_sql_result,
 )
@@ -56,6 +57,7 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredProjectInputs,
     DiscoveredSqlScenarioFile,
     DiscoveredSqlTestBlock,
+    DiscoveredSqlTestCase,
     DiscoveredSqlTestFile,
     EnumDeclaration,
 )
@@ -124,79 +126,112 @@ def build_test_inputs(
                 file_path=test_file.file_path,
                 resource=resource,
             )
-            test_mode: SqlTestMode = test_block.mode
-            tested_resource_names: tuple[str, ...] = ()
-            if test_mode in {SqlTestMode.MACRO, SqlTestMode.UDF, SqlTestMode.TABLE_FN}:
-                raw_test_ctes: CompileSqlTestCtes = _validate_raw_direct_logic_test_ctes(
-                    test_block=test_block,
-                    test_file=test_file,
-                    test_mode=test_mode,
-                )
-                tested_resource_names = _infer_tested_direct_logic_resource_names(
-                    raw_test_ctes=raw_test_ctes,
-                    test_file=test_file,
-                    loaded_macros=loaded_macros,
-                    known_function_names=known_function_names,
-                    known_table_function_names=known_table_function_names,
-                    table_function_argument_counts=table_function_argument_counts,
-                )
-            expansion: AuthoredSqlExpansionResult = expand_authored_sql_result(
-                sql=test_block.sql_body,
-                file_path=test_file.file_path,
-                effective_vars=vars_for_substitution,
-                loaded_macros=loaded_macros,
-                macro_context=macro_context,
-                declarations=(
-                    replace(scoped_declarations.declarations, consumer=None)
-                    if test_mode is SqlTestMode.MACRO
-                    else scoped_declarations.declarations
-                ),
-                declaration_resolver=scoped_declarations.resolver,
-                value_renderer=scoped_declarations.value_renderer,
-                collection_rendering=scoped_declarations.collection_rendering,
-            )
-            expanded_sql_body: str = expansion.sql
-            reject_cursor_intrinsics(
-                sql=expanded_sql_body,
-                context=f"SQL test '{test_block.name or test_file.file_path.stem}'",
-            )
-            test_ctes: CompileSqlTestCtes = extract_sql_test_ctes(
-                sql=expanded_sql_body,
-                file_label=str(test_file.relative_path),
-                mode=test_mode,
-            )
-            validate_test_ctes(
-                test_ctes=test_ctes,
-                test_file=test_file,
-                known_model_names=known_model_names,
-                known_seed_names=known_seed_names,
-                known_source_names=known_source_names,
-                loaded_macros=loaded_macros,
-            )
-            test_payload: (
-                CompileModelSqlTestInputPayload | CompileDirectLogicSqlTestInputPayload
-            ) = _build_test_input_payload(
-                test_ctes=test_ctes,
-                tested_resource_names=tested_resource_names,
-            )
-            test_inputs.append(
-                CompileSqlTestInput(
-                    test_file=test_file,
-                    test_block=test_block,
-                    sql_body=expanded_sql_body,
-                    mode=test_mode,
-                    payload=test_payload,
-                    declaration_usages=(
-                        declaration_usage_records(
-                            sql=test_block.sql_body,
-                            resource=resource,
-                            declarations=scoped_declarations.declarations,
+            case_variants: tuple[DiscoveredSqlTestCase | None, ...] = test_block.cases or (None,)
+            test_case: DiscoveredSqlTestCase | None
+            for test_case in case_variants:
+                parameter_sql: str = test_block.sql_body
+                if test_case is not None:
+                    parameter_sql, used_parameters = expand_test_parameters(
+                        sql=test_block.sql_body,
+                        file_path=test_file.file_path,
+                        values=test_case.values,
+                        value_renderer=scoped_declarations.value_renderer,
+                        test_name=test_block.name or test_file.file_path.stem,
+                        case_name=test_case.name,
+                    )
+                    unused_parameters: tuple[str, ...] = tuple(
+                        parameter.name
+                        for parameter in test_block.parameters
+                        if parameter.name not in used_parameters
+                    )
+                    if unused_parameters:
+                        raise CompileInputError(
+                            f"SQL test '{test_block.name or test_file.file_path.stem}' declares "
+                            f"unused parameters: {', '.join(unused_parameters)} in case "
+                            f"'{test_case.name}'"
                         )
-                        if test_mode is SqlTestMode.MACRO
-                        else expansion.usages
-                    ),
+                expanded_test_block: DiscoveredSqlTestBlock = replace(
+                    test_block,
+                    sql_body=parameter_sql,
                 )
-            )
+                test_mode: SqlTestMode = test_block.mode
+                tested_resource_names: tuple[str, ...] = ()
+                if test_mode in {SqlTestMode.MACRO, SqlTestMode.UDF, SqlTestMode.TABLE_FN}:
+                    raw_test_ctes: CompileSqlTestCtes = _validate_raw_direct_logic_test_ctes(
+                        test_block=expanded_test_block,
+                        test_file=test_file,
+                        test_mode=test_mode,
+                    )
+                    tested_resource_names = _infer_tested_direct_logic_resource_names(
+                        raw_test_ctes=raw_test_ctes,
+                        test_file=test_file,
+                        loaded_macros=loaded_macros,
+                        known_function_names=known_function_names,
+                        known_table_function_names=known_table_function_names,
+                        table_function_argument_counts=table_function_argument_counts,
+                    )
+                expansion: AuthoredSqlExpansionResult = expand_authored_sql_result(
+                    sql=parameter_sql,
+                    file_path=test_file.file_path,
+                    effective_vars=vars_for_substitution,
+                    loaded_macros=loaded_macros,
+                    macro_context=macro_context,
+                    declarations=(
+                        replace(scoped_declarations.declarations, consumer=None)
+                        if test_mode is SqlTestMode.MACRO
+                        else scoped_declarations.declarations
+                    ),
+                    declaration_resolver=scoped_declarations.resolver,
+                    value_renderer=scoped_declarations.value_renderer,
+                    collection_rendering=scoped_declarations.collection_rendering,
+                )
+                expanded_sql_body: str = expansion.sql
+                reject_cursor_intrinsics(
+                    sql=expanded_sql_body,
+                    context=f"SQL test '{test_block.name or test_file.file_path.stem}'",
+                )
+                test_ctes: CompileSqlTestCtes = extract_sql_test_ctes(
+                    sql=expanded_sql_body,
+                    file_label=str(test_file.relative_path),
+                    mode=test_mode,
+                )
+                validate_test_ctes(
+                    test_ctes=test_ctes,
+                    test_file=test_file,
+                    known_model_names=known_model_names,
+                    known_seed_names=known_seed_names,
+                    known_source_names=known_source_names,
+                    loaded_macros=loaded_macros,
+                )
+                test_payload: (
+                    CompileModelSqlTestInputPayload | CompileDirectLogicSqlTestInputPayload
+                ) = _build_test_input_payload(
+                    test_ctes=test_ctes,
+                    tested_resource_names=tested_resource_names,
+                )
+                test_inputs.append(
+                    CompileSqlTestInput(
+                        test_file=test_file,
+                        test_block=test_block,
+                        sql_body=expanded_sql_body,
+                        mode=test_mode,
+                        payload=test_payload,
+                        declaration_usages=(
+                            declaration_usage_records(
+                                sql=parameter_sql,
+                                resource=resource,
+                                declarations=scoped_declarations.declarations,
+                            )
+                            if test_mode is SqlTestMode.MACRO
+                            else expansion.usages
+                        ),
+                        parent_name=test_block.name or test_file.relative_path.stem,
+                        case_name=test_case.name if test_case is not None else None,
+                        case_index=test_case.case_index if test_case is not None else None,
+                        parameter_schema=test_block.parameters,
+                        parameter_values=test_case.values if test_case is not None else (),
+                    )
+                )
     return tuple(test_inputs)
 
 

--- a/src/sqlbuild/compiler/compile/_helpers/render/parameters.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/parameters.py
@@ -1,0 +1,88 @@
+"""Typed parameter expansion for SQL-native test cases."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from sqlbuild.compiler.compile.constants import SQL_QUOTE_TOKENS
+from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.compiler.compile.types import TypedSqlValueRenderer
+from sqlbuild.compiler.sql_analysis.main._skip_block_comment import skip_block_comment
+from sqlbuild.compiler.sql_analysis.main._skip_line_comment import skip_line_comment
+from sqlbuild.compiler.sql_analysis.main._skip_quoted_text import skip_quoted_text
+from sqlbuild.sql_values.exceptions import SqlValueRenderingError, SqlValueValidationError
+from sqlbuild.sql_values.main.validate_rendered_size import validate_rendered_sql_value_size
+from sqlbuild.sql_values.models import SqlValue
+
+_PARAMETER_REFERENCE: re.Pattern[str] = re.compile(
+    r'@param(?![A-Za-z0-9_])\s*\(\s*"(?P<name>[A-Za-z_][A-Za-z0-9_]*)"\s*\)'
+)
+_PARAMETER_TOKEN: re.Pattern[str] = re.compile(r"@param(?![A-Za-z0-9_])")
+
+
+def expand_test_parameters(
+    *,
+    sql: str,
+    file_path: Path,
+    values: tuple[tuple[str, SqlValue], ...],
+    value_renderer: TypedSqlValueRenderer,
+    test_name: str,
+    case_name: str,
+) -> tuple[str, frozenset[str]]:
+    """Render active parameter references while leaving comments and quoted text unchanged."""
+
+    value_lookup: dict[str, SqlValue] = dict(values)
+    used_names: set[str] = set()
+    parts: list[str] = []
+    cursor: int = 0
+    while cursor < len(sql):
+        character: str = sql[cursor]
+        if character in SQL_QUOTE_TOKENS:
+            end: int = skip_quoted_text(sql=sql, start=cursor)
+            parts.append(sql[cursor:end])
+            cursor = end
+            continue
+        if sql.startswith("--", cursor):
+            end = skip_line_comment(sql=sql, start=cursor)
+            parts.append(sql[cursor:end])
+            cursor = end
+            continue
+        if sql.startswith("/*", cursor):
+            end = skip_block_comment(sql=sql, start=cursor)
+            parts.append(sql[cursor:end])
+            cursor = end
+            continue
+        if _PARAMETER_TOKEN.match(sql, cursor):
+            match: re.Match[str] | None = _PARAMETER_REFERENCE.match(sql, cursor)
+            if match is None:
+                raise CompileInputError(
+                    f"SQL test '{test_name}' case '{case_name}' in '{file_path}' has malformed "
+                    "@param reference; expected "
+                    '@param("name")'
+                )
+            name: str = match.group("name")
+            value: SqlValue | None = value_lookup.get(name)
+            if value is None:
+                raise CompileInputError(
+                    f"SQL test '{test_name}' case '{case_name}' in '{file_path}' references "
+                    f"undeclared parameter '{name}'"
+                )
+            try:
+                rendered: str = value_renderer.render_typed_scalar(value=value)
+                validate_rendered_sql_value_size(
+                    rendered_sql=rendered,
+                    context=(f"SQL test '{test_name}' case '{case_name}' parameter '{name}'"),
+                )
+            except (SqlValueRenderingError, SqlValueValidationError) as error:
+                raise CompileInputError(
+                    f"SQL test '{test_name}' case '{case_name}' parameter '{name}' could not "
+                    f"be rendered by adapter '{value_renderer.adapter_name}': {error}"
+                ) from error
+            parts.append(rendered)
+            used_names.add(name)
+            cursor = match.end()
+            continue
+        parts.append(character)
+        cursor += 1
+    return "".join(parts), frozenset(used_names)

--- a/src/sqlbuild/compiler/compile/_helpers/sql_tests/identity.py
+++ b/src/sqlbuild/compiler/compile/_helpers/sql_tests/identity.py
@@ -1,0 +1,46 @@
+"""Version identity for one expanded SQL test case."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledSqlTestResource
+from sqlbuild.compiler.discovery.models import SqlTestParameterDeclaration
+from sqlbuild.sql_values.main.identity import sql_value_identity
+from sqlbuild.sql_values.models import SqlValue
+
+
+def build_sql_test_case_fingerprint(
+    *,
+    source_path: Path,
+    block_index: int,
+    case_name: str,
+    parameter_schema: tuple[SqlTestParameterDeclaration, ...],
+    parameter_values: tuple[tuple[str, SqlValue], ...],
+    expanded_sql: str,
+    scope_deps: tuple[CompiledObjectKey, ...],
+    tested_resources: tuple[CompiledSqlTestResource, ...],
+) -> str:
+    """Hash all compile-resolved inputs that version a stable test case."""
+
+    payload: dict[str, object] = {
+        "source_path": source_path.as_posix(),
+        "block_index": block_index,
+        "case_name": case_name,
+        "parameter_schema": [
+            (parameter.name, parameter.value_type.value, parameter.nullable)
+            for parameter in parameter_schema
+        ],
+        "parameter_values": [
+            (name, sql_value_identity(value=value)) for name, value in parameter_values
+        ],
+        "expanded_sql": expanded_sql,
+        "scope_deps": sorted((str(dep.resource_type), dep.name) for dep in scope_deps),
+        "tested_resources": sorted(
+            (resource.kind.value, resource.name) for resource in tested_resources
+        ),
+    }
+    encoded: str = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -36,6 +36,7 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlTestFile,
     EnumDeclaration,
     ModelSchemaDeclaration,
+    SqlTestParameterDeclaration,
 )
 from sqlbuild.compiler.lineage.types import (
     ColumnLineageConfidence,
@@ -64,6 +65,7 @@ from sqlbuild.spec.contracts.models import (
     SourceLocation,
     TargetConfig,
 )
+from sqlbuild.sql_values.models import SqlValue
 from sqlbuild.sql_values.types import CollectionRendering
 
 
@@ -847,6 +849,11 @@ class CompileSqlTestInput:
         default_factory=CompileModelSqlTestInputPayload
     )
     declaration_usages: tuple[UsageRecord, ...] = field(default_factory=tuple)
+    parent_name: str | None = None
+    case_name: str | None = None
+    case_index: int | None = None
+    parameter_schema: tuple[SqlTestParameterDeclaration, ...] = field(default_factory=tuple)
+    parameter_values: tuple[tuple[str, SqlValue], ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -935,6 +942,12 @@ class CompiledSqlTest:
     ownership_root: Path | None = None
     block_index: int | None = None
     explicit_name: str | None = None
+    parent_name: str | None = None
+    case_name: str | None = None
+    case_index: int | None = None
+    case_fingerprint: str | None = None
+    parameter_schema: tuple[SqlTestParameterDeclaration, ...] = field(default_factory=tuple)
+    parameter_values: tuple[tuple[str, SqlValue], ...] = field(default_factory=tuple)
     expected_model_names: tuple[str, ...] = field(default_factory=tuple)
     assertion_names: tuple[str, ...] = field(default_factory=tuple)
     assertion_target_model_names: tuple[str, ...] = field(default_factory=tuple)
@@ -950,3 +963,9 @@ class CompiledSqlTest:
             object.__setattr__(self, "block_index", self.test_block.test_index)
         if self.explicit_name is None and self.test_block.name is not None:
             object.__setattr__(self, "explicit_name", self.test_block.name)
+        if self.parent_name is None:
+            object.__setattr__(
+                self,
+                "parent_name",
+                self.test_block.name or self.test_file.relative_path.stem,
+            )

--- a/src/sqlbuild/compiler/dag/_helpers/artifact.py
+++ b/src/sqlbuild/compiler/dag/_helpers/artifact.py
@@ -37,6 +37,7 @@ from sqlbuild.compiler.python_nodes.types import PythonNodeKind
 from sqlbuild.python_nodes.models import ColumnLineageRef, SqlResourceRef
 from sqlbuild.python_nodes.types import SqlResourceRefKind
 from sqlbuild.spec.contracts.models import SchemaColumn, SourceColumnEntry, SourceEntry
+from sqlbuild.sql_values.types import SqlValueKind
 
 _DAG_VERSION: int = 1
 
@@ -305,13 +306,53 @@ def _build_checks(
 
 def _build_sql_test_check(test: CompiledSqlTest) -> DagCheck:
     return DagCheck(
-        id=_node_id(test.key),
+        id=_sql_test_check_id(test),
         kind="sql_test",
         name=test.name,
         checked_asset_ids=tuple(_node_id(key) for key in test.scope_deps),
         path=str(test.test_file.relative_path),
         mode=test.mode.value,
+        meta=_sql_test_meta(test),
     )
+
+
+def _sql_test_check_id(test: CompiledSqlTest) -> str:
+    if test.case_name is None:
+        return _node_id(test.key)
+    source_path: str = (test.source_path or test.test_file.relative_path).as_posix()
+    return f"sql_test:{source_path}:{test.block_index}:{test.case_name}"
+
+
+def _sql_test_meta(test: CompiledSqlTest) -> dict[str, object]:
+    if test.case_name is None:
+        return {}
+    parameter_types: dict[str, str] = {
+        parameter.name: parameter.value_type.value for parameter in test.parameter_schema
+    }
+    return {
+        "source_path": (test.source_path or test.test_file.relative_path).as_posix(),
+        "block_index": test.block_index,
+        "parent_name": test.parent_name,
+        "case_name": test.case_name,
+        "case_index": test.case_index,
+        "case_fingerprint": test.case_fingerprint,
+        "parameter_schema": [
+            {
+                "name": parameter.name,
+                "type": parameter.value_type.value,
+                "nullable": parameter.nullable,
+            }
+            for parameter in test.parameter_schema
+        ],
+        "parameters": [
+            {
+                "name": name,
+                "type": parameter_types[name],
+                "value": (str(value.value) if value.kind == SqlValueKind.DECIMAL else value.value),
+            }
+            for name, value in test.parameter_values
+        ],
+    }
 
 
 def _build_audit_check(audit: CompiledAudit) -> DagCheck:

--- a/src/sqlbuild/compiler/discovery/_helpers/sql/tests.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/sql/tests.py
@@ -11,7 +11,15 @@ from sqlbuild.compiler.compile.constants import DEFAULT_SQL_TEST_MODE
 from sqlbuild.compiler.compile.types import SqlTestMode
 from sqlbuild.compiler.discovery._helpers.sql.model_files import parse_header_values
 from sqlbuild.compiler.discovery.exceptions import SqlTestParseError
-from sqlbuild.compiler.discovery.models import DiscoveredSqlTestBlock
+from sqlbuild.compiler.discovery.models import (
+    DiscoveredSqlTestBlock,
+    DiscoveredSqlTestCase,
+    SqlTestParameterDeclaration,
+)
+from sqlbuild.sql_values.exceptions import SqlValueValidationError
+from sqlbuild.sql_values.main.normalize import normalize_sql_value
+from sqlbuild.sql_values.models import SqlValue
+from sqlbuild.sql_values.types import SqlValueKind
 
 _TEST_HEADER_PATTERN: re.Pattern[str] = re.compile(
     r"^\s*TEST\s*\((?P<header>.*?)\)\s*;\s*(?P<sql>.*)\Z",
@@ -23,6 +31,16 @@ _TEST_HEADER_ONLY_PATTERN: re.Pattern[str] = re.compile(
 )
 _TEST_NAME_HEADER_KEY: str = "name"
 _TEST_MODE_HEADER_KEY: str = "mode"
+_TEST_PARAMETERS_HEADER_KEY: str = "parameters"
+_TEST_CASES_HEADER_KEY: str = "cases"
+_PARAMETER_TYPES: tuple[SqlValueKind, ...] = (
+    SqlValueKind.STRING,
+    SqlValueKind.INTEGER,
+    SqlValueKind.BOOLEAN,
+    SqlValueKind.FLOAT,
+    SqlValueKind.DECIMAL,
+)
+_IDENTIFIER_PATTERN: re.Pattern[str] = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def parse_sql_test_file(*, contents: str, file_path: Path) -> tuple[DiscoveredSqlTestBlock, ...]:
@@ -99,12 +117,18 @@ def _parse_single_sql_test_block(
     test_name: str | None = cast(str | None, name_value)
     mode_value: object = header_values.get("mode", DEFAULT_SQL_TEST_MODE.value)
     test_mode: SqlTestMode = SqlTestMode(str(mode_value))
+    parameters, cases = _parse_test_parameters_and_cases(
+        header_values=header_values,
+        file_path=file_path,
+    )
     return DiscoveredSqlTestBlock(
         test_index=test_index,
         header_values=header_values,
         sql_body=sql_body,
         name=test_name,
         mode=test_mode,
+        parameters=parameters,
+        cases=cases,
     )
 
 
@@ -116,13 +140,21 @@ def _parse_test_header(*, header: str, file_path: Path) -> dict[str, object]:
         error_class=SqlTestParseError,
     )
 
-    supported_keys: frozenset[str] = frozenset({_TEST_NAME_HEADER_KEY, _TEST_MODE_HEADER_KEY})
+    supported_keys: frozenset[str] = frozenset(
+        {
+            _TEST_NAME_HEADER_KEY,
+            _TEST_MODE_HEADER_KEY,
+            _TEST_PARAMETERS_HEADER_KEY,
+            _TEST_CASES_HEADER_KEY,
+        }
+    )
     unsupported_keys: tuple[str, ...] = tuple(
         str(key) for key in parsed_header if key not in supported_keys
     )
     if unsupported_keys:
         raise SqlTestParseError(
-            f"TEST() in '{file_path}' only supports `name` and `mode`; unsupported keys: "
+            f"TEST() in '{file_path}' only supports `name`, `mode`, `parameters`, and "
+            "`cases`; unsupported keys: "
             f"{', '.join(unsupported_keys)}"
         )
 
@@ -132,6 +164,152 @@ def _parse_test_header(*, header: str, file_path: Path) -> dict[str, object]:
         _validate_test_mode(mode_value=parsed_header[_TEST_MODE_HEADER_KEY], file_path=file_path)
 
     return parsed_header
+
+
+def _parse_test_parameters_and_cases(
+    *, header_values: dict[str, object], file_path: Path
+) -> tuple[tuple[SqlTestParameterDeclaration, ...], tuple[DiscoveredSqlTestCase, ...]]:
+    raw_parameters: object | None = header_values.get(_TEST_PARAMETERS_HEADER_KEY)
+    raw_cases: object | None = header_values.get(_TEST_CASES_HEADER_KEY)
+    if raw_parameters is None and raw_cases is None:
+        return (), ()
+    if raw_parameters is None or raw_cases is None:
+        raise SqlTestParseError(
+            f"TEST() in '{file_path}' must define `parameters` and `cases` together"
+        )
+    if not isinstance(raw_parameters, dict) or not raw_parameters:
+        raise SqlTestParseError(f"TEST() parameters in '{file_path}' must be a non-empty mapping")
+    if not isinstance(raw_cases, dict) or not raw_cases:
+        raise SqlTestParseError(f"TEST() cases in '{file_path}' must be a non-empty mapping")
+
+    parameters: tuple[SqlTestParameterDeclaration, ...] = tuple(
+        _parse_parameter_declaration(
+            name=name,
+            raw_declaration=raw_declaration,
+            file_path=file_path,
+        )
+        for name, raw_declaration in cast(dict[object, object], raw_parameters).items()
+    )
+    parameter_names: tuple[str, ...] = tuple(parameter.name for parameter in parameters)
+    cases: tuple[DiscoveredSqlTestCase, ...] = tuple(
+        _parse_test_case(
+            name=name,
+            raw_values=raw_values,
+            case_index=case_index,
+            parameters=parameters,
+            parameter_names=parameter_names,
+            file_path=file_path,
+        )
+        for case_index, (name, raw_values) in enumerate(
+            cast(dict[object, object], raw_cases).items()
+        )
+    )
+    return parameters, cases
+
+
+def _parse_parameter_declaration(
+    *, name: object, raw_declaration: object, file_path: Path
+) -> SqlTestParameterDeclaration:
+    parameter_name: str = _parse_test_identifier(value=name, label="parameter", file_path=file_path)
+    nullable: bool = False
+    raw_type: object = raw_declaration
+    if isinstance(raw_declaration, dict):
+        declaration_options: dict[object, object] = cast(dict[object, object], raw_declaration)
+        unknown_options: set[object] = set(declaration_options) - {"type", "nullable"}
+        if unknown_options:
+            names: str = ", ".join(sorted(str(option) for option in unknown_options))
+            raise SqlTestParseError(
+                f"TEST() parameter '{parameter_name}' in '{file_path}' has unsupported "
+                f"options: {names}"
+            )
+        raw_type = declaration_options.get("type")
+        raw_nullable: object = declaration_options.get("nullable", False)
+        if not isinstance(raw_nullable, bool):
+            raise SqlTestParseError(
+                f"TEST() parameter '{parameter_name}' nullable option in '{file_path}' "
+                "must be boolean"
+            )
+        nullable = raw_nullable
+    if not isinstance(raw_type, str):
+        raise SqlTestParseError(
+            f"TEST() parameter '{parameter_name}' type in '{file_path}' must be an identifier"
+        )
+    try:
+        value_type: SqlValueKind = SqlValueKind(raw_type.lower())
+    except ValueError as error:
+        raise SqlTestParseError(
+            f"TEST() parameter '{parameter_name}' in '{file_path}' has unsupported "
+            f"type '{raw_type}'"
+        ) from error
+    if value_type not in _PARAMETER_TYPES:
+        allowed: str = ", ".join(value.value for value in _PARAMETER_TYPES)
+        raise SqlTestParseError(
+            f"TEST() parameter '{parameter_name}' in '{file_path}' must use a scalar "
+            f"type: {allowed}"
+        )
+    return SqlTestParameterDeclaration(
+        name=parameter_name,
+        value_type=value_type,
+        nullable=nullable,
+    )
+
+
+def _parse_test_case(
+    *,
+    name: object,
+    raw_values: object,
+    case_index: int,
+    parameters: tuple[SqlTestParameterDeclaration, ...],
+    parameter_names: tuple[str, ...],
+    file_path: Path,
+) -> DiscoveredSqlTestCase:
+    case_name: str = _parse_test_identifier(value=name, label="case", file_path=file_path)
+    if not isinstance(raw_values, dict):
+        raise SqlTestParseError(
+            f"TEST() case '{case_name}' in '{file_path}' must define a parameter mapping"
+        )
+    values: dict[object, object] = cast(dict[object, object], raw_values)
+    missing: tuple[str, ...] = tuple(name for name in parameter_names if name not in values)
+    extra: tuple[str, ...] = tuple(str(name) for name in values if name not in parameter_names)
+    if missing:
+        raise SqlTestParseError(
+            f"TEST() case '{case_name}' in '{file_path}' is missing parameters: "
+            f"{', '.join(missing)}"
+        )
+    if extra:
+        raise SqlTestParseError(
+            f"TEST() case '{case_name}' in '{file_path}' has undeclared parameters: "
+            f"{', '.join(extra)}"
+        )
+    normalized_values: list[tuple[str, SqlValue]] = []
+    parameter: SqlTestParameterDeclaration
+    for parameter in parameters:
+        raw_value: object = values[parameter.name]
+        if raw_value is None and not parameter.nullable:
+            raise SqlTestParseError(
+                f"TEST() case '{case_name}' parameter '{parameter.name}' in '{file_path}' "
+                "is not nullable"
+            )
+        try:
+            value: SqlValue = normalize_sql_value(
+                raw_value=raw_value,
+                explicit_type=None if raw_value is None else parameter.value_type.value,
+                context=f"TEST() case '{case_name}' parameter '{parameter.name}' in '{file_path}'",
+            )
+        except SqlValueValidationError as error:
+            raise SqlTestParseError(str(error)) from error
+        normalized_values.append((parameter.name, value))
+    return DiscoveredSqlTestCase(
+        name=case_name,
+        values=tuple(normalized_values),
+        case_index=case_index,
+    )
+
+
+def _parse_test_identifier(*, value: object, label: str, file_path: Path) -> str:
+    if not isinstance(value, str) or not _IDENTIFIER_PATTERN.fullmatch(value):
+        raise SqlTestParseError(f"TEST() {label} name in '{file_path}' must be a SQL identifier")
+    return value
 
 
 def _validate_test_name(*, name_value: object, file_path: Path) -> None:

--- a/src/sqlbuild/compiler/discovery/models.py
+++ b/src/sqlbuild/compiler/discovery/models.py
@@ -253,6 +253,24 @@ class DiscoveredSqlTestFile:
 
 
 @dataclass(frozen=True)
+class SqlTestParameterDeclaration:
+    """One typed parameter declared by a SQL-native test template."""
+
+    name: str
+    value_type: SqlValueKind
+    nullable: bool = False
+
+
+@dataclass(frozen=True)
+class DiscoveredSqlTestCase:
+    """One ordered named case belonging to a SQL-native test template."""
+
+    name: str
+    values: tuple[tuple[str, SqlValue], ...]
+    case_index: int
+
+
+@dataclass(frozen=True)
 class DiscoveredSqlTestBlock:
     """One raw TEST(...) block discovered from a SQL-native test file."""
 
@@ -261,6 +279,8 @@ class DiscoveredSqlTestBlock:
     sql_body: str
     name: str | None = None
     mode: SqlTestMode = DEFAULT_SQL_TEST_MODE
+    parameters: tuple[SqlTestParameterDeclaration, ...] = field(default_factory=tuple)
+    cases: tuple[DiscoveredSqlTestCase, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/manifest/_helpers/graph_maps.py
+++ b/src/sqlbuild/compiler/manifest/_helpers/graph_maps.py
@@ -6,19 +6,13 @@ from sqlbuild.compiler.compile.models import (
     CompiledObjectKey,
     CompiledProject,
 )
+from sqlbuild.compiler.manifest._helpers.shared import _key_to_unique_id
 
 
 def build_unique_id(*, key: CompiledObjectKey, project_name: str, project: CompiledProject) -> str:
     """Build a dbt-style unique_id from a CompiledObjectKey."""
-
-    source_names: frozenset[str] = frozenset(s.name for s in project.sources)
-    seed_names: frozenset[str] = frozenset(s.name for s in project.seeds)
-
-    if key.name in source_names:
-        return f"source.{project_name}.{key.name}"
-    if key.name in seed_names:
-        return f"seed.{project_name}.{key.name}"
-    return f"model.{project_name}.{key.name}"
+    del project
+    return _key_to_unique_id(key=key, project_name=project_name)
 
 
 def build_parent_map(

--- a/src/sqlbuild/compiler/manifest/_helpers/tests.py
+++ b/src/sqlbuild/compiler/manifest/_helpers/tests.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from sqlbuild.compiler.manifest._helpers.shared import _key_to_unique_id
 from sqlbuild.compiler.manifest.constants import CHECKSUM_HASH_NAME, RESOURCE_TYPE_TEST
 from sqlbuild.compiler.planner.models import AuditPlanEntry, ChainStep, SqlTestPlanEntry
+from sqlbuild.sql_values.types import SqlValueKind
 
 _TEST_CONFIG: dict[str, object] = {
     "enabled": True,
@@ -90,7 +91,7 @@ def build_sql_test_nodes(
 ) -> dict[str, dict[str, object]]:
     """Build dbt-compatible SingularTest nodes from one SQL test plan entry."""
 
-    unique_id: str = f"test.{project_name}.{test_entry.name}"
+    unique_id: str = _key_to_unique_id(key=test_entry.key, project_name=project_name)
 
     compiled_parts: list[str] = []
     step: ChainStep
@@ -114,12 +115,15 @@ def build_sql_test_nodes(
         "unique_id": unique_id,
         "fqn": [project_name, test_entry.name],
         "alias": test_entry.name,
-        "checksum": {"name": CHECKSUM_HASH_NAME, "checksum": ""},
+        "checksum": {
+            "name": CHECKSUM_HASH_NAME,
+            "checksum": test_entry.case_fingerprint or "",
+        },
         "config": dict(_TEST_CONFIG),
         "tags": [],
         "description": "",
         "columns": {},
-        "meta": {"sqlbuild_test_type": "sql_native"},
+        "meta": _sql_test_meta(test_entry),
         "group": None,
         "docs": {"show": True, "node_color": None},
         "patch_path": None,
@@ -134,3 +138,41 @@ def build_sql_test_nodes(
         "depends_on": {"macros": [], "nodes": depends_on_nodes},
     }
     return {unique_id: node}
+
+
+def _sql_test_meta(test_entry: SqlTestPlanEntry) -> dict[str, object]:
+    meta: dict[str, object] = {"sqlbuild_test_type": "sql_native"}
+    if test_entry.case_name is None or test_entry.source_path is None:
+        return meta
+    parameter_types: dict[str, str] = {
+        parameter.name: parameter.value_type.value for parameter in test_entry.parameter_schema
+    }
+    meta.update(
+        {
+            "sqlbuild_source_path": test_entry.source_path.as_posix(),
+            "sqlbuild_block_index": test_entry.block_index,
+            "sqlbuild_parent_name": test_entry.parent_name,
+            "sqlbuild_case_name": test_entry.case_name,
+            "sqlbuild_case_index": test_entry.case_index,
+            "sqlbuild_case_fingerprint": test_entry.case_fingerprint,
+            "sqlbuild_parameter_schema": [
+                {
+                    "name": parameter.name,
+                    "type": parameter.value_type.value,
+                    "nullable": parameter.nullable,
+                }
+                for parameter in test_entry.parameter_schema
+            ],
+            "sqlbuild_parameters": [
+                {
+                    "name": name,
+                    "type": parameter_types[name],
+                    "value": (
+                        str(value.value) if value.kind == SqlValueKind.DECIMAL else value.value
+                    ),
+                }
+                for name, value in test_entry.parameter_values
+            ],
+        }
+    )
+    return meta

--- a/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
+++ b/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
@@ -251,6 +251,14 @@ def plan_test(
     entry: SqlTestPlanEntry = SqlTestPlanEntry(
         key=test.key,
         name=test.name,
+        source_path=test.source_path,
+        block_index=test.block_index,
+        parent_name=test.parent_name,
+        case_name=test.case_name,
+        case_index=test.case_index,
+        case_fingerprint=test.case_fingerprint,
+        parameter_schema=test.parameter_schema,
+        parameter_values=test.parameter_values,
         chain=tuple(chain_steps),
         assertions=assertion_steps,
         scope_deps=test.scope_deps,
@@ -351,6 +359,14 @@ def _plan_direct_logic_test(
     return SqlTestPlanEntry(
         key=test.key,
         name=test.name,
+        source_path=test.source_path,
+        block_index=test.block_index,
+        parent_name=test.parent_name,
+        case_name=test.case_name,
+        case_index=test.case_index,
+        case_fingerprint=test.case_fingerprint,
+        parameter_schema=test.parameter_schema,
+        parameter_values=test.parameter_values,
         chain=(
             ChainStep(
                 model_name=f"{label} {test.name}",

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -27,7 +27,7 @@ from sqlbuild.compiler.compile.models import (
     FunctionReturnColumn,
 )
 from sqlbuild.compiler.compile.types import FunctionLanguage
-from sqlbuild.compiler.discovery.models import DiscoveredHookFunction
+from sqlbuild.compiler.discovery.models import DiscoveredHookFunction, SqlTestParameterDeclaration
 from sqlbuild.compiler.fingerprints.models import Fingerprint
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.types import (
@@ -54,6 +54,7 @@ from sqlbuild.compiler.source_freshness.models import (
 from sqlbuild.runtime.contracts.types import ExecutionResourceKind
 from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig, SeedCsvSettings, SourceEntry
 from sqlbuild.spec.contracts.types import SourceWriteStrategy
+from sqlbuild.sql_values.models import SqlValue
 
 
 @dataclass(frozen=True)
@@ -790,6 +791,14 @@ class SqlTestPlanEntry:
 
     key: CompiledObjectKey
     name: str
+    source_path: Path | None = None
+    block_index: int | None = None
+    parent_name: str | None = None
+    case_name: str | None = None
+    case_index: int | None = None
+    case_fingerprint: str | None = None
+    parameter_schema: tuple[SqlTestParameterDeclaration, ...] = field(default_factory=tuple)
+    parameter_values: tuple[tuple[str, SqlValue], ...] = field(default_factory=tuple)
     chain: tuple[ChainStep, ...] = field(default_factory=tuple)
     assertions: tuple[SqlTestAssertionStep, ...] = field(default_factory=tuple)
     scope_deps: tuple[CompiledObjectKey, ...] = field(default_factory=tuple)

--- a/src/sqlbuild/executor/build/classes/build_scheduler.py
+++ b/src/sqlbuild/executor/build/classes/build_scheduler.py
@@ -105,6 +105,18 @@ from sqlbuild.spec.contracts.models import SnapshotsConfig, SourceEntry
 _DEBUG_LOGGER: logging.Logger = logging.getLogger("sqlbuild.execution")
 
 
+def _test_result_authored_order(*, plan: PlanOutput, result: SqlTestExecutionResult) -> int:
+    entry: SqlTestPlanEntry
+    for index, entry in enumerate(plan.test_entries):
+        if (
+            entry.source_path == result.source_path
+            and entry.block_index == result.block_index
+            and entry.case_index == result.case_index
+        ):
+            return index
+    return len(plan.test_entries)
+
+
 class BuildScheduler:
     """DAG-aware scheduler that dispatches nodes as their dependencies complete."""
 
@@ -246,10 +258,13 @@ class BuildScheduler:
             tuple(self._seed_results),
             tuple(self._function_results),
             tuple(self._load_results),
-            tuple(self._test_results),
+            tuple(sorted(self._test_results, key=self._test_result_order)),
             tuple(self._source_audit_results),
             end_audit_results,
         )
+
+    def _test_result_order(self, result: SqlTestExecutionResult) -> int:
+        return _test_result_authored_order(plan=self._plan, result=result)
 
     def _provision_direct_microbatch_state(self) -> None:
         if self._runtime.microbatch_state_resolver is not None:

--- a/src/sqlbuild/executor/pipeline/_helpers/testing.py
+++ b/src/sqlbuild/executor/pipeline/_helpers/testing.py
@@ -54,10 +54,12 @@ def run_test_pipeline(
         preflight_start: float = time.monotonic()
         if on_progress is not None:
             on_progress("Preparing test functions...")
-        missing_functions_by_test: dict[str, tuple[str, ...]] = _prepare_test_functions(
-            plan=plan,
-            adapter=adapter,
-            connection=connection,
+        missing_functions_by_test: dict[CompiledObjectKey, tuple[str, ...]] = (
+            _prepare_test_functions(
+                plan=plan,
+                adapter=adapter,
+                connection=connection,
+            )
         )
         if on_progress is not None:
             on_progress(f"Prepared test functions. ({time.monotonic() - preflight_start:.2f}s)")
@@ -66,7 +68,7 @@ def run_test_pipeline(
         for entry in plan.test_entries:
             if on_test_start is not None:
                 on_test_start(entry)
-            missing_functions: tuple[str, ...] = missing_functions_by_test.get(entry.name, ())
+            missing_functions: tuple[str, ...] = missing_functions_by_test.get(entry.key, ())
             if missing_functions:
                 result: SqlTestExecutionResult = _build_missing_function_result(
                     test_entry=entry,
@@ -92,7 +94,7 @@ def _prepare_test_functions(
     plan: PlanOutput,
     adapter: BaseAdapter,
     connection: Any,
-) -> dict[str, tuple[str, ...]]:
+) -> dict[CompiledObjectKey, tuple[str, ...]]:
     function_entries: dict[CompiledObjectKey, FunctionPlanEntry] = {
         entry.key: entry for entry in plan.function_entries
     }
@@ -143,13 +145,13 @@ def _prepare_test_functions(
         connection=connection,
     )
 
-    missing_by_test: dict[str, tuple[str, ...]] = {}
+    missing_by_test: dict[CompiledObjectKey, tuple[str, ...]] = {}
     for test_entry in plan.test_entries:
         missing_names: tuple[str, ...] = tuple(
             missing_by_key[dep] for dep in test_entry.function_deps if dep in missing_by_key
         )
         if missing_names:
-            missing_by_test[test_entry.name] = missing_names
+            missing_by_test[test_entry.key] = missing_names
     return missing_by_test
 
 
@@ -214,6 +216,14 @@ def _build_missing_function_result(
     return SqlTestExecutionResult(
         test_name=test_entry.name,
         outcome=SqlTestOutcome.ERROR,
+        source_path=test_entry.source_path,
+        block_index=test_entry.block_index,
+        parent_name=test_entry.parent_name,
+        case_name=test_entry.case_name,
+        case_index=test_entry.case_index,
+        case_fingerprint=test_entry.case_fingerprint,
+        parameter_schema=test_entry.parameter_schema,
+        parameter_values=test_entry.parameter_values,
         step_results=(
             StepResult(
                 model_name=model_name,

--- a/src/sqlbuild/executor/testing/main/_execute.py
+++ b/src/sqlbuild/executor/testing/main/_execute.py
@@ -51,6 +51,14 @@ def execute_sql_test(
         return SqlTestExecutionResult(
             test_name=test_entry.name,
             outcome=SqlTestOutcome.ERROR,
+            source_path=test_entry.source_path,
+            block_index=test_entry.block_index,
+            parent_name=test_entry.parent_name,
+            case_name=test_entry.case_name,
+            case_index=test_entry.case_index,
+            case_fingerprint=test_entry.case_fingerprint,
+            parameter_schema=test_entry.parameter_schema,
+            parameter_values=test_entry.parameter_values,
             step_results=(
                 StepResult(
                     model_name=error_model_name,
@@ -74,6 +82,14 @@ def execute_sql_test(
         return SqlTestExecutionResult(
             test_name=test_entry.name,
             outcome=SqlTestOutcome.ERROR,
+            source_path=test_entry.source_path,
+            block_index=test_entry.block_index,
+            parent_name=test_entry.parent_name,
+            case_name=test_entry.case_name,
+            case_index=test_entry.case_index,
+            case_fingerprint=test_entry.case_fingerprint,
+            parameter_schema=test_entry.parameter_schema,
+            parameter_values=test_entry.parameter_values,
             step_results=(
                 StepResult(
                     model_name=error_model_name,
@@ -103,6 +119,14 @@ def execute_sql_test(
     return SqlTestExecutionResult(
         test_name=test_entry.name,
         outcome=overall_outcome,
+        source_path=test_entry.source_path,
+        block_index=test_entry.block_index,
+        parent_name=test_entry.parent_name,
+        case_name=test_entry.case_name,
+        case_index=test_entry.case_index,
+        case_fingerprint=test_entry.case_fingerprint,
+        parameter_schema=test_entry.parameter_schema,
+        parameter_values=test_entry.parameter_values,
         step_results=tuple(step_results),
         error_code=SQL_TEST_ASSERTION_FAILED_CODE
         if overall_outcome == SqlTestOutcome.FAIL

--- a/src/sqlbuild/executor/testing/models.py
+++ b/src/sqlbuild/executor/testing/models.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 
+from sqlbuild.compiler.discovery.models import SqlTestParameterDeclaration
 from sqlbuild.executor.testing.types import SqlTestOutcome
+from sqlbuild.sql_values.models import SqlValue
 
 
 @dataclass(frozen=True)
@@ -27,6 +30,14 @@ class SqlTestExecutionResult:
 
     test_name: str
     outcome: SqlTestOutcome
+    source_path: Path | None = None
+    block_index: int | None = None
+    parent_name: str | None = None
+    case_name: str | None = None
+    case_index: int | None = None
+    case_fingerprint: str | None = None
+    parameter_schema: tuple[SqlTestParameterDeclaration, ...] = field(default_factory=tuple)
+    parameter_values: tuple[tuple[str, SqlValue], ...] = field(default_factory=tuple)
     step_results: tuple[StepResult, ...] = field(default_factory=tuple)
     error_code: str | None = None
     error_help: str | None = None

--- a/src/sqlbuild/kata_engine/_helpers/engine/native.py
+++ b/src/sqlbuild/kata_engine/_helpers/engine/native.py
@@ -214,7 +214,7 @@ def _sql_test_payloads(project: CompiledProject) -> list[dict[str, object]]:
 
 
 def _sql_test_payload(test: CompiledSqlTest) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "source_path": (test.source_path or test.test_file.relative_path).as_posix(),
         "ownership_root": (test.ownership_root or test.test_file.ownership_root).as_posix(),
         "block_index": test.block_index or test.test_block.test_index,
@@ -230,6 +230,35 @@ def _sql_test_payload(test: CompiledSqlTest) -> dict[str, object]:
             for resource in test.tested_resources
         ],
     }
+    if test.case_name is not None:
+        parameter_types: dict[str, str] = {
+            parameter.name: parameter.value_type.value for parameter in test.parameter_schema
+        }
+        payload.update(
+            {
+                "parent_name": test.parent_name,
+                "case_name": test.case_name,
+                "case_index": test.case_index,
+                "case_fingerprint": test.case_fingerprint,
+                "parameter_schema": [
+                    {
+                        "name": parameter.name,
+                        "type": parameter.value_type.value,
+                        "nullable": parameter.nullable,
+                    }
+                    for parameter in test.parameter_schema
+                ],
+                "parameters": [
+                    {
+                        "name": name,
+                        "type": parameter_types[name],
+                        "value": _typed_value_payload(value),
+                    }
+                    for name, value in test.parameter_values
+                ],
+            }
+        )
+    return payload
 
 
 def _sql_scenario_payloads(project: CompiledProject) -> list[dict[str, object]]:

--- a/src/sqlbuild/sql_values/main/identity.py
+++ b/src/sqlbuild/sql_values/main/identity.py
@@ -1,0 +1,10 @@
+"""Public entry point for typed SQL value identity."""
+
+from sqlbuild.sql_values._helpers.normalization import sql_value_identity as _sql_value_identity
+from sqlbuild.sql_values.models import SqlValue
+
+
+def sql_value_identity(*, value: SqlValue) -> tuple[object, ...]:
+    """Return the normalized typed identity of a SQL value."""
+
+    return _sql_value_identity(value=value)

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/_test_types.py
@@ -21,3 +21,11 @@ class ExecuteMacroTestCase:
     actual_sql: str
     expected_sql: str
     expected_rows: tuple[tuple[object, ...], ...]
+
+
+@dataclass(frozen=True)
+class ExecuteParameterizedTestCase:
+    description: str
+    parameter_value: int
+    expected_case_name: str
+    expected_outcome: str

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_execute_chain.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_execute_chain.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -14,7 +15,9 @@ from sqlbuild.compiler.compile.models import (
     CompileSqlTestCte,
 )
 from sqlbuild.compiler.compile.types import CompiledResourceType, SqlTestMode
+from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredSqlTestBlock, DiscoveredSqlTestFile
+from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
 from sqlbuild.compiler.planner._helpers.sql_tests.assembly import plan_test
 from sqlbuild.compiler.planner.models import ChainStep, SqlTestPlanEntry
 from sqlbuild.executor.testing.main._execute import execute_sql_test
@@ -23,10 +26,74 @@ from sqlbuild.executor.testing.types import SqlTestOutcome
 from tests.integration.src.sqlbuild.compiler.planner._helpers.sql_test_assembly._test_types import (
     ExecuteChainTestCase,
     ExecuteMacroTestCase,
+    ExecuteParameterizedTestCase,
 )
 from tests.integration.src.sqlbuild.compiler.planner._helpers.sql_test_assembly.helpers import (
     build_test_and_project,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ExecuteParameterizedTestCase(
+            description="expanded integer case executes against DuckDB",
+            parameter_value=7,
+            expected_case_name="seven",
+            expected_outcome="pass",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_parameterized_model_test_when_compiled_and_executed_then_duckdb_passes(
+    test_case: ExecuteParameterizedTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+    adapter: DuckDbAdapter,
+    connection: Any,
+) -> None:
+    write_repo_files(
+        tmp_path,
+        {
+            "sqlbuild_project.toml": 'name = "demo"\nadapter = "duckdb"\n',
+            "sources/raw.yml": (
+                "sources:\n  - name: raw_orders\n    expression: SELECT 1 AS order_id\n"
+            ),
+            "models/orders.sql": ('MODEL ();\n\nSELECT order_id FROM __source("raw_orders")\n'),
+            "tests/unit/orders.sql": f"""
+TEST (
+  name "parameterized orders",
+  parameters (order_id integer),
+  cases (seven (order_id {test_case.parameter_value})),
+);
+
+WITH
+__source__raw_orders AS (SELECT @param("order_id") AS order_id),
+__expected__orders AS (SELECT @param("order_id") AS order_id)
+SELECT 1
+""".strip()
+            + "\n",
+        },
+    )
+    project: CompiledProject = build_compiled_project(
+        discovered_inputs=discover_project_inputs(project_dir=tmp_path),
+        adapter=adapter,
+    )
+    entry, warnings = plan_test(
+        test=project.sql_tests[0],
+        adapter=adapter,
+        project=project,
+    )
+
+    result: SqlTestExecutionResult = execute_sql_test(
+        test_entry=entry,
+        adapter=adapter,
+        connection=connection,
+    )
+
+    assert warnings == ()
+    assert entry.case_name == test_case.expected_case_name
+    assert result.outcome.value == test_case.expected_outcome
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
@@ -14,7 +14,7 @@ from sqlbuild.cli.commands._helpers.compile.target_writer import (
 )
 from sqlbuild.cli.commands.models import WrittenTarget
 from sqlbuild.compiler.compile.models import CompiledProject
-from sqlbuild.compiler.planner.models import PlanOutput
+from sqlbuild.compiler.planner.models import PlanOutput, SqlTestPlanEntry
 from sqlbuild.executor.testing.main.comparison_sql import build_sql_test_comparison_sql
 from tests.unit.src.sqlbuild.cli.commands.main.compile._test_types import (
     TargetWriterTestCase,
@@ -85,6 +85,50 @@ def test_given_plan_output_when_writing_target_then_expected_files_are_written(
     assert json.loads(manifest_path.read_text()) == manifest
     assert manifest_path.stat().st_mtime_ns == unchanged_mtime_ns
     assert not (tmp_path / "target" / "run").exists()
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TargetWriterTestCase(
+            description="writes SQL test cases to source and block scoped paths",
+            expected_files={
+                "compiled/tests/tests/unit/orders/block_1__small.sql": "",
+                "compiled/tests/tests/unit/orders/block_1__large.sql": "",
+            },
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_parameterized_test_entries_when_writing_target_then_case_artifacts_do_not_collide(
+    test_case: TargetWriterTestCase,
+    tmp_path: Path,
+) -> None:
+    plan_output: PlanOutput = build_target_writer_plan_output()
+    template: SqlTestPlanEntry = plan_output.test_entries[0]
+    case_entries: tuple[SqlTestPlanEntry, ...] = tuple(
+        replace(
+            template,
+            key=replace(template.key, name=f"orders [{case_name}]"),
+            name=f"orders [{case_name}]",
+            source_path=Path("tests/unit/orders.sql"),
+            block_index=1,
+            parent_name="orders",
+            case_name=case_name,
+        )
+        for case_name in ("small", "large")
+    )
+    parameterized_plan: PlanOutput = replace(plan_output, test_entries=case_entries)
+
+    write_compile_target(
+        target_dir=tmp_path / "target",
+        adapter=DuckDbAdapter(),
+        plan_output=parameterized_plan,
+    )
+
+    expected_path: str
+    for expected_path in test_case.expected_files:
+        assert (tmp_path / "target" / expected_path).is_file()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
@@ -10,3 +10,14 @@ class MicrobatchExecutionProtocolTestCase:
     description: str
     expected_run_type: str
     expected_replay_state: str
+
+
+@dataclass(frozen=True)
+class SqlTestCaseExecutionProtocolTestCase:
+    """Expected identity and typed parameter fields for one SQL test case."""
+
+    description: str
+    expected_check_id: str
+    expected_decimal_value: str
+    expected_fingerprint: str
+    expected_text_label: str

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_protocol_v1.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_protocol_v1.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
+from pathlib import Path
+
 import pytest
 
-from sqlbuild.cli.output._helpers.execution_protocol_v1 import _format_model_assets
+from sqlbuild.cli.commands._helpers.test.sql_progress import format_parameterized_test_label
+from sqlbuild.cli.output._helpers.execution_protocol_v1 import (
+    _format_model_assets,
+    _format_sql_test_checks,
+)
+from sqlbuild.compiler.discovery.models import SqlTestParameterDeclaration
 from sqlbuild.executor.run.models import (
     MicrobatchAccountingInterval,
     ModelExecutionResult,
 )
 from sqlbuild.executor.scheduling.types import ExecutionStatus
+from sqlbuild.executor.testing.models import SqlTestExecutionResult
+from sqlbuild.executor.testing.types import SqlTestOutcome
+from sqlbuild.sql_values.models import SqlLogicalType, SqlValue
+from sqlbuild.sql_values.types import SqlValueKind
 from tests.unit.src.sqlbuild.cli.output._helpers._test_types import (
     MicrobatchExecutionProtocolTestCase,
+    SqlTestCaseExecutionProtocolTestCase,
 )
 
 
@@ -91,3 +104,92 @@ def test_given_microbatch_result_when_formatting_json_then_interval_provenance_i
             }
         ],
     }
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SqlTestCaseExecutionProtocolTestCase(
+            description="parameterized SQL test emits stable identity and safe decimal value",
+            expected_check_id="sql_test:tests/unit/orders.sql:2:large_order",
+            expected_decimal_value="12.3400",
+            expected_fingerprint="a" * 64,
+            expected_text_label=(
+                "order totals [large_order] (tests/unit/orders.sql; "
+                'amount:decimal="12.3400", note:string?=null)'
+            ),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_parameterized_sql_test_result_when_formatting_json_then_case_metadata_is_safe(
+    test_case: SqlTestCaseExecutionProtocolTestCase,
+) -> None:
+    result: SqlTestExecutionResult = SqlTestExecutionResult(
+        test_name="order totals [large_order]",
+        outcome=SqlTestOutcome.PASS,
+        source_path=Path("tests/unit/orders.sql"),
+        block_index=2,
+        parent_name="order totals",
+        case_name="large_order",
+        case_index=1,
+        case_fingerprint=test_case.expected_fingerprint,
+        parameter_schema=(
+            SqlTestParameterDeclaration(
+                name="amount",
+                value_type=SqlValueKind.DECIMAL,
+            ),
+            SqlTestParameterDeclaration(
+                name="note",
+                value_type=SqlValueKind.STRING,
+                nullable=True,
+            ),
+        ),
+        parameter_values=(
+            (
+                "amount",
+                SqlValue(
+                    logical_type=SqlLogicalType(SqlValueKind.DECIMAL),
+                    value=Decimal(test_case.expected_decimal_value),
+                ),
+            ),
+            (
+                "note",
+                SqlValue(
+                    logical_type=SqlLogicalType(SqlValueKind.NULL),
+                    value=None,
+                ),
+            ),
+        ),
+    )
+
+    check: dict[str, object] = _format_sql_test_checks((result,))[0]
+
+    assert check["check_id"] == test_case.expected_check_id
+    assert check["source_path"] == "tests/unit/orders.sql"
+    assert check["block_index"] == 2
+    assert check["parent_name"] == "order totals"
+    assert check["case_name"] == "large_order"
+    assert check["case_index"] == 1
+    assert check["case_fingerprint"] == test_case.expected_fingerprint
+    assert check["parameter_schema"] == (
+        {"name": "amount", "type": "decimal", "nullable": False},
+        {"name": "note", "type": "string", "nullable": True},
+    )
+    assert check["parameters"] == (
+        {
+            "name": "amount",
+            "type": "decimal",
+            "value": test_case.expected_decimal_value,
+        },
+        {"name": "note", "type": "string", "value": None},
+    )
+    assert (
+        format_parameterized_test_label(
+            name=result.test_name,
+            source_path=result.source_path,
+            parameter_schema=result.parameter_schema,
+            parameter_values=result.parameter_values,
+        )
+        == test_case.expected_text_label
+    )

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
@@ -14,6 +14,7 @@ from sqlbuild.compiler.compile.types import AttachedAuditTargetKind, SqlTestMode
 from sqlbuild.compiler.lineage.types import InferredNullability
 from sqlbuild.compiler.scopes.models import UsageRecord
 from sqlbuild.compiler.scopes.types import ScopeKind
+from sqlbuild.sql_values.models import SqlValue
 
 
 @dataclass(frozen=True)
@@ -163,6 +164,37 @@ class RelationshipUsageTestCase:
     description: str
     files: dict[str, str]
     expected_usage: UsageRecord
+
+
+@dataclass(frozen=True)
+class ParameterizedSqlTestCompilationTestCase:
+    description: str
+    repo_files: dict[str, str]
+    expected_names: tuple[str, ...]
+    expected_case_names: tuple[str, ...]
+    expected_sql_fragments: tuple[tuple[str, ...], ...]
+
+
+@dataclass(frozen=True)
+class ParameterizedSqlTestCompilationErrorTestCase:
+    description: str
+    test_sql: str
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
+class ParameterizedSqlTestRenderingErrorTestCase:
+    description: str
+    rendered_value: str
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
+class ParameterizedSqlTestAdapterRenderingTestCase:
+    description: str
+    adapter_name: str
+    value: SqlValue
+    expected_sql: str
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_parameterized_sql_tests.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_parameterized_sql_tests.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from sqlbuild.adapters.bigquery.classes.bigquery_adapter import BigQueryAdapter
+from sqlbuild.adapters.sqlserver.classes.sqlserver_adapter import SqlServerAdapter
+from sqlbuild.compiler.compile._helpers.assembly.project import assemble_compiled_project
+from sqlbuild.compiler.compile._helpers.render.parameters import expand_test_parameters
+from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.compiler.compile.models import (
+    CompiledObjectKey,
+    CompiledProject,
+    CompiledSqlTest,
+    CompileProjectInputs,
+)
+from sqlbuild.compiler.compile.types import CompiledResourceType, TypedSqlValueRenderer
+from sqlbuild.compiler.planner._helpers.output.plan_entry import scope_overlaps
+from sqlbuild.sql_values.models import SqlLogicalType, SqlValue
+from sqlbuild.sql_values.types import SqlValueKind
+from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
+    ParameterizedSqlTestAdapterRenderingTestCase,
+    ParameterizedSqlTestCompilationErrorTestCase,
+    ParameterizedSqlTestCompilationTestCase,
+    ParameterizedSqlTestRenderingErrorTestCase,
+)
+from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import compile_project_inputs
+from tests.unit.src.sqlbuild.compiler.compile._test_helpers import base_repo_files
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ParameterizedSqlTestCompilationTestCase(
+            description="expands ordered typed model and macro test cases before macros",
+            repo_files=base_repo_files()
+            | {
+                "models/orders.sql": "MODEL ();\n\nSELECT 'open' AS status\n",
+                "models/customers.sql": "MODEL ();\n\nSELECT 1 AS customer_id\n",
+                "sources/raw.yml": "sources:\n  - name: raw_orders\n    expression: SELECT 1 AS order_id\n",
+                "seeds/schema.yml": (
+                    "seeds:\n  - name: country_codes\n    columns:\n"
+                    "      - name: code\n        type: VARCHAR\n"
+                ),
+                "seeds/country_codes.csv": "code\nGB\n",
+                "constants/offset.sql": "CONSTANT (name offset, value 2);\n",
+                "enums/state.sql": "ENUM (name state, members [OPEN, CLOSED]);\n",
+                "functions/sql/add_one.sql": """
+FUNCTION (arguments (value INTEGER), returns INTEGER);
+
+value + 1
+""".strip()
+                + "\n",
+                "functions/sql/by_customer.sql": """
+FUNCTION (
+  arguments (customer_id INTEGER),
+  returns table (customer_id INTEGER)
+);
+
+SELECT customer_id
+""".strip()
+                + "\n",
+                "macros/identity.py": (
+                    "def identity(value):\n    return value\n\n"
+                    "def parameterized_fixture(value):\n    return str(value)\n"
+                ),
+                "tests/unit/a_model_cases.sql": """
+TEST (
+  name "status mapping",
+  parameters (
+    status string,
+    count integer,
+    enabled boolean,
+    ratio float,
+    amount decimal,
+    note (type string, nullable true),
+  ),
+  cases (
+    open_case (
+      status "O'Brien",
+      count -7,
+      enabled true,
+      ratio 1.25,
+      amount "2.4700",
+      note null,
+    ),
+    closed_case (
+      status "closed",
+      count 8,
+      enabled false,
+      ratio -0.5,
+      amount "3.00",
+      note "kept",
+    ),
+  ),
+);
+
+WITH
+__source__raw_orders AS (SELECT @param("count") AS order_id),
+__ref__orders AS (
+  SELECT
+    @identity(@param("status")) AS status,
+    @param("status") AS status_copy,
+    @param("count") AS count,
+    @parameterized_fixture(@param("count")) AS boundary_count,
+    @param("enabled") AS enabled,
+    @param("ratio") AS ratio,
+    @param("amount") AS amount,
+    @param("note") AS note,
+    @param("count") + @const("offset") AS adjusted_count,
+    @enum("state").OPEN AS state,
+    '@param("status")' AS quoted_marker
+  -- @param("status") remains a comment
+),
+__ref__customers AS (SELECT @param("count") AS customer_id),
+__seed__country_codes AS (SELECT @param("status") AS code),
+__expected__orders AS (SELECT @param("status") AS status),
+__expected__customers AS (SELECT @param("count") AS customer_id),
+__assert__positive_count AS (SELECT 1 WHERE @param("count") < 0)
+SELECT 1
+""".strip()
+                + "\n",
+                "tests/unit/b_macro_cases.sql": """
+TEST (
+  name "identity macro",
+  mode macro,
+  parameters (value string),
+  cases (first (value "one"), second (value "two")),
+);
+
+WITH
+__macro_actual__ AS (SELECT @identity(@param("value")) AS value),
+__macro_expected__ AS (SELECT @param("value") AS value)
+SELECT 1
+""".strip()
+                + "\n",
+                "tests/unit/c_udf_cases.sql": """
+TEST (
+  name "add one udf",
+  mode udf,
+  parameters (value integer),
+  cases (small (value 2), large (value 9)),
+);
+
+WITH
+__udf_actual__ AS (SELECT __udf("add_one")(@param("value")) AS value),
+__udf_expected__ AS (SELECT @param("value") + 1 AS value)
+SELECT 1
+""".strip()
+                + "\n",
+                "tests/unit/d_table_fn_cases.sql": """
+TEST (
+  name "by customer table function",
+  mode table_fn,
+  parameters (customer_id integer),
+  cases (first (customer_id 11), second (customer_id 22)),
+);
+
+WITH
+__table_fn_actual__ AS (
+  SELECT customer_id FROM __table_fn("by_customer")(@param("customer_id"))
+),
+__table_fn_expected__ AS (SELECT @param("customer_id") AS customer_id)
+SELECT 1
+""".strip()
+                + "\n",
+                "tests/scenarios/status.sql": """
+SCENARIO (description "ordinary scenario");
+
+WITH
+__ref__orders AS (SELECT 'open' AS status),
+__expected__orders AS (SELECT 'open' AS status)
+SELECT 1
+""".strip()
+                + "\n",
+            },
+            expected_names=(
+                "status mapping [open_case]",
+                "status mapping [closed_case]",
+                "identity macro [first]",
+                "identity macro [second]",
+                "add one udf [small]",
+                "add one udf [large]",
+                "by customer table function [first]",
+                "by customer table function [second]",
+            ),
+            expected_case_names=(
+                "open_case",
+                "closed_case",
+                "first",
+                "second",
+                "small",
+                "large",
+                "first",
+                "second",
+            ),
+            expected_sql_fragments=(
+                (
+                    "'O''Brien' AS status",
+                    "'O''Brien' AS status_copy",
+                    "-7 AS count",
+                    "-7 AS boundary_count",
+                    "TRUE AS enabled",
+                    "1.25 AS ratio",
+                    "2.4700 AS amount",
+                    "NULL AS note",
+                    "-7 + 2 AS adjusted_count",
+                    "'OPEN' AS state",
+                    "SELECT -7 AS order_id",
+                    "SELECT 'O''Brien' AS code",
+                    "SELECT 'O''Brien' AS status",
+                    "SELECT -7 AS customer_id",
+                    "SELECT 1 WHERE -7 < 0",
+                    "'@param(\"status\")' AS quoted_marker",
+                    '-- @param("status") remains a comment',
+                ),
+                (
+                    "'closed' AS status",
+                    "'closed' AS status_copy",
+                    "8 AS count",
+                    "FALSE AS enabled",
+                    "-0.5 AS ratio",
+                    "3.00 AS amount",
+                    "'kept' AS note",
+                    "8 + 2 AS adjusted_count",
+                ),
+                ("SELECT one AS value", "SELECT 'one' AS value"),
+                ("SELECT two AS value", "SELECT 'two' AS value"),
+                ('__udf("add_one")(2)', "SELECT 2 + 1 AS value"),
+                ('__udf("add_one")(9)', "SELECT 9 + 1 AS value"),
+                ('__table_fn("by_customer")(11)', "SELECT 11 AS customer_id"),
+                ('__table_fn("by_customer")(22)', "SELECT 22 AS customer_id"),
+            ),
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_parameterized_sql_tests_when_compiling_then_cases_have_typed_unique_identities(
+    test_case: ParameterizedSqlTestCompilationTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, test_case.repo_files)
+    compile_inputs: CompileProjectInputs = compile_project_inputs(project_dir=tmp_path)
+    compiled: CompiledProject = assemble_compiled_project(inputs=compile_inputs)
+
+    assert tuple(test.name for test in compiled.sql_tests) == test_case.expected_names
+    assert tuple(test.key.name for test in compiled.sql_tests) == test_case.expected_names
+    assert tuple(test.case_name for test in compiled.sql_tests) == test_case.expected_case_names
+    assert tuple(test.case_index for test in compiled.sql_tests) == (0, 1, 0, 1, 0, 1, 0, 1)
+    assert tuple(test.parent_name for test in compiled.sql_tests) == (
+        "status mapping",
+        "status mapping",
+        "identity macro",
+        "identity macro",
+        "add one udf",
+        "add one udf",
+        "by customer table function",
+        "by customer table function",
+    )
+    compiled_test: CompiledSqlTest
+    expected_fragments: tuple[str, ...]
+    for compiled_test, expected_fragments in zip(
+        compiled.sql_tests,
+        test_case.expected_sql_fragments,
+        strict=True,
+    ):
+        for fragment in expected_fragments:
+            assert fragment in compiled_test.sql_body, compiled_test.sql_body
+    assert tuple(value.kind.value for _name, value in compiled.sql_tests[0].parameter_values) == (
+        "string",
+        "integer",
+        "boolean",
+        "float",
+        "decimal",
+        "null",
+    )
+    original_fingerprints: tuple[str | None, ...] = tuple(
+        test.case_fingerprint for test in compiled.sql_tests
+    )
+    assert all(original_fingerprints)
+    model_test_path: Path = tmp_path / "tests/unit/a_model_cases.sql"
+    model_test_path.write_text(
+        model_test_path.read_text(encoding="utf-8").replace('amount "2.4700"', 'amount "2.4800"'),
+        encoding="utf-8",
+    )
+    changed: CompiledProject = assemble_compiled_project(
+        inputs=compile_project_inputs(project_dir=tmp_path)
+    )
+    changed_fingerprints: tuple[str | None, ...] = tuple(
+        test.case_fingerprint for test in changed.sql_tests
+    )
+    assert changed_fingerprints[0] != original_fingerprints[0]
+    assert changed_fingerprints[1:] == original_fingerprints[1:]
+    model_cases: tuple[CompiledSqlTest, ...] = compiled.sql_tests[:2]
+    selected_orders: frozenset[CompiledObjectKey] = frozenset(
+        (
+            CompiledObjectKey(
+                resource_type=CompiledResourceType.MODEL,
+                name="orders",
+            ),
+        )
+    )
+    assert all(
+        scope_overlaps(scope_deps=test.scope_deps, selected_keys=selected_orders)
+        for test in model_cases
+    )
+    assert tuple(test.payload.expected_model_names for test in model_cases) == (
+        ("orders", "customers"),
+        ("orders", "customers"),
+    )
+    assert tuple(scenario.name for scenario in compiled.sql_scenarios) == ("status",)
+    assert compiled.sql_scenarios[0].sql_body.endswith("SELECT 1")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ParameterizedSqlTestAdapterRenderingTestCase(
+            description="BigQuery preserves decimal scale with a NUMERIC literal",
+            adapter_name="bigquery",
+            value=SqlValue(
+                logical_type=SqlLogicalType(SqlValueKind.DECIMAL),
+                value=Decimal("12.3400"),
+            ),
+            expected_sql="SELECT NUMERIC '12.3400'",
+        ),
+        ParameterizedSqlTestAdapterRenderingTestCase(
+            description="SQL Server uses a Unicode string literal",
+            adapter_name="sqlserver",
+            value=SqlValue(
+                logical_type=SqlLogicalType(SqlValueKind.STRING),
+                value="O'Brien",
+            ),
+            expected_sql="SELECT N'O''Brien'",
+        ),
+        ParameterizedSqlTestAdapterRenderingTestCase(
+            description="SQL Server renders true as a bit-compatible scalar",
+            adapter_name="sqlserver",
+            value=SqlValue(
+                logical_type=SqlLogicalType(SqlValueKind.BOOLEAN),
+                value=True,
+            ),
+            expected_sql="SELECT 1",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_adapter_specific_parameter_when_expanding_then_adapter_literal_is_used(
+    test_case: ParameterizedSqlTestAdapterRenderingTestCase,
+) -> None:
+    renderer: TypedSqlValueRenderer = {
+        "bigquery": BigQueryAdapter(),
+        "sqlserver": SqlServerAdapter(),
+    }[test_case.adapter_name]
+
+    rendered, used_names = expand_test_parameters(
+        sql='SELECT @param("value")',
+        file_path=Path("tests/unit/adapter.sql"),
+        values=(("value", test_case.value),),
+        value_renderer=renderer,
+        test_name="adapter rendering",
+        case_name="one",
+    )
+
+    assert rendered == test_case.expected_sql
+    assert used_names == frozenset(("value",))
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ParameterizedSqlTestCompilationErrorTestCase(
+            description="rejects declared parameters unused by the template",
+            test_sql=('TEST (parameters (value string), cases (one (value "x")));\n\nSELECT 1\n'),
+            expected_error_fragment="declares unused parameters: value in case 'one'",
+        ),
+        ParameterizedSqlTestCompilationErrorTestCase(
+            description="rejects references to undeclared parameters",
+            test_sql=(
+                'TEST (parameters (value string), cases (one (value "x")));\n\n'
+                'SELECT @param("value"), @param("other")\n'
+            ),
+            expected_error_fragment="case 'one'.*references undeclared parameter 'other'",
+        ),
+        ParameterizedSqlTestCompilationErrorTestCase(
+            description="rejects malformed parameter references",
+            test_sql=(
+                'TEST (parameters (value string), cases (one (value "x")));\n\n'
+                "SELECT @param('value')\n"
+            ),
+            expected_error_fragment="case 'one'.*malformed @param reference",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_invalid_parameter_references_when_compiling_then_clear_error_is_raised(
+    test_case: ParameterizedSqlTestCompilationErrorTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(
+        tmp_path,
+        base_repo_files() | {"tests/unit/invalid_parameters.sql": test_case.test_sql},
+    )
+
+    with pytest.raises(CompileInputError, match=test_case.expected_error_fragment):
+        compile_project_inputs(project_dir=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ParameterizedSqlTestRenderingErrorTestCase(
+            description="reports adapter test case and parameter when rendered value is oversized",
+            rendered_value="x" * 1_000_001,
+            expected_error_fragment=(
+                "SQL test 'large values' case 'oversized' parameter 'value' could not be "
+                "rendered by adapter 'test_adapter'"
+            ),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_oversized_rendered_parameter_when_expanding_then_contextual_error_is_raised(
+    test_case: ParameterizedSqlTestRenderingErrorTestCase,
+) -> None:
+    renderer: Mock = Mock()
+    renderer.adapter_name = "test_adapter"
+    renderer.render_typed_scalar.return_value = test_case.rendered_value
+    value: SqlValue = SqlValue(
+        logical_type=SqlLogicalType(SqlValueKind.STRING),
+        value="safe",
+    )
+
+    with pytest.raises(CompileInputError, match=test_case.expected_error_fragment):
+        expand_test_parameters(
+            sql='SELECT @param("value")',
+            file_path=Path("tests/unit/large.sql"),
+            values=(("value", value),),
+            value_renderer=renderer,
+            test_name="large values",
+            case_name="oversized",
+        )

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
@@ -364,6 +364,10 @@ class ParseSqlTestFileTestCase:
     expected_sql_bodies: tuple[str, ...]
     expected_test_indexes: tuple[int, ...]
     expected_header_values: tuple[dict[str, object], ...] = ()
+    expected_parameter_types: tuple[str, ...] = ()
+    expected_parameter_nullability: tuple[bool, ...] = ()
+    expected_case_names: tuple[str, ...] = ()
+    expected_case_values: tuple[tuple[object, ...], ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/helpers.py
@@ -11,6 +11,9 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredConstantFile,
     DiscoveredEnumFile,
     DiscoveredMacroFile,
+    DiscoveredSqlTestBlock,
+    DiscoveredSqlTestCase,
+    SqlTestParameterDeclaration,
 )
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
     LoadProjectConfigTestCase,
@@ -53,3 +56,33 @@ def discover_declarations(
     *, project_dir: Path, kind: str
 ) -> tuple[DiscoveredMacroFile | DiscoveredEnumFile | DiscoveredConstantFile, ...]:
     return _DECLARATION_DISCOVERER_BY_KIND[kind](project_dir=project_dir)
+
+
+def discovered_test_parameters(
+    *, blocks: tuple[DiscoveredSqlTestBlock, ...]
+) -> tuple[SqlTestParameterDeclaration, ...]:
+    parameters: list[SqlTestParameterDeclaration] = []
+    block: DiscoveredSqlTestBlock
+    for block in blocks:
+        parameters.extend(block.parameters)
+    return tuple(parameters)
+
+
+def discovered_test_cases(
+    *, blocks: tuple[DiscoveredSqlTestBlock, ...]
+) -> tuple[DiscoveredSqlTestCase, ...]:
+    cases: list[DiscoveredSqlTestCase] = []
+    block: DiscoveredSqlTestBlock
+    for block in blocks:
+        cases.extend(block.cases)
+    return tuple(cases)
+
+
+def discovered_test_case_values(
+    *, cases: tuple[DiscoveredSqlTestCase, ...]
+) -> tuple[tuple[object, ...], ...]:
+    case_values: list[tuple[object, ...]] = []
+    test_case: DiscoveredSqlTestCase
+    for test_case in cases:
+        case_values.append(tuple(value.value for _name, value in test_case.values))
+    return tuple(case_values)

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_tests.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_sql_tests.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
 
 from sqlbuild.compiler.discovery._helpers.sql.tests import parse_sql_test_file
 from sqlbuild.compiler.discovery.exceptions import SqlTestParseError
-from sqlbuild.compiler.discovery.models import DiscoveredSqlTestBlock
+from sqlbuild.compiler.discovery.models import (
+    DiscoveredSqlTestBlock,
+    DiscoveredSqlTestCase,
+    SqlTestParameterDeclaration,
+)
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
     ParseSqlTestFileErrorTestCase,
     ParseSqlTestFileTestCase,
+)
+from tests.unit.src.sqlbuild.compiler.discovery._helpers.helpers import (
+    discovered_test_case_values,
+    discovered_test_cases,
+    discovered_test_parameters,
 )
 
 
@@ -73,6 +83,90 @@ from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
             expected_test_indexes=(1,),
             expected_header_values=({"name": "orders logic", "mode": "macro"},),
         ),
+        ParseSqlTestFileTestCase(
+            description="parses typed ordered cases with nullable values",
+            contents="""
+        TEST (
+          name "typed values",
+          parameters (
+            text_value string,
+            integer_value integer,
+            boolean_value boolean,
+            float_value float,
+            decimal_value decimal,
+            optional_value (type string, nullable true),
+          ),
+          cases (
+            first (
+              text_value "O\\'Brien",
+              integer_value -7,
+              boolean_value true,
+              float_value 1.25,
+              decimal_value "2.4700",
+              optional_value null,
+            ),
+            second (
+              text_value "open",
+              integer_value 8,
+              boolean_value false,
+              float_value -0.5,
+              decimal_value "3.00",
+              optional_value "present",
+            ),
+          ),
+        );
+
+        SELECT @param("text_value")
+        """,
+            expected_names=("typed values",),
+            expected_sql_bodies=('SELECT @param("text_value")',),
+            expected_test_indexes=(1,),
+            expected_header_values=(
+                {
+                    "name": "typed values",
+                    "parameters": {
+                        "text_value": "string",
+                        "integer_value": "integer",
+                        "boolean_value": "boolean",
+                        "float_value": "float",
+                        "decimal_value": "decimal",
+                        "optional_value": {"type": "string", "nullable": True},
+                    },
+                    "cases": {
+                        "first": {
+                            "text_value": "O'Brien",
+                            "integer_value": -7,
+                            "boolean_value": True,
+                            "float_value": 1.25,
+                            "decimal_value": "2.4700",
+                            "optional_value": None,
+                        },
+                        "second": {
+                            "text_value": "open",
+                            "integer_value": 8,
+                            "boolean_value": False,
+                            "float_value": -0.5,
+                            "decimal_value": "3.00",
+                            "optional_value": "present",
+                        },
+                    },
+                },
+            ),
+            expected_parameter_types=(
+                "string",
+                "integer",
+                "boolean",
+                "float",
+                "decimal",
+                "string",
+            ),
+            expected_parameter_nullability=(False, False, False, False, False, True),
+            expected_case_names=("first", "second"),
+            expected_case_values=(
+                ("O'Brien", -7, True, 1.25, Decimal("2.4700"), None),
+                ("open", 8, False, -0.5, Decimal("3.00"), "present"),
+            ),
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -89,6 +183,19 @@ def test_given_sql_test_file_variants_when_parsing_then_it_returns_expected_raw_
     assert tuple(block.header_values for block in discovered_blocks) == (
         test_case.expected_header_values
     )
+    parameters: tuple[SqlTestParameterDeclaration, ...] = discovered_test_parameters(
+        blocks=discovered_blocks
+    )
+    cases: tuple[DiscoveredSqlTestCase, ...] = discovered_test_cases(blocks=discovered_blocks)
+    assert tuple(parameter.value_type.value for parameter in parameters) == (
+        test_case.expected_parameter_types
+    )
+    assert tuple(parameter.nullable for parameter in parameters) == (
+        test_case.expected_parameter_nullability
+    )
+    assert tuple(case.name for case in cases) == test_case.expected_case_names
+    assert tuple(case.case_index for case in cases) == tuple(range(len(cases)))
+    assert discovered_test_case_values(cases=cases) == test_case.expected_case_values
 
 
 @pytest.mark.parametrize(
@@ -125,7 +232,7 @@ def test_given_sql_test_file_variants_when_parsing_then_it_returns_expected_raw_
 
         SELECT 1
         """,
-            expected_error_fragment="only supports `name` and `mode`; unsupported keys: chain",
+            expected_error_fragment="unsupported keys: chain",
         ),
         ParseSqlTestFileErrorTestCase(
             description="raises when the test name is blank",
@@ -190,6 +297,61 @@ def test_given_sql_test_file_variants_when_parsing_then_it_returns_expected_raw_
             description="rejects an unknown test mode",
             contents="TEST (mode integration);\n\nSELECT 1\n",
             expected_error_fragment="mode.*must be one of",
+        ),
+        ParseSqlTestFileErrorTestCase(
+            description="rejects parameters without cases",
+            contents="TEST (parameters (status string));\n\nSELECT 1\n",
+            expected_error_fragment="must define `parameters` and `cases` together",
+        ),
+        ParseSqlTestFileErrorTestCase(
+            description="rejects duplicate parameter names",
+            contents=(
+                "TEST (parameters (status string, status string), "
+                'cases (one (status "open")));\nSELECT 1\n'
+            ),
+            expected_error_fragment="duplicate key 'status'",
+        ),
+        ParseSqlTestFileErrorTestCase(
+            description="rejects duplicate case names",
+            contents=(
+                "TEST (parameters (status string), cases ("
+                'one (status "open"), one (status "closed")));\nSELECT 1\n'
+            ),
+            expected_error_fragment="duplicate key 'one'",
+        ),
+        ParseSqlTestFileErrorTestCase(
+            description="rejects missing case parameters",
+            contents=(
+                "TEST (parameters (status string, expected string), "
+                'cases (one (status "open")));\nSELECT 1\n'
+            ),
+            expected_error_fragment="missing parameters: expected",
+        ),
+        ParseSqlTestFileErrorTestCase(
+            description="rejects undeclared case parameters",
+            contents=(
+                "TEST (parameters (status string), "
+                'cases (one (status "open", expected "open")));\nSELECT 1\n'
+            ),
+            expected_error_fragment="undeclared parameters: expected",
+        ),
+        ParseSqlTestFileErrorTestCase(
+            description="rejects incompatible typed values",
+            contents=('TEST (parameters (count integer), cases (one (count "1")));\nSELECT 1\n'),
+            expected_error_fragment="has type str; expected integer",
+        ),
+        ParseSqlTestFileErrorTestCase(
+            description="rejects null for non-nullable parameters",
+            contents="TEST (parameters (status string), cases (one (status null)));\nSELECT 1\n",
+            expected_error_fragment="is not nullable",
+        ),
+        ParseSqlTestFileErrorTestCase(
+            description="rejects malformed case names",
+            contents=(
+                "TEST (parameters (status string), "
+                'cases ("not valid" (status "open")));\nSELECT 1\n'
+            ),
+            expected_error_fragment="expected key",
         ),
     ],
     ids=lambda case: case.description,

--- a/tests/unit/src/sqlbuild/compiler/manifest/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/manifest/test_main.py
@@ -835,6 +835,15 @@ def test_given_sql_test_when_building_manifest_then_produces_test_node(
         chain=chain,
         scope_deps=(model_key("orders"),),
     )
+    test_entry = replace(
+        test_entry,
+        source_path=Path("tests/unit/orders.sql"),
+        block_index=1,
+        parent_name="test_orders",
+        case_name="first",
+        case_index=0,
+        case_fingerprint="f" * 64,
+    )
     plan_output: PlanOutput = build_test_plan_output(
         model_entries=(build_test_plan_entry(name="orders"),),
         test_entries=(test_entry,),
@@ -845,8 +854,8 @@ def test_given_sql_test_when_building_manifest_then_produces_test_node(
         plan_output=plan_output,
         project_name=test_case.project_name,
         adapter_type=_ADAPTER,
-        upstream_deps={},
-        downstream_deps={},
+        upstream_deps={test_entry.key: (model.key,)},
+        downstream_deps={model.key: (test_entry.key,)},
     )
 
     node: dict[str, Any] = manifest_nodes(result)[test_case.expected_unique_id]
@@ -855,6 +864,11 @@ def test_given_sql_test_when_building_manifest_then_produces_test_node(
     assert node["resource_type"] == test_case.expected_resource_type
     assert node["name"] == test_case.expected_name
     assert node["meta"]["sqlbuild_test_type"] == test_case.expected_sqlbuild_test_type
+    assert node["checksum"] == {"name": "sha256", "checksum": "f" * 64}
+    assert node["meta"]["sqlbuild_case_index"] == 0
+    assert node["meta"]["sqlbuild_case_fingerprint"] == "f" * 64
+    assert result["parent_map"][test_case.expected_unique_id] == [f"model.{_PROJECT}.orders"]
+    assert f"model.{_PROJECT}.test_orders" not in result["parent_map"]
     assert test_case.expected_compiled_code_fragment in node["compiled_code"]
     dep_id: str
     for dep_id in test_case.expected_depends_on_nodes:

--- a/tests/unit/src/sqlbuild/executor/build/classes/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/build/classes/_test_types.py
@@ -12,3 +12,10 @@ class MicrobatchBoundedFutureTestCase:
     global_concurrency: int
     model_concurrency: int
     expected_max_subworker_futures: int
+
+
+@dataclass(frozen=True)
+class SqlTestAuthoredOrderTestCase:
+    description: str
+    case_names: tuple[str, ...]
+    expected_order: tuple[str, ...]

--- a/tests/unit/src/sqlbuild/executor/build/classes/test_build_scheduler_test_order.py
+++ b/tests/unit/src/sqlbuild/executor/build/classes/test_build_scheduler_test_order.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.planner.models import PlanOutput, SqlTestPlanEntry
+from sqlbuild.executor.build.classes.build_scheduler import _test_result_authored_order
+from sqlbuild.executor.testing.models import SqlTestExecutionResult
+from sqlbuild.executor.testing.types import SqlTestOutcome
+from tests.unit.src.sqlbuild.executor.build.classes._test_types import (
+    SqlTestAuthoredOrderTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SqlTestAuthoredOrderTestCase(
+            description="case index preserves authored order instead of alphabetical names",
+            case_names=("zebra", "alpha"),
+            expected_order=("zebra", "alpha"),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_out_of_order_case_names_when_sorting_build_results_then_authored_order_is_preserved(
+    test_case: SqlTestAuthoredOrderTestCase,
+) -> None:
+    source_path: Path = Path("tests/unit/status.sql")
+    entries: tuple[SqlTestPlanEntry, ...] = tuple(
+        SqlTestPlanEntry(
+            key=CompiledObjectKey(
+                resource_type=CompiledResourceType.SQL_TEST,
+                name=f"status [{case_name}]",
+            ),
+            name=f"status [{case_name}]",
+            source_path=source_path,
+            block_index=1,
+            case_name=case_name,
+            case_index=case_index,
+        )
+        for case_index, case_name in enumerate(test_case.case_names)
+    )
+    plan: PlanOutput = PlanOutput(test_entries=entries)
+    results: list[SqlTestExecutionResult] = [
+        SqlTestExecutionResult(
+            test_name=entry.name,
+            outcome=SqlTestOutcome.PASS,
+            source_path=entry.source_path,
+            block_index=entry.block_index,
+            case_name=entry.case_name,
+            case_index=entry.case_index,
+        )
+        for entry in reversed(entries)
+    ]
+
+    ordered: list[SqlTestExecutionResult] = sorted(
+        results,
+        key=lambda result: _test_result_authored_order(plan=plan, result=result),
+    )
+
+    assert tuple(result.case_name for result in ordered) == test_case.expected_order


### PR DESCRIPTION
## Why

Repeated SQL test structures need independent case identity and diagnostics without introducing raw SQL parameters or a second typed-value system.

## Changes

- add typed scalar TEST parameter schemas and ordered named cases using the CHI-90 value/adapter boundary
- expand `@param` before declarations and macros into independent compiled, planned, and executed cases
- propagate stable case identity and content fingerprints through text/JSON, manifests, DAG, artifacts, build ordering, and Kata facts
- cover model, macro, UDF, table-function, multi-model, adapter, selection, and real DuckDB execution paths

## Verification

- complete unit suite: `4016 passed`
- `make check-ci`
- `make rust-check`
- `uv run fensu check --no-cache` (`0 faults`)
- focused compiler/integration execution suite
- generated SQLBuild skill byte reproducibility

Docs: chio-labs/sqlbuild-docs#14

Linear: CHI-116
