### PR TITLE
feat(macros): restore Python composition

### DIFF
--- a/.github/workflows/scope-performance.yml
+++ b/.github/workflows/scope-performance.yml
@@ -1,0 +1,53 @@
+name: Scope Performance
+
+on:
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scope-performance-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Large Scope Explorer benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.12.3"
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            Cargo.lock
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Install Python
+        run: uv python install 3.12
+      - name: Install dependencies
+        run: uv sync --locked --all-groups --all-extras
+      - name: Run large scope benchmark
+        env:
+          SQLBUILD_RUN_LARGE_SCOPE_BENCHMARK: "1"
+        run: |
+          mkdir -p /tmp/opencode
+          uv run pytest \
+            tests/e2e/src/sqlbuild/cli/commands/main/scope/test_scope_performance.py \
+            -m performance -vv -s --log-cli-level=INFO \
+            -o junit_family=legacy \
+            --junitxml=/tmp/opencode/scope-performance.xml
+      - name: Upload benchmark result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scope-performance-${{ github.run_id }}
+          path: /tmp/opencode/scope-performance.xml
+          if-no-files-found: error
+          retention-days: 90

--- a/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
+++ b/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
@@ -37,14 +37,13 @@ This file is generated from the SQLBuild documentation. Use it as the source of 
 - `concepts/models/hooks/sql`
 - `concepts/models/hooks/python`
 - `concepts/models/configuration`
-- `concepts/kata`
-- `concepts/kata/custom-rules`
-- `concepts/declaration-scopes`
-- `concepts/declaration-scopes/visibility`
-- `concepts/declaration-scopes/placement`
-- `concepts/enums-and-constants`
+- `concepts/enums`
+- `concepts/constants`
+- `concepts/constants/collections-and-rendering`
+- `concepts/enums/model-contracts`
+- `concepts/model-private-values`
 - `concepts/macros`
-- `concepts/declaration-scopes/explorer`
+- `concepts/macros/composition-and-context`
 - `concepts/interpolation`
 - `concepts/functions`
 - `concepts/incremental`
@@ -59,6 +58,12 @@ This file is generated from the SQLBuild documentation. Use it as the source of 
 - `concepts/selectors`
 - `concepts/column-lineage`
 - `concepts/diff`
+- `concepts/declaration-scopes`
+- `concepts/declaration-scopes/visibility`
+- `concepts/declaration-scopes/placement`
+- `concepts/declaration-scopes/explorer`
+- `concepts/kata`
+- `concepts/kata/custom-rules`
 - `concepts/python-nodes/overview`
 - `concepts/python-nodes/loaders`
 - `concepts/python-nodes/tasks`
@@ -112,6 +117,7 @@ This file is generated from the SQLBuild documentation. Use it as the source of 
 - `cli/promote`
 - `cli/rollback`
 - `cli/reconcile`
+- `concepts/enums-and-constants`
 
 ## Introduction
 
@@ -1214,7 +1220,7 @@ collection_rendering = "array"
 
 `collection_rendering` accepts `value_list` (the SQLBuild default) or `array`. A public constant's `render_as` field or a model-local `constant(...)` wrapper overrides the project setting. The complete precedence order is declaration override, project setting, then `value_list`.
 
-This setting does not make unsupported adapter features portable. In particular, SQL Server rejects native arrays, and BigQuery rejects nested arrays. See [Enums and Constants](/concepts/enums-and-constants#rendering-configuration) for syntax, adapter output, and value-list usage constraints.
+This setting does not make unsupported adapter features portable. In particular, SQL Server rejects native arrays, and BigQuery rejects nested arrays. See [Collections and Rendering](/concepts/constants/collections-and-rendering#project-default) for syntax, adapter output, and value-list usage constraints.
 
 ### Path defaults
 
@@ -1802,7 +1808,7 @@ NUMERIC '2.4700'
 
 BigQuery does not support arrays of arrays. A nested list or set requested with `render_as array` fails at compile time rather than producing invalid BigQuery SQL. Parenthesized `value_list` rendering remains available for ordinary scalar collections used with `IN`.
 
-See [Enums and Constants](/concepts/enums-and-constants#adapter-matrix) for declarations, rendering precedence, and the cross-adapter matrix.
+See [Collections and Rendering](/concepts/constants/collections-and-rendering#native-array-rendering) for declarations, rendering precedence, and the cross-adapter matrix.
 
 ## Databricks
 
@@ -1953,7 +1959,7 @@ JSON_QUERY(N'{"GB":"Great Britain"}')
 
 SQL Server has no supported first-class native array expression. Any list or set that resolves to `render_as array`, whether through its declaration or `[constants].collection_rendering`, fails at compile time. SQLBuild does not silently substitute a value list or quoted JSON string.
 
-See [Enums and Constants](/concepts/enums-and-constants#adapter-matrix) for declarations, rendering precedence, and the cross-adapter matrix.
+See [Collections and Rendering](/concepts/constants/collections-and-rendering#native-array-rendering) for declarations, rendering precedence, and the cross-adapter matrix.
 
 ### Per-target connections
 
@@ -2017,7 +2023,9 @@ sources:
 
 Expression sources are resolved at compile time. They're the escape hatch for anything the framework doesn't natively model: external tables, warehouse-specific syntax, function calls, or any other relation type that doesn't fit a standard table reference.
 
-Macros, constants, and enums in an inline expression resolve from the source definition's authored path under `sources/`. Scoped declaration directories beside or above one source definition do not leak into sibling source paths. See [Declaration Scopes](/concepts/declaration-scopes).
+An inline source expression uses macros, constants, and enums available from its source definition
+under `sources/`. Declarations limited to one source folder are not available in sibling folders.
+See [How Visibility Works](/concepts/declaration-scopes/visibility).
 
 ### Source audits
 
@@ -2785,7 +2793,7 @@ MODEL (
 
 This does not require, create, or reference a warehouse-native enum type. SQLBuild resolves string-valued enums to `VARCHAR` and integer-valued enums to `INTEGER`. Under `contract enforced`, it also generates an `accepted_values` audit for the declared members. Audit severity and timing follow normal audit configuration and materialization behavior. With the default error severity, it gates staged-table promotion and pre-DML delta paths; views and custom materializations may already have changed their relation when the audit runs.
 
-Enum member references such as `@enum("market_type").WIN` are a separate feature that render one validated SQL literal. See [Enums and Constants](/concepts/enums-and-constants#enum-typed-contracts) for the complete distinction and lowering behavior.
+Enum member references such as `@enum("market_type").WIN` are a separate feature that render one validated SQL literal. See [Enum Model Contracts](/concepts/enums/model-contracts) for the complete distinction and lowering behavior.
 
 ### Related policies
 
@@ -3022,7 +3030,9 @@ Both named and inline SQL hooks receive the invoking model's runtime context. Th
 
 For named hooks, SQLBuild first substitutes `@name` and `@'name'` arguments into the hook body. A supplied argument such as `relation: "@@CTX:destination.qualified"` therefore resolves to the invoking model's final target-overridden destination.
 
-Declaration visibility is lexical: an inline hook resolves macros, constants, and enums from the model file's path, while a named hook resolves them from its definition path under `hooks/sql/`. See [Visibility and Resolution](/concepts/declaration-scopes/visibility#which-path-resolves-sql).
+An inline hook uses macros, constants, and enums available to its model file. A named hook uses those
+available to its own file under `hooks/sql/`. See
+[How Visibility Works](/concepts/declaration-scopes/visibility#which-file-controls-visibility).
 
 `${...}` config-template syntax is not valid in SQL hooks.
 
@@ -3261,761 +3271,29 @@ See [Snapshots](/concepts/snapshots) for strategy combinations, defaults, and sa
 | `row_diff_exclude_columns` | Columns excluded from row-level comparison |
 | `row_diff_tolerances` | Numeric comparison tolerances |
 
-## Kata SQL Architecture Checks
+## Enums
 
-Source: `concepts/kata.mdx`
+Source: `concepts/enums.mdx`
 
-Enforce opt-in SQL architecture and model-shape policy over your compiled project.
+Define a fixed set of named string or integer values and use them safely in SQL.
 
-Kata is SQLBuild's opt-in SQL architecture policy. It compiles the project, then checks model
-structure, naming, dependency boundaries, joins, contracts, and test coverage. Built-in checks run
-offline: they do not execute warehouse SQL or rewrite source files. Findings have stable codes and
-concrete remediations.
+Enums give a name to a fixed set of allowed values. SQLBuild checks the enum and every member
+reference during compilation, then renders the selected value as a safe SQL literal.
 
-Kata is error-only: every retained finding blocks the command. Use it for conventions that a team
-has deliberately adopted, not as a collection of advisory style warnings.
+### Create an enum
 
-Tests codify behavioral expectations; Kata codifies architectural expectations for SQL models.
-For equivalent boundaries, repository structure, and code-shape checks in Python projects, see
-[Fensu](https://docs.fensu.dev/).
-
-### Where Kata fits
-
-| Command | Responsibility |
-|---------|----------------|
-| `sqb compile` | SQL validity, references, inferred columns, contracts, and lineage |
-| `sqb lint` / `sqb format` | SQL presentation and formatting |
-| `sqb kata` | Repository architecture and model-shape conventions |
-| `sqb test` | Transformation behavior |
-| `sqb audit` | Data quality against materialized data |
-
-Kata is a separate command. It is not run automatically by `compile` or `build`.
-
-### Enable Kata
-
-Commit the shared policy to `sqlbuild_project.toml`:
-
-```toml
-[kata]
-select = ["SQBK"]
-```
-
-This activates the complete standard policy. Start here, then use `ignore` to switch off conventions
-the repository is not ready to enforce.
-
-Kata evaluates no rules when `[kata].select` is empty. Prefixes select matching rules that are
-enabled by default; exact codes also select individually opt-in rules. All current built-ins are
-enabled by default, so `SQBK` selects the complete built-in catalogue.
-
-Rule selectors are case-sensitive prefixes. They do not use `*` wildcards:
-
-- Built-in rules use `SQBK<family><three digits>`, such as `SQBKS101`.
-- Custom rules use `XSQBK<family><three digits>`, such as `XSQBKP001`.
-- `select` activates rules; `ignore` removes matching rules from the active policy.
-- An exact code activates that rule even when it is opt-in.
-- The CLI `--select` and `--exclude` flags scope models, not rules.
-
-Inspect any built-in or configured custom rule without enabling it:
-
-```bash
-sqb kata rule SQBKS101
-```
-
-### Built-in rules
-
-All current built-ins form the standard policy and are enabled by matching prefixes.
-
-#### Structure
-
-| Code | Check |
-|------|-------|
-| `SQBKS000` | Standalone comments belong on the first inner line of a CTE |
-| `SQBKS001` | Transformation logic belongs in top-level CTEs |
-| `SQBKS002` | The terminal SELECT reads plainly from the final top-level CTE |
-| `SQBKS101` | Each `__ref` and `__source` is isolated in one dependency import CTE |
-| `SQBKS201` | `SELECT *` is restricted to dependency import CTEs |
-| `SQBKS202` | Positional set-operation branches enumerate their columns |
-| `SQBKS301` | CTEs are top-level, not nested |
-| `SQBKS302` | Recursive CTEs are not permitted |
-| `SQBKS401` | View materialization agrees with the `stg_v`, `int_v`, or `mart_v` marker |
-| `SQBKS501` | CTE names describe their contents |
-
-#### Layers and model grammar
-
-| Code | Check |
-|------|-------|
-| `SQBKL001` | Dependencies flow forward through the layer order |
-| `SQBKL101` | Qualified table dependencies use `__ref` or `__source` |
-| `SQBKR001` | Model names follow `<domain>__<layer>__<entity>[__<source>]` |
-| `SQBKR002` | Model layer names agree with their folders |
-| `SQBKR201` | Model source suffixes and source dependency names use approved, current tokens |
-| `SQBKR301` | Referenced model identifiers follow Kata model-name grammar |
-| `SQBKR401` | Models declare `contract enforced` |
-
-#### Joins
-
-| Code | Check |
-|------|-------|
-| `SQBKJ001` | Implicit comma joins are not permitted |
-| `SQBKJ002` | Cross joins require an exact, reasoned exception |
-| `SQBKJ101` | Non-cross joins declare `ON` or `USING` keys |
-
-#### Column naming and types
-
-| Code | Check |
-|------|-------|
-| `SQBKN001` | `is_`, `has_`, and `can_` columns are BOOLEAN |
-| `SQBKN002` | `*_at`, `*_ts`, and `*_timestamp` columns use timestamp types |
-| `SQBKN003` | `*_date` columns are DATE |
-
-These checks use declared contract columns, not inferred output columns.
-
-#### Decision hygiene
-
-| Code | Check |
-|------|-------|
-| `SQBKH001` | Enum comparisons use declared members and normalized operands |
-| `SQBKH002` | Non-canonical numeric decisions use named constants |
-| `SQBKH101` | Identical enum domains are consolidated |
-| `SQBKH201` | Public enum and constant files live under domain folders |
-
-`SQBKH001` requires direct comparisons to `@enum("<enum>").<MEMBER>`. Normalize controlled values
-upstream rather than wrapping either comparison operand. A direct source-side value may be
-normalized in the comparison because the project does not control source casing; the enum member
-must still remain unwrapped.
-
-#### Tests and coverage
-
-| Code | Check |
-|------|-------|
-| `SQBKX001` | Non-passthrough models meet the configured audit minimum |
-| `SQBKX002` | Non-passthrough models meet the configured SQL test minimum |
-| `SQBKX201` | Selected custom rules have statically discoverable public-harness test cases |
-
-Selecting a custom rule automatically adds `SQBKX201` unless the policy ignores it. This is a
-static check for conventional `RuleCase` and `evaluate_rule` usage; it does not execute the tests.
-Thresholds default to one and can be set to zero to disable the corresponding minimum:
-
-```toml
-[kata.thresholds]
-min_audits_per_model = 1
-min_tests_per_model = 1
-min_custom_rule_test_cases = 1
-```
-
-#### SQL tests and scenarios
-
-The `SQBKT` family governs SQL authored under `tests/unit/` and `tests/scenarios/`. It consumes
-compiler-resolved test targets and resource ownership; it does not infer ownership from filenames
-or repeat compiler diagnostics for malformed tests.
-
-| Code | Check |
-|------|-------|
-| `SQBKT001` | Unit tests and scenarios use their compiler-owned canonical roots |
-| `SQBKT002` | Unit and scenario filenames identify their subject and behavior |
-| `SQBKT003` | Unit tests mirror resolved model, macro, UDF, or table-function ownership |
-| `SQBKT004` | Every `TEST` block has an explicit target-aware `subject: expected behavior` name |
-| `SQBKT101` | Scenario descriptions identify a concrete business behavior rather than generic case numbering |
-
-Select the family independently when adopting these conventions:
-
-```toml
-[kata]
-select = ["SQBKT"]
-```
-
-Every unit-test block, including the only block in a file, has an explicit name:
-
-```sql
-TEST (
-  name "stg_orders: excludes cancelled orders",
-);
-```
-
-The first colon separates a nonempty subject from nonempty behavior. Later colons are ordinary
-behavior prose. Single-model subjects match the resolved expected model, direct-mode subjects match
-the tested macro, UDF, or table function, and multi-model subjects name the common domain or an
-explicit pipeline. Generic values such as `test`, `works`, `basic`, and `case 1` are rejected without
-maintaining a verb allowlist.
-
-Unit filenames use either `test_<subject>.sql` or `test_<subject>__<behavior>.sql`. When a behavior
-suffix is present, it corresponds to the normalized behavior text; concise prefixes such as
-`excludes_cancelled` for `excludes cancelled orders` are valid. Scenario filenames omit the
-redundant prefix and use `<subject>__<behavior>.sql`:
-
-```text
-tests/unit/staging/test_stg_orders__excludes_cancelled.sql
-tests/scenarios/daily_revenue__multiple_orders.sql
-```
-
-Mirroring uses compiled relationships:
-
-- A single-model test mirrors the model parent below its compiler-owned model root.
-- A multi-model test mirrors the nearest common model-domain parent.
-- Models with no meaningful common parent use the configured pipeline directory.
-- Macro, UDF, and table-function tests mirror all resolved direct resource owners.
-- When ownership cannot be proven from compiler facts, Kata skips mirroring rather than guessing.
-
-The pipeline directory is relative to `tests/unit/`, normalized, and included in cache and generated
-guidance identity. The default is `pipelines`:
-
-```toml
-[kata.sql_tests]
-pipeline_directory = "chains/commerce"
-```
-
-This maps cross-domain tests to `tests/unit/chains/commerce/`. Absolute paths, traversal, repeated
-separators, and backslash paths are invalid configuration.
-
-### Naming policy
-
-Naming and layer rules can use a closed project vocabulary:
-
-```toml
-[kata]
-domains = ["finance", "market"]
-approved_source_tokens = ["salesforce", "stripe"]
-cte_name_whitelist = ["finalized_rows"]
-cte_name_denylist = ["scratch_result"]
-
-[kata.retired_source_tokens]
-old_crm = "salesforce"
-```
-
-Valid Kata layers are `stg`, `stg_v`, `int_clean`, `int_v`, `int_enriched`, `mart`, and
-`mart_v`. Configuration supplies vocabulary to active rules; it does not activate them. When
-`SQBKR001` or `SQBKH201` is active, a non-empty `domains` list constrains model or declaration
-domains respectively.
-
-### Exceptions and scoped ignores
-
-Choose the narrowest mechanism that represents the policy:
-
-| Mechanism | Scope | Reason required | Stale-checked |
-|-----------|-------|-----------------|---------------|
-| `ignore` | Disable rules globally | No | No |
-| `rule_exceptions` | One exact rule and exact file | Yes | Yes |
-| `rule_ignores` | Rule prefixes or codes across path globs | Yes | No |
-| `select_star_allow` | Path-glob allowance for `SQBKS201` | Yes | No |
-
-```toml
-[[kata.rule_exceptions]]
-rule = "SQBKJ002"
-path = "models/mart/market__mart__matrix.sql"
-reason = "Intentional Cartesian product over a bounded dimension"
-
-[[kata.rule_ignores]]
-rules = ["SQBKS"]
-paths = ["models/legacy/**"]
-reason = "Legacy migration boundary"
-
-[[kata.select_star_allow]]
-paths = ["models/mart/*_export.sql"]
-reason = "Intentional passthrough export"
-```
-
-An exact exception fails when its active rule no longer produces a fault at that file, prompting
-the repository to remove obsolete exceptions. Broad migration boundaries and lone-star allowances
-remain reasoned but are intentionally not stale-checked.
-
-### Cache and CI
-
-Built-in policies use a persistent cache under `target/kata-cache`. Compiled model content, active
-rules, options, thresholds, naming vocabulary, and relevant project files participate in cache
-identity. Disable it when diagnosing cache behavior:
-
-```toml
-[kata.cache]
-enabled = false
-```
-
-Run Kata directly in CI. It exits `1` when faults remain:
-
-```bash
-sqb kata
-sqb kata --json
-```
-
-Generate agent guidance from the same resolved policy and verify that committed guidance remains
-fresh:
-
-```bash
-sqb kata skills
-sqb kata skills --check
-```
-
-Kata manages `.agents/skills/sqlbuild-kata/SKILL.md`,
-`.claude/skills/sqlbuild-kata/SKILL.md`, and `.opencode/skills/sqlbuild-kata/SKILL.md`. It refuses
-to overwrite divergent or unowned files.
-
-See [Custom Kata Rules](/concepts/kata/custom-rules) to encode repository-specific policy and the
-[Kata CLI reference](/cli/kata) for command output and exit behavior.
-
-## Custom Kata Rules
-
-Source: `concepts/kata/custom-rules.mdx`
-
-Define and test repository-owned SQL architecture rules with the public Kata API.
-
-Custom Kata rules extend the built-in policy when a repository has domain conventions that cannot
-be expressed by configuration alone. They use the same selection, suppression, deterministic
-ordering, and remediation output as built-ins.
-
-Custom rule codes use `XSQBK<family><three digits>`. Keep codes stable after adoption because they
-become part of configuration, CI output, and exceptions.
-
-### Define a rule
-
-```python
-from sqlbuild.kata import KataFault, RuleContext, kata
-
-@kata(
-    code="XSQBKP001",
-    family="prices",
-    slug="typed-currency",
-    message="price models must declare a currency column",
-    remediation="Declare currency in the MODEL columns contract.",
-)
-def typed_currency(*, model, ctx: RuleContext) -> list[KataFault]:
-    if any(column.name == "currency" for column in ctx.declared_columns):
-        return []
-    return [ctx.path_fault()]
-```
-
-The function signature is exactly two keyword-only arguments named `model` and `ctx`. Return an
-empty list when the model passes or one or more `KataFault` values when it fails.
-
-`RuleContext` exposes the compiled model, authored SQL, raw Polyglot AST, references, parsed model
-name, materialization, declared columns, audit and test counts, public declarations, active policy,
-and fault constructors. Repository files can be read safely through `project_read_text` and
-`project_glob`.
-
-### Load and select rules
-
-Load repository-owned files or dotted modules from `sqlbuild_project.toml`:
-
-```toml
-[kata]
-select = ["XSQBKP001"]
-rule_paths = ["kata/rules"]
-rule_modules = ["project_kata.rules"]
-```
-
-A directory in `rule_paths` is scanned recursively for Python files containing `@kata`. Dotted
-modules must resolve beneath the project root. Codes must be unique across built-in and custom
-rules.
-
-Custom rules require exact selectors by default. Set `enabled_by_default=True` on the decorator to
-include a rule in matching prefix selections. This does not activate Kata when
-`[kata].select` is empty.
-
-### Typed options
-
-Declare options with `RuleOption.boolean`, `integer`, `string`, `string_list`, or `integer_list`:
-
-```python
-from sqlbuild.kata import KataFault, RuleContext, RuleOption, kata
-
-REQUIRED_DOMAIN = RuleOption.string(
-    name="required_domain",
-    default="market",
-    description="Domain that owns price models",
-)
-
-@kata(
-    code="XSQBKP002",
-    family="prices",
-    slug="required-domain",
-    message="price models must belong to the configured domain",
-    remediation="Move or rename this model for the configured domain.",
-    options=(REQUIRED_DOMAIN,),
-)
-def required_domain(*, model, ctx: RuleContext) -> list[KataFault]:
-    parts = ctx.name_parts
-    if parts is not None and parts.domain == ctx.option(REQUIRED_DOMAIN):
-        return []
-    return [ctx.path_fault()]
-```
-
-Configure options under the exact rule code. Unknown rules, option names, or invalid values fail
-configuration:
-
-```toml
-[kata.rule_options.XSQBKP002]
-required_domain = "finance"
-```
-
-### Test every rule
-
-Use the public harness so tests exercise normal SQLBuild discovery, compilation, rule loading, and
-structured fault evaluation:
-
-```python
-from sqlbuild.kata import RuleCase, evaluate_rule
-
-from kata.rules.prices import typed_currency
-
-def test_missing_currency_faults() -> None:
-    result = evaluate_rule(
-        rule=typed_currency,
-        test_case=RuleCase(
-            description="missing currency faults",
-            source=(
-                "MODEL (materialized table);\n\n"
-                "WITH final AS (SELECT 1 AS price)\n"
-                "SELECT price FROM final\n"
-            ),
-            path="models/mart/market__mart__prices.sql",
-            expected_fault_count=1,
-        ),
-    )
-
-    assert result.fault_count == 1
-```
-
-`RuleCase.files` can add supporting project files and `RuleCase.config` supplies the rule's option
-values. Keep conventional `RuleCase` and `evaluate_rule` calls under `tests/` so `SQBKX201` can
-count statically discoverable harness cases. This coverage check does not execute the tests, so run
-the test suite separately in CI.
-
-### Execution and caching
-
-Selected custom rules execute in a bounded Python subprocess with a 30-second timeout. Exceptions
-are reported with the rule code and model path, and returned faults rejoin normal suppressions and
-deterministic ordering.
-
-Selecting any custom rule disables the model cache by default. To keep the built-in cache available,
-require hermetic custom rules explicitly:
-
-```toml
-[kata.cache]
-enabled = true
-require_cacheable = true
-```
-
-Cacheable rules may import supported pure modules such as `collections`, `dataclasses`, `enum`,
-`math`, `re`, `typing`, and `sqlbuild.kata`. Use `RuleContext` rather than direct filesystem calls.
-SQLBuild validates these constraints before evaluation.
-
-Custom findings are still recomputed on each invocation. `require_cacheable` preserves the native
-model cache around them; it does not cache custom subprocess output.
-
-Return to [Kata SQL Architecture Checks](/concepts/kata) for built-in rules, selectors, and
-exceptions.
-
-## Overview
-
-Source: `concepts/declaration-scopes.mdx`
-
-Place macros, enums, and constants where the SQL that owns them can see them.
-
-SQLBuild gives macros, enums, and constants lexical visibility based on the filesystem. Put shared
-vocabulary in a top-level declaration root, or place an underscored declaration directory beside
-the SQL that owns narrower vocabulary. The compiler resolves visibility, records usage, and checks
-that narrow declarations use the closest valid location.
-
-Declaration scopes require no TOML configuration.
-
-| Scope | Declaration form | Visibility |
-|-------|------------------|------------|
-| Project-wide | `macros/`, `constants/`, `enums/` | Every supported SQL surface |
-| Inherited | `_macros/`, `_constants/`, `_enums/` | Owning path and every descendant |
-| Exact-local | `_local_macros/`, `_local_constants/`, `_local_enums/` | Direct children of one owning path |
-| Model-private | Underscore-prefixed constants and enums in `MODEL()` | One model and its inline SQL hooks |
-
-### Read a scope tree
-
-The declaration directory's parent is its owning path:
-
-```text
-models/
-├── _constants/                 inherited throughout models/
-│   └── warehouse.sql
-└── commerce/
-    ├── _macros/                inherited throughout commerce/
-    │   └── currency.py
-    ├── _local_enums/           exact commerce/ directory only
-    │   └── grain.sql
-    ├── orders.sql              sees warehouse, currency, and grain
-    ├── finance/
-    │   ├── _macros/            inherited throughout finance/
-    │   │   └── tax.py
-    │   └── revenue.sql         sees warehouse, currency, and tax
-    └── fulfillment/
-        └── shipments.sql       sees warehouse and currency
-```
-
-Inherited declarations compose from every matching ancestor. They do not stop at the nearest
-declaration directory. Exact-local declarations do not flow into child directories.
-
-| Resource | Visible from the example tree | Not visible |
-|----------|-------------------------------|-------------|
-| `orders.sql` | Warehouse constant, commerce macro, commerce-local enum | Finance macro |
-| `finance/revenue.sql` | Warehouse constant, commerce macro, finance macro | Commerce-local enum |
-| `fulfillment/shipments.sql` | Warehouse constant, commerce macro | Commerce-local enum, finance macro |
-
-Declarations never flow upward, sideways into siblings, or out of their authored resource root.
-An inaccessible name produces a different compiler diagnostic from a name that does not exist.
-
-### Choose a scope
-
-| Consumer shape | Choose | Placement |
-|----------------|--------|-----------|
-| One model only | Model-private | In that model's `MODEL()` header |
-| One exact directory | Exact-local | Beside the consumers |
-| Multiple directories in one resource tree | Inherited | At their lowest common ancestor |
-| Multiple authored resource roots | Project-wide | Top-level declaration root |
-
-Public project-wide declarations are a deliberate stable API. SQLBuild does not ask you to narrow
-one merely because its current consumers happen to be close together. For narrow declarations, the
-compiler reports the exact required scope and destination when placement is too broad or too narrow.
-
-### Explore the feature
-
-    Learn which authored path controls resolution, how expected-model grants work, and why macro
-    dependencies resolve from their definition paths.
-    Understand genuine usage, closest placement, unused declarations, and move diagnostics.
-    Inspect a resource's scope chain, explain visibility, browse nearby declarations, and preview
-    moves offline.
-    Define typed domain vocabulary and model-private values.
-
-See [Python Macros](/concepts/macros) for macro authoring and lexical macro composition.
-See [Interpolation](/concepts/interpolation) for project, environment, and runtime context values;
-those are separate from declarations.
-
-## Visibility and Resolution
-
-Source: `concepts/declaration-scopes/visibility.mdx`
-
-Understand authored-path visibility, expected-model grants, and lexical macro resolution.
-
-SQLBuild resolves declarations from the path where SQL is authored. Visibility is a compiler fact;
-filenames, test placement, and runtime execution order do not create implicit relationships.
-
-### Authored resource roots
-
-Inherited and exact-local declaration directories may appear below these canonical roots:
-
-| Root | Authored SQL |
-|------|--------------|
-| `models/` | Model queries and inline model hooks |
-| `tests/unit/` | SQL unit tests |
-| `tests/scenarios/` | Scenario worlds and assertions |
-| `hooks/sql/` | Named SQL hooks |
-| `functions/sql/` | SQL UDFs and table functions |
-| `audits/` | Singular and generic audits |
-| `sources/` | Inline source expressions |
-
-Files may be organized recursively inside a declaration directory. That internal organization does
-not change the directory's owning path.
-
-### Which path resolves SQL
-
-    A model query and its inline SQL hooks resolve from the model file. Model-private constants and
-    enums are available only in that model's query and inline hooks.
-    Authored test or scenario SQL resolves from its file path. Expected-model relationships can add
-    public constants and enums through a separate compiler grant.
-    A named hook resolves from its definition under `hooks/sql/`. A SQL function resolves from its
-    definition under `functions/sql/`, even when a model invokes it elsewhere.
-    Audit SQL resolves from its audit definition. An inline source expression resolves from the
-    source definition under `sources/`.
-
-Named hook arguments and `@@CTX` values still describe the invoking model. Only declaration
-resolution comes from the named hook's definition path.
-
-### Expected-model grants
-
-A test or scenario has two distinct visibility sources:
-
-```text
-tests/unit/commerce/test_orders.sql
-|-- path scope
-|   |-- macros visible from the test path
-|   |-- enums visible from the test path
-|   `-- constants visible from the test path
-|
-`-- __expected__orders relationship
-    |-- grants public enums visible to orders
-    |-- grants public constants visible to orders
-    |-- does not grant macros
-    `-- does not grant model-private declarations
-```
-
-Multiple expected models contribute a deterministic union with provenance retained for every
-granting model. Public names remain globally unique, so grants cannot shadow one another.
-
-Only explicit expected-model relationships create grants. A matching filename, mirrored test path,
-mocked `__ref__`, or nearby model does not.
-
-### Macro lexical resolution
-
-Calls written directly in authored SQL resolve from that SQL's path, including nested argument calls:
-
-```sql
-@format_money(@net_amount("amount_cents"))
-```
-
-Both calls initially resolve from the path containing the expression. If `format_money` returns SQL
-containing another macro call, that emitted call resolves from `format_money`'s definition path:
-
-```text
-models/commerce/orders.sql
-`-- calls commerce/_macros/format_money.py
-    `-- emitted @currency_symbol() resolves from commerce/_macros/
-        `-- not from orders.sql or whichever model called format_money
-```
-
-This keeps macro dependencies lexical and statically trackable. Project macro modules must compose
-through `@macro()` calls rather than importing one another in Python. SQLBuild rejects inaccessible
-emitted dependencies and dependency cycles. A project-wide macro cannot depend on an inherited or
-exact-local macro because its top-level definition path cannot see narrower declarations.
-
-Generated manifest macro nodes expose declaration scope, owning path, and tracked macro dependencies.
-
-### Names and shadowing
-
-Every public name must be globally unique within its declaration kind. A narrower declaration
-cannot shadow a project-wide or ancestor declaration, even when their visible scopes do not overlap.
-
-Macro, constant, and enum namespaces remain independent. These may coexist because each reference
-identifies its kind:
-
-```sql
-@format_currency()
-@const("format_currency")
-@enum("format_currency").USD
-```
-
-Model-private constants and enums are different. Their names begin with exactly one underscore and
-their identities include the owning model, such as `enum:model:stg_orders._state`. They may repeat
-across models because they never enter the public namespace. Names beginning with `__` are reserved
-for SQLBuild.
-
-  See how compiler-recorded usage determines the closest valid declaration directory.
-
-## Placement and Usage
-
-Source: `concepts/declaration-scopes/placement.mdx`
-
-Use compiler-recorded consumers to place declarations at the closest valid scope.
-
-SQLBuild records resolved enum, constant, and macro use while expanding the complete project. It
-uses those relationships to reject unused declarations and validate the placement of narrow ones.
-
-### What counts as usage
-
-| Evidence | Counts as usage? |
-|----------|------------------|
-| Expanded model, hook, function, audit, source, test, or scenario SQL | Yes |
-| Generated enum contracts and enum-backed audits | Yes |
-| A macro dependency reached through an expanded macro call | Yes |
-| Expected-model enum or constant grant used by a test | Yes |
-| A reference inside a SQL comment or quoted string | No |
-| A mock, direct macro-test identity check, comment, or quoted value | No |
-| A declaration that is merely visible | No |
-
-Every project-wide, inherited, exact-local, and model-private declaration must have a genuine use.
-Unused declarations fail compilation.
-
-### Closest valid placement
-
-Use the consumer shape to choose the directory:
-
-| First matching consumer shape | Required scope | Required location |
-|-------------------------------|----------------|-------------------|
-| One model, with no intended external consumer | Model-private | The model's `MODEL()` header |
-| One exact parent directory | Exact-local | `_local_.../` beside the consumers |
-| Multiple directories in one authored root | Inherited | `_.../` at their lowest common ancestor |
-| Multiple authored resource roots | Project-wide | Top-level `macros/`, `constants/`, or `enums/` |
-
-### Placement examples
-
-#### One exact directory
-
-```text
-Consumers
-models/commerce/orders.sql
-models/commerce/customers.sql
-
-Required placement
-models/commerce/_local_constants/minimum_value.sql
-```
-
-#### Multiple descendant directories
-
-```text
-Consumers
-models/commerce/finance/revenue.sql
-models/commerce/fulfillment/shipments.sql
-
-Lowest common ancestor
-models/commerce/
-
-Required placement
-models/commerce/_constants/reporting_day.sql
-```
-
-#### Multiple authored roots
-
-```text
-Consumers
-models/commerce/orders.sql
-tests/scenarios/commerce/order_lifecycle.sql
-
-Required placement
-constants/order_status.sql
-```
-
-Expected-model grants anchor test and scenario enum/constant use through the granting model, not
-through the test file's directory. Macro dependencies anchor through the consuming macro's lexical
-scope. These rules prevent relationship-driven use from producing misleading filesystem placement.
-
-### Stable project-wide APIs
-
-A used project-wide declaration remains valid even if all current consumers could fit under a
-narrower root. Moving a public declaration is an API decision, not automatic cleanup. Closest exact
-placement applies when a declaration is already narrow.
-
-When placement is wrong, the compiler reports:
-
-- The current declaration path and scope
-- The required scope and owning path
-- The consumers that determine that placement
-- The exact destination directory
-
-  Use Scope Explorer to inspect placement facts and preview whether moving an authored resource
-  preserves its declaration visibility.
-
-## Enums and Constants
-
-Source: `concepts/enums-and-constants.mdx`
-
-Declare compiler-validated domain values and typed constants for use across SQLBuild SQL.
-
-Enums name a fixed domain of string or integer values. Constants name a compiler-validated SQL value: a scalar, list, set, or object. SQLBuild validates and normalizes declarations at compile time, then asks the active adapter to render them safely for its SQL dialect.
-
-### Project-wide declarations
-
-Project-wide declarations are available throughout the project. Put enum files anywhere under the top-level `enums/` root and constant files anywhere under the top-level `constants/` root; both roots are discovered recursively.
+Put project-wide enums under the top-level `enums/` directory. Files are discovered recursively, so
+subdirectories can organize a large enum library without changing where the enums are available.
 
 ```text
 my_project/
-├── enums/                      project-wide enum declarations
+├── enums/
 │   ├── market/
 │   │   └── market_type.sql
 │   └── order_status.sql
-├── constants/                  project-wide constant declarations
-│   ├── market/
-│   │   └── thresholds.sql
-│   └── reporting_day.sql
 ├── models/
-├── tests/
 └── sqlbuild_project.toml
 ```
-
-Folders below `enums/` and `constants/` are for organization; they do not change visibility.
-Public names remain globally unique within each declaration kind and cannot shadow one another. An
-enum and a constant may use the same name because their namespaces are independent.
 
 ```sql
 -- enums/market/market_type.sql
@@ -4025,7 +3303,8 @@ ENUM (
 );
 ```
 
-Shorthand members use the member name as the string value. Use explicit members when the reference name and stored value differ, or for integer enums:
+The shorthand above uses each member name as its string value. Use explicit values when the name
+used in SQLBuild should differ from the stored value:
 
 ```sql
 ENUM (
@@ -4035,14 +3314,77 @@ ENUM (
     PARISTURF "paristurf",
   ),
 );
+```
 
+Integer enums always use explicit values:
+
+```sql
 ENUM (
   name priority,
   members (LOW 1, HIGH 3),
 );
 ```
 
-Constants use canonical key-value fields. A file may contain multiple declarations:
+### Use an enum member
+
+Reference one member with `@enum("name").MEMBER`:
+
+```sql
+SELECT *
+FROM prices
+WHERE market_type = @enum("market_type").WIN
+  AND source = @enum("source").CENTRUM
+```
+
+SQLBuild validates the enum name and member name before the query runs. The active adapter safely
+renders the underlying string or integer value.
+
+Enum references work in model queries, SQL hooks, SQL functions, audits, unit tests, scenarios, and
+inline source expressions.
+
+### Validation rules
+
+- An enum must contain at least one member.
+- Every member must use the same value type: all strings or all integers.
+- Enum names and member names must be SQL identifiers.
+- Member names must be uppercase and lookup is case-sensitive.
+- Enum names must be unique across all public enums in the project.
+- Project-wide names cannot begin with `_`; that prefix is reserved for model-private values.
+
+Invalid declarations, unknown enums, and unknown members fail compilation.
+
+### More enum features
+
+    Use an enum as a portable model-column domain and generate accepted-value validation.
+    Keep an enum inside one model when no other resource should use it.
+
+To limit an enum to one folder, or to that folder and its child folders, see
+[Declarations and Scopes](/concepts/declaration-scopes).
+
+## Constants
+
+Source: `concepts/constants.mdx`
+
+Define reusable compiler-validated values and reference them safely from SQL.
+
+Constants give a name to a value used in SQL. SQLBuild validates the value during compilation and
+asks the active adapter to render it safely for its SQL dialect. Constant values are data, never raw
+SQL snippets.
+
+### Create a constant
+
+Put project-wide constants under the top-level `constants/` directory. Files are discovered
+recursively, and one file may contain more than one declaration.
+
+```text
+my_project/
+├── constants/
+│   ├── market/
+│   │   └── thresholds.sql
+│   └── reporting_day.sql
+├── models/
+└── sqlbuild_project.toml
+```
 
 ```sql
 -- constants/market/thresholds.sql
@@ -4053,13 +3395,28 @@ CONSTANT (name ratio, value 0.75);
 CONSTANT (name missing_value, value null);
 ```
 
-Public names must not start with `_`.
+Folders below `constants/` are organizational. They do not change where project-wide constants are
+available.
 
-### Constant values
+### Use a constant
 
-#### Scalars
+Reference a constant with `@const("name")`:
 
-Constants support strings, signed integers, booleans, finite floating-point numbers, exact decimals, and null. Integers use a portable signed 64-bit baseline. Non-finite floats such as NaN and positive or negative infinity are rejected.
+```sql
+SELECT *
+FROM prices
+WHERE runner_count >= @const("min_runners")
+  AND source = @const("fallback_source")
+```
+
+References work in model queries, SQL hooks, SQL functions, audits, unit tests, scenarios, and
+inline source expressions. An unknown constant fails compilation.
+
+### Scalar values
+
+Constants support strings, signed integers, booleans, finite floating-point numbers, exact
+decimals, and `null`. Integers use a portable signed 64-bit range. `NaN` and positive or negative
+infinity are rejected.
 
 Use `type decimal` with a quoted value when decimal precision must be exact:
 
@@ -4071,9 +3428,32 @@ CONSTANT (
 );
 ```
 
-SQLBuild parses the quoted representation directly as a decimal, without converting it through a binary float. An incompatible `type` and `value` fails compilation. Strings are otherwise kept as strings; SQLBuild never interprets a constant value as raw SQL.
+SQLBuild parses the quoted value directly as a decimal rather than first converting it to a binary
+float. An incompatible `type` and `value` fails compilation.
 
-#### Lists
+### Naming rules
+
+Public constant names must be unique among public constants and cannot begin with `_`. Enum,
+constant, and macro names use separate namespaces, so an enum and a constant may share a name.
+
+### More constant features
+
+    Define lists, sets, and objects, then choose value-list or native-array rendering.
+    Keep a constant inside one model when no other resource should use it.
+
+To limit a constant to one folder, or to that folder and its child folders, see
+[Declarations and Scopes](/concepts/declaration-scopes).
+
+## Collections and Rendering
+
+Source: `concepts/constants/collections-and-rendering.mdx`
+
+Define list, set, and object constants and control their adapter-specific SQL rendering.
+
+Constants can hold collections as well as scalar values. Use this page when a constant represents
+a reusable value list, native array, set, or structured object.
+
+### Lists
 
 Square brackets declare an ordered list. Lists preserve authored order and allow duplicates:
 
@@ -4084,9 +3464,10 @@ CONSTANT (
 );
 ```
 
-#### Sets
+### Sets
 
-Curly braces declare a semantic set. Sets reject duplicate typed values and use a stable canonical order for rendering and identity:
+Curly braces declare a set. Sets reject duplicate typed values and use a stable order when SQLBuild
+renders or fingerprints them:
 
 ```sql
 CONSTANT (
@@ -4095,11 +3476,13 @@ CONSTANT (
 );
 ```
 
-For example, `{true, 1}` does not contain a duplicate because boolean and integer are distinct logical types. By contrast, `{"GB", "FR", "GB"}` fails compilation rather than silently discarding the second `"GB"`.
+`{true, 1}` is valid because a boolean and an integer are different logical types.
+`{"GB", "FR", "GB"}` fails compilation instead of silently discarding the duplicate.
 
-#### Objects
+### Objects
 
-Parenthesized key-value entries declare a string-keyed object. Object values may themselves be scalars, lists, sets, or objects:
+Parenthesized key-value entries declare a string-keyed object. Values may be scalars, lists, sets,
+or other objects:
 
 ```sql
 CONSTANT (
@@ -4121,57 +3504,44 @@ CONSTANT (
 );
 ```
 
-Object keys must be unique strings accepted by header syntax. SQLBuild canonicalizes keys into a stable order. Objects are logical JSON values, not portable homogeneous SQL maps or structs.
+Object keys must be unique. Objects are logical JSON values rather than portable homogeneous SQL
+maps or structs.
 
-Nested numeric tokens are finite floating-point values. Exact decimal parsing currently applies to a top-level constant declared with `type decimal`; nested exact decimals require a future nested typed-value syntax.
+### Collection rules
 
-#### Collection restrictions
-
-Lists and sets must be non-empty and have one recursively compatible element type. Nullable elements are ignored while inferring that type, so `[1, null, 2]` is valid, but the following declarations fail:
+Lists and sets must be non-empty and have one compatible element type. Nullable elements do not
+determine the type, so `[1, null, 2]` is valid, while these declarations fail:
 
 ```sql
 CONSTANT (name empty_values, value []);          -- no element type
 CONSTANT (name unknown_values, value [null]);    -- no non-null element type
-CONSTANT (name mixed_values, value [1, "two"]); -- integer and string
+CONSTANT (name mixed_values, value [1, "two"]); -- incompatible types
 ```
 
-The same empty, all-null, and mixed-type restrictions apply to sets. Objects may contain values of different types because each key has its own recursively validated value. SQLBuild also applies nesting-depth, element-count, and rendered-size safety limits; errors identify the declaration path and nested value path.
+Objects may contain different value types because each key is checked independently. SQLBuild also
+applies nesting-depth, element-count, and rendered-size safety limits.
 
-### References and rendering
+### Value-list rendering
 
-Use `@enum("name").MEMBER` and `@const("name")` anywhere public declarations are supported:
-
-```sql
-SELECT *
-FROM prices
-WHERE market_type = @enum("market_type").WIN
-  AND runner_count > @const("min_runners")
-  AND country_code IN @const("supported_countries")
-```
-
-Public references work in model queries, SQL hooks, SQL functions, audits, unit tests, scenarios, and inline source expressions. Unknown declarations or enum members fail compilation.
-
-#### Value-list rendering
-
-Lists and sets render as `value_list` by default on every adapter. This targets the common `IN` use case:
+Lists and sets render as a parenthesized value list by default. This is designed for `IN`:
 
 ```sql
 WHERE country_code IN @const("supported_countries")
 ```
 
-compiles to:
-
 ```sql
 WHERE country_code IN ('GB', 'FR', 'HK')
 ```
 
-Every element is escaped by the active adapter before SQLBuild constructs the parenthesized list.
+Every element is escaped by the active adapter.
 
-A `value_list` constant is a SQL fragment intended for a value-list position such as `IN (...)`. It is not a portable standalone projection or a first-class array value. For example, `SELECT @const("supported_countries")` does not have consistent meaning across adapters. Use `render_as array` when the constant must be an array expression.
+  A value-list constant is intended for a value-list position such as `IN (...)`. It is not a
+  portable standalone projection. Use native-array rendering when the constant must be an array
+  expression.
 
-#### Array rendering
+### Native-array rendering
 
-Set `render_as array` to request a first-class adapter-native array. SQLBuild does not rewrite array membership operations, so use the operators and functions appropriate for your adapter.
+Set `render_as array` to request an adapter-native array:
 
 ```sql
 CONSTANT (
@@ -4181,11 +3551,11 @@ CONSTANT (
 );
 ```
 
-Sets support the same rendering modes after duplicate validation and canonical ordering. Scalars and objects reject `render_as` because value-list and array modes have no defined meaning for them.
+SQLBuild does not rewrite array membership operations. Use the operators and functions provided by
+your adapter.
 
-#### Adapter matrix
-
-The selected rendering mode has the same semantics on every adapter; only its SQL spelling changes.
+Sets support the same `value_list` and `array` modes as lists. Scalar and object constants reject
+`render_as` because those rendering modes do not apply to them.
 
 | Adapter | Native array expression | Object/JSON expression |
 |---------|-------------------------|------------------------|
@@ -4197,33 +3567,91 @@ The selected rendering mode has the same semantics on every adapter; only its SQ
 | PostgreSQL | `ARRAY['GB', 'FR', 'HK']` | `'{"GB":"Great Britain"}'::JSONB` |
 | SQL Server | Unsupported | `JSON_QUERY(N'{"GB":"Great Britain"}')` |
 
-Object constants always use the adapter's native JSON or semi-structured expression, or its validated JSON-text equivalent; they are not emitted as an ordinary quoted JSON string. Every nested scalar and key is escaped safely.
+BigQuery does not support arrays containing arrays. SQL Server has no native array representation.
+Unsupported requests fail compilation rather than silently changing representation.
 
-BigQuery supports native arrays but does not support arrays whose elements are arrays. A nested-array constant requested with `render_as array` therefore fails during compilation. SQL Server has no native array representation, so any array request fails during compilation rather than falling back to a value list or string. See the [BigQuery](/concepts/adapters/bigquery#typed-constants) and [SQL Server](/concepts/adapters/sqlserver#typed-constants) adapter pages.
+### Project default
 
-### Rendering configuration
-
-Change the project default for list and set declarations in `sqlbuild_project.toml`:
+Set the default for list and set constants in `sqlbuild_project.toml`:
 
 ```toml
 [constants]
 collection_rendering = "array"
 ```
 
-Allowed values are `value_list` and `array`. Rendering mode is resolved in this order:
+SQLBuild chooses the rendering mode in this order:
 
 1. The declaration's `render_as` field
 2. Project `[constants].collection_rendering`
-3. SQLBuild's `value_list` default
+3. The `value_list` default
 
-The project default applies to project-wide and model-private collection constants. There is no
-reference-site override: one declaration has one representation throughout a compilation. Changing
-the resolved mode changes dependent rendered SQL and query identity.
+One constant has one representation throughout a compilation. Changing its value or rendering mode
+changes the identity of SQL that uses it.
 
-### Model-private declarations
+### Stable values
 
-Use model-private declarations for values that belong to one model and should not enter the
-project-wide namespace. The shorthand accepts every scalar and collection form:
+- List order and duplicates are preserved.
+- Set order is ignored; membership is stored in a stable order.
+- Object key order is ignored; keys are stored in a stable order.
+- Changing set membership or object values changes dependent query identity.
+
+## Enum Model Contracts
+
+Source: `concepts/enums/model-contracts.mdx`
+
+Use an enum as a portable model-column domain with generated accepted-value validation.
+
+An enum can describe the allowed domain of a model column as well as provide individual SQL
+literals.
+
+These are separate uses:
+
+- `@enum("market_type").WIN` inserts one validated value into SQL.
+- `type market_type` declares that a model column uses the complete enum domain.
+
+### Declare an enum-typed column
+
+Use the enum name as the column type:
+
+```sql
+MODEL (
+  contract enforced,
+  columns (
+    market_type (type market_type),
+  ),
+);
+```
+
+SQLBuild does not send `market_type` to the warehouse as a physical type and does not create a
+warehouse-native enum. It translates the enum into portable column metadata:
+
+| Enum values | Physical column type | Generated validation |
+|-------------|----------------------|----------------------|
+| Strings such as `WIN` and `PLACE` | `VARCHAR` | `accepted_values` for the enum strings |
+| Integers such as `1` and `3` | `INTEGER` | `accepted_values` for the enum integers |
+
+### Contract behavior
+
+With `contract enforced`, SQLBuild runs the generated `accepted_values` audit with the model's other
+audits. Its severity and timing follow the model's ordinary audit and materialization settings.
+
+With `contract none`, SQLBuild still resolves the enum to its portable scalar column type but does
+not generate the domain audit.
+
+This behavior is the same on adapters with and without native enum support. The physical warehouse
+column remains an ordinary string or integer column.
+
+Changing the members of an enum-typed contract changes the model's contract identity and generated
+validation.
+
+## Model-Private Values
+
+Source: `concepts/model-private-values.mdx`
+
+Keep enums and constants inside one model when no other resource should use them.
+
+Put an enum or constant directly in `MODEL()` when it belongs to one model and should not enter the
+project-wide namespace.
 
 ```sql
 MODEL (
@@ -4233,11 +3661,6 @@ MODEL (
   constants (
     _min_runners 7,
     _supported_countries ["GB", "FR", "HK"],
-    _unique_countries {"GB", "FR", "HK"},
-    _country_labels (
-      GB "Great Britain",
-      FR "France",
-    ),
   ),
 );
 
@@ -4248,7 +3671,27 @@ WHERE state = @enum("_state").OPEN
   AND country_code IN @const("_supported_countries")
 ```
 
-Use the `constant(...)` wrapper when a local declaration needs an explicit type or rendering override:
+### Where private values work
+
+A model-private value is available in:
+
+- The owning model's query
+- Inline SQL hooks written in that model
+
+It is not available in:
+
+- Another model
+- A child or sibling model directory
+- A unit test or scenario
+- A named SQL hook stored under `hooks/sql/`
+
+Private names begin with exactly one `_`. Names beginning with `__` are reserved for SQLBuild.
+Because the model owns the name, different models may each define `_state` without creating a
+collision.
+
+### Explicit types and rendering
+
+Use `constant(...)` when a private constant needs an exact type or rendering choice:
 
 ```sql
 MODEL (
@@ -4265,119 +3708,46 @@ MODEL (
 );
 ```
 
-The wrapper is distinct from object syntax, so an object with keys named `value` or `render_as` remains unambiguous. Model-private names must start with exactly one `_`; names beginning with `__` are reserved for SQLBuild. They are available only in that model's query and inline SQL hooks; named SQL hooks resolve from their own definition paths, and no test, scenario, descendant, or other model can resolve them. Scope introspection qualifies private identities with their owner, such as `constant:model:stg_orders._minimum_value`; this does not change SQL reference syntax.
+### When a value becomes shared
 
-  This page focuses on the normal project-wide layout and declarations owned by one model. For
-  declarations shared by only part of a larger project, see
-  [Declarations and Scopes](/concepts/declaration-scopes).
+Move the declaration out of `MODEL()` when another resource needs it. Remove the `_` prefix and put
+it in the narrowest suitable enum or constant directory. See
+[Declarations and Scopes](/concepts/declaration-scopes) for those advanced placement options.
 
-### Determinism and identity
-
-SQLBuild normalizes constants before rendering and fingerprinting:
-
-- List order and duplicates are preserved, so changing either changes rendered SQL and query identity.
-- Set declaration order is ignored; membership is canonicalized, so reordering alone changes neither rendered SQL nor query identity.
-- Object key declaration order is ignored; keys are canonicalized, so reordering alone changes neither rendered SQL nor query identity.
-- Set membership, object values, rendering mode, and an applicable project rendering default all participate in dependent query identity.
-- A declaration change affects the identities of its consumers rather than unrelated models. Completely unused declarations fail project validation.
-
-### Enum validation
-
-Enums must contain at least one member and use one consistent scalar type. String and integer members cannot be mixed. Integer values use explicit member syntax.
-
-Names must be SQL identifiers. Enum member identifiers must be uppercase, even when an explicit member's stored value is lowercase. Member lookup is case-sensitive, so `.WIN` is valid for `WIN "win"` and `.win` is not. Duplicate declaration names, duplicate member names, invalid visibility prefixes, and malformed references all fail compilation.
-
-### Enum-typed contracts
-
-Enum references and enum-typed columns are separate capabilities:
-
-- `@enum("market_type").WIN` inserts one compiler-validated scalar literal into SQL.
-- `type market_type` uses the complete enum as a portable logical domain type for a model column.
-
-For the second form, use an enum name in a model column declaration:
-
-```sql
-MODEL (
-  contract enforced,
-  columns (
-    market_type (type market_type),
-  ),
-);
-```
-
-`market_type` is not sent to the warehouse as a physical type name. SQLBuild does not create a warehouse-native enum or emit enum DDL. Instead, it lowers the logical domain to portable model metadata:
-
-| Enum member values | Physical column type | Enforced domain check |
-|--------------------|----------------------|-----------------------|
-| Strings such as `WIN` and `PLACE` | `VARCHAR` | `accepted_values` for the declared strings |
-| Integers such as `1` and `3` | `INTEGER` | `accepted_values` for the declared integers |
-
-With `contract enforced`, the generated `accepted_values` audit runs with the model's other audits even though the warehouse column itself is an ordinary `VARCHAR` or `INTEGER`:
-
-```sql
--- Conceptual physical shape and validation, not generated source syntax:
-market_type VARCHAR
-accepted_values(market_type, ["WIN", "PLACE", "SHOW"])
-```
-
-Its severity and timing follow ordinary audit configuration and materialization behavior. With the default error severity, an out-of-domain value gates staged-table promotion and pre-DML delta paths. Views run audits after replacement, and custom materializations control their own audit timing.
-
-With `contract none`, SQLBuild still resolves the logical enum to its physical scalar type, but it does not generate the domain audit. Use `contract enforced` when SQLBuild should generate member validation, and choose a materialization path whose audit timing provides the gate your workflow requires.
-
-This behavior is intentionally independent of whether a particular warehouse supports native enums. A project has the same model contract and validation semantics across adapters.
-
-Declaration changes participate in change detection. A changed referenced value changes compiled SQL; changed members of an enum-typed contract change the model's contract identity.
-
-## Python Macros
+## Writing Macros
 
 Source: `concepts/macros.mdx`
 
-Reusable Python functions that generate SQL fragments at compile time.
+Write Python functions that generate reusable SQL fragments at compile time.
 
-Macros are Python functions that generate SQL fragments at compile time. Instead of Jinja templates, you write real Python - testable, debuggable, and composable with standard tooling.
+Macros are Python functions that generate SQL during compilation. They provide reusable,
+parameterized SQL without introducing a separate template language.
 
-For the full picture of how macros fit into SQLBuild's interpolation system, see [Interpolation](/concepts/interpolation).
+### Create a macro
 
-### Defining macros
+Put project-wide macros in Python files under the top-level `macros/` directory:
 
-Create Python files under the top-level `macros/` directory for project-wide macros. Every public ordinary function defined by a macro module becomes a callable macro:
+```text
+my_project/
+├── macros/
+│   ├── currency.py
+│   └── test_helpers.py
+├── models/
+└── sqlbuild_project.toml
+```
+
+Every public function defined by a macro file becomes callable from SQL:
 
 ```python
 # macros/currency.py
-def cents_to_dollars(column):
-    """Convert a cents integer column to a dollars decimal."""
-    return f"ROUND(CAST({column} AS DOUBLE) / 100, 2)"
+def cents_to_dollars(expression: str) -> str:
+    """Convert a cents expression to dollars."""
+    return f"ROUND(CAST({expression} AS DOUBLE) / 100, 2)"
 ```
 
-Macros can accept any Python arguments (strings, numbers, lists, dicts, booleans) and must return a SQL string when called from SQL.
+### Call a macro from SQL
 
-Only functions owned by the module are exported. Imported callables and classes remain implementation dependencies and do not become macros. Module-owned constants, classes, type aliases, and helper functions must use underscore-private names:
-
-```python
-# macros/orders.py
-from urllib.parse import quote
-
-_DEFAULT_STATUS = "completed"
-type _ColumnName = str
-
-class _ColumnFormatter:
-    def format(self, column: _ColumnName) -> str:
-        return quote(column)
-
-def _status_filter(status: str) -> str:
-    return f"status = '{status}'"
-
-def completed_orders() -> str:
-    return _status_filter(_DEFAULT_STATUS)
-```
-
-Here, only `completed_orders` is exported as a macro. `quote`, `_ColumnFormatter`, and `_status_filter` are implementation details.
-
-Macros may instead be inherited from `_macros/` directories or restricted to an exact directory with `_local_macros/`. See [Declaration Scopes](/concepts/declaration-scopes) for placement and lexical visibility. Public macro names remain globally unique even when their scopes do not overlap.
-
-### Using macros in models
-
-Call macros in model SQL using the `@macro_name(args)` syntax:
+Use `@macro_name(...)` in a model query:
 
 ```sql
 MODEL (
@@ -4386,25 +3756,68 @@ MODEL (
 );
 
 SELECT
-  CAST(o.ordered_at AS DATE) AS revenue_date,
-  COUNT(DISTINCT o.order_id) AS order_count,
-  SUM(p.amount_cents) AS total_revenue_cents,
-  @cents_to_dollars('SUM(p.amount_cents)') AS total_revenue_dollars
-FROM __ref("stg_orders") o
-INNER JOIN __ref("stg_payments") p ON o.order_id = p.order_id
-GROUP BY CAST(o.ordered_at AS DATE)
+  order_id,
+  @cents_to_dollars("amount_cents") AS amount_dollars
+FROM __ref("stg_orders")
 ```
 
-At compile time, `@cents_to_dollars('SUM(p.amount_cents)')` expands to `ROUND(CAST(SUM(p.amount_cents) AS DOUBLE) / 100, 2)`.
+During compilation, SQLBuild replaces the call with the function's returned SQL:
 
-### Using macros in tests
+```sql
+ROUND(CAST(amount_cents AS DOUBLE) / 100, 2)
+```
 
-Because unit tests are written in SQL, they support macro calls. This is useful for reusable mock data generators:
+A macro used directly in SQL must return a string.
+
+### Arguments
+
+Macro calls accept Python literal values:
+
+- Strings: `"value"` or `'value'`
+- Numbers: `42`, `3.14`, `-1`
+- Booleans: `True`, `False`
+- Lists: `[1, 2, 3]`
+- Dictionaries: `{"key": "value"}`
+- `None`
+- The result of another macro call
+
+Positional and keyword arguments are supported:
+
+```sql
+@mock_orders(count=5, status="completed")
+```
+
+Use quoted strings when passing SQL expressions such as column names. The macro decides how to
+place that text into its returned SQL.
+
+### Keep implementation details private
+
+Only public functions owned by the file are exported as macros. Prefix helpers, constants, classes,
+and type aliases with `_`:
+
+```python
+# macros/orders.py
+_DEFAULT_STATUS = "completed"
+
+def _status_filter(status: str) -> str:
+    return f"status = '{status}'"
+
+def completed_orders() -> str:
+    return _status_filter(_DEFAULT_STATUS)
+```
+
+Here, SQL may call `@completed_orders()`. `_status_filter` and `_DEFAULT_STATUS` remain ordinary
+Python implementation details.
+
+Imported functions are not re-exported as new macros from the importing file.
+
+### Use macros in tests
+
+Tests are SQL, so they can use macros as reusable fixture generators:
 
 ```python
 # macros/test_helpers.py
-def mock_orders(count=1):
-    """Generate mock order rows."""
+def mock_orders(count: int = 1) -> str:
     rows = [
         f"SELECT {i} AS id, {i * 100} AS customer_id, 'completed' AS status"
         for i in range(1, count + 1)
@@ -4429,49 +3842,164 @@ __expected__stg_orders AS (
 SELECT 1
 ```
 
-### Using macros in hooks
+### Use macros in hooks
 
-Macros are expanded inside `inline_sql(...)` entries and reusable `sql("name", ...)` hook files in `pre_hooks` and `post_hooks`:
+Macros work inside inline and named SQL hooks:
 
 ```python
 # macros/permissions.py
-def grant_target(target):
+def grant_target(target: str) -> str:
     return f"GRANT SELECT ON {target} TO analyst_role"
 ```
 
 ```sql
 MODEL (
-  materialized table,
   post_hooks [inline_sql('@grant_target(@@CTX:destination.qualified)')],
 );
 
 SELECT 1 AS id
 ```
 
-Hook SQL is validated at compile time, so invalid hook SQL is caught before execution. SQL hooks also support `@@CTX:` context variables, `@@name` project variables, and `@@ENV:NAME` environment variables directly without needing a macro wrapper.
+See [SQL Hooks](/concepts/models/hooks/sql) for hook lifecycle and context syntax.
 
-For shared parameterized SQL, put the statement under `hooks/sql/` and invoke it with `sql("name", args...)`. For hooks that need runtime control flow, providers, or skip decisions, use `python(...)` hooks instead. See [Hooks](/concepts/models/hooks) for the complete lifecycle hook syntax.
+### Where macros work
+
+Macros are supported in:
+
+- Model query SQL
+- Inline and named SQL hooks
+- Unit tests and scenarios
+- Standalone audit SQL
+- SQL functions and supported inline source expressions
+
+Macros are not accepted in ordinary `MODEL()` configuration fields. SQL hook entries are the
+exception because their contents are SQL.
+
+### Next steps
+
+    Compose macros through Python imports and use adapter or target context.
+    Limit a macro to one folder, or to that folder and its child folders.
+
+## Composition and Context
+
+Source: `concepts/macros/composition-and-context.mdx`
+
+Compose macros through Python, use compile context, and understand scoped imports.
+
+Macros are Python functions, so reusable macros should compose through ordinary Python calls. A
+macro returns final SQL; SQLBuild does not treat its output as another layer of macro source.
+
+### Compose helpers in one file
+
+Use underscore-prefixed helpers for implementation details that should not be callable from SQL:
+
+```python
+# macros/currency.py
+def _divide_by_100(expression: str) -> str:
+    return f"({expression} / 100.0)"
+
+def cents_to_dollars(expression: str) -> str:
+    return f"ROUND({_divide_by_100(expression)}, 2)"
+```
+
+Only `cents_to_dollars` is exported as a SQLBuild macro.
+
+Public macros in the same file are also ordinary Python functions and may call one another:
+
+```python
+def add_tax(expression: str) -> str:
+    return f"({expression} * 1.2)"
+
+def round_money(expression: str) -> str:
+    return f"ROUND({expression}, 2)"
+
+def formatted_total(expression: str) -> str:
+    return round_money(add_tax(expression))
+```
+
+### Compose macros from different files
+
+Import another project macro when it is visible from the importing macro file:
+
+```python
+# macros/orders.py
+from macros.currency import add_tax, round_money
+
+def formatted_order_total(expression: str) -> str:
+    return round_money(add_tax(expression))
+```
+
+SQLBuild records the imported macro files as dependencies. It rejects an import when the target
+macro is outside the importing file's declaration scope or when imports form a cycle.
+
+Imported functions do not become duplicate exports from the importing file. In the example above,
+`add_tax` and `round_money` retain their original identities; only `formatted_order_total` is newly
+exported by `orders.py`.
+
+The same visibility direction applies to scoped macros:
+
+- A scoped macro may import a project-wide macro.
+- A scoped macro may import a macro available from its own or an ancestor directory.
+- A project-wide macro cannot import a narrower macro.
+- A macro cannot import from a sibling or unrelated scope.
+
+See [Declarations and Scopes](/concepts/declaration-scopes) when macros are stored under `_macros/`
+or `_local_macros/`.
+
+### Macro output is final SQL
+
+Do not return SQL containing another `@macro()` call:
+
+```python
+# Invalid: creates another macro-expansion layer.
+def formatted_order_total(expression: str) -> str:
+    return f"@round_money(@add_tax({expression!r}))"
+```
+
+SQLBuild rejects this output. Import and call the Python functions instead:
+
+```python
+from macros.currency import add_tax, round_money
+
+def formatted_order_total(expression: str) -> str:
+    return round_money(add_tax(expression))
+```
+
+This keeps macro behavior readable in Python and ensures one expansion produces final SQL.
+
+### Nested calls written in SQL
+
+The SQL author may explicitly pass one macro's result to another:
+
+```sql
+SELECT @round_money(@add_tax("subtotal")) AS order_total
+```
+
+SQLBuild evaluates `add_tax` first and passes its returned string to `round_money`. This is not a
+second expansion of generated output: both calls are visible in the SQL source.
+
+Inner macros may return any Python value accepted by the outer macro. A macro used directly in SQL
+must return a string.
 
 ### Macro context
 
-When a macro function accepts a `ctx` parameter as its first argument, SQLBuild passes a `MacroContext` object with adapter and target information:
+When the first parameter is named `ctx`, SQLBuild passes a `MacroContext` with adapter, target, and
+project-variable information:
 
 ```python
 # macros/datetime.py
-def timestamp_trunc(ctx, grain: str, expr: str) -> str:
+def timestamp_trunc(ctx, grain: str, expression: str) -> str:
     if ctx.adapter_name == "bigquery":
-        return f"TIMESTAMP_TRUNC({expr}, {grain.upper()})"
-    return f"DATE_TRUNC('{grain}', {expr})"
+        return f"TIMESTAMP_TRUNC({expression}, {grain.upper()})"
+    return f"DATE_TRUNC('{grain}', {expression})"
 ```
-
-The macro context provides:
 
 | Field | Description |
 |-------|-------------|
-| `adapter_name` | The active adapter (e.g. `duckdb`, `snowflake`) |
+| `adapter_name` | Active adapter, such as `duckdb` or `snowflake` |
 | `sql_analysis_enabled` | Whether SQL analysis is enabled |
-| `target_name` | The active target name, if any |
-| `vars` | Effective project variables as a dict (merged from project config, target, local config, and CLI `--vars`) |
+| `target_name` | Active target name, when selected |
+| `vars` | Effective project variables after project, target, local, and CLI merging |
 
 ```python
 def schema_qualified(ctx, table: str) -> str:
@@ -4479,200 +4007,8 @@ def schema_qualified(ctx, table: str) -> str:
     return f"{schema}.{table}"
 ```
 
-### Macro arguments
-
-Macro arguments use Python literal syntax. Supported types:
-
-- **Strings:** `'value'` or `"value"`
-- **Numbers:** `42`, `3.14`, `-1`
-- **Booleans:** `True`, `False`
-- **Lists:** `[1, 2, 3]`
-- **Dicts:** `{'key': 'value'}`
-- **None:** `None`
-- **Nested macro calls:** `@other_macro('arg')`
-
-Keyword arguments are supported:
-
-```sql
-@mock_orders(count=5, status='completed')
-```
-
-#### Nested macro calls in arguments
-
-Macros can be passed as arguments to other macros. The inner macro evaluates first and its result becomes an argument to the outer macro:
-
-```sql
-@format_column('revenue', @cents_to_dollars('SUM(amount_cents)'))
-```
-
-You can mix regular arguments with nested macro calls:
-
-```sql
-@wrap_with_alias(@cents_to_dollars('total_cents'), 'total_dollars')
-```
-
-Inner macros used as arguments don't have to return strings - they can return any Python object that the outer macro accepts.
-
-### Composing macros
-
-Macro output may contain further `@macro()` calls. SQLBuild expands those calls under the emitting macro's definition-path scope. Calls written as nested arguments resolve under the current SQL author's scope before the outer macro runs. Inaccessible dependencies and dependency cycles fail compilation.
-
-For implementation details used by one macro, call an underscore-private helper in the same file:
-
-```python
-# macros/reporting.py
-def _with_alias(expression, alias):
-    return f"{expression} AS {alias}"
-
-def revenue_column(expression, alias):
-    return _with_alias(expression, alias)
-```
-
-Macro modules cannot import other project macro modules. To compose macros defined in different files, keep the calls in authored SQL using the tracked `@macro_name(...)` syntax. Nested calls evaluate from the inside out, so each macro call remains visible to SQLBuild:
-
-```sql
-SELECT
-  @revenue_column(
-    @cents_to_dollars('total_cents'),
-    'total_dollars'
-  )
-FROM __ref("fact_orders")
-```
-
-In this example, `cents_to_dollars` and `revenue_column` can be defined in separate macro files. Do not import one from the other in Python.
-
-An emitting macro can also compose lexically in its returned SQL:
-
-```python
-# models/commerce/_macros/revenue.py
-def revenue_column(column):
-    return f"@cents_to_dollars('{column}') AS revenue_dollars"
-```
-
-Here `cents_to_dollars` must be visible from `models/commerce/_macros/revenue.py`. It is not borrowed from whichever model calls `revenue_column`. In particular, a project-wide macro under `macros/` cannot depend on an inherited or local macro.
-
-### Where macros are allowed
-
-- **Model query SQL** - the SELECT statement after the MODEL() header
-- **SQL hooks** - `inline_sql(...)` entries and named hook files invoked by `sql("name", ...)`
-- **Test SQL** - unit test CTE bodies
-- **Audit SQL** - singular audit queries
-
-Macros are **not allowed** in MODEL() config values (other than SQL hook entries). If a config field contains `@macro()`, SQLBuild raises a compile error.
-
-### Discovery rules
-
-- SQLBuild discovers `.py` files recursively under top-level `macros/` and scoped `_macros/` or `_local_macros/` directories below canonical authored roots
-- Only public ordinary functions defined by the macro module become macros
-- Imported callables and classes are not exported as macros
-- Module-owned constants, classes, type aliases, and helper functions must start with `_`
-- A macro module must not Python-import another project macro module
-- Public macro names must be unique across all macro files; scopes do not provide shadowing
-- Macros are loaded once at compile time, not per-model
-- Manifest macro nodes expose declaration scope, owning path, and tracked macro dependencies
-
-## Scope Explorer
-
-Source: `concepts/declaration-scopes/explorer.mdx`
-
-Inspect visibility, explain resolution, browse declarations, and preview moves offline.
-
-Scope Explorer exposes the compiler's declaration index through `sqb scope`. It is read-only and
-offline: it never connects to the warehouse, moves files, or edits configuration.
-
-Use this page for common workflows. See the [`sqb scope` CLI reference](/cli/scope) for every flag,
-filter, text section, and JSON field.
-
-### Inspect a resource
-
-Start with a model, test, scenario, hook, function, audit, source, or declaration identity:
-
-```bash
-sqb scope model:stg_orders
-sqb scope test:orders__completed_only
-sqb scope macro:normalize_order_status
-```
-
-The report separates concepts that are easy to conflate:
-
-| Section | What it answers |
-|---------|-----------------|
-| Scope chain | Which exact-local, inherited, and global tiers apply? |
-| Available | What can this resource resolve through its lexical path? |
-| Used declarations | What did compilation actually consume? |
-| Relationship scope | Which expected models granted constants or enums? |
-| Nearby unavailable | Which close declarations are outside scope? This is opt-in. |
-| Placement | Is each narrow declaration at its closest valid location? |
-
-### Explain one declaration
-
-Ask why a declaration is visible, inaccessible, used, or granted:
-
-```bash
-sqb scope model:stg_orders --explain enum:customer_status
-sqb scope test:orders__completed_only --explain constant:order_status
-```
-
-Explanation output retains the resolution route. Expected-model grants remain distinct from path
-visibility, and macro dependency routes retain the consuming macro.
-
-### Browse nearby declarations
-
-Use nearby output when you know the resource but not the declaration name:
-
-```bash
-sqb scope model:stg_orders --include-nearby
-sqb scope model:stg_orders --include-nearby --nearby-depth 2
-```
-
-Browse the scope index like a deterministic tree when exploring a larger project:
-
-```bash
-sqb scope model:stg_orders --browse .
-sqb scope model:stg_orders --browse global
-sqb scope model:stg_orders --list global/macros/finance/payments
-```
-
-Filters for declaration kind, definition path, glob matching, and actual usage can be combined. Use
-pagination for large reports rather than trimming the compiler facts.
-
-### Check a prospective path
-
-Inspect what a resource would see before its file exists:
-
-```bash
-sqb scope --at models/commerce/finance/new_revenue.sql
-sqb scope --at tests/unit/commerce/orders/
-```
-
-Use `--as-path` to evaluate an existing resource from a proposed destination without moving it:
-
-```bash
-sqb scope model:stg_orders --as-path models/commerce/staging/stg_orders.sql
-```
-
-### Preview a resource move
-
-Use `--as-path` to preview moving an existing authored resource such as a model, test, hook, or
-function. The report shows retained, gained, and lost declarations and direct usages the move would
-invalidate:
-
-```bash
-sqb scope model:stg_orders \
-  --as-path models/marts/orders/stg_orders.sql
-```
-
-The destination must be valid for that resource kind. Scope Explorer does not move the file or
-preview moving declaration files themselves.
-
-### Automation
-
-Use `--json` for editor integrations and repository tooling. Scope JSON has a versioned schema,
-stable ordering, value-free declaration metadata, completeness facts, filters, pagination, and move
-preview results. Secret connection settings and declaration values are not included.
-
-    Review the compiler rules behind the report.
-    See all selectors, filters, pagination options, output sections, and JSON behavior.
+Use context when generated SQL genuinely differs by adapter or target. Prefer ordinary parameters
+for values that the SQL caller should choose explicitly.
 
 ## Interpolation
 
@@ -4705,9 +4041,13 @@ The rule is simple: if it's any SQL that will be executed, it uses `@`. If it's 
 
 `@@CTX:` is intentionally SQL-hook-only. Model SQL describes a relation's data and should not reference its own destination identity. SQL hooks are the operational SQL layer where destination context is useful - grants, logging, post-materialization DDL. Python hooks access the same information through `ctx.destination` on the [`HookContext`](/concepts/models/hooks/python#hook-context) object.
 
-See [Enums and Constants](/concepts/enums-and-constants) for scalar and collection syntax, visibility, collection-rendering precedence, adapter behavior, and contract integration.
+See [Enums](/concepts/enums) and [Constants](/concepts/constants) for reusable validated values. See
+[Collections and Rendering](/concepts/constants/collections-and-rendering) for lists, sets, objects,
+and adapter-specific rendering.
 
-Macros, enums, and constants are resolved lexically. The authored resource path normally supplies the scope; named SQL hooks and macro-emitted calls use their definition paths. See [Declaration Scopes](/concepts/declaration-scopes) for the complete path and composition rules.
+SQLBuild uses the location of a SQL file to determine which macros, enums, and constants it can
+use. Named SQL hooks use their own file location rather than the location of the calling model. See
+[How Visibility Works](/concepts/declaration-scopes/visibility) for the complete directory rules.
 
 ### Project variables
 
@@ -4986,7 +4326,9 @@ SQL functions can reference the same resources as models:
 
 These references are resolved at compile time and create DAG edges. If a referenced model changes, the function is redeployed.
 
-Macros, constants, and enums used in a SQL function resolve from the function definition's authored path. Put inherited declarations in `_macros/`, `_constants/`, or `_enums/` above that function, or exact-directory declarations in the corresponding `_local_...` directory. See [Declaration Scopes](/concepts/declaration-scopes).
+A SQL function uses macros, constants, and enums available from its file under `functions/sql/`.
+See [How Visibility Works](/concepts/declaration-scopes/visibility) to limit declarations to one
+function folder or to that folder and its children.
 
 ### Change propagation
 
@@ -5996,7 +5338,9 @@ Generic audit SQL uses `@name` for parameter placeholders. These are resolved by
 | `@'name'` | A quoted parameter passed from the audit declaration (e.g. `@'values'`) |
 | `@name` | An unquoted parameter passed from the audit declaration (e.g. `@expression`) |
 
-Macros, constants, and enums in both generic and singular audit SQL resolve from the audit definition's authored path under `audits/`, not from the path of a model or source that attaches the audit. See [Declaration Scopes](/concepts/declaration-scopes).
+Generic and singular audit SQL uses macros, constants, and enums available from the audit file under
+`audits/`, not from a model or source that uses the audit. See
+[How Visibility Works](/concepts/declaration-scopes/visibility).
 
 #### Attaching custom generic audits
 
@@ -6296,7 +5640,9 @@ SELECT 1
 
 If the expected models form a chain (e.g. `stg_orders` feeds into `fact_orders` which feeds into `dim_customers`), SQLBuild resolves them in dependency order, using the output of earlier steps as input to later ones.
 
-Each explicit `__expected__<model>` CTE also grants the test authored SQL the public enums and constants visible to that model. A test with multiple expected models receives the deterministic union, with provenance retained for every granting model. Public names remain globally unique, so the union cannot shadow declarations.
+When a test defines `__expected__model_name` output, it may also use the public enums and constants
+available to that model. A test that checks several models may use the public enums and constants
+available to each of them. Public names are unique, so those values cannot conflict.
 
 Only explicit expected CTEs create grants. A matching test filename, `__ref__` mock, or nearby model path does not. Model-private declarations and macros are never granted through expected models.
 
@@ -6323,7 +5669,10 @@ SELECT 1
 
 The `@mock_orders()` call expands at compile time to whatever SQL the Python macro function returns.
 
-Macros and directly visible enums and constants in authored test SQL resolve from that test file's path under `tests/unit/`. This includes inherited declarations from every matching ancestor and local declarations owned by the test's exact parent directory; sibling and descendant declarations are inaccessible. Public enums and constants may also be available through explicit expected-model grants. Model-private constants and enums are not exported to tests. See [Declaration Scopes](/concepts/declaration-scopes).
+Test SQL uses macros, enums, and constants available from the test file's directory under
+`tests/unit/`. Public enums and constants available to a model are also available when the test
+defines `__expected__model_name` output for that model. Model-private values are not available to
+tests. See [How Visibility Works](/concepts/declaration-scopes/visibility#tests-and-expected-models).
 
 ### Macro mocking
 
@@ -6731,7 +6080,11 @@ For sources with two-part identity, use double underscores: `__source__raw__orde
 
 Every scenario must have at least one fixture CTE and at least one `__expected__` or `__assert__` CTE.
 
-Macros and directly visible constants and enums in authored scenario SQL resolve from that scenario file's path under `tests/scenarios/`. Inherited ancestors compose and local declarations apply only to the exact parent directory. Each explicit `__expected__<model>` CTE additionally grants the public enums and constants visible to that expected model. Multiple expected models contribute a deterministic union with per-model provenance; they do not grant macros or model-private declarations. See [Declaration Scopes](/concepts/declaration-scopes).
+Scenario SQL uses macros, enums, and constants available from the scenario file's directory under
+`tests/scenarios/`. Public enums and constants available to a model are also available when the
+scenario defines `__expected__model_name` output for that model. Model-private values and macros
+available only to the model are not included. See
+[How Visibility Works](/concepts/declaration-scopes/visibility#tests-and-expected-models).
 
 #### SCENARIO() header
 
@@ -7371,6 +6724,860 @@ sqb diff prod:dev --full --select tag:acceptance
 ### Exit codes
 
 `sqb diff` returns exit code `0` when all selected models have no differences, and `1` when any model has schema or row differences. This makes it usable in CI pipelines as a validation gate.
+
+## Overview
+
+Source: `concepts/declaration-scopes.mdx`
+
+Limit enums, constants, and macros to the parts of a project that use them.
+
+Most projects can keep enums, constants, and macros in their ordinary top-level directories. Those
+declarations are available throughout the project.
+
+When an enum, constant, or macro should be available only within one folder or its child folders,
+you can keep it near the SQL that uses it. SQLBuild uses the declaration directory's location to
+decide which files can access it. No TOML configuration is required.
+
+| Scope | Declaration form | Visibility |
+|-------|------------------|------------|
+| Project-wide | `macros/`, `constants/`, `enums/` | Every supported SQL surface |
+| Inherited | `_macros/`, `_constants/`, `_enums/` | Owning path and every descendant |
+| Exact-local | `_local_macros/`, `_local_constants/`, `_local_enums/` | Direct children of one owning path |
+| Model-private | Underscore-prefixed constants and enums in `MODEL()` | One model and its inline SQL hooks |
+
+### Example
+
+The annotation beside each directory shows where its contents are available:
+
+```text
+models/
+├── _constants/                 inherited throughout models/
+│   └── warehouse.sql
+└── commerce/
+    ├── _macros/                inherited throughout commerce/
+    │   └── currency.py
+    ├── _local_enums/           exact commerce/ directory only
+    │   └── grain.sql
+    ├── orders.sql              sees warehouse, currency, and grain
+    ├── finance/
+    │   ├── _macros/            inherited throughout finance/
+    │   │   └── tax.py
+    │   └── revenue.sql         sees warehouse, currency, and tax
+    └── fulfillment/
+        └── shipments.sql       sees warehouse and currency
+```
+
+An inherited directory applies at its location and below it. An exact-local directory applies only
+to SQL files directly beside it.
+
+| Resource | Visible from the example tree | Not visible |
+|----------|-------------------------------|-------------|
+| `orders.sql` | Warehouse constant, commerce macro, commerce-local enum | Finance macro |
+| `finance/revenue.sql` | Warehouse constant, commerce macro, finance macro | Commerce-local enum |
+| `fulfillment/shipments.sql` | Warehouse constant, commerce macro | Commerce-local enum, finance macro |
+
+Declarations do not flow upward or sideways into sibling directories.
+
+### Choose a scope
+
+| Where the value is needed | Choose | Placement |
+|----------------|--------|-----------|
+| One model only | Model-private | In that model's `MODEL()` header |
+| One exact directory | Exact-local | Beside the consumers |
+| Multiple directories in one resource tree | Inherited | At their lowest common ancestor |
+| Different resource trees, such as models and tests | Project-wide | Top-level declaration root |
+
+SQLBuild does not ask you to narrow a project-wide declaration merely because its current users are
+close together. If a declaration is already scoped, SQLBuild checks that it is placed close enough
+to the files that use it.
+
+### Explore the feature
+
+    See which declarations a model, test, hook, or function can use.
+    Choose between project-wide, inherited, exact-local, and model-private placement.
+    Ask SQLBuild what a file can use and preview how moving it would change that answer.
+
+Learn the features themselves in [Enums](/concepts/enums), [Constants](/concepts/constants), and
+[Writing Macros](/concepts/macros). See [Interpolation](/concepts/interpolation) for project,
+environment, and runtime context values, which are separate from declarations.
+
+## How Visibility Works
+
+Source: `concepts/declaration-scopes/visibility.mdx`
+
+See which enums, constants, and macros are available to each SQL file.
+
+For most SQL, the rule is simple:
+
+> A file can use project-wide declarations, declarations inherited from `_.../` directories above
+> it, and declarations in a `_local_.../` directory directly beside it.
+
+### Start from the SQL file
+
+SQLBuild starts from the file containing the SQL and walks up that file's directory tree.
+
+```text
+models/
+├── _constants/                 available throughout models/
+│   └── warehouse.sql
+└── commerce/
+    ├── _enums/                 available throughout commerce/
+    │   └── order_status.sql
+    ├── _local_constants/       available directly in commerce/ only
+    │   └── minimum_value.sql
+    ├── orders.sql
+    └── history/
+        └── archived_orders.sql
+```
+
+From this tree:
+
+| File | Can use |
+|------|---------|
+| `orders.sql` | `warehouse`, `order_status`, and `minimum_value` |
+| `history/archived_orders.sql` | `warehouse` and `order_status` |
+
+`minimum_value` is not available in `history/` because `_local_constants/` applies only to files
+directly beside it.
+
+### Supported resource trees
+
+Scoped declaration directories can be placed below these SQL resource roots:
+
+| Root | Contents |
+|------|----------|
+| `models/` | Models and inline model hooks |
+| `tests/unit/` | Unit tests |
+| `tests/scenarios/` | Scenarios |
+| `hooks/sql/` | Named SQL hooks |
+| `functions/sql/` | SQL functions |
+| `audits/` | Audits |
+| `sources/` | Inline source expressions |
+
+Each root is a separate tree. For example, `models/_constants/` does not flow into `tests/`. Put a
+declaration in the top-level `constants/`, `enums/`, or `macros/` directory when it must be available
+across different resource trees. A project-root `_constants/`, `_enums/`, or `_macros/` directory is
+invalid.
+
+### Which file controls visibility?
+
+| SQL being compiled | SQLBuild starts from |
+|--------------------|----------------------|
+| Model query | The model file |
+| Inline SQL hook in a model | The model file |
+| Unit test or scenario SQL | The test or scenario file |
+| Named SQL hook | The hook file under `hooks/sql/` |
+| SQL function | The function file under `functions/sql/` |
+| Audit | The audit file |
+| Inline source expression | The source definition |
+
+This means a reusable named hook does not change meaning depending on which model calls it. The
+hook uses declarations available where the hook itself is stored.
+
+### Tests and expected models
+
+A test first sees declarations available from the test file's own directory. It may also use public
+enums and constants available to a model for which it defines expected output.
+
+```sql
+TEST();
+
+WITH
+__expected__orders AS (
+  SELECT
+    1 AS order_id,
+    @enum("order_status").COMPLETED AS status
+)
+SELECT 1
+```
+
+Because the test defines `__expected__orders`, it may use public enums and constants available to
+the `orders` model. This makes it possible for expected rows to use the same domain values as the
+model they check.
+
+This additional access does **not** include:
+
+- Macros available only to the model
+- Enums or constants declared privately inside the model's `MODEL()` header
+- Declarations from a model merely mentioned by filename or directory layout
+
+Only an explicit `__expected__model_name` relationship adds the model's public enums and constants.
+When a test checks several models, it can use the public enums and constants available to each of
+those models.
+
+### Macros importing macros
+
+A macro file may import another project macro file when the imported macro is available from the
+importing file's location. The same directory rules apply as they do to SQL.
+
+```python
+# models/commerce/_macros/orders.py
+from macros.currency import round_money
+
+def formatted_total(expression: str) -> str:
+    return round_money(expression)
+```
+
+A broadly available macro cannot import a macro from a narrower child or sibling directory. See
+[Composition and Context](/concepts/macros/composition-and-context) for complete examples.
+
+### Names do not shadow
+
+Public names must be unique within their feature:
+
+- One public macro name cannot be defined twice.
+- One public enum name cannot be defined twice.
+- One public constant name cannot be defined twice.
+
+Moving a declaration into a narrower directory changes where it is available; it does not create a
+second version that overrides another declaration.
+
+Macros, enums, and constants use separate namespaces, so these three references may coexist:
+
+```sql
+@format_currency()
+@const("format_currency")
+@enum("format_currency").USD
+```
+
+  Choose the simplest directory that matches where a declaration is used.
+
+## Where to Put Declarations
+
+Source: `concepts/declaration-scopes/placement.mdx`
+
+Choose project-wide, inherited, exact-local, or model-private placement.
+
+Start with the ordinary project-wide directories unless you have a reason to limit access:
+
+```text
+macros/
+enums/
+constants/
+```
+
+Use scoped directories when a declaration should be available only within one folder or its child
+folders.
+
+### Choose a location
+
+| Where it is needed | Location |
+|--------------------|----------|
+| One model only | Inside that model's `MODEL()` header, for enums and constants |
+| SQL files directly in one directory | `_local_macros/`, `_local_enums/`, or `_local_constants/` |
+| A directory and its descendants | `_macros/`, `_enums/`, or `_constants/` |
+| Different trees, such as models and tests | Top-level `macros/`, `enums/`, or `constants/` |
+
+### One directory
+
+These two models use the same constant and both sit directly in `commerce/`:
+
+```text
+models/
+└── commerce/
+    ├── _local_constants/
+    │   └── minimum_value.sql
+    ├── orders.sql
+    └── customers.sql
+```
+
+Use `_local_constants/` because no descendant directory needs the value.
+
+### One directory tree
+
+These models use the same constant across two child directories:
+
+```text
+models/
+└── commerce/
+    ├── _constants/
+    │   └── reporting_day.sql
+    ├── finance/
+    │   └── revenue.sql
+    └── fulfillment/
+        └── shipments.sql
+```
+
+Use `_constants/` in `commerce/` so both child directories inherit it.
+
+### Different resource trees
+
+When a declaration is used directly from unrelated trees, make it project-wide:
+
+```text
+my_project/
+├── constants/
+│   └── order_status.sql
+├── models/
+│   └── commerce/orders.sql
+└── tests/
+    └── scenarios/order_lifecycle.sql
+```
+
+Top-level placement is also valid when you deliberately want a stable, easy-to-discover project API.
+SQLBuild does not force a used project-wide declaration into a narrower directory.
+
+### What SQLBuild checks
+
+Every declaration must be used by real compiled SQL. A name appearing only in a comment, quoted
+string, mock identity, or documentation does not count as use.
+
+For declarations already placed in `_.../` or `_local_.../` directories, SQLBuild checks that the
+location matches the files that use them. If not, the error shows:
+
+- Where the declaration is now
+- Which files use it
+- Which directory form is required
+- The destination directory
+
+These checks use the complete project rather than only the models selected by the current command.
+
+  Use Scope Explorer to see what a file can access or preview moving the file.
+
+## Scope Explorer
+
+Source: `concepts/declaration-scopes/explorer.mdx`
+
+Inspect visibility, explain resolution, browse declarations, and preview moves offline.
+
+Scope Explorer answers questions about declaration visibility through `sqb scope`. It is read-only
+and offline: it never connects to the warehouse, moves files, or edits configuration.
+
+Use this page for common workflows. See the [`sqb scope` CLI reference](/cli/scope) for every flag,
+filter, text section, and JSON field.
+
+### Inspect a resource
+
+Start with a model, test, scenario, hook, function, audit, source, or declaration identity:
+
+```bash
+sqb scope model:stg_orders
+sqb scope test:orders__completed_only
+sqb scope macro:normalize_order_status
+```
+
+The report separates what a file can use from what it actually uses:
+
+| Section | What it answers |
+|---------|-----------------|
+| Scope chain | Which exact-local, inherited, and project-wide directories apply? |
+| Available | Which declarations can this file use? |
+| Used declarations | Which declarations does it currently use? |
+| Expected models | Which enums and constants are available through expected model output? |
+| Nearby unavailable | Which nearby declarations are outside its scope? This is opt-in. |
+| Placement | Is each scoped declaration in the right directory? |
+
+### Explain one declaration
+
+Ask why a declaration is available, unavailable, or used:
+
+```bash
+sqb scope model:stg_orders --explain enum:customer_status
+sqb scope test:orders__completed_only --explain constant:order_status
+```
+
+For a test, the explanation keeps declarations from the test's directory separate from enums and
+constants made available through an expected model.
+
+### Browse nearby declarations
+
+Use nearby output when you know the resource but not the declaration name:
+
+```bash
+sqb scope model:stg_orders --include-nearby
+sqb scope model:stg_orders --include-nearby --nearby-depth 2
+```
+
+Browse declarations by folder when a project contains more than a short list:
+
+```bash
+sqb scope model:stg_orders --browse .
+sqb scope model:stg_orders --browse global
+sqb scope model:stg_orders --list global/macros/finance/payments
+```
+
+Filters for declaration kind, definition path, glob matching, and actual usage can be combined. Use
+pagination for large reports rather than trimming the compiler facts.
+
+### Check a prospective path
+
+Inspect what a resource would see before its file exists:
+
+```bash
+sqb scope --at models/commerce/finance/new_revenue.sql
+sqb scope --at tests/unit/commerce/orders/
+```
+
+Use `--as-path` to evaluate an existing resource from a proposed destination without moving it:
+
+```bash
+sqb scope model:stg_orders --as-path models/commerce/staging/stg_orders.sql
+```
+
+### Preview a resource move
+
+Use `--as-path` to preview moving an existing authored resource such as a model, test, hook, or
+function. The report shows retained, gained, and lost declarations and direct usages the move would
+invalidate:
+
+```bash
+sqb scope model:stg_orders \
+  --as-path models/marts/orders/stg_orders.sql
+```
+
+The destination must be valid for that resource kind. Scope Explorer does not move the file or
+preview moving declaration files themselves.
+
+### Automation
+
+Use `--json` for editor integrations and repository tooling. Output has a versioned schema, stable
+ordering, filters, pagination, and move-preview results. Constant values, credentials, and secret
+connection settings are not included.
+
+    Review the directory rules behind the report.
+    See all selectors, filters, pagination options, output sections, and JSON behavior.
+
+## Kata SQL Architecture Checks
+
+Source: `concepts/kata.mdx`
+
+Enforce opt-in SQL architecture and model-shape policy over your compiled project.
+
+Kata is SQLBuild's opt-in SQL architecture policy. It compiles the project, then checks model
+structure, naming, dependency boundaries, joins, contracts, and test coverage. Built-in checks run
+offline: they do not execute warehouse SQL or rewrite source files. Findings have stable codes and
+concrete remediations.
+
+Kata is error-only: every retained finding blocks the command. Use it for conventions that a team
+has deliberately adopted, not as a collection of advisory style warnings.
+
+Tests codify behavioral expectations; Kata codifies architectural expectations for SQL models.
+For equivalent boundaries, repository structure, and code-shape checks in Python projects, see
+[Fensu](https://docs.fensu.dev/).
+
+### Where Kata fits
+
+| Command | Responsibility |
+|---------|----------------|
+| `sqb compile` | SQL validity, references, inferred columns, contracts, and lineage |
+| `sqb lint` / `sqb format` | SQL presentation and formatting |
+| `sqb kata` | Repository architecture and model-shape conventions |
+| `sqb test` | Transformation behavior |
+| `sqb audit` | Data quality against materialized data |
+
+Kata is a separate command. It is not run automatically by `compile` or `build`.
+
+### Enable Kata
+
+Commit the shared policy to `sqlbuild_project.toml`:
+
+```toml
+[kata]
+select = ["SQBK"]
+```
+
+This activates the complete standard policy. Start here, then use `ignore` to switch off conventions
+the repository is not ready to enforce.
+
+Kata evaluates no rules when `[kata].select` is empty. Prefixes select matching rules that are
+enabled by default; exact codes also select individually opt-in rules. All current built-ins are
+enabled by default, so `SQBK` selects the complete built-in catalogue.
+
+Rule selectors are case-sensitive prefixes. They do not use `*` wildcards:
+
+- Built-in rules use `SQBK<family><three digits>`, such as `SQBKS101`.
+- Custom rules use `XSQBK<family><three digits>`, such as `XSQBKP001`.
+- `select` activates rules; `ignore` removes matching rules from the active policy.
+- An exact code activates that rule even when it is opt-in.
+- The CLI `--select` and `--exclude` flags scope models, not rules.
+
+Inspect any built-in or configured custom rule without enabling it:
+
+```bash
+sqb kata rule SQBKS101
+```
+
+### Built-in rules
+
+All current built-ins form the standard policy and are enabled by matching prefixes.
+
+#### Structure
+
+| Code | Check |
+|------|-------|
+| `SQBKS000` | Standalone comments belong on the first inner line of a CTE |
+| `SQBKS001` | Transformation logic belongs in top-level CTEs |
+| `SQBKS002` | The terminal SELECT reads plainly from the final top-level CTE |
+| `SQBKS101` | Each `__ref` and `__source` is isolated in one dependency import CTE |
+| `SQBKS201` | `SELECT *` is restricted to dependency import CTEs |
+| `SQBKS202` | Positional set-operation branches enumerate their columns |
+| `SQBKS301` | CTEs are top-level, not nested |
+| `SQBKS302` | Recursive CTEs are not permitted |
+| `SQBKS401` | View materialization agrees with the `stg_v`, `int_v`, or `mart_v` marker |
+| `SQBKS501` | CTE names describe their contents |
+
+#### Layers and model grammar
+
+| Code | Check |
+|------|-------|
+| `SQBKL001` | Dependencies flow forward through the layer order |
+| `SQBKL101` | Qualified table dependencies use `__ref` or `__source` |
+| `SQBKR001` | Model names follow `<domain>__<layer>__<entity>[__<source>]` |
+| `SQBKR002` | Model layer names agree with their folders |
+| `SQBKR201` | Model source suffixes and source dependency names use approved, current tokens |
+| `SQBKR301` | Referenced model identifiers follow Kata model-name grammar |
+| `SQBKR401` | Models declare `contract enforced` |
+
+#### Joins
+
+| Code | Check |
+|------|-------|
+| `SQBKJ001` | Implicit comma joins are not permitted |
+| `SQBKJ002` | Cross joins require an exact, reasoned exception |
+| `SQBKJ101` | Non-cross joins declare `ON` or `USING` keys |
+
+#### Column naming and types
+
+| Code | Check |
+|------|-------|
+| `SQBKN001` | `is_`, `has_`, and `can_` columns are BOOLEAN |
+| `SQBKN002` | `*_at`, `*_ts`, and `*_timestamp` columns use timestamp types |
+| `SQBKN003` | `*_date` columns are DATE |
+
+These checks use declared contract columns, not inferred output columns.
+
+#### Decision hygiene
+
+| Code | Check |
+|------|-------|
+| `SQBKH001` | Enum comparisons use declared members and normalized operands |
+| `SQBKH002` | Non-canonical numeric decisions use named constants |
+| `SQBKH101` | Identical enum domains are consolidated |
+| `SQBKH201` | Public enum and constant files live under domain folders |
+
+`SQBKH001` requires direct comparisons to `@enum("<enum>").<MEMBER>`. Normalize controlled values
+upstream rather than wrapping either comparison operand. A direct source-side value may be
+normalized in the comparison because the project does not control source casing; the enum member
+must still remain unwrapped.
+
+#### Tests and coverage
+
+| Code | Check |
+|------|-------|
+| `SQBKX001` | Non-passthrough models meet the configured audit minimum |
+| `SQBKX002` | Non-passthrough models meet the configured SQL test minimum |
+| `SQBKX201` | Selected custom rules have statically discoverable public-harness test cases |
+
+Selecting a custom rule automatically adds `SQBKX201` unless the policy ignores it. This is a
+static check for conventional `RuleCase` and `evaluate_rule` usage; it does not execute the tests.
+Thresholds default to one and can be set to zero to disable the corresponding minimum:
+
+```toml
+[kata.thresholds]
+min_audits_per_model = 1
+min_tests_per_model = 1
+min_custom_rule_test_cases = 1
+```
+
+#### SQL tests and scenarios
+
+The `SQBKT` family governs SQL authored under `tests/unit/` and `tests/scenarios/`. It consumes
+compiler-resolved test targets and resource ownership; it does not infer ownership from filenames
+or repeat compiler diagnostics for malformed tests.
+
+| Code | Check |
+|------|-------|
+| `SQBKT001` | Unit tests and scenarios use their compiler-owned canonical roots |
+| `SQBKT002` | Unit and scenario filenames identify their subject and behavior |
+| `SQBKT003` | Unit tests mirror resolved model, macro, UDF, or table-function ownership |
+| `SQBKT004` | Every `TEST` block has an explicit target-aware `subject: expected behavior` name |
+| `SQBKT101` | Scenario descriptions identify a concrete business behavior rather than generic case numbering |
+
+Select the family independently when adopting these conventions:
+
+```toml
+[kata]
+select = ["SQBKT"]
+```
+
+Every unit-test block, including the only block in a file, has an explicit name:
+
+```sql
+TEST (
+  name "stg_orders: excludes cancelled orders",
+);
+```
+
+The first colon separates a nonempty subject from nonempty behavior. Later colons are ordinary
+behavior prose. Single-model subjects match the resolved expected model, direct-mode subjects match
+the tested macro, UDF, or table function, and multi-model subjects name the common domain or an
+explicit pipeline. Generic values such as `test`, `works`, `basic`, and `case 1` are rejected without
+maintaining a verb allowlist.
+
+Unit filenames use either `test_<subject>.sql` or `test_<subject>__<behavior>.sql`. When a behavior
+suffix is present, it corresponds to the normalized behavior text; concise prefixes such as
+`excludes_cancelled` for `excludes cancelled orders` are valid. Scenario filenames omit the
+redundant prefix and use `<subject>__<behavior>.sql`:
+
+```text
+tests/unit/staging/test_stg_orders__excludes_cancelled.sql
+tests/scenarios/daily_revenue__multiple_orders.sql
+```
+
+Mirroring uses compiled relationships:
+
+- A single-model test mirrors the model parent below its compiler-owned model root.
+- A multi-model test mirrors the nearest common model-domain parent.
+- Models with no meaningful common parent use the configured pipeline directory.
+- Macro, UDF, and table-function tests mirror all resolved direct resource owners.
+- When ownership cannot be proven from compiler facts, Kata skips mirroring rather than guessing.
+
+The pipeline directory is relative to `tests/unit/`, normalized, and included in cache and generated
+guidance identity. The default is `pipelines`:
+
+```toml
+[kata.sql_tests]
+pipeline_directory = "chains/commerce"
+```
+
+This maps cross-domain tests to `tests/unit/chains/commerce/`. Absolute paths, traversal, repeated
+separators, and backslash paths are invalid configuration.
+
+### Naming policy
+
+Naming and layer rules can use a closed project vocabulary:
+
+```toml
+[kata]
+domains = ["finance", "market"]
+approved_source_tokens = ["salesforce", "stripe"]
+cte_name_whitelist = ["finalized_rows"]
+cte_name_denylist = ["scratch_result"]
+
+[kata.retired_source_tokens]
+old_crm = "salesforce"
+```
+
+Valid Kata layers are `stg`, `stg_v`, `int_clean`, `int_v`, `int_enriched`, `mart`, and
+`mart_v`. Configuration supplies vocabulary to active rules; it does not activate them. When
+`SQBKR001` or `SQBKH201` is active, a non-empty `domains` list constrains model or declaration
+domains respectively.
+
+### Exceptions and scoped ignores
+
+Choose the narrowest mechanism that represents the policy:
+
+| Mechanism | Scope | Reason required | Stale-checked |
+|-----------|-------|-----------------|---------------|
+| `ignore` | Disable rules globally | No | No |
+| `rule_exceptions` | One exact rule and exact file | Yes | Yes |
+| `rule_ignores` | Rule prefixes or codes across path globs | Yes | No |
+| `select_star_allow` | Path-glob allowance for `SQBKS201` | Yes | No |
+
+```toml
+[[kata.rule_exceptions]]
+rule = "SQBKJ002"
+path = "models/mart/market__mart__matrix.sql"
+reason = "Intentional Cartesian product over a bounded dimension"
+
+[[kata.rule_ignores]]
+rules = ["SQBKS"]
+paths = ["models/legacy/**"]
+reason = "Legacy migration boundary"
+
+[[kata.select_star_allow]]
+paths = ["models/mart/*_export.sql"]
+reason = "Intentional passthrough export"
+```
+
+An exact exception fails when its active rule no longer produces a fault at that file, prompting
+the repository to remove obsolete exceptions. Broad migration boundaries and lone-star allowances
+remain reasoned but are intentionally not stale-checked.
+
+### Cache and CI
+
+Built-in policies use a persistent cache under `target/kata-cache`. Compiled model content, active
+rules, options, thresholds, naming vocabulary, and relevant project files participate in cache
+identity. Disable it when diagnosing cache behavior:
+
+```toml
+[kata.cache]
+enabled = false
+```
+
+Run Kata directly in CI. It exits `1` when faults remain:
+
+```bash
+sqb kata
+sqb kata --json
+```
+
+Generate agent guidance from the same resolved policy and verify that committed guidance remains
+fresh:
+
+```bash
+sqb kata skills
+sqb kata skills --check
+```
+
+Kata manages `.agents/skills/sqlbuild-kata/SKILL.md`,
+`.claude/skills/sqlbuild-kata/SKILL.md`, and `.opencode/skills/sqlbuild-kata/SKILL.md`. It refuses
+to overwrite divergent or unowned files.
+
+See [Custom Kata Rules](/concepts/kata/custom-rules) to encode repository-specific policy and the
+[Kata CLI reference](/cli/kata) for command output and exit behavior.
+
+## Custom Kata Rules
+
+Source: `concepts/kata/custom-rules.mdx`
+
+Define and test repository-owned SQL architecture rules with the public Kata API.
+
+Custom Kata rules extend the built-in policy when a repository has domain conventions that cannot
+be expressed by configuration alone. They use the same selection, suppression, deterministic
+ordering, and remediation output as built-ins.
+
+Custom rule codes use `XSQBK<family><three digits>`. Keep codes stable after adoption because they
+become part of configuration, CI output, and exceptions.
+
+### Define a rule
+
+```python
+from sqlbuild.kata import KataFault, RuleContext, kata
+
+@kata(
+    code="XSQBKP001",
+    family="prices",
+    slug="typed-currency",
+    message="price models must declare a currency column",
+    remediation="Declare currency in the MODEL columns contract.",
+)
+def typed_currency(*, model, ctx: RuleContext) -> list[KataFault]:
+    if any(column.name == "currency" for column in ctx.declared_columns):
+        return []
+    return [ctx.path_fault()]
+```
+
+The function signature is exactly two keyword-only arguments named `model` and `ctx`. Return an
+empty list when the model passes or one or more `KataFault` values when it fails.
+
+`RuleContext` exposes the compiled model, authored SQL, raw Polyglot AST, references, parsed model
+name, materialization, declared columns, audit and test counts, public declarations, active policy,
+and fault constructors. Repository files can be read safely through `project_read_text` and
+`project_glob`.
+
+### Load and select rules
+
+Load repository-owned files or dotted modules from `sqlbuild_project.toml`:
+
+```toml
+[kata]
+select = ["XSQBKP001"]
+rule_paths = ["kata/rules"]
+rule_modules = ["project_kata.rules"]
+```
+
+A directory in `rule_paths` is scanned recursively for Python files containing `@kata`. Dotted
+modules must resolve beneath the project root. Codes must be unique across built-in and custom
+rules.
+
+Custom rules require exact selectors by default. Set `enabled_by_default=True` on the decorator to
+include a rule in matching prefix selections. This does not activate Kata when
+`[kata].select` is empty.
+
+### Typed options
+
+Declare options with `RuleOption.boolean`, `integer`, `string`, `string_list`, or `integer_list`:
+
+```python
+from sqlbuild.kata import KataFault, RuleContext, RuleOption, kata
+
+REQUIRED_DOMAIN = RuleOption.string(
+    name="required_domain",
+    default="market",
+    description="Domain that owns price models",
+)
+
+@kata(
+    code="XSQBKP002",
+    family="prices",
+    slug="required-domain",
+    message="price models must belong to the configured domain",
+    remediation="Move or rename this model for the configured domain.",
+    options=(REQUIRED_DOMAIN,),
+)
+def required_domain(*, model, ctx: RuleContext) -> list[KataFault]:
+    parts = ctx.name_parts
+    if parts is not None and parts.domain == ctx.option(REQUIRED_DOMAIN):
+        return []
+    return [ctx.path_fault()]
+```
+
+Configure options under the exact rule code. Unknown rules, option names, or invalid values fail
+configuration:
+
+```toml
+[kata.rule_options.XSQBKP002]
+required_domain = "finance"
+```
+
+### Test every rule
+
+Use the public harness so tests exercise normal SQLBuild discovery, compilation, rule loading, and
+structured fault evaluation:
+
+```python
+from sqlbuild.kata import RuleCase, evaluate_rule
+
+from kata.rules.prices import typed_currency
+
+def test_missing_currency_faults() -> None:
+    result = evaluate_rule(
+        rule=typed_currency,
+        test_case=RuleCase(
+            description="missing currency faults",
+            source=(
+                "MODEL (materialized table);\n\n"
+                "WITH final AS (SELECT 1 AS price)\n"
+                "SELECT price FROM final\n"
+            ),
+            path="models/mart/market__mart__prices.sql",
+            expected_fault_count=1,
+        ),
+    )
+
+    assert result.fault_count == 1
+```
+
+`RuleCase.files` can add supporting project files and `RuleCase.config` supplies the rule's option
+values. Keep conventional `RuleCase` and `evaluate_rule` calls under `tests/` so `SQBKX201` can
+count statically discoverable harness cases. This coverage check does not execute the tests, so run
+the test suite separately in CI.
+
+### Execution and caching
+
+Selected custom rules execute in a bounded Python subprocess with a 30-second timeout. Exceptions
+are reported with the rule code and model path, and returned faults rejoin normal suppressions and
+deterministic ordering.
+
+Selecting any custom rule disables the model cache by default. To keep the built-in cache available,
+require hermetic custom rules explicitly:
+
+```toml
+[kata.cache]
+enabled = true
+require_cacheable = true
+```
+
+Cacheable rules may import supported pure modules such as `collections`, `dataclasses`, `enum`,
+`math`, `re`, `typing`, and `sqlbuild.kata`. Use `RuleContext` rather than direct filesystem calls.
+SQLBuild validates these constraints before evaluation.
+
+Custom findings are still recomputed on each invocation. `require_cacheable` preserves the native
+model cache around them; it does not cache custom subprocess output.
+
+Return to [Kata SQL Architecture Checks](/concepts/kata) for built-in rules, selectors, and
+exceptions.
 
 ## Overview
 
@@ -11290,7 +11497,10 @@ sqb scope model:stg_orders --include-nearby --nearby-depth 2
 sqb scope model:stg_orders --explain enum:customer_status
 ```
 
-An explanation distinguishes an inaccessible known declaration from an unknown identity. It reports the declaration's definition and ownership, the visibility or boundary reason, consumers and macro dependencies, expected-model grants, required placement, and promotion impact. It does not move or rewrite the declaration.
+An explanation distinguishes a known but unavailable declaration from an unknown name. It reports
+where the declaration is defined, why it is or is not available, which files use it, expected-model
+access, required placement, and the impact of broadening its scope. It does not move or rewrite the
+declaration.
 
 `--dependency-depth` is separate from `--nearby-depth`: it follows tracked declaration dependencies from the used section rather than filesystem proximity.
 
@@ -11399,7 +11609,8 @@ There is no `--show-values` option.
 
 `sqb scope` inspects native SQLBuild authored resources and declarations. It does not discover or emulate dbt models, dbt or Jinja macros, package dispatch, dbt manifests, dbt selectors, dbt tests, or dbt schema YAML visibility. An external dbt graph dependency does not contribute declarations or lexical scope.
 
-For the declaration directory rules, all-ancestor composition, placement validation, expected-model grants, and macro expansion semantics, see [Declaration Scopes](/concepts/declaration-scopes).
+For declaration directory rules, placement checks, test access through expected models, and scoped
+macro imports, see [Declarations and Scopes](/concepts/declaration-scopes).
 
 ## kata
 
@@ -13512,3 +13723,54 @@ sqb reconcile attach --virtual-env dev --model fact_orders \
 ```
 
 See [Reconcile](/concepts/virtual-environments/reconcile) for details on guards and when to use each subcommand.
+
+## Enums and Constants Have Moved
+
+Source: `concepts/enums-and-constants.mdx`
+
+Find the new focused guides for enums, constants, collections, contracts, and private values.
+
+Enums and constants now have separate guides so each feature is easier to find and learn. This page
+remains available for existing links and bookmarks but is not part of the main navigation.
+
+    Define fixed string or integer domains and reference validated members.
+    Define reusable scalar values and reference them safely from SQL.
+    Work with lists, sets, objects, value lists, and native arrays.
+    Keep enums and constants inside one model.
+
+### Public declarations
+
+See [Enums](/concepts/enums) and [Constants](/concepts/constants) for project-wide declarations.
+
+### Constant values
+
+See [Constants](/concepts/constants#scalar-values) for scalars and
+[Collections and Rendering](/concepts/constants/collections-and-rendering) for collections.
+
+### References and rendering
+
+See [Collections and Rendering](/concepts/constants/collections-and-rendering).
+
+### Adapter matrix
+
+See the [native-array rendering matrix](/concepts/constants/collections-and-rendering#native-array-rendering).
+
+### Rendering configuration
+
+See [Project default](/concepts/constants/collections-and-rendering#project-default).
+
+### Model-local declarations
+
+See [Model-Private Values](/concepts/model-private-values).
+
+### Model-private declarations
+
+See [Model-Private Values](/concepts/model-private-values).
+
+### Enum validation
+
+See [Enum validation rules](/concepts/enums#validation-rules).
+
+### Enum-typed contracts
+
+See [Enum Model Contracts](/concepts/enums/model-contracts).

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
@@ -140,6 +140,9 @@ class _VisibleModelDeclarations:
     inaccessible_constants: dict[str, DeclarationRecord]
     enum_visibility: dict[str, tuple[VisibilityRecord, ...]]
     constant_visibility: dict[str, tuple[VisibilityRecord, ...]]
+    macros: dict[str, LoadedMacro]
+    macro_records: dict[str, DeclarationRecord]
+    inaccessible_macros: dict[str, DeclarationRecord]
 
 
 @dataclass(frozen=True)
@@ -259,18 +262,22 @@ def _build_model_inputs(
         model_identity: ResourceIdentity = ResourceIdentity(
             ResourceKind.MODEL, model_file.file_path.stem
         )
+        declaration_context: DeclarationResolutionContext = DeclarationResolutionContext(
+            enums=declarations.enums,
+            constants=declarations.constants,
+            inaccessible_enums=declarations.inaccessible_enums,
+            inaccessible_constants=declarations.inaccessible_constants,
+            enum_visibility=declarations.enum_visibility,
+            constant_visibility=declarations.constant_visibility,
+            macros=declarations.macros,
+            macro_records=declarations.macro_records,
+            inaccessible_macros=declarations.inaccessible_macros,
+            consumer=model_identity,
+        )
         declaration_expansion: DeclarationExpansionResult = expand_declaration_references_result(
             sql=var_substituted_sql,
             file_path=model_file.file_path,
-            declarations=DeclarationResolutionContext(
-                enums=declarations.enums,
-                constants=declarations.constants,
-                inaccessible_enums=declarations.inaccessible_enums,
-                inaccessible_constants=declarations.inaccessible_constants,
-                enum_visibility=declarations.enum_visibility,
-                constant_visibility=declarations.constant_visibility,
-                consumer=model_identity,
-            ),
+            declarations=declaration_context,
             value_renderer=context.value_renderer,
             collection_rendering=context.collection_rendering,
         )
@@ -281,6 +288,9 @@ def _build_model_inputs(
             loaded_macros=loaded_macros,
             macro_context=macro_context,
             declaration_resolver=context.declaration_resolver,
+            declarations=(
+                declaration_context if context.declaration_resolver is not None else None
+            ),
             consumer=model_identity,
         )
         expanded_query_sql: str = macro_expansion.sql
@@ -523,6 +533,9 @@ def _build_visible_declaration_indexes(
             )
             for name in local_constants
         },
+        macros=visible.macros,
+        macro_records=visible.macro_records,
+        inaccessible_macros=visible.inaccessible_macros,
     )
 
 

--- a/src/sqlbuild/compiler/compile/_helpers/render/macros.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/macros.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import ast
+import copy
 import hashlib
-import importlib.util
 import inspect
 import re
+import sys
+import threading
 from dataclasses import dataclass, field
-from importlib.machinery import ModuleSpec
 from pathlib import Path
 from types import ModuleType
 
@@ -39,7 +40,7 @@ from sqlbuild.compiler.scopes.models import (
     ResourceIdentity,
     UsageRecord,
 )
-from sqlbuild.compiler.scopes.types import DeclarationKind, UsageKind
+from sqlbuild.compiler.scopes.types import DeclarationKind, ScopeKind, UsageKind
 from sqlbuild.compiler.sql_analysis.main._find_matching_paren import find_matching_paren
 from sqlbuild.compiler.sql_analysis.main._is_identifier_character import (
     is_identifier_character as _is_identifier_continue,
@@ -56,6 +57,27 @@ _LINE_COMMENT_TOKEN: str = "--"
 _BLOCK_COMMENT_TOKEN: str = "/*"
 _STAR_IMPORT_NAME: str = "*"
 _MACRO_SCAN_PATTERN: re.Pattern[str] = re.compile(r"@|--|/\*|'|\"|`")
+_SYNTHETIC_PACKAGE_PREFIX: str = "_sqlbuild_project_macros_"
+_MACRO_MODULE_LOAD_LOCK: threading.RLock = threading.RLock()
+
+
+@dataclass(frozen=True)
+class _MacroModuleAnalysis:
+    file: DiscoveredMacroFile
+    name: str
+    tree: ast.Module
+    exports: tuple[str, ...]
+    dependencies: dict[str, tuple[DeclarationIdentity, ...]]
+    module_dependencies: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _MacroAnalysisInputs:
+    files: dict[str, DiscoveredMacroFile]
+    trees: dict[str, ast.Module]
+    exports: dict[str, frozenset[str]]
+    module_names: frozenset[str]
+    package_names: frozenset[str]
 
 
 @dataclass
@@ -93,9 +115,16 @@ def load_project_macros(macro_files: tuple[DiscoveredMacroFile, ...]) -> dict[st
     if inventory.faults:
         raise CompileInputError(inventory.faults[0].message)
 
+    analyses: dict[str, _MacroModuleAnalysis] = _analyze_project_macro_modules(
+        macro_files=macro_files
+    )
+    modules: dict[str, ModuleType] = _load_macro_modules(analyses=analyses)
+    export_dependencies: dict[tuple[Path, str], tuple[DeclarationIdentity, ...]] = {
+        (item.relative_path, item.name): item.dependencies for item in inventory.exports
+    }
     loaded_macros: dict[str, LoadedMacro] = {}
     for macro_file in macro_files:
-        module: ModuleType = _load_macro_module(macro_file=macro_file)
+        module: ModuleType = modules[_macro_module_name(macro_file)]
         attribute_name: str
         for attribute_name in dir(module):
             if attribute_name.startswith("_"):
@@ -118,6 +147,7 @@ def load_project_macros(macro_files: tuple[DiscoveredMacroFile, ...]) -> dict[st
                 relative_path=macro_file.relative_path,
                 raw_source=macro_file.contents,
                 function=attribute_value,
+                dependencies=export_dependencies[(macro_file.relative_path, attribute_name)],
             )
     return loaded_macros
 
@@ -127,73 +157,162 @@ def _inventory_project_macros(
 ) -> StaticMacroInventory:
     """Validate and inventory project macro exports without executing authored code."""
 
-    module_names: frozenset[str] = frozenset(_macro_module_name(file) for file in macro_files)
-    exports: list[StaticMacroExport] = []
+    try:
+        analyses: dict[str, _MacroModuleAnalysis] = _analyze_project_macro_modules(
+            macro_files=macro_files
+        )
+    except CompileInputError:
+        return _inventory_project_macros_tolerantly(macro_files=macro_files)
+    return _inventory_from_analyses(macro_files=macro_files, analyses=analyses)
+
+
+def _macro_inventory_fault(
+    *, error: CompileInputError, macro_files: tuple[DiscoveredMacroFile, ...]
+) -> StaticMacroFault:
+    relative_path: Path = next(
+        (item.relative_path for item in macro_files if item.relative_path.as_posix() in str(error)),
+        macro_files[0].relative_path if macro_files else Path("macros"),
+    )
+    return StaticMacroFault(relative_path=relative_path, message=str(error))
+
+
+def _inventory_project_macros_tolerantly(
+    *, macro_files: tuple[DiscoveredMacroFile, ...]
+) -> StaticMacroInventory:
+    remaining: list[DiscoveredMacroFile] = list(macro_files)
     faults: list[StaticMacroFault] = []
-    owners: dict[str, Path] = {}
-    for macro_file in macro_files:
+    while remaining:
+        current: tuple[DiscoveredMacroFile, ...] = tuple(remaining)
         try:
-            module_ast: ast.Module = _validate_macro_module(
-                macro_file=macro_file, module_names=module_names
+            analyses: dict[str, _MacroModuleAnalysis] = _analyze_project_macro_modules(
+                macro_files=current
             )
         except CompileInputError as error:
-            faults.append(
-                StaticMacroFault(
-                    relative_path=macro_file.relative_path,
-                    message=str(error).replace(
-                        str(macro_file.file_path), macro_file.relative_path.as_posix()
-                    ),
-                )
+            collisions: tuple[tuple[str, tuple[DiscoveredMacroFile, ...]], ...] = (
+                _macro_module_path_collisions(macro_files=current)
             )
+            if collisions:
+                collided_paths: set[Path] = set()
+                for module_name, files in collisions:
+                    paths: str = " and ".join(str(file.relative_path) for file in files)
+                    for file in files:
+                        collided_paths.add(file.relative_path)
+                        faults.append(
+                            StaticMacroFault(
+                                relative_path=file.relative_path,
+                                message=(
+                                    f"Macro module path collision for '{module_name}': {paths}"
+                                ),
+                            )
+                        )
+                remaining = [item for item in remaining if item.relative_path not in collided_paths]
+                continue
+            fault: StaticMacroFault = _macro_inventory_fault(error=error, macro_files=current)
+            faults.append(fault)
+            remaining = [item for item in remaining if item.relative_path != fault.relative_path]
             continue
-        statement: ast.stmt
-        for statement in module_ast.body:
+        inventory: StaticMacroInventory = _inventory_from_analyses(
+            macro_files=current, analyses=analyses
+        )
+        return StaticMacroInventory(
+            exports=inventory.exports,
+            faults=_deduplicated_macro_faults((*faults, *inventory.faults)),
+        )
+    return StaticMacroInventory(faults=_deduplicated_macro_faults(tuple(faults)))
+
+
+def _macro_module_path_collisions(
+    *, macro_files: tuple[DiscoveredMacroFile, ...]
+) -> tuple[tuple[str, tuple[DiscoveredMacroFile, ...]], ...]:
+    grouped: dict[str, list[DiscoveredMacroFile]] = {}
+    for file in macro_files:
+        grouped.setdefault(_macro_module_name(file), []).append(file)
+    collisions: list[tuple[str, tuple[DiscoveredMacroFile, ...]]] = []
+    for module_name in sorted(grouped):
+        files: list[DiscoveredMacroFile] = grouped[module_name]
+        if len(files) > 1:
+            collisions.append((module_name, tuple(files)))
+    return tuple(collisions)
+
+
+def _inventory_from_analyses(
+    *,
+    macro_files: tuple[DiscoveredMacroFile, ...],
+    analyses: dict[str, _MacroModuleAnalysis],
+) -> StaticMacroInventory:
+    exports: dict[str, StaticMacroExport] = {}
+    collided_names: set[str] = set()
+    faults: list[StaticMacroFault] = []
+    for macro_file in macro_files:
+        analysis: _MacroModuleAnalysis = analyses[_macro_module_name(macro_file)]
+        for statement in analysis.tree.body:
             if not isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef):
                 continue
             if statement.name.startswith("_"):
                 continue
-            existing: Path | None = owners.get(statement.name)
+            item: StaticMacroExport = _static_macro_export(
+                macro_file=macro_file, analysis=analysis, statement=statement
+            )
+            existing: StaticMacroExport | None = exports.pop(item.name, None)
             if existing is not None:
-                collision_error: CompileInputError = CompileInputError(
-                    f"Macro name collision for '{statement.name}': "
-                    f"{existing} and {macro_file.file_path}"
-                )
+                collided_names.add(item.name)
                 faults.append(
                     StaticMacroFault(
-                        relative_path=macro_file.relative_path,
-                        message=str(collision_error),
+                        relative_path=item.relative_path,
+                        message=(
+                            f"Macro name collision for '{item.name}': "
+                            f"{existing.relative_path} and {item.relative_path}"
+                        ),
                     )
                 )
-                continue
-            owners[statement.name] = macro_file.file_path
-            arguments: ast.arguments = statement.args
-            exports.append(
-                StaticMacroExport(
-                    name=statement.name,
-                    relative_path=macro_file.relative_path,
-                    parameters=tuple(
-                        argument.arg for argument in (*arguments.posonlyargs, *arguments.args)
+            elif item.name in collided_names:
+                faults.append(
+                    StaticMacroFault(
+                        relative_path=item.relative_path,
+                        message=f"Macro name collision for '{item.name}' at {item.relative_path}",
                     )
-                    + ((arguments.vararg.arg,) if arguments.vararg is not None else ())
-                    + tuple(argument.arg for argument in arguments.kwonlyargs)
-                    + ((arguments.kwarg.arg,) if arguments.kwarg is not None else ()),
-                    line=statement.lineno,
-                    source_digest=hashlib.sha256(macro_file.contents.encode()).hexdigest(),
                 )
-            )
+            else:
+                exports[item.name] = item
     return StaticMacroInventory(
-        exports=tuple(sorted(exports, key=lambda item: (item.name, item.relative_path.as_posix()))),
+        exports=tuple(
+            sorted(exports.values(), key=lambda item: (item.name, item.relative_path.as_posix()))
+        ),
         faults=tuple(faults),
     )
+
+
+def _static_macro_export(
+    *,
+    macro_file: DiscoveredMacroFile,
+    analysis: _MacroModuleAnalysis,
+    statement: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> StaticMacroExport:
+    arguments: ast.arguments = statement.args
+    return StaticMacroExport(
+        name=statement.name,
+        relative_path=macro_file.relative_path,
+        parameters=tuple(argument.arg for argument in (*arguments.posonlyargs, *arguments.args))
+        + ((arguments.vararg.arg,) if arguments.vararg is not None else ())
+        + tuple(argument.arg for argument in arguments.kwonlyargs)
+        + ((arguments.kwarg.arg,) if arguments.kwarg is not None else ()),
+        line=statement.lineno,
+        source_digest=hashlib.sha256(macro_file.contents.encode()).hexdigest(),
+        dependencies=analysis.dependencies[statement.name],
+    )
+
+
+def _deduplicated_macro_faults(
+    faults: tuple[StaticMacroFault, ...],
+) -> tuple[StaticMacroFault, ...]:
+    return tuple(dict.fromkeys(faults))
 
 
 def _macro_module_name(macro_file: DiscoveredMacroFile) -> str:
     return ".".join(macro_file.relative_path.with_suffix("").parts)
 
 
-def _validate_macro_module(
-    *, macro_file: DiscoveredMacroFile, module_names: frozenset[str]
-) -> ast.Module:
+def _parse_macro_module(*, macro_file: DiscoveredMacroFile) -> ast.Module:
     try:
         module_ast: ast.Module = ast.parse(macro_file.contents, filename=str(macro_file.file_path))
     except SyntaxError as error:
@@ -201,28 +320,7 @@ def _validate_macro_module(
             f"Failed to parse macros from '{macro_file.file_path}': {error}"
         ) from error
 
-    statement: ast.stmt
     for statement in module_ast.body:
-        imported_module_names: tuple[str, ...] = _imported_module_names(
-            statement=statement,
-            current_module_name=_macro_module_name(macro_file),
-        )
-        matching_names: list[str] = []
-        imported_name: str
-        for imported_name in imported_module_names:
-            if _matches_macro_module(imported_name=imported_name, module_names=module_names):
-                matching_names.append(imported_name)
-        matched_module_names: tuple[str, ...] = tuple(
-            sorted(
-                matching_names,
-                key=lambda name: (name not in module_names, -len(name), name),
-            )
-        )
-        if matched_module_names:
-            raise CompileInputError(
-                f"Macro module '{macro_file.relative_path}' must not import project macro module "
-                f"'{matched_module_names[0]}'"
-            )
         public_declaration_name: str | None = _public_non_function_declaration_name(statement)
         if public_declaration_name is not None:
             raise CompileInputError(
@@ -232,12 +330,644 @@ def _validate_macro_module(
     return module_ast
 
 
+def _analyze_project_macro_modules(
+    *, macro_files: tuple[DiscoveredMacroFile, ...]
+) -> dict[str, _MacroModuleAnalysis]:
+    """Analyze every authored module and dependency edge before executing any of them."""
+
+    inputs: _MacroAnalysisInputs = _macro_analysis_inputs(macro_files=macro_files)
+    analyses: dict[str, _MacroModuleAnalysis] = {
+        module_name: _analyze_macro_module(module_name=module_name, inputs=inputs)
+        for module_name in inputs.trees
+    }
+    return _validated_macro_analyses(analyses=analyses)
+
+
+def _analyze_macro_module(
+    *, module_name: str, inputs: _MacroAnalysisInputs
+) -> _MacroModuleAnalysis:
+    tree: ast.Module = inputs.trees[module_name]
+    file: DiscoveredMacroFile = inputs.files[module_name]
+    _validate_no_nested_project_imports(
+        tree=tree,
+        module_name=module_name,
+        file=file,
+        module_names=inputs.module_names,
+        package_names=inputs.package_names,
+    )
+    imported, module_dependencies = _analyze_macro_imports(
+        tree=tree, module_name=module_name, inputs=inputs
+    )
+    functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {
+        statement.name: statement
+        for statement in tree.body
+        if isinstance(statement, ast.FunctionDef | ast.AsyncFunctionDef)
+    }
+    shadowed_imports: set[str] = set(functions).intersection(imported)
+    if shadowed_imports:
+        shadowed_name: str = sorted(shadowed_imports)[0]
+        raise CompileInputError(
+            f"Macro module '{file.relative_path}' defines function '{shadowed_name}' over an "
+            "imported macro binding; imported macros must not be replaced"
+        )
+    direct_dependencies, helper_calls, runtime_node_ids = _analyze_macro_calls(
+        functions=functions, imported=imported, file=file
+    )
+    _validate_local_call_cycles(
+        exports=inputs.exports[module_name], helper_calls=helper_calls, file=file
+    )
+    _validate_call_use_locations(
+        tree=tree,
+        imported=imported,
+        local_functions=frozenset(functions),
+        runtime_node_ids=runtime_node_ids,
+        file=file,
+    )
+    return _MacroModuleAnalysis(
+        file=file,
+        name=module_name,
+        tree=tree,
+        exports=tuple(sorted(inputs.exports[module_name])),
+        dependencies=_export_dependencies(
+            exports=inputs.exports[module_name],
+            direct_dependencies=direct_dependencies,
+            helper_calls=helper_calls,
+        ),
+        module_dependencies=module_dependencies,
+    )
+
+
+def _macro_analysis_inputs(*, macro_files: tuple[DiscoveredMacroFile, ...]) -> _MacroAnalysisInputs:
+    files: dict[str, DiscoveredMacroFile] = {}
+    for item in macro_files:
+        module_name: str = _macro_module_name(item)
+        existing: DiscoveredMacroFile | None = files.get(module_name)
+        if existing is not None:
+            raise CompileInputError(
+                f"Macro module path collision for '{module_name}': "
+                f"{existing.relative_path} and {item.relative_path}"
+            )
+        files[module_name] = item
+    trees: dict[str, ast.Module] = {
+        name: _parse_macro_module(macro_file=item) for name, item in files.items()
+    }
+    exports: dict[str, frozenset[str]] = {
+        name: _module_exports(tree=tree) for name, tree in trees.items()
+    }
+    return _MacroAnalysisInputs(
+        files=files,
+        trees=trees,
+        exports=exports,
+        module_names=frozenset(files),
+        package_names=frozenset(_macro_package_name(file) for file in files.values()),
+    )
+
+
+def _module_exports(*, tree: ast.Module) -> frozenset[str]:
+    exports: set[str] = set()
+    for statement in tree.body:
+        if isinstance(
+            statement, ast.FunctionDef | ast.AsyncFunctionDef
+        ) and not statement.name.startswith("_"):
+            exports.add(statement.name)
+    return frozenset(exports)
+
+
+def _analyze_macro_imports(
+    *,
+    tree: ast.Module,
+    module_name: str,
+    inputs: _MacroAnalysisInputs,
+) -> tuple[dict[str, DeclarationIdentity], tuple[str, ...]]:
+    imported: dict[str, DeclarationIdentity] = {}
+    module_dependencies: list[str] = []
+    file: DiscoveredMacroFile = inputs.files[module_name]
+    for statement in tree.body:
+        if isinstance(statement, ast.Import):
+            local_names: list[str] = [
+                name
+                for name in _imported_module_names(
+                    statement=statement, current_module_name=module_name
+                )
+                if _is_project_macro_import(
+                    imported_name=name,
+                    module_names=inputs.module_names,
+                    package_names=inputs.package_names,
+                )
+            ]
+            if local_names:
+                raise CompileInputError(
+                    f"Macro module '{file.relative_path}' must use 'from ... import ...' for "
+                    "project macro imports; module imports are not supported"
+                )
+            continue
+        if not isinstance(statement, ast.ImportFrom):
+            continue
+        resolved_module: str = _resolve_import_from_module(
+            statement=statement, current_module_name=module_name
+        )
+        if resolved_module not in inputs.files:
+            if _is_project_macro_import(
+                imported_name=resolved_module,
+                module_names=inputs.module_names,
+                package_names=inputs.package_names,
+            ):
+                raise CompileInputError(
+                    f"Macro module '{file.relative_path}' imports project package "
+                    f"'{resolved_module}' instead of a macro module"
+                )
+            continue
+        module_dependencies.append(resolved_module)
+        imported = _record_imported_macro_bindings(
+            statement=statement,
+            importer=file,
+            imported_file=inputs.files[resolved_module],
+            exported_names=inputs.exports[resolved_module],
+            imported=imported,
+            resolved_module=resolved_module,
+        )
+    return imported, tuple(dict.fromkeys(module_dependencies))
+
+
+def _record_imported_macro_bindings(
+    *,
+    statement: ast.ImportFrom,
+    importer: DiscoveredMacroFile,
+    imported_file: DiscoveredMacroFile,
+    exported_names: frozenset[str],
+    imported: dict[str, DeclarationIdentity],
+    resolved_module: str,
+) -> dict[str, DeclarationIdentity]:
+    updated: dict[str, DeclarationIdentity] = dict(imported)
+    for alias in statement.names:
+        if alias.name == _STAR_IMPORT_NAME:
+            raise CompileInputError(
+                f"Macro module '{importer.relative_path}' must not use star imports for project "
+                "macros"
+            )
+        if alias.name not in exported_names:
+            raise CompileInputError(
+                f"Macro module '{importer.relative_path}' cannot import '{alias.name}' from "
+                f"project macro module '{resolved_module}'; the name is not an exported macro"
+            )
+        _validate_macro_import_visibility(
+            importer=importer, imported=imported_file, name=alias.name
+        )
+        binding: str = alias.asname or alias.name
+        if binding in updated:
+            raise CompileInputError(
+                f"Macro module '{importer.relative_path}' binds project macro import '{binding}' "
+                "more than once"
+            )
+        updated[binding] = DeclarationIdentity(DeclarationKind.MACRO, alias.name)
+    return updated
+
+
+def _analyze_macro_calls(
+    *,
+    functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef],
+    imported: dict[str, DeclarationIdentity],
+    file: DiscoveredMacroFile,
+) -> tuple[
+    dict[str, tuple[DeclarationIdentity, ...]],
+    dict[str, tuple[str, ...]],
+    frozenset[int],
+]:
+    direct_dependencies: dict[str, tuple[DeclarationIdentity, ...]] = {}
+    helper_calls: dict[str, tuple[str, ...]] = {}
+    runtime_node_ids: set[int] = set()
+    for function_name, function in functions.items():
+        runtime_nodes: tuple[ast.AST, ...] = _runtime_function_nodes(function=function)
+        runtime_node_ids.update(id(node) for node in runtime_nodes)
+        dependencies, called_helpers = _analyze_function_calls(
+            function=function,
+            runtime_nodes=runtime_nodes,
+            functions=frozenset(functions),
+            imported=imported,
+            file=file,
+        )
+        direct_dependencies[function_name] = dependencies
+        helper_calls[function_name] = called_helpers
+    return direct_dependencies, helper_calls, frozenset(runtime_node_ids)
+
+
+def _analyze_function_calls(
+    *,
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    runtime_nodes: tuple[ast.AST, ...],
+    functions: frozenset[str],
+    imported: dict[str, DeclarationIdentity],
+    file: DiscoveredMacroFile,
+) -> tuple[tuple[DeclarationIdentity, ...], tuple[str, ...]]:
+    bound_names: set[str] = _function_bound_names(function=function, runtime_nodes=runtime_nodes)
+    shadowed_imports: set[str] = bound_names.intersection(imported)
+    if shadowed_imports:
+        shadowed_name: str = sorted(shadowed_imports)[0]
+        raise CompileInputError(
+            f"Macro module '{file.relative_path}' shadows imported macro '{shadowed_name}'; "
+            "imported macros must be called directly without shadowing"
+        )
+    dependencies: list[DeclarationIdentity] = []
+    called_helpers: list[str] = []
+    direct_call_nodes: set[int] = {
+        id(node.func)
+        for node in runtime_nodes
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    for node in runtime_nodes:
+        if isinstance(node, ast.Name) and node.id in imported and id(node) not in direct_call_nodes:
+            raise CompileInputError(
+                f"Macro module '{file.relative_path}' uses imported macro '{node.id}' "
+                "dynamically; call imported macros directly"
+            )
+        if (
+            isinstance(node, ast.Name)
+            and node.id in functions
+            and id(node) not in direct_call_nodes
+        ):
+            raise CompileInputError(
+                f"Macro module '{file.relative_path}' uses local helper '{node.id}' dynamically; "
+                "call local macros and helpers directly"
+            )
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id in imported:
+            dependencies.append(imported[node.func.id])
+        elif node.func.id in functions:
+            if node.func.id in bound_names:
+                raise CompileInputError(
+                    f"Macro module '{file.relative_path}' shadows local helper '{node.func.id}'; "
+                    "static macro dependency analysis cannot resolve this call"
+                )
+            called_helpers.append(node.func.id)
+    return tuple(dict.fromkeys(dependencies)), tuple(dict.fromkeys(called_helpers))
+
+
+def _function_bound_names(
+    *, function: ast.FunctionDef | ast.AsyncFunctionDef, runtime_nodes: tuple[ast.AST, ...]
+) -> set[str]:
+    names: set[str] = {
+        argument.arg
+        for argument in (
+            *function.args.posonlyargs,
+            *function.args.args,
+            *function.args.kwonlyargs,
+        )
+    }
+    if function.args.vararg is not None:
+        names.add(function.args.vararg.arg)
+    if function.args.kwarg is not None:
+        names.add(function.args.kwarg.arg)
+    names.update(
+        node.id
+        for node in runtime_nodes
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)
+    )
+    return names
+
+
+def _validate_call_use_locations(
+    *,
+    tree: ast.Module,
+    imported: dict[str, DeclarationIdentity],
+    local_functions: frozenset[str],
+    runtime_node_ids: frozenset[int],
+    file: DiscoveredMacroFile,
+) -> None:
+    unsupported: ast.Name | None = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Name)
+            and node.id in imported
+            and id(node) not in runtime_node_ids
+        ),
+        None,
+    )
+    if unsupported is not None:
+        raise CompileInputError(
+            f"Macro module '{file.relative_path}' uses imported macro '{unsupported.id}' outside "
+            "an ordinary function body; call imported macros directly from module-level macro or "
+            "helper functions"
+        )
+    unsupported_local: ast.Name | None = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Name)
+            and node.id in local_functions
+            and id(node) not in runtime_node_ids
+        ),
+        None,
+    )
+    if unsupported_local is not None:
+        raise CompileInputError(
+            f"Macro module '{file.relative_path}' uses local helper "
+            f"'{unsupported_local.id}' outside an ordinary function body; call local macros and "
+            "helpers directly from module-level macro or helper functions"
+        )
+
+
+def _macro_package_name(file: DiscoveredMacroFile) -> str:
+    root: Path = file.declaration_root or Path(file.relative_path.parts[0])
+    return ".".join(root.parts)
+
+
+def _runtime_function_nodes(
+    *, function: ast.FunctionDef | ast.AsyncFunctionDef
+) -> tuple[ast.AST, ...]:
+    """Return function-body nodes without entering dynamically nested scopes."""
+
+    nodes: list[ast.AST] = []
+    pending: list[ast.AST] = list(reversed(function.body))
+    while pending:
+        node: ast.AST = pending.pop()
+        nodes.append(node)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda | ast.ClassDef):
+            continue
+        pending.extend(reversed(tuple(ast.iter_child_nodes(node))))
+    return tuple(nodes)
+
+
+def _export_dependencies(
+    *,
+    exports: frozenset[str],
+    direct_dependencies: dict[str, tuple[DeclarationIdentity, ...]],
+    helper_calls: dict[str, tuple[str, ...]],
+) -> dict[str, tuple[DeclarationIdentity, ...]]:
+    dependencies: dict[str, tuple[DeclarationIdentity, ...]] = {}
+    for export in exports:
+        found: list[DeclarationIdentity] = []
+        pending: list[str] = [export]
+        visited: set[str] = set()
+        while pending:
+            function_name: str = pending.pop(0)
+            if function_name in visited:
+                continue
+            visited.add(function_name)
+            found.extend(direct_dependencies[function_name])
+            for called_function in helper_calls[function_name]:
+                if called_function in exports:
+                    found.append(DeclarationIdentity(DeclarationKind.MACRO, called_function))
+                pending.append(called_function)
+        dependencies[export] = tuple(dict.fromkeys(found))
+    return dependencies
+
+
+def _validate_local_call_cycles(
+    *,
+    exports: frozenset[str],
+    helper_calls: dict[str, tuple[str, ...]],
+    file: DiscoveredMacroFile,
+) -> None:
+    completed: frozenset[str] = frozenset()
+    for export in sorted(exports):
+        completed = _visit_local_call(
+            name=export,
+            helper_calls=helper_calls,
+            file=file,
+            active=(),
+            completed=completed,
+        )
+
+
+def _visit_local_call(
+    *,
+    name: str,
+    helper_calls: dict[str, tuple[str, ...]],
+    file: DiscoveredMacroFile,
+    active: tuple[str, ...],
+    completed: frozenset[str],
+) -> frozenset[str]:
+    if name in active:
+        cycle: tuple[str, ...] = (*active[active.index(name) :], name)
+        raise CompileInputError(f"Macro call cycle in '{file.relative_path}': {' -> '.join(cycle)}")
+    if name in completed:
+        return completed
+    updated: frozenset[str] = completed
+    for dependency in helper_calls[name]:
+        updated = _visit_local_call(
+            name=dependency,
+            helper_calls=helper_calls,
+            file=file,
+            active=(*active, name),
+            completed=updated,
+        )
+    return updated.union((name,))
+
+
+def _validated_macro_analyses(
+    *, analyses: dict[str, _MacroModuleAnalysis]
+) -> dict[str, _MacroModuleAnalysis]:
+    _validate_import_cycles(analyses=analyses)
+    return analyses
+
+
+def _resolve_import_from_module(*, statement: ast.ImportFrom, current_module_name: str) -> str:
+    base: str = statement.module or ""
+    if not statement.level:
+        return base
+    package_parts: list[str] = current_module_name.split(".")[:-1]
+    if statement.level > len(package_parts):
+        raise CompileInputError(
+            f"Relative project macro import in '{current_module_name}' escapes its top-level "
+            "package"
+        )
+    retained: int = len(package_parts) - statement.level + 1
+    parts: list[str] = package_parts[: max(retained, 0)]
+    if base:
+        parts.extend(base.split("."))
+    return ".".join(parts)
+
+
+def _validate_no_nested_project_imports(
+    *,
+    tree: ast.Module,
+    module_name: str,
+    file: DiscoveredMacroFile,
+    module_names: frozenset[str],
+    package_names: frozenset[str],
+) -> None:
+    top_level_imports: set[ast.Import | ast.ImportFrom] = {
+        statement for statement in tree.body if isinstance(statement, ast.Import | ast.ImportFrom)
+    }
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Import | ast.ImportFrom) or node in top_level_imports:
+            continue
+        imported_names: tuple[str, ...] = _imported_module_names(
+            statement=node, current_module_name=module_name
+        )
+        if any(
+            _is_project_macro_import(
+                imported_name=name,
+                module_names=module_names,
+                package_names=package_names,
+            )
+            for name in imported_names
+        ):
+            raise CompileInputError(
+                f"Macro module '{file.relative_path}' contains a nested project macro import; "
+                "project macro imports must be static and module-level"
+            )
+
+
+def _validate_macro_import_visibility(
+    *, importer: DiscoveredMacroFile, imported: DiscoveredMacroFile, name: str
+) -> None:
+    visible: bool = imported.scope_kind is ScopeKind.GLOBAL
+    importer_parent: Path = importer.owning_path or importer.relative_path.parent
+    owner: Path = imported.owning_path or Path(".")
+    if imported.scope_kind is ScopeKind.LOCAL:
+        visible = importer_parent == owner
+    elif imported.scope_kind is ScopeKind.INHERITED:
+        visible = importer_parent == owner or owner in importer_parent.parents
+    if not visible:
+        raise CompileInputError(
+            f"Macro module '{importer.relative_path}' cannot import macro '{name}' from "
+            f"'{imported.relative_path}': the imported macro is not visible from the importer scope"
+        )
+
+
+def _validate_import_cycles(*, analyses: dict[str, _MacroModuleAnalysis]) -> None:
+    completed: frozenset[str] = frozenset()
+    for name in sorted(analyses):
+        completed = _visit_macro_import(
+            name=name, analyses=analyses, active=(), completed=completed
+        )
+
+
+def _visit_macro_import(
+    *,
+    name: str,
+    analyses: dict[str, _MacroModuleAnalysis],
+    active: tuple[str, ...],
+    completed: frozenset[str],
+) -> frozenset[str]:
+    if name in active:
+        cycle: tuple[str, ...] = (*active[active.index(name) :], name)
+        raise CompileInputError(
+            f"Macro import cycle in '{analyses[name].file.relative_path}': {' -> '.join(cycle)}"
+        )
+    if name in completed:
+        return completed
+    updated: frozenset[str] = completed
+    for dependency in analyses[name].module_dependencies:
+        updated = _visit_macro_import(
+            name=dependency,
+            analyses=analyses,
+            active=(*active, name),
+            completed=updated,
+        )
+    return updated.union((name,))
+
+
+def _load_macro_modules(*, analyses: dict[str, _MacroModuleAnalysis]) -> dict[str, ModuleType]:
+    with _MACRO_MODULE_LOAD_LOCK:
+        return _load_macro_modules_locked(analyses=analyses)
+
+
+def _load_macro_modules_locked(
+    *, analyses: dict[str, _MacroModuleAnalysis]
+) -> dict[str, ModuleType]:
+    digest: str = hashlib.sha256(
+        "\0".join(
+            f"{name}\0{analyses[name].file.file_path}\0{analyses[name].file.contents}"
+            for name in sorted(analyses)
+        ).encode()
+    ).hexdigest()[:16]
+    root: str = f"{_SYNTHETIC_PACKAGE_PREFIX}{digest}"
+    synthetic_names: list[str] = []
+    previous_modules: dict[str, ModuleType] = {}
+    modules: dict[str, ModuleType] = {}
+    try:
+        package_names: set[str] = {root}
+        for name in analyses:
+            parts: list[str] = name.split(".")[:-1]
+            package_names.update(
+                f"{root}.{'/'.join(parts[:index]).replace('/', '.')}"
+                for index in range(1, len(parts) + 1)
+            )
+        for package_name in sorted(package_names, key=lambda item: item.count(".")):
+            package: ModuleType = ModuleType(package_name)
+            package.__package__ = package_name
+            package.__path__ = []  # type: ignore[attr-defined]
+            previous: ModuleType | None = sys.modules.get(package_name)
+            if previous is not None:
+                previous_modules[package_name] = previous
+            sys.modules[package_name] = package
+            synthetic_names.append(package_name)
+
+        pending: set[str] = set(analyses)
+        while pending:
+            name: str = min(
+                item
+                for item in pending
+                if not set(analyses[item].module_dependencies).intersection(pending)
+            )
+            analysis: _MacroModuleAnalysis = analyses[name]
+            synthetic_name: str = f"{root}.{name}"
+            module: ModuleType = ModuleType(synthetic_name)
+            module.__file__ = str(analysis.file.file_path)
+            module.__package__ = synthetic_name.rpartition(".")[0]
+            tree: ast.Module = _rewrite_absolute_project_imports(
+                tree=analysis.tree, module_names=frozenset(analyses), root=root
+            )
+            previous = sys.modules.get(synthetic_name)
+            if previous is not None:
+                previous_modules[synthetic_name] = previous
+            sys.modules[synthetic_name] = module
+            synthetic_names.append(synthetic_name)
+            try:
+                exec(compile(tree, str(analysis.file.file_path), "exec"), module.__dict__)
+            except Exception as error:
+                raise CompileInputError(
+                    f"Failed to load macros from '{analysis.file.file_path}': {error}"
+                ) from error
+            modules[name] = module
+            pending.remove(name)
+        return modules
+    finally:
+        for synthetic_name in reversed(synthetic_names):
+            previous = previous_modules.get(synthetic_name)
+            if previous is None:
+                sys.modules.pop(synthetic_name, None)
+            else:
+                sys.modules[synthetic_name] = previous
+
+
+def _rewrite_absolute_project_imports(
+    *, tree: ast.Module, module_names: frozenset[str], root: str
+) -> ast.Module:
+    class Rewriter(ast.NodeTransformer):
+        def visit_ImportFrom(self, node: ast.ImportFrom) -> ast.ImportFrom:  # noqa: N802
+            if node.level == 0 and node.module in module_names:
+                return ast.copy_location(
+                    ast.ImportFrom(module=f"{root}.{node.module}", names=node.names, level=0),
+                    node,
+                )
+            return node
+
+    return ast.fix_missing_locations(Rewriter().visit(copy.deepcopy(tree)))
+
+
 def _matches_macro_module(*, imported_name: str, module_names: frozenset[str]) -> bool:
     module_name: str
     for module_name in module_names:
         if module_name == imported_name or module_name.startswith(f"{imported_name}."):
             return True
     return False
+
+
+def _is_project_macro_import(
+    *,
+    imported_name: str,
+    module_names: frozenset[str],
+    package_names: frozenset[str],
+) -> bool:
+    return _matches_macro_module(imported_name=imported_name, module_names=module_names) or any(
+        imported_name == package or imported_name.startswith(f"{package}.")
+        for package in package_names
+    )
 
 
 def _imported_module_names(*, statement: ast.stmt, current_module_name: str) -> tuple[str, ...]:
@@ -436,6 +1166,14 @@ def _expand_sql_macros(
 def find_macro_call_names(sql: str) -> tuple[str, ...]:
     """Return unique authored macro call names in encounter order."""
 
+    return tuple(
+        name for name in _find_sqlbuild_call_names(sql) if name not in DECLARATION_REFERENCE_NAMES
+    )
+
+
+def _find_sqlbuild_call_names(sql: str) -> tuple[str, ...]:
+    """Return executable SQLBuild call names, excluding quoted and commented text."""
+
     if MACRO_TOKEN not in sql:
         return ()
 
@@ -447,7 +1185,7 @@ def find_macro_call_names(sql: str) -> tuple[str, ...]:
         if macro_start_index is None:
             break
         macro_name: str = _parse_macro_name(sql=sql, call_start_index=macro_start_index)
-        if macro_name not in seen and macro_name not in DECLARATION_REFERENCE_NAMES:
+        if macro_name not in seen:
             seen.add(macro_name)
             names.append(macro_name)
         opening_paren_index: int = _skip_whitespace(
@@ -455,25 +1193,6 @@ def find_macro_call_names(sql: str) -> tuple[str, ...]:
         )
         cursor = _find_matching_paren(sql=sql, opening_paren_index=opening_paren_index) + 1
     return tuple(names)
-
-
-def _load_macro_module(*, macro_file: DiscoveredMacroFile) -> ModuleType:
-    module_name: str = "sqlbuild_project_macro_" + "_".join(
-        macro_file.relative_path.with_suffix("").parts
-    ).replace("-", "_")
-    spec: ModuleSpec | None = importlib.util.spec_from_file_location(
-        module_name, macro_file.file_path
-    )
-    if spec is None or spec.loader is None:
-        raise CompileInputError(f"Could not load macros from '{macro_file.file_path}'")
-    module: ModuleType = importlib.util.module_from_spec(spec)
-    try:
-        spec.loader.exec_module(module)
-    except Exception as error:
-        raise CompileInputError(
-            f"Failed to load macros from '{macro_file.file_path}': {error}"
-        ) from error
-    return module
 
 
 def _evaluate_macro_call(
@@ -516,6 +1235,9 @@ def _evaluate_macro_call(
         sql=sql, opening_paren_index=opening_paren_index
     )
     if override_value is not None:
+        _validate_final_macro_sql(
+            macro_name=macro_name, file_path=file_path, macro_result=override_value
+        )
         return override_value, closing_paren_index + 1
     identity: DeclarationIdentity = (
         declarations.macro_records[macro_name].identity
@@ -568,14 +1290,24 @@ def _evaluate_macro_call(
             f"Macro '@{macro_name}' in '{file_path}' must return a SQL string when "
             "used directly in SQL"
         )
-    if isinstance(macro_result, str) and MACRO_TOKEN in macro_result:
-        macro_result, _ = _expand_sql_macros(
-            sql=macro_result,
-            consumer_path=loaded_macro.file_path,
-            state=state,
-            stack=(*stack, identity),
+    if isinstance(macro_result, str):
+        _validate_final_macro_sql(
+            macro_name=macro_name, file_path=file_path, macro_result=macro_result
         )
     return macro_result, closing_paren_index + 1
+
+
+def _validate_final_macro_sql(*, macro_name: str, file_path: Path, macro_result: str) -> None:
+    generated_calls: tuple[str, ...] = _find_sqlbuild_call_names(macro_result)
+    if not generated_calls:
+        return
+    calls: str = ", ".join(f"@{name}()" for name in generated_calls)
+    raise CompileInputError(
+        f"Macro '@{macro_name}' in '{file_path}' returned SQLBuild call(s) {calls}. "
+        "Macro output must be final SQL. Compose macros with ordinary Python imports and "
+        "function calls instead; nested @macro() calls are supported only when explicitly "
+        "authored in SQL"
+    )
 
 
 def _call_loaded_macro(

--- a/src/sqlbuild/compiler/compile/_helpers/render/macros.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/macros.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import copy
 import hashlib
+import heapq
 import inspect
 import re
 import sys
@@ -104,6 +105,7 @@ class _ExpansionState:
     macro_overrides: dict[str, str]
     macro_context: MacroContext
     declaration_resolver: DeclarationScopeResolver | None
+    declarations: DeclarationResolutionContext | None
     facts: _ExpansionFacts
     consumer: ResourceIdentity | DeclarationIdentity | None = None
 
@@ -111,13 +113,23 @@ class _ExpansionState:
 def load_project_macros(macro_files: tuple[DiscoveredMacroFile, ...]) -> dict[str, LoadedMacro]:
     """Load discovered project macro functions into a collision-checked registry."""
 
-    inventory: StaticMacroInventory = _inventory_project_macros(macro_files=macro_files)
+    if not macro_files:
+        return {}
+    try:
+        analyses: dict[str, _MacroModuleAnalysis] = _analyze_project_macro_modules(
+            macro_files=macro_files
+        )
+    except CompileInputError:
+        fault_inventory: StaticMacroInventory = _inventory_project_macros_tolerantly(
+            macro_files=macro_files
+        )
+        raise CompileInputError(fault_inventory.faults[0].message) from None
+    inventory: StaticMacroInventory = _inventory_from_analyses(
+        macro_files=macro_files, analyses=analyses
+    )
     if inventory.faults:
         raise CompileInputError(inventory.faults[0].message)
 
-    analyses: dict[str, _MacroModuleAnalysis] = _analyze_project_macro_modules(
-        macro_files=macro_files
-    )
     modules: dict[str, ModuleType] = _load_macro_modules(analyses=analyses)
     export_dependencies: dict[tuple[Path, str], tuple[DeclarationIdentity, ...]] = {
         (item.relative_path, item.name): item.dependencies for item in inventory.exports
@@ -897,13 +909,21 @@ def _load_macro_modules_locked(
             sys.modules[package_name] = package
             synthetic_names.append(package_name)
 
-        pending: set[str] = set(analyses)
-        while pending:
-            name: str = min(
-                item
-                for item in pending
-                if not set(analyses[item].module_dependencies).intersection(pending)
-            )
+        remaining_dependencies: dict[str, int] = {
+            name: len(analysis.module_dependencies) for name, analysis in analyses.items()
+        }
+        dependents: dict[str, list[str]] = {}
+        for name, analysis in analyses.items():
+            for dependency in analysis.module_dependencies:
+                dependents.setdefault(dependency, []).append(name)
+        ready: list[str] = [
+            name
+            for name, dependency_count in remaining_dependencies.items()
+            if dependency_count == 0
+        ]
+        heapq.heapify(ready)
+        while ready:
+            name: str = heapq.heappop(ready)
             analysis: _MacroModuleAnalysis = analyses[name]
             synthetic_name: str = f"{root}.{name}"
             module: ModuleType = ModuleType(synthetic_name)
@@ -924,7 +944,10 @@ def _load_macro_modules_locked(
                     f"Failed to load macros from '{analysis.file.file_path}': {error}"
                 ) from error
             modules[name] = module
-            pending.remove(name)
+            for dependent in dependents.get(name, ()):
+                remaining_dependencies[dependent] -= 1
+                if remaining_dependencies[dependent] == 0:
+                    heapq.heappush(ready, dependent)
         return modules
     finally:
         for synthetic_name in reversed(synthetic_names):
@@ -1074,6 +1097,7 @@ def expand_sql_macros_result(
     macro_overrides: dict[str, str] | None = None,
     macro_context: MacroContext,
     declaration_resolver: DeclarationScopeResolver | None = None,
+    declarations: DeclarationResolutionContext | None = None,
     consumer: ResourceIdentity | DeclarationIdentity | None = None,
 ) -> MacroExpansionResult:
     """Expand macros and retain deterministic resolved dependency facts."""
@@ -1084,6 +1108,7 @@ def expand_sql_macros_result(
         macro_overrides={} if macro_overrides is None else macro_overrides,
         macro_context=macro_context,
         declaration_resolver=declaration_resolver,
+        declarations=declarations,
         facts=facts,
         consumer=consumer,
     )
@@ -1111,8 +1136,8 @@ def _expand_sql_macros(
     if MACRO_TOKEN not in sql:
         return sql, ()
 
-    declarations: DeclarationResolutionContext | None = None
-    if state.declaration_resolver is not None:
+    declarations: DeclarationResolutionContext | None = state.declarations
+    if declarations is None and state.declaration_resolver is not None:
         from sqlbuild.compiler.compile._helpers.render.declarations import (
             resolve_declaration_context,
         )

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -156,6 +156,7 @@ class LoadedMacro:
     relative_path: Path
     raw_source: str
     function: Callable[..., object]
+    dependencies: tuple[DeclarationIdentity, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -167,6 +168,7 @@ class StaticMacroExport:
     parameters: tuple[str, ...]
     line: int
     source_digest: str
+    dependencies: tuple[DeclarationIdentity, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/scopes/_helpers/builder.py
+++ b/src/sqlbuild/compiler/scopes/_helpers/builder.py
@@ -47,6 +47,7 @@ from sqlbuild.compiler.scopes.models import (
     ScopeCompleteness,
     ScopeDiagnostic,
     ScopeIndex,
+    UsageRecord,
 )
 from sqlbuild.compiler.scopes.types import (
     DeclarationKind,
@@ -54,6 +55,7 @@ from sqlbuild.compiler.scopes.types import (
     ResourceKind,
     ScopeDiagnosticCode,
     ScopeKind,
+    UsageKind,
 )
 from sqlbuild.sql_values.types import SqlValueKind
 
@@ -172,6 +174,7 @@ def build_index(
             key=_diagnostic_key,
         )
     )
+    usages: tuple[UsageRecord, ...] = _macro_dependency_usages(declarations=declarations)
     return ScopeIndex(
         ownership_roots=tuple(
             OwnershipRoot(path=path, resource_kind=kind)
@@ -179,6 +182,7 @@ def build_index(
         ),
         resources=tuple(sorted(resources, key=_resource_key)),
         declarations=tuple(sorted(declarations, key=_declaration_key)),
+        usages=usages,
         diagnostics=diagnostics,
         completeness=ScopeCompleteness(
             runtime_usage=False,
@@ -187,6 +191,22 @@ def build_index(
             promotion_impact=False,
         ),
     )
+
+
+def _macro_dependency_usages(*, declarations: list[DeclarationRecord]) -> tuple[UsageRecord, ...]:
+    usages: list[UsageRecord] = []
+    for record in declarations:
+        if record.macro is None:
+            continue
+        for dependency in record.macro.dependencies:
+            usages.append(
+                UsageRecord(
+                    consumer=record.identity,
+                    declaration=dependency,
+                    kind=UsageKind.DECLARATION_DEPENDENCY,
+                )
+            )
+    return tuple(dict.fromkeys(usages))
 
 
 def build_tolerant_scope_index(*, project_dir: Path) -> ScopeIndex:
@@ -478,6 +498,7 @@ def _macro_record(
         owning_path=owning_path,
         macro=MacroMetadata(
             parameters=tuple(inspect.signature(loaded.function).parameters),
+            dependencies=loaded.dependencies,
             source_digest=hashlib.sha256(loaded.raw_source.encode()).hexdigest(),
         ),
     )
@@ -503,7 +524,11 @@ def _static_macro_record(
             if discovered is not None and discovered.owning_path is not None
             else None
         ),
-        macro=MacroMetadata(parameters=item.parameters, source_digest=item.source_digest),
+        macro=MacroMetadata(
+            parameters=item.parameters,
+            dependencies=item.dependencies,
+            source_digest=item.source_digest,
+        ),
     )
 
 

--- a/src/sqlbuild/compiler/scopes/_helpers/paths.py
+++ b/src/sqlbuild/compiler/scopes/_helpers/paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 from pathlib import PurePath
 
 from sqlbuild.compiler.scopes.constants import (
@@ -14,11 +15,13 @@ from sqlbuild.compiler.scopes.constants import (
 from sqlbuild.compiler.scopes.exceptions import InvalidScopePathError
 
 
+@lru_cache(maxsize=65_536)
 def normalize_path(*, path: str | PurePath) -> str:
-    raw: str = str(path).replace("\\", PATH_SEPARATOR)
+    display_path: str = str(path)
+    raw: str = display_path.replace("\\", PATH_SEPARATOR)
     has_drive: bool = len(raw) >= WINDOWS_DRIVE_PREFIX_LENGTH and raw[1] == WINDOWS_DRIVE_SEPARATOR
     if not raw or raw.startswith(PATH_SEPARATOR) or has_drive:
-        raise InvalidScopePathError(f"Scope path must be project-relative: {path!s}")
+        raise InvalidScopePathError(f"Scope path must be project-relative: {display_path}")
 
     components: list[str] = []
     ignored_components: frozenset[str] = frozenset({"", CURRENT_PATH_COMPONENT})
@@ -27,7 +30,7 @@ def normalize_path(*, path: str | PurePath) -> str:
             continue
         if component == PARENT_PATH_COMPONENT:
             if not components:
-                raise InvalidScopePathError(f"Scope path escapes the project: {path!s}")
+                raise InvalidScopePathError(f"Scope path escapes the project: {display_path}")
             components.pop()
             continue
         components.append(component)
@@ -35,9 +38,14 @@ def normalize_path(*, path: str | PurePath) -> str:
 
 
 def is_equal_or_descendant(*, path: str | PurePath, ancestor: str | PurePath) -> bool:
-    path_parts: list[str] = normalize_path(path=path).split(PATH_SEPARATOR)
+    path_parts: tuple[str, ...] = _path_parts(normalize_path(path=path))
     ancestor_path: str = normalize_path(path=ancestor)
-    ancestor_parts: list[str] = (
-        [] if ancestor_path == CURRENT_PATH_COMPONENT else ancestor_path.split(PATH_SEPARATOR)
+    ancestor_parts: tuple[str, ...] = (
+        () if ancestor_path == CURRENT_PATH_COMPONENT else _path_parts(ancestor_path)
     )
     return path_parts[: len(ancestor_parts)] == ancestor_parts
+
+
+@lru_cache(maxsize=65_536)
+def _path_parts(path: str) -> tuple[str, ...]:
+    return tuple(path.split(PATH_SEPARATOR))

--- a/src/sqlbuild/compiler/scopes/_helpers/visibility.py
+++ b/src/sqlbuild/compiler/scopes/_helpers/visibility.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 from pathlib import PurePath
 
 from sqlbuild.compiler.scopes._helpers.identities import parse_identity
-from sqlbuild.compiler.scopes._helpers.paths import is_equal_or_descendant, normalize_path
+from sqlbuild.compiler.scopes._helpers.paths import normalize_path
 from sqlbuild.compiler.scopes.constants import (
     CURRENT_PATH_COMPONENT,
     PATH_SEPARATOR,
@@ -134,11 +135,11 @@ def _visibility_reason(
             if declaration.identity.owner == resource.identity
             else None
         )
-    owner: str = declaration.owning_path or CURRENT_PATH_COMPONENT
+    owner: str = _canonical_owner(declaration.owning_path or CURRENT_PATH_COMPONENT)
     parent: str = _parent(resource.path)
     if declaration.scope is ScopeKind.LOCAL:
         return VisibilityReason.LOCAL_OWNER if parent == owner else None
-    if declaration.scope is ScopeKind.INHERITED and is_equal_or_descendant(
+    if declaration.scope is ScopeKind.INHERITED and _is_canonical_descendant(
         path=parent, ancestor=owner
     ):
         return VisibilityReason.INHERITED_ANCESTOR
@@ -152,15 +153,16 @@ def _inaccessible_reason(
         return InaccessibleReason.PRIVATE_OWNER
     if declaration.scope is ScopeKind.LOCAL:
         return InaccessibleReason.LOCAL_BOUNDARY
-    owner: str = declaration.owning_path or CURRENT_PATH_COMPONENT
+    owner: str = _canonical_owner(declaration.owning_path or CURRENT_PATH_COMPONENT)
     parent: str = _parent(resource.path)
-    if is_equal_or_descendant(path=owner, ancestor=parent):
+    if _is_canonical_descendant(path=owner, ancestor=parent):
         return InaccessibleReason.DESCENDANT_SCOPE
     if declaration.ownership_root.path == resource.ownership_root.path:
         return InaccessibleReason.SIBLING_SCOPE
     return InaccessibleReason.UNRELATED_SCOPE
 
 
+@lru_cache(maxsize=65_536)
 def _parent(path: str) -> str:
     normalized: str = normalize_path(path=path)
     return (
@@ -168,3 +170,16 @@ def _parent(path: str) -> str:
         if PATH_SEPARATOR in normalized
         else CURRENT_PATH_COMPONENT
     )
+
+
+def _is_canonical_descendant(*, path: str, ancestor: str) -> bool:
+    return (
+        ancestor == CURRENT_PATH_COMPONENT
+        or path == ancestor
+        or path.startswith(f"{ancestor}{PATH_SEPARATOR}")
+    )
+
+
+@lru_cache(maxsize=65_536)
+def _canonical_owner(path: str) -> str:
+    return normalize_path(path=path)

--- a/tests/e2e/src/sqlbuild/cli/commands/main/scope/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/scope/_test_types.py
@@ -7,3 +7,31 @@ from dataclasses import dataclass
 class ScopeE2eCase:
     description: str
     expected_exit_code: int
+
+
+@dataclass(frozen=True)
+class ScopePerformanceCase:
+    description: str
+    small_model_count: int
+    small_domain_count: int
+    large_model_count: int
+    large_domain_count: int
+    sample_count: int
+    expected_max_small_seconds: float
+    expected_max_large_seconds: float
+    expected_max_warm_seconds: float
+    expected_max_scaling_ratio: float
+    expected_max_cache_bytes: int
+    command_timeout_seconds: float
+
+
+@dataclass(frozen=True)
+class LargeScopePerformanceCase:
+    description: str
+    model_count: int
+    domain_count: int
+    warm_sample_count: int
+    expected_max_cold_seconds: float
+    expected_max_warm_seconds: float
+    expected_max_cache_bytes: int
+    command_timeout_seconds: float

--- a/tests/e2e/src/sqlbuild/cli/commands/main/scope/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/scope/helpers.py
@@ -1,18 +1,152 @@
 """Scope E2E subprocess helpers."""
 
+import shutil
+import statistics
 import subprocess
+import sys
+from collections.abc import Callable
 from pathlib import Path
+from time import perf_counter
 
 from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import REPO_ROOT
 
 
 def run_scope_alias(
-    *, alias: str, project_dir: Path, args: tuple[str, ...]
+    *,
+    alias: str,
+    project_dir: Path,
+    args: tuple[str, ...],
+    timeout_seconds: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["uv", "run", alias, "--project-dir", str(project_dir), "scope", *args],
+        [
+            str(Path(sys.executable).with_name(alias)),
+            "--project-dir",
+            str(project_dir),
+            "scope",
+            *args,
+        ],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
         check=False,
+        timeout=timeout_seconds,
     )
+
+
+def write_scope_performance_project(
+    *, project_dir: Path, model_count: int, domain_count: int
+) -> None:
+    """Write a valid domain-shaped project with inherited macros."""
+
+    project_dir.mkdir(parents=True)
+    (project_dir / "sqlbuild_project.toml").write_text(
+        'name = "scope_performance"\nadapter = "duckdb"\n', encoding="utf-8"
+    )
+    for domain in range(domain_count):
+        first_model_index: int = domain * model_count // domain_count
+        next_model_index: int = (domain + 1) * model_count // domain_count
+        models_in_domain: int = next_model_index - first_model_index
+        root_model_count: int = min(10, models_in_domain)
+        domain_dir: Path = project_dir / "models" / f"domain_{domain:03d}"
+        macros_dir: Path = domain_dir / "_macros"
+        macros_dir.mkdir(parents=True)
+        macro_source: str = "\n\n".join(
+            f"def domain_{domain:03d}_identity_{offset:02d}(expression: str) -> str:\n"
+            "    return expression\n"
+            for offset in range(10)
+        )
+        (macros_dir / "identity.py").write_text(macro_source, encoding="utf-8")
+        for offset in range(root_model_count):
+            model_index: int = first_model_index + offset
+            _write_scope_model(
+                model_dir=domain_dir,
+                model_index=model_index,
+                macro_name=f"domain_{domain:03d}_identity_{offset:02d}",
+            )
+        detail_dir: Path = domain_dir / "detail"
+        detail_dir.mkdir()
+        for offset in range(root_model_count, models_in_domain):
+            model_index = first_model_index + offset
+            _write_scope_model(
+                model_dir=detail_dir,
+                model_index=model_index,
+                macro_name=f"domain_{domain:03d}_identity_{offset % 10:02d}",
+            )
+
+
+def _write_scope_model(*, model_dir: Path, model_index: int, macro_name: str) -> None:
+    (model_dir / f"model_{model_index:05d}.sql").write_text(
+        f'MODEL();\nSELECT @{macro_name}("id") AS id\n', encoding="utf-8"
+    )
+
+
+def measure_cold_scope_commands(
+    *, project_dir: Path, target: str, sample_count: int, timeout_seconds: float
+) -> tuple[float, ...]:
+    """Measure successful scope commands with no persistent cache."""
+
+    return _measure_scope_commands(
+        project_dir=project_dir,
+        target=target,
+        sample_count=sample_count,
+        prepare_sample=_clear_scope_cache,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def measure_warm_scope_commands(
+    *, project_dir: Path, target: str, sample_count: int, timeout_seconds: float
+) -> tuple[float, ...]:
+    """Measure successful scope commands against the persistent cache."""
+
+    return _measure_scope_commands(
+        project_dir=project_dir,
+        target=target,
+        sample_count=sample_count,
+        prepare_sample=_preserve_scope_cache,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _measure_scope_commands(
+    *,
+    project_dir: Path,
+    target: str,
+    sample_count: int,
+    prepare_sample: Callable[[Path], None],
+    timeout_seconds: float,
+) -> tuple[float, ...]:
+    measurements: list[float] = []
+    for _ in range(sample_count):
+        prepare_sample(project_dir)
+        started: float = perf_counter()
+        result: subprocess.CompletedProcess[str] = run_scope_alias(
+            alias="sqb",
+            project_dir=project_dir,
+            args=(target, "--json"),
+            timeout_seconds=timeout_seconds,
+        )
+        measurements.append(perf_counter() - started)
+        result.check_returncode()
+    return tuple(measurements)
+
+
+def _clear_scope_cache(project_dir: Path) -> None:
+    shutil.rmtree(project_dir / "target", ignore_errors=True)
+
+
+def _preserve_scope_cache(project_dir: Path) -> None:
+    del project_dir
+
+
+def median_seconds(values: tuple[float, ...]) -> float:
+    """Return the median benchmark duration."""
+
+    return statistics.median(values)
+
+
+def scope_cache_path(*, project_dir: Path) -> Path:
+    """Return the persistent Scope Explorer cache path."""
+
+    return project_dir / "target/compile-cache/declaration-scopes-v1/scope-index.json"

--- a/tests/e2e/src/sqlbuild/cli/commands/main/scope/test_scope_performance.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/scope/test_scope_performance.py
@@ -1,0 +1,180 @@
+"""Performance guards for real Scope Explorer project loading and cache reuse."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.src.sqlbuild.cli.commands.main.scope._test_types import (
+    LargeScopePerformanceCase,
+    ScopePerformanceCase,
+)
+from tests.e2e.src.sqlbuild.cli.commands.main.scope.helpers import (
+    measure_cold_scope_commands,
+    measure_warm_scope_commands,
+    median_seconds,
+    scope_cache_path,
+    write_scope_performance_project,
+)
+
+_LARGE_BENCHMARK_ENV: str = "SQLBUILD_RUN_LARGE_SCOPE_BENCHMARK"
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+@pytest.mark.performance
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ScopePerformanceCase(
+            description="doubling models and inherited macros keeps cold scope scaling bounded",
+            small_model_count=1_000,
+            small_domain_count=10,
+            large_model_count=2_000,
+            large_domain_count=20,
+            sample_count=3,
+            expected_max_small_seconds=8.0,
+            expected_max_large_seconds=18.0,
+            expected_max_warm_seconds=4.0,
+            expected_max_scaling_ratio=3.0,
+            expected_max_cache_bytes=16 * 1024 * 1024,
+            command_timeout_seconds=30.0,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_domain_shaped_projects_when_doubling_size_then_scope_scaling_stays_bounded(
+    tmp_path: Path,
+    test_case: ScopePerformanceCase,
+    record_property: Callable[[str, object], None],
+) -> None:
+    small_project: Path = tmp_path / "small"
+    large_project: Path = tmp_path / "large"
+    write_scope_performance_project(
+        project_dir=small_project,
+        model_count=test_case.small_model_count,
+        domain_count=test_case.small_domain_count,
+    )
+    write_scope_performance_project(
+        project_dir=large_project,
+        model_count=test_case.large_model_count,
+        domain_count=test_case.large_domain_count,
+    )
+
+    small_cold: float = median_seconds(
+        measure_cold_scope_commands(
+            project_dir=small_project,
+            target="model:model_00000",
+            sample_count=test_case.sample_count,
+            timeout_seconds=test_case.command_timeout_seconds,
+        )
+    )
+    large_cold: float = median_seconds(
+        measure_cold_scope_commands(
+            project_dir=large_project,
+            target="model:model_00000",
+            sample_count=test_case.sample_count,
+            timeout_seconds=test_case.command_timeout_seconds,
+        )
+    )
+    large_warm: float = median_seconds(
+        measure_warm_scope_commands(
+            project_dir=large_project,
+            target="model:model_00000",
+            sample_count=test_case.sample_count,
+            timeout_seconds=test_case.command_timeout_seconds,
+        )
+    )
+    cache_bytes: int = scope_cache_path(project_dir=large_project).stat().st_size
+    scaling_ratio: float = large_cold / small_cold
+    for name, value in (
+        ("small_cold_seconds", small_cold),
+        ("large_cold_seconds", large_cold),
+        ("large_warm_seconds", large_warm),
+        ("cold_scaling_ratio", scaling_ratio),
+        ("cache_bytes", cache_bytes),
+    ):
+        record_property(name, value)
+    _LOGGER.info(
+        f"scope scaling small={small_cold:.3f}s large={large_cold:.3f}s "
+        f"warm={large_warm:.3f}s ratio={scaling_ratio:.3f} cache={cache_bytes}B"
+    )
+
+    assert small_cold < test_case.expected_max_small_seconds
+    assert large_cold < test_case.expected_max_large_seconds
+    assert large_warm < test_case.expected_max_warm_seconds
+    assert scaling_ratio < test_case.expected_max_scaling_ratio
+    assert cache_bytes < test_case.expected_max_cache_bytes
+
+
+@pytest.mark.performance
+@pytest.mark.skipif(
+    os.environ.get(_LARGE_BENCHMARK_ENV) != "1",
+    reason=f"Set {_LARGE_BENCHMARK_ENV}=1 for the scheduled large benchmark",
+)
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        LargeScopePerformanceCase(
+            description="ten thousand models and one thousand macros remain cacheable",
+            model_count=10_000,
+            domain_count=100,
+            warm_sample_count=3,
+            expected_max_cold_seconds=90.0,
+            expected_max_warm_seconds=10.0,
+            expected_max_cache_bytes=16 * 1024 * 1024,
+            command_timeout_seconds=120.0,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_large_domain_project_when_inspecting_scope_then_records_cold_and_warm_cost(
+    tmp_path: Path,
+    test_case: LargeScopePerformanceCase,
+    record_property: Callable[[str, object], None],
+) -> None:
+    project_dir: Path = tmp_path / "large_scope"
+    write_scope_performance_project(
+        project_dir=project_dir,
+        model_count=test_case.model_count,
+        domain_count=test_case.domain_count,
+    )
+
+    cold_seconds: float = median_seconds(
+        measure_cold_scope_commands(
+            project_dir=project_dir,
+            target="model:model_00000",
+            sample_count=1,
+            timeout_seconds=test_case.command_timeout_seconds,
+        )
+    )
+    warm_seconds: float = median_seconds(
+        measure_warm_scope_commands(
+            project_dir=project_dir,
+            target="model:model_00000",
+            sample_count=test_case.warm_sample_count,
+            timeout_seconds=test_case.command_timeout_seconds,
+        )
+    )
+    cache_bytes: int = scope_cache_path(project_dir=project_dir).stat().st_size
+    for name, value in (
+        ("cold_seconds", cold_seconds),
+        ("warm_seconds", warm_seconds),
+        ("cache_bytes", cache_bytes),
+    ):
+        record_property(name, value)
+    _LOGGER.info(
+        f"large scope models={test_case.model_count} macros={test_case.domain_count * 10} "
+        f"cold={cold_seconds:.3f}s warm={warm_seconds:.3f}s cache={cache_bytes}B"
+    )
+
+    assert cold_seconds < test_case.expected_max_cold_seconds
+    assert warm_seconds < test_case.expected_max_warm_seconds
+    assert cache_bytes < test_case.expected_max_cache_bytes
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv", "-s", "--log-cli-level=INFO"])

--- a/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
@@ -38,6 +38,14 @@ class MacroLoadCountIntegrationTestCase:
 
 
 @dataclass(frozen=True)
+class MacroCompositionIntegrationTestCase:
+    description: str
+    project_files: dict[str, str]
+    macro_name: str
+    expected_dependencies: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class CompileProgressIntegrationTestCase:
     description: str
     project_files: dict[str, str]

--- a/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
@@ -35,6 +35,7 @@ class MacroLoadCountIntegrationTestCase:
     description: str
     project_files: dict[str, str]
     expected_macro_import_count: int
+    expected_declaration_resolution_count: int
 
 
 @dataclass(frozen=True)
@@ -43,6 +44,7 @@ class MacroCompositionIntegrationTestCase:
     project_files: dict[str, str]
     macro_name: str
     expected_dependencies: tuple[str, ...]
+    expected_declaration_resolution_count: int
 
 
 @dataclass(frozen=True)

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_load_count.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_load_count.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 from typing import cast
+from unittest.mock import Mock
 
 import pytest
 
 from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.compiler.compile._helpers.attachment import core as attachment_core
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.scopes.models import DeclarationRecord
 from tests.integration.src.sqlbuild.compiler.pipeline._test_types import (
@@ -46,6 +48,7 @@ _COUNTING_MACRO_MODULE: str = (
                 ),
             },
             expected_macro_import_count=1,
+            expected_declaration_resolution_count=1,
         )
     ],
     ids=lambda case: case.description,
@@ -54,7 +57,10 @@ def test_given_side_effect_macro_when_compiling_manifest_then_imports_macros_onc
     test_case: MacroLoadCountIntegrationTestCase,
     tmp_path: Path,
     write_repo_files: Callable[[Path, dict[str, str]], None],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    resolver: Mock = Mock(wraps=attachment_core.resolve_declaration_context)
+    monkeypatch.setattr(attachment_core, "resolve_declaration_context", resolver)
     write_repo_files(tmp_path, test_case.project_files)
 
     result: CompilePipelineResult = run_compile_pipeline_for_project(
@@ -69,6 +75,7 @@ def test_given_side_effect_macro_when_compiling_manifest_then_imports_macros_onc
 
     import_log: str = (tmp_path / "macro_import_log.txt").read_text(encoding="utf-8")
     assert import_log.count("import") == test_case.expected_macro_import_count
+    assert resolver.call_count == test_case.expected_declaration_resolution_count
 
 
 @pytest.mark.parametrize(
@@ -88,6 +95,7 @@ def test_given_side_effect_macro_when_compiling_manifest_then_imports_macros_onc
             },
             macro_name="order_column",
             expected_dependencies=("shared",),
+            expected_declaration_resolution_count=1,
         )
     ],
     ids=lambda case: case.description,
@@ -96,7 +104,10 @@ def test_given_composed_macro_when_compiling_then_scope_and_manifest_emit_depend
     test_case: MacroCompositionIntegrationTestCase,
     tmp_path: Path,
     write_repo_files: Callable[[Path, dict[str, str]], None],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    resolver: Mock = Mock(wraps=attachment_core.resolve_declaration_context)
+    monkeypatch.setattr(attachment_core, "resolve_declaration_context", resolver)
     write_repo_files(tmp_path, test_case.project_files)
 
     result: CompilePipelineResult = run_compile_pipeline_for_project(
@@ -125,3 +136,4 @@ def test_given_composed_macro_when_compiling_then_scope_and_manifest_emit_depend
     assert macro_node["depends_on"] == {
         "macros": [f"macro.demo.{name}" for name in test_case.expected_dependencies]
     }
+    assert resolver.call_count == test_case.expected_declaration_resolution_count

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_load_count.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_load_count.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import cast
 
 import pytest
 
 from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
+from sqlbuild.compiler.scopes.models import DeclarationRecord
 from tests.integration.src.sqlbuild.compiler.pipeline._test_types import (
+    MacroCompositionIntegrationTestCase,
     MacroLoadCountIntegrationTestCase,
 )
 from tests.integration.src.sqlbuild.compiler.pipeline.helpers import (
@@ -66,3 +69,59 @@ def test_given_side_effect_macro_when_compiling_manifest_then_imports_macros_onc
 
     import_log: str = (tmp_path / "macro_import_log.txt").read_text(encoding="utf-8")
     assert import_log.count("import") == test_case.expected_macro_import_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MacroCompositionIntegrationTestCase(
+            description="private helper composition reaches scope and manifest dependency",
+            project_files={
+                "sqlbuild_project.toml": _PROJECT_TOML,
+                "macros/shared.py": "def shared() -> str:\n    return 'order_id'\n",
+                "macros/orders.py": (
+                    "from macros.shared import shared\n\n"
+                    "def _helper() -> str:\n    return shared()\n\n"
+                    "def order_column() -> str:\n    return _helper()\n"
+                ),
+                "models/orders.sql": "MODEL (materialized table);\n\nSELECT @order_column()",
+            },
+            macro_name="order_column",
+            expected_dependencies=("shared",),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_composed_macro_when_compiling_then_scope_and_manifest_emit_dependency(
+    test_case: MacroCompositionIntegrationTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, test_case.project_files)
+
+    result: CompilePipelineResult = run_compile_pipeline_for_project(
+        project_dir=tmp_path,
+        adapter=DuckDbAdapter(),
+    )
+    manifest: dict[str, object] = build_manifest_for_pipeline_result(
+        result=result,
+        project_name="demo",
+        adapter_type="duckdb",
+    )
+
+    records: dict[str, DeclarationRecord] = {
+        record.identity.name: record for record in result.project.scope_index.declarations
+    }
+    order_record: DeclarationRecord = records[test_case.macro_name]
+    assert order_record.macro is not None
+    assert (
+        tuple(item.name for item in order_record.macro.dependencies)
+        == test_case.expected_dependencies
+    )
+    macros: dict[str, object] = cast(dict[str, object], manifest["macros"])
+    macro_node: dict[str, object] = cast(
+        dict[str, object], macros[f"macro.demo.{test_case.macro_name}"]
+    )
+    assert macro_node["depends_on"] == {
+        "macros": [f"macro.demo.{name}" for name in test_case.expected_dependencies]
+    }

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
@@ -47,6 +47,21 @@ class LoadProjectMacrosErrorTestCase:
 
 
 @dataclass(frozen=True)
+class MacroDependencyTestCase:
+    description: str
+    macro_files: dict[str, str]
+    macro_name: str
+    expected_result: str
+    expected_dependencies: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ScopedMacroImportErrorTestCase:
+    description: str
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
 class ExpandSqlMacrosTestCase:
     description: str
     macro_file_contents: str
@@ -61,6 +76,7 @@ class ExpandSqlMacrosErrorTestCase:
     macro_file_contents: str
     sql: str
     expected_error_fragment: str
+    macro_overrides: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_macros.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_macros.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
+from sqlbuild.compiler.compile._helpers.render import macros as macros_module
 from sqlbuild.compiler.compile._helpers.render.macros import (
     expand_sql_macros,
     find_macro_call_names,
@@ -83,7 +85,10 @@ def order_columns() -> str:
 def test_given_macro_modules_when_loading_then_exports_only_owned_public_functions(
     test_case: LoadProjectMacrosTestCase,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    parser: Mock = Mock(wraps=macros_module._parse_macro_module)
+    monkeypatch.setattr(macros_module, "_parse_macro_module", parser)
     macro_files: list[DiscoveredMacroFile] = []
     relative_path: str
     contents: str
@@ -102,6 +107,7 @@ def test_given_macro_modules_when_loading_then_exports_only_owned_public_functio
     loaded_macros: dict[str, LoadedMacro] = load_project_macros(tuple(macro_files))
 
     assert tuple(loaded_macros) == test_case.expected_macro_names
+    assert parser.call_count == len(test_case.macro_files)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_macros.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_macros.py
@@ -6,14 +6,12 @@ import pytest
 
 from sqlbuild.compiler.compile._helpers.render.macros import (
     expand_sql_macros,
-    expand_sql_macros_result,
     find_macro_call_names,
     load_project_macros,
 )
 from sqlbuild.compiler.compile.models import (
     LoadedMacro,
     MacroContext,
-    MacroExpansionResult,
 )
 from sqlbuild.compiler.discovery.models import DiscoveredMacroFile
 from sqlbuild.compiler.scopes.types import ScopeKind
@@ -23,13 +21,10 @@ from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
     FindMacroCallNamesTestCase,
     LoadProjectMacrosErrorTestCase,
     LoadProjectMacrosTestCase,
-    ScopedMacroExpansionErrorTestCase,
-    ScopedMacroExpansionTestCase,
+    MacroDependencyTestCase,
+    ScopedMacroImportErrorTestCase,
 )
-from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import (
-    build_loaded_macros,
-    build_scoped_macro_resolver,
-)
+from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import build_loaded_macros
 
 _MACRO_CONTEXT: MacroContext = MacroContext(
     adapter_name="bigquery",
@@ -67,6 +62,21 @@ def order_columns() -> str:
             },
             expected_macro_names=("order_columns",),
         ),
+        LoadProjectMacrosTestCase(
+            description="composes absolute and relative project macro imports without re-export",
+            macro_files={
+                "macros/shared.py": "def shared(value: str) -> str:\n    return value.upper()\n",
+                "macros/absolute.py": (
+                    "from macros.shared import shared as render_shared\n\n"
+                    "def absolute_macro() -> str:\n    return render_shared('absolute')\n"
+                ),
+                "macros/relative.py": (
+                    "from .shared import shared\n\n"
+                    "def relative_macro() -> str:\n    return shared('relative')\n"
+                ),
+            },
+            expected_macro_names=("shared", "absolute_macro", "relative_macro"),
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -97,25 +107,125 @@ def test_given_macro_modules_when_loading_then_exports_only_owned_public_functio
 @pytest.mark.parametrize(
     "test_case",
     [
+        MacroDependencyTestCase(
+            description="tracks imported macro called through a private helper but not unused import",
+            macro_files={
+                "macros/shared.py": (
+                    "def used(value: str) -> str:\n    return value.upper()\n\n"
+                    "def unused() -> str:\n    return 'unused'\n"
+                ),
+                "macros/orders.py": (
+                    "from macros.shared import used as render_used, unused\n\n"
+                    "def _render(value: str) -> str:\n    return render_used(value)\n\n"
+                    "def orders() -> str:\n    return _render('orders')\n"
+                ),
+            },
+            macro_name="orders",
+            expected_result="ORDERS",
+            expected_dependencies=("used",),
+        ),
+        MacroDependencyTestCase(
+            description="tracks public macro called through private helper in same module",
+            macro_files={
+                "macros/composed.py": (
+                    "def base(value: str) -> str:\n    return value.upper()\n\n"
+                    "def _helper(value: str) -> str:\n    return base(value)\n\n"
+                    "def composed() -> str:\n    return _helper('composed')\n"
+                )
+            },
+            macro_name="composed",
+            expected_result="COMPOSED",
+            expected_dependencies=("base",),
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_composed_macro_when_loading_then_tracks_actual_macro_dependencies(
+    test_case: MacroDependencyTestCase,
+    tmp_path: Path,
+) -> None:
+    macro_files: list[DiscoveredMacroFile] = []
+    for relative_path, source in test_case.macro_files.items():
+        file_path: Path = tmp_path / relative_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(source, encoding="utf-8")
+        macro_files.append(DiscoveredMacroFile(file_path, Path(relative_path), source))
+
+    loaded_macros: dict[str, LoadedMacro] = load_project_macros(tuple(macro_files))
+
+    macro: LoadedMacro = loaded_macros[test_case.macro_name]
+    assert macro.function() == test_case.expected_result
+    assert tuple(item.name for item in macro.dependencies) == test_case.expected_dependencies
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ScopedMacroImportErrorTestCase(
+            description="rejects sibling local macro import before execution",
+            expected_error_fragment="not visible from the importer scope",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_inaccessible_scoped_macro_import_when_loading_then_rejects_before_execution(
+    test_case: ScopedMacroImportErrorTestCase,
+    tmp_path: Path,
+) -> None:
+    shared_source: str = "def shared() -> str:\n    return 'shared'\n"
+    consumer_source: str = (
+        "from pathlib import Path\n"
+        "Path(__file__).parents[3].joinpath('executed').touch()\n"
+        "from models.sales._local_macros.shared import shared\n\n"
+        "def consumer() -> str:\n    return shared()\n"
+    )
+    shared_path: Path = tmp_path / "models/sales/_local_macros/shared.py"
+    consumer_path: Path = tmp_path / "models/finance/_macros/consumer.py"
+    shared_path.parent.mkdir(parents=True)
+    consumer_path.parent.mkdir(parents=True)
+    shared_path.write_text(shared_source, encoding="utf-8")
+    consumer_path.write_text(consumer_source, encoding="utf-8")
+    macro_files: tuple[DiscoveredMacroFile, ...] = (
+        DiscoveredMacroFile(
+            shared_path,
+            Path("models/sales/_local_macros/shared.py"),
+            shared_source,
+            ScopeKind.LOCAL,
+            Path("models"),
+            Path("models/sales"),
+            Path("models/sales/_local_macros"),
+        ),
+        DiscoveredMacroFile(
+            consumer_path,
+            Path("models/finance/_macros/consumer.py"),
+            consumer_source,
+            ScopeKind.INHERITED,
+            Path("models"),
+            Path("models/finance"),
+            Path("models/finance/_macros"),
+        ),
+    )
+
+    with pytest.raises(ValueError, match=test_case.expected_error_fragment):
+        load_project_macros(macro_files)
+
+    assert not (tmp_path / "executed").exists()
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
         LoadProjectMacrosErrorTestCase(
-            description="rejects an absolute import of another project macro before execution",
+            description="rejects a relative project module import before execution",
             macro_files={
                 "macros/a_consumer.py": (
                     "from pathlib import Path\n"
                     "Path(__file__).parent.parent.joinpath('executed').touch()\n"
-                    "from macros.shared import shared_macro\n"
+                    "from . import shared\n"
                 ),
                 "macros/shared.py": "def shared_macro() -> str:\n    return 'shared'\n",
             },
-            expected_error_fragment="must not import project macro module 'macros.shared'",
-        ),
-        LoadProjectMacrosErrorTestCase(
-            description="rejects a relative import of another project macro before execution",
-            macro_files={
-                "macros/a_consumer.py": "from . import shared\n",
-                "macros/shared.py": "def shared_macro() -> str:\n    return 'shared'\n",
-            },
-            expected_error_fragment="must not import project macro module 'macros.shared'",
+            expected_error_fragment="imports project package 'macros' instead of a macro module",
         ),
         LoadProjectMacrosErrorTestCase(
             description="rejects an import of a package containing project macros",
@@ -123,7 +233,122 @@ def test_given_macro_modules_when_loading_then_exports_only_owned_public_functio
                 "macros/a_consumer.py": "import macros\n",
                 "macros/shared.py": "def shared_macro() -> str:\n    return 'shared'\n",
             },
-            expected_error_fragment="must not import project macro module 'macros'",
+            expected_error_fragment="module imports are not supported",
+        ),
+        LoadProjectMacrosErrorTestCase(
+            description="rejects missing project macro module before execution",
+            macro_files={
+                "macros/consumer.py": (
+                    "from pathlib import Path\n"
+                    "Path(__file__).parent.parent.joinpath('executed').touch()\n"
+                    "from macros.missing import missing\n\n"
+                    "def consumer() -> str:\n    return missing()\n"
+                )
+            },
+            expected_error_fragment="imports project package 'macros.missing'",
+        ),
+        LoadProjectMacrosErrorTestCase(
+            description="rejects project macro import cycle before execution",
+            macro_files={
+                "macros/first.py": (
+                    "from pathlib import Path\n"
+                    "Path(__file__).parent.parent.joinpath('executed').touch()\n"
+                    "from macros.second import second\n\n"
+                    "def first() -> str:\n    return second()\n"
+                ),
+                "macros/second.py": (
+                    "from macros.first import first\n\ndef second() -> str:\n    return first()\n"
+                ),
+            },
+            expected_error_fragment="Macro import cycle",
+        ),
+        LoadProjectMacrosErrorTestCase(
+            description="rejects local macro call cycle before execution",
+            macro_files={
+                "macros/cycle.py": (
+                    "from pathlib import Path\n"
+                    "Path(__file__).parent.parent.joinpath('executed').touch()\n\n"
+                    "def first() -> str:\n    return second()\n\n"
+                    "def second() -> str:\n    return first()\n"
+                )
+            },
+            expected_error_fragment="Macro call cycle.*first -> second -> first",
+        ),
+        LoadProjectMacrosErrorTestCase(
+            description="rejects relative import escaping macro package before dependency executes",
+            macro_files={
+                "macros/consumer.py": (
+                    "from ....macros.shared import shared\n\n"
+                    "def consumer() -> str:\n    return shared()\n"
+                ),
+                "macros/shared.py": (
+                    "from pathlib import Path\n"
+                    "Path(__file__).parent.parent.joinpath('executed').touch()\n\n"
+                    "def shared() -> str:\n    return 'shared'\n"
+                ),
+            },
+            expected_error_fragment="escapes its top-level package",
+        ),
+        LoadProjectMacrosErrorTestCase(
+            description="rejects dynamic local helper alias before execution",
+            macro_files={
+                "macros/helpers.py": (
+                    "def _helper() -> str:\n    return 'helper'\n\n"
+                    "def outer() -> str:\n"
+                    "    alias = _helper\n"
+                    "    return alias()\n"
+                )
+            },
+            expected_error_fragment="uses local helper '_helper' dynamically",
+        ),
+        LoadProjectMacrosErrorTestCase(
+            description="rejects module-level local helper alias before execution",
+            macro_files={
+                "macros/shared.py": "def shared() -> str:\n    return 'shared'\n",
+                "macros/helpers.py": (
+                    "from macros.shared import shared\n\n"
+                    "def _helper() -> str:\n    return shared()\n\n"
+                    "_alias = _helper\n\n"
+                    "def outer() -> str:\n    return _alias()\n"
+                ),
+            },
+            expected_error_fragment=(
+                "uses local helper '_helper' outside an ordinary function body"
+            ),
+        ),
+        LoadProjectMacrosErrorTestCase(
+            description="rejects local helper call in macro default before execution",
+            macro_files={
+                "macros/shared.py": "def shared() -> str:\n    return 'shared'\n",
+                "macros/helpers.py": (
+                    "from macros.shared import shared\n\n"
+                    "def _helper() -> str:\n    return shared()\n\n"
+                    "def outer(value=_helper()) -> str:\n    return value\n"
+                ),
+            },
+            expected_error_fragment=(
+                "uses local helper '_helper' outside an ordinary function body"
+            ),
+        ),
+        LoadProjectMacrosErrorTestCase(
+            description="rejects module function replacing imported macro binding",
+            macro_files={
+                "macros/shared.py": "def shared() -> str:\n    return 'shared'\n",
+                "macros/consumer.py": (
+                    "from macros.shared import shared as _helper\n\n"
+                    "def _helper() -> str:\n    return 'local'\n\n"
+                    "def outer() -> str:\n    return _helper()\n"
+                ),
+            },
+            expected_error_fragment="defines function '_helper' over an imported macro binding",
+        ),
+        LoadProjectMacrosErrorTestCase(
+            description="rejects normalized project macro module path collision",
+            macro_files={
+                "macros/a.b.py": "def dotted() -> str:\n    return 'dotted'\n",
+                "macros/a/b.py": "def nested() -> str:\n    return 'nested'\n",
+            },
+            expected_error_fragment="Macro module path collision for 'macros.a.b'",
         ),
         LoadProjectMacrosErrorTestCase(
             description="rejects public module owned constants",
@@ -166,19 +391,6 @@ def test_given_invalid_macro_module_when_loading_then_rejects_before_execution(
 @pytest.mark.parametrize(
     "test_case",
     [
-        ExpandSqlMacrosTestCase(
-            description="recursively expands macro calls emitted by macro output",
-            macro_file_contents="""
-def outer_macro() -> str:
-    return "@inner_macro()"
-
-def inner_macro() -> str:
-    return "order_id"
-""".strip()
-            + "\n",
-            sql="SELECT @outer_macro() FROM raw_orders",
-            expected_sql="SELECT order_id FROM raw_orders",
-        ),
         ExpandSqlMacrosTestCase(
             description="uses macro override text instead of loaded macro function",
             macro_file_contents="""
@@ -347,6 +559,14 @@ def context_summary(ctx) -> str:
             sql="@context_summary()",
             expected_sql="SELECT 'bigquery|True|dev|demo'",
         ),
+        ExpandSqlMacrosTestCase(
+            description="ignores generated call text inside comments and quoted strings",
+            macro_file_contents=(
+                "def literal_sql() -> str:\n    return \"'@quoted()' /* @commented() */\"\n"
+            ),
+            sql="SELECT @literal_sql()",
+            expected_sql="SELECT '@quoted()' /* @commented() */",
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -392,6 +612,38 @@ def bad_macro() -> list[str]:
             sql="SELECT @bad_macro() FROM raw_orders",
             expected_error_fragment="must return a SQL string when used directly in SQL",
         ),
+        ExpandSqlMacrosErrorTestCase(
+            description="raises when generated SQL contains an ordinary macro call",
+            macro_file_contents=(
+                "def outer_macro() -> str:\n    return '@inner_macro()'\n\n"
+                "def inner_macro() -> str:\n    return 'order_id'\n"
+            ),
+            sql="SELECT @outer_macro() FROM raw_orders",
+            expected_error_fragment="Compose macros with ordinary Python imports and function calls",
+        ),
+        ExpandSqlMacrosErrorTestCase(
+            description="raises when generated SQL contains a constant reference",
+            macro_file_contents=(
+                "def generated_constant() -> str:\n    return '@const(\"limit\")'\n"
+            ),
+            sql="SELECT @generated_constant()",
+            expected_error_fragment="Macro output must be final SQL",
+        ),
+        ExpandSqlMacrosErrorTestCase(
+            description="raises when generated SQL contains an enum reference",
+            macro_file_contents=(
+                "def generated_enum() -> str:\n    return '@enum(\"status\").ACTIVE'\n"
+            ),
+            sql="SELECT @generated_enum()",
+            expected_error_fragment="Macro output must be final SQL",
+        ),
+        ExpandSqlMacrosErrorTestCase(
+            description="raises when macro override contains generated macro call",
+            macro_file_contents="def outer() -> str:\n    return 'order_id'\n",
+            sql="SELECT @outer()",
+            expected_error_fragment="Macro output must be final SQL",
+            macro_overrides={"outer": "@inner()"},
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -408,6 +660,7 @@ def test_given_invalid_sql_macro_usage_when_expanding_then_it_raises_clear_error
             sql=test_case.sql,
             file_path=tmp_path / "models" / "orders.sql",
             loaded_macros=loaded_macros,
+            macro_overrides=test_case.macro_overrides,
             macro_context=_MACRO_CONTEXT,
         )
 
@@ -441,121 +694,3 @@ def test_given_sql_with_at_tokens_when_finding_macro_calls_then_returns_real_uni
     test_case: FindMacroCallNamesTestCase,
 ) -> None:
     assert find_macro_call_names(test_case.sql) == test_case.expected_names
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        ScopedMacroExpansionTestCase(
-            description="callee sees same-owner inherited local and global macros",
-            definitions={
-                "global_value": ("global", ScopeKind.GLOBAL, None, "macros/global_value.py"),
-                "same_scope": (
-                    "same",
-                    ScopeKind.INHERITED,
-                    "models/marts",
-                    "models/marts/_macros/same_scope.py",
-                ),
-                "same_local": (
-                    "local",
-                    ScopeKind.LOCAL,
-                    "models/marts",
-                    "models/marts/_local_macros/same_local.py",
-                ),
-                "outer": (
-                    "@same_scope() || @same_local() || @global_value()",
-                    ScopeKind.INHERITED,
-                    "models/marts",
-                    "models/marts/_macros/outer.py",
-                ),
-            },
-            expected_sql="SELECT same || local || global",
-            expected_dependencies=("outer", "same_scope", "same_local", "global_value"),
-            expected_usages=(
-                ("outer", "same_scope"),
-                ("outer", "same_local"),
-                ("outer", "global_value"),
-            ),
-        )
-    ],
-    ids=lambda case: case.description,
-)
-def test_given_scoped_composition_when_expanding_then_uses_callee_lexical_scope(
-    test_case: ScopedMacroExpansionTestCase,
-    tmp_path: Path,
-) -> None:
-    loaded, resolver = build_scoped_macro_resolver(
-        tmp_path=tmp_path, definitions=test_case.definitions
-    )
-
-    result: MacroExpansionResult = expand_sql_macros_result(
-        sql="SELECT @outer()",
-        file_path=tmp_path / "models/marts/finance/orders.sql",
-        loaded_macros=loaded,
-        macro_context=_MACRO_CONTEXT,
-        declaration_resolver=resolver,
-    )
-
-    assert result.sql == test_case.expected_sql
-    assert tuple(item.name for item in result.dependencies) == test_case.expected_dependencies
-    assert (
-        tuple((item.consumer.name, item.declaration.name) for item in result.usages)
-        == test_case.expected_usages
-    )
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        ScopedMacroExpansionErrorTestCase(
-            description="global macro cannot emit scoped call",
-            definitions={
-                "scoped_value": (
-                    "scoped",
-                    ScopeKind.INHERITED,
-                    "models/marts",
-                    "models/marts/_macros/scoped_value.py",
-                ),
-                "global_outer": (
-                    "@scoped_value()",
-                    ScopeKind.GLOBAL,
-                    None,
-                    "macros/global_outer.py",
-                ),
-            },
-            sql="SELECT @global_outer()",
-            expected_error_fragment=(
-                r"scoped_value.*inaccessible.*models/marts/_macros/scoped_value.py.*"
-                r"scope owner 'models/marts'"
-            ),
-        ),
-        ScopedMacroExpansionErrorTestCase(
-            description="recursive output reports complete cycle",
-            definitions={
-                "first": ("@second()", ScopeKind.GLOBAL, None, "macros/first.py"),
-                "second": ("@first()", ScopeKind.GLOBAL, None, "macros/second.py"),
-            },
-            sql="SELECT @first()",
-            expected_error_fragment=(
-                r"first -> second -> first.*macros/first.py -> macros/second.py -> macros/first.py"
-            ),
-        ),
-    ],
-    ids=lambda case: case.description,
-)
-def test_given_global_macro_emits_scoped_call_when_expanding_then_reports_inaccessible(
-    test_case: ScopedMacroExpansionErrorTestCase,
-    tmp_path: Path,
-) -> None:
-    loaded, resolver = build_scoped_macro_resolver(
-        tmp_path=tmp_path, definitions=test_case.definitions
-    )
-
-    with pytest.raises(ValueError, match=test_case.expected_error_fragment):
-        expand_sql_macros(
-            sql=test_case.sql,
-            file_path=tmp_path / "models/marts/finance/orders.sql",
-            loaded_macros=loaded,
-            macro_context=_MACRO_CONTEXT,
-            declaration_resolver=resolver,
-        )

--- a/tests/unit/src/sqlbuild/compiler/scopes/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/_test_types.py
@@ -25,6 +25,19 @@ class PathNormalizationCase:
 
 
 @dataclass(frozen=True)
+class PathNormalizationCacheCase:
+    """Expected bounded-cache behavior for repeated path normalization."""
+
+    description: str
+    path: str
+    call_count: int
+    expected_hits: int
+    expected_misses: int
+    expected_max_size: int
+    expected_current_size: int
+
+
+@dataclass(frozen=True)
 class PathVisibilityCase:
     """One component-aware lexical visibility case."""
 

--- a/tests/unit/src/sqlbuild/compiler/scopes/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/_test_types.py
@@ -144,6 +144,18 @@ class OfflineScopeCase:
 
 
 @dataclass(frozen=True)
+class TolerantMacroInventoryCase:
+    """Macro faults and declarations retained by tolerant offline inventory."""
+
+    description: str
+    files: dict[str, str]
+    expected_names: frozenset[str]
+    unexpected_names: frozenset[str]
+    expected_dependencies: tuple[tuple[str, str], ...] = ()
+    expected_diagnostic_fragments: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class TolerantCategoryCase:
     """One broken authored file with a valid sibling retained by tolerant discovery."""
 

--- a/tests/unit/src/sqlbuild/compiler/scopes/test_builder_and_visibility.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/test_builder_and_visibility.py
@@ -161,6 +161,9 @@ def test_given_every_authored_resource_kind_when_building_then_uses_canonical_ro
         VisibilityExpectation("global", "global", VisibilityReason.GLOBAL),
         VisibilityExpectation("root_ancestor", "root", VisibilityReason.INHERITED_ANCESTOR),
         VisibilityExpectation("near_ancestor", "near", VisibilityReason.INHERITED_ANCESTOR),
+        VisibilityExpectation(
+            "noncanonical_ancestor", "noncanonical", VisibilityReason.INHERITED_ANCESTOR
+        ),
         VisibilityExpectation("local", "local", VisibilityReason.LOCAL_OWNER),
         VisibilityExpectation("private", "_private", VisibilityReason.PRIVATE_OWNER),
     ],
@@ -180,6 +183,11 @@ def test_given_all_scope_tiers_when_resolving_then_classifies_without_shadow_res
         declaration_record(name="global", scope=ScopeKind.GLOBAL, owner_path=None),
         declaration_record(name="root", scope=ScopeKind.INHERITED, owner_path="models"),
         declaration_record(name="near", scope=ScopeKind.INHERITED, owner_path="models/sales"),
+        declaration_record(
+            name="noncanonical",
+            scope=ScopeKind.INHERITED,
+            owner_path=r"models\.\sales\daily\..",
+        ),
         declaration_record(name="local", scope=ScopeKind.LOCAL, owner_path="models/sales/daily"),
         declaration_record(
             name="_private", scope=ScopeKind.PRIVATE, owner_path="models/sales/daily", owner=target

--- a/tests/unit/src/sqlbuild/compiler/scopes/test_offline_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/test_offline_cache.py
@@ -19,6 +19,7 @@ from tests.unit.src.sqlbuild.compiler.scopes._test_types import (
     FingerprintMutationCase,
     OfflineScopeCase,
     TolerantCategoryCase,
+    TolerantMacroInventoryCase,
 )
 from tests.unit.src.sqlbuild.compiler.scopes.helpers import (
     SCOPE_CACHE_MODEL,
@@ -245,10 +246,10 @@ def test_given_authored_values_and_secrets_when_caching_then_payload_is_value_fr
 
 @pytest.mark.parametrize(
     "test_case",
-    (OfflineScopeCase("target switch invalidates target-aware macro usage"),),
+    (OfflineScopeCase("target switch preserves static Python macro dependencies"),),
     ids=lambda case: case.description,
 )
-def test_given_target_aware_macro_when_switching_target_then_cache_rebuilds_usage(
+def test_given_target_aware_python_composition_when_switching_target_then_dependencies_are_static(
     test_case: OfflineScopeCase,
     tmp_path: Path,
     write_repo_files: Callable[[Path, dict[str, str]], None],
@@ -262,11 +263,13 @@ def test_given_target_aware_macro_when_switching_target_then_cache_rebuilds_usag
             "sqlbuild_local.toml": 'target = "dev"\n',
             "models/orders.sql": "MODEL();\nSELECT @choose() AS value\n",
             "macros/choose.py": (
-                'def choose(ctx):\n    return "@dev_macro()" '
-                'if ctx.target_name == "dev" else "@prod_macro()"\n\n'
-                'def dev_macro():\n    return "1"\n\n'
-                'def prod_macro():\n    return "2"\n'
+                "from macros.dev import dev_macro\n"
+                "from macros.prod import prod_macro\n\n"
+                "def choose(ctx):\n    return dev_macro() "
+                'if ctx.target_name == "dev" else prod_macro()\n'
             ),
+            "macros/dev.py": 'def dev_macro():\n    return "1"\n',
+            "macros/prod.py": 'def prod_macro():\n    return "2"\n',
         },
     )
 
@@ -277,10 +280,8 @@ def test_given_target_aware_macro_when_switching_target_then_cache_rebuilds_usag
     prod_names: set[str] = {usage.declaration.name for usage in prod.usages}
 
     assert (
-        "dev_macro" in dev_names
-        and "prod_macro" not in dev_names
-        and "prod_macro" in prod_names
-        and "dev_macro" not in prod_names
+        {"choose", "dev_macro", "prod_macro"}.issubset(dev_names)
+        and {"choose", "dev_macro", "prod_macro"}.issubset(prod_names)
     ) is test_case.expected_result
 
 
@@ -313,6 +314,105 @@ def test_given_broken_declaration_category_when_loading_then_other_categories_re
     assert ({"limit", "identity"} <= identities and not index.completeness.discovery) is (
         test_case.expected_result
     )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        TolerantMacroInventoryCase(
+            description="syntax error retains valid composed macro and dependency",
+            files={
+                "macros/shared.py": "def shared():\n    return 'shared'\n",
+                "macros/consumer.py": (
+                    "from macros.shared import shared\n\ndef consumer():\n    return shared()\n"
+                ),
+                "macros/broken.py": "def broken(:\n    return 'broken'\n",
+            },
+            expected_names=frozenset({"shared", "consumer"}),
+            unexpected_names=frozenset({"broken"}),
+            expected_dependencies=(("consumer", "shared"),),
+            expected_diagnostic_fragments=("Failed to parse macros",),
+        ),
+        TolerantMacroInventoryCase(
+            description="scope-invalid macro import is omitted with diagnostic",
+            files={
+                "models/sales/_local_macros/shared.py": ("def shared():\n    return 'shared'\n"),
+                "models/finance/_macros/consumer.py": (
+                    "from models.sales._local_macros.shared import shared\n\n"
+                    "def consumer():\n    return shared()\n"
+                ),
+                "macros/broken.py": "def broken(:\n    return 'broken'\n",
+            },
+            expected_names=frozenset({"shared"}),
+            unexpected_names=frozenset({"consumer", "broken"}),
+            expected_diagnostic_fragments=("not visible from the importer scope",),
+        ),
+        TolerantMacroInventoryCase(
+            description="name collision retains unrelated valid macro",
+            files={
+                "macros/valid.py": "def valid():\n    return 'valid'\n",
+                "macros/first.py": "def duplicate():\n    return 'first'\n",
+                "macros/second.py": "def duplicate():\n    return 'second'\n",
+            },
+            expected_names=frozenset({"valid"}),
+            unexpected_names=frozenset({"duplicate"}),
+            expected_diagnostic_fragments=("Macro name collision for 'duplicate'",),
+        ),
+        TolerantMacroInventoryCase(
+            description="import cycle retains unrelated valid macro",
+            files={
+                "macros/valid.py": "def valid():\n    return 'valid'\n",
+                "macros/first.py": (
+                    "from macros.second import second\n\ndef first():\n    return second()\n"
+                ),
+                "macros/second.py": (
+                    "from macros.first import first\n\ndef second():\n    return first()\n"
+                ),
+            },
+            expected_names=frozenset({"valid"}),
+            unexpected_names=frozenset({"first", "second"}),
+            expected_diagnostic_fragments=("Macro import cycle",),
+        ),
+        TolerantMacroInventoryCase(
+            description="module path collision omits both ambiguous modules",
+            files={
+                "macros/valid.py": "def valid():\n    return 'valid'\n",
+                "macros/a.b.py": "def dotted():\n    return 'dotted'\n",
+                "macros/a/b.py": "def nested():\n    return 'nested'\n",
+            },
+            expected_names=frozenset({"valid"}),
+            unexpected_names=frozenset({"dotted", "nested"}),
+            expected_diagnostic_fragments=("Macro module path collision for 'macros.a.b'",),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_macro_fault_when_loading_offline_then_valid_macro_facts_are_retained(
+    test_case: TolerantMacroInventoryCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(
+        tmp_path,
+        {
+            "sqlbuild_project.toml": _PROJECT,
+            "models/orders.sql": _MODEL,
+            **test_case.files,
+        },
+    )
+
+    index: ScopeIndex = load_or_build_scope_index(project_dir=tmp_path, no_cache=True)
+    identities: set[str] = {record.identity.name for record in index.declarations}
+    dependencies: tuple[tuple[str, str], ...] = tuple(
+        (usage.consumer.name, usage.declaration.name) for usage in index.usages
+    )
+    diagnostics: str = "\n".join(item.message for item in index.diagnostics)
+
+    assert test_case.expected_names <= identities
+    assert not test_case.unexpected_names.intersection(identities)
+    assert dependencies == test_case.expected_dependencies
+    assert all(fragment in diagnostics for fragment in test_case.expected_diagnostic_fragments)
+    assert not index.completeness.discovery
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/scopes/test_paths.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/test_paths.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from sqlbuild.compiler.scopes._helpers.paths import normalize_path
 from sqlbuild.compiler.scopes.main._normalize_scope_path import normalize_scope_path
 from sqlbuild.compiler.scopes.main._path_is_equal_or_descendant import (
     path_is_equal_or_descendant,
@@ -11,6 +12,7 @@ from sqlbuild.compiler.scopes.main._path_is_equal_or_descendant import (
 from sqlbuild.compiler.scopes.main._scope_is_path_visible import scope_is_path_visible
 from sqlbuild.compiler.scopes.types import ScopeKind
 from tests.unit.src.sqlbuild.compiler.scopes._test_types import (
+    PathNormalizationCacheCase,
     PathNormalizationCase,
     PathVisibilityCase,
 )
@@ -41,6 +43,36 @@ def test_given_posix_or_windows_path_when_normalizing_then_returns_canonical_pos
     test_case: PathNormalizationCase,
 ) -> None:
     assert normalize_scope_path(path=test_case.path) == test_case.expected_path
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        PathNormalizationCacheCase(
+            description="repeated canonical path uses one normalization result",
+            path="models/commerce/orders.sql",
+            call_count=1_000,
+            expected_hits=999,
+            expected_misses=1,
+            expected_max_size=65_536,
+            expected_current_size=1,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_repeated_path_when_normalizing_then_reuses_bounded_cache(
+    test_case: PathNormalizationCacheCase,
+) -> None:
+    normalize_path.cache_clear()
+
+    for _ in range(test_case.call_count):
+        _ = normalize_path(path=test_case.path)
+
+    assert normalize_path.cache_info().hits == test_case.expected_hits
+    assert normalize_path.cache_info().misses == test_case.expected_misses
+    assert normalize_path.cache_info().maxsize == test_case.expected_max_size
+    assert normalize_path.cache_info().currsize == test_case.expected_current_size
+    normalize_path.cache_clear()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/lint/test_expanded_lint.py
+++ b/tests/unit/src/sqlbuild/lint/test_expanded_lint.py
@@ -177,14 +177,14 @@ def test_given_project_when_linting_expanded_sql_then_positions_are_authored(
             expected_message_fragment="SQLBUILD_ABSENT_VAR",
         ),
         LintCompileFailureTestCase(
-            description="project macro imports fail before lint expansion",
+            description="unsupported project module imports fail before lint expansion",
             project_files={
                 "sqlbuild_project.toml": PROJECT_TOML,
-                "macros/orders.py": "from macros.shared import shared_macro\n",
+                "macros/orders.py": "import macros.shared\n",
                 "macros/shared.py": "def shared_macro() -> str:\n    return 'order_id'\n",
                 "models/demo.sql": f"{HEADER}SELECT 1 AS x\n",
             },
-            expected_message_fragment="must not import project macro module 'macros.shared'",
+            expected_message_fragment="module imports are not supported",
         ),
         LintCompileFailureTestCase(
             description="inaccessible declaration fails lint with compile visibility diagnostic",


### PR DESCRIPTION
## Why

SQLBuild 0.62 replaced Python macro composition with recursive expansion of `@macro()` calls returned inside generated SQL. This restores the original boundary: project macros compose as Python functions and return final SQL.

Closes [CHI-124](https://linear.app/chio-labs/issue/CHI-124/restore-python-macro-composition-and-reject-generated-macro-expansion).

## Changes

- allow absolute and relative `from ... import ...` composition between visible exported project macros
- validate project imports, scope boundaries, symbols, aliases, dynamic use, and cycles before authored modules execute
- load modules once through isolated packages without executing `__init__.py` or leaking `sys.modules` state
- record actual imported and same-module calls reached through public macros and private helpers; unused imports create no dependency
- expose dependencies through Scope Explorer, offline indexes, placement checks, manifests, and change identity
- reject generated `@macro()`, `@const()`, and `@enum()` calls because macro output must be final SQL
- retain nested macro calls explicitly authored in SQL
- preserve valid offline facts around unrelated syntax, scope, cycle, name-collision, and module-path faults
- regenerate the packaged skill from sqlbuild-docs#17 and #18

## Verification

- `make test`: 4617 passed
- `make type`, Ruff, and `git diff --check`: passed
- Fensu: 0 faults
- `make rust-check`: format, Clippy, structure checker, and 10 tests passed
- focused macro/scope/lint/pipeline suite: 85 passed
- generated skill reproduced twice: `2dfb3ecb9d257677162f8bfd659938c56bac4dbf4459bca8acd343f5f7d64b42`
- independent final review: no blocking or medium findings
