### PR TITLE
fix(planning): reduce warehouse inspection overhead

### DIFF
--- a/src/sqlbuild/adapter/contract/classes/base_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/base_adapter.py
@@ -43,6 +43,9 @@ from sqlbuild.adapter.contract.types import (
     PromotionStrategy,
     TablePromotionMode,
 )
+from sqlbuild.adapter.relations.main.get_columns_for_relations import (
+    get_columns_for_relations_bulk,
+)
 from sqlbuild.adapter.state_sql.main.render_insert_source_freshness_records_sql import (
     render_insert_source_freshness_records_sql,
 )
@@ -369,6 +372,18 @@ class BaseAdapter(StrictAdapter):
                 result[table_name] = []
             result[table_name].append(ColumnInfo(name=row[1], type=row[2]))
         return {k: tuple(v) for k, v in result.items()}
+
+    def get_columns_for_relations(
+        self,
+        *,
+        connection: Any,
+        relations: tuple[RelationInfo, ...],
+    ) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+        """Fetch columns keyed by fully qualified physical relation identity."""
+
+        return get_columns_for_relations_bulk(
+            adapter=self, connection=connection, relations=relations
+        )
 
     def render_create_schema(
         self,

--- a/src/sqlbuild/adapter/contract/classes/duckdb_backed_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/duckdb_backed_adapter.py
@@ -51,6 +51,9 @@ from sqlbuild.adapter.contract.types import (
     PromotionStrategy,
     TablePromotionMode,
 )
+from sqlbuild.adapter.relations.main.get_columns_for_relations import (
+    get_columns_for_relations_bulk,
+)
 from sqlbuild.adapter.state_sql.main.render_insert_source_freshness_records_sql import (
     render_insert_source_freshness_records_sql,
 )
@@ -68,6 +71,16 @@ from sqlbuild.sql_values.models import SqlValue
 
 class DuckDbBackedAdapter(BaseAdapter):
     """Shared adapter implementation for DuckDB-backed connections."""
+
+    def get_columns_for_relations(
+        self,
+        *,
+        connection: Any,
+        relations: tuple[RelationInfo, ...],
+    ) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+        return get_columns_for_relations_bulk(
+            adapter=self, connection=connection, relations=relations
+        )
 
     sql_analysis_dialect_name: ClassVar[str | None] = "duckdb"
 

--- a/src/sqlbuild/adapter/contract/classes/schema.py
+++ b/src/sqlbuild/adapter/contract/classes/schema.py
@@ -60,6 +60,16 @@ class SchemaMixin(ABC):
         ...
 
     @abstractmethod
+    def get_columns_for_relations(
+        self,
+        *,
+        connection: Any,
+        relations: tuple[RelationInfo, ...],
+    ) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+        """Return columns keyed by fully qualified physical relation identity."""
+        ...
+
+    @abstractmethod
     def relation_exists(
         self,
         *,

--- a/src/sqlbuild/adapter/contract/models.py
+++ b/src/sqlbuild/adapter/contract/models.py
@@ -73,6 +73,12 @@ class RelationInfo:
     last_altered_at: datetime | None = None
     is_transient: bool | None = None
 
+    @property
+    def identity(self) -> tuple[str | None, str | None, str]:
+        """Return the case-insensitive physical relation identity."""
+
+        return RelationLookup.key(database=self.database, schema=self.schema, name=self.name)
+
 
 @dataclass(frozen=True)
 class RelationLookup:

--- a/src/sqlbuild/adapter/relations/constants.py
+++ b/src/sqlbuild/adapter/relations/constants.py
@@ -1,0 +1,3 @@
+"""Shared relation metadata limits."""
+
+METADATA_NAME_FILTER_LIMIT: int = 250

--- a/src/sqlbuild/adapter/relations/main/get_columns_for_relations.py
+++ b/src/sqlbuild/adapter/relations/main/get_columns_for_relations.py
@@ -1,0 +1,71 @@
+"""Adapter-neutral qualified bulk column retrieval."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlbuild.adapter.contract.models import ColumnInfo, RelationInfo
+from sqlbuild.adapter.relations.constants import METADATA_NAME_FILTER_LIMIT
+
+
+def get_columns_for_relations_bulk(
+    *,
+    adapter: Any,
+    connection: Any,
+    relations: tuple[RelationInfo, ...],
+) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+    """Fetch one bulk column result per database/schema and restore qualified keys."""
+
+    relations_by_scope: dict[tuple[str | None, str | None], list[RelationInfo]] = {}
+    relation: RelationInfo
+    for relation in relations:
+        scope: tuple[str | None, str | None] = (relation.database, relation.schema)
+        relations_by_scope.setdefault(scope, []).append(relation)
+    return _gather_scope_columns(
+        adapter=adapter,
+        connection=connection,
+        scopes=tuple(relations_by_scope.items()),
+        scope_index=0,
+        result={},
+    )
+
+
+def _gather_scope_columns(
+    *,
+    adapter: Any,
+    connection: Any,
+    scopes: tuple[
+        tuple[tuple[str | None, str | None], list[RelationInfo]], ...
+    ],
+    scope_index: int,
+    result: dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]],
+) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+    if scope_index >= len(scopes):
+        return result
+    scope, relations = scopes[scope_index]
+    database, schema = scope
+    columns_by_name: dict[str, tuple[ColumnInfo, ...]] = adapter.get_all_columns(
+        connection=connection,
+        database=database,
+        schemas=None if schema is None else (schema,),
+        names=(
+            None
+            if len(relations) > METADATA_NAME_FILTER_LIMIT
+            else tuple(relation.name for relation in relations)
+        ),
+    )
+    normalized_columns: dict[str, tuple[ColumnInfo, ...]] = {
+        name.lower(): columns for name, columns in columns_by_name.items()
+    }
+    relation: RelationInfo
+    for relation in relations:
+        columns: tuple[ColumnInfo, ...] | None = normalized_columns.get(relation.name.lower())
+        if columns is not None:
+            result[relation.identity] = columns
+    return _gather_scope_columns(
+        adapter=adapter,
+        connection=connection,
+        scopes=scopes,
+        scope_index=scope_index + 1,
+        result=result,
+    )

--- a/src/sqlbuild/adapters/bigquery/classes/bigquery_adapter.py
+++ b/src/sqlbuild/adapters/bigquery/classes/bigquery_adapter.py
@@ -52,6 +52,9 @@ from sqlbuild.adapter.contract.types import (
     PromotionStrategy,
     TablePromotionMode,
 )
+from sqlbuild.adapter.relations.main.get_columns_for_relations import (
+    get_columns_for_relations_bulk,
+)
 from sqlbuild.adapter.state_sql.main.render_insert_source_freshness_records_sql import (
     render_insert_source_freshness_records_sql,
 )
@@ -91,6 +94,16 @@ from sqlbuild.sql_values.types import SqlValueKind
 
 class BigQueryAdapter(MicrobatchMixin, BaseAdapter):
     """BigQuery adapter backed by google-cloud-bigquery."""
+
+    def get_columns_for_relations(
+        self,
+        *,
+        connection: Any,
+        relations: tuple[RelationInfo, ...],
+    ) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+        return get_columns_for_relations_bulk(
+            adapter=self, connection=connection, relations=relations
+        )
 
     adapter_name: ClassVar[str] = BuiltinAdapter.BIGQUERY.value
     sql_analysis_dialect_name: ClassVar[str | None] = "bigquery"

--- a/src/sqlbuild/adapters/databricks/classes/databricks_adapter.py
+++ b/src/sqlbuild/adapters/databricks/classes/databricks_adapter.py
@@ -49,6 +49,9 @@ from sqlbuild.adapter.contract.types import (
     RelationType,
     TablePromotionMode,
 )
+from sqlbuild.adapter.relations.main.get_columns_for_relations import (
+    get_columns_for_relations_bulk,
+)
 from sqlbuild.adapter.state_sql.main.render_insert_source_freshness_records_sql import (
     render_insert_source_freshness_records_sql,
 )
@@ -74,6 +77,16 @@ from sqlbuild.sql_values.models import SqlValue
 
 class DatabricksAdapter(MicrobatchMixin, BaseAdapter):
     """Databricks adapter backed by databricks-sql-connector."""
+
+    def get_columns_for_relations(
+        self,
+        *,
+        connection: Any,
+        relations: tuple[RelationInfo, ...],
+    ) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+        return get_columns_for_relations_bulk(
+            adapter=self, connection=connection, relations=relations
+        )
 
     adapter_name: ClassVar[str] = BuiltinAdapter.DATABRICKS.value
     sql_analysis_dialect_name: ClassVar[str | None] = "databricks"

--- a/src/sqlbuild/adapters/postgres/classes/postgres_adapter.py
+++ b/src/sqlbuild/adapters/postgres/classes/postgres_adapter.py
@@ -63,6 +63,9 @@ from sqlbuild.adapter.contract.types import (
     PromotionStrategy,
     TablePromotionMode,
 )
+from sqlbuild.adapter.relations.main.get_columns_for_relations import (
+    get_columns_for_relations_bulk,
+)
 from sqlbuild.adapter.state_sql.main.render_insert_source_freshness_records_sql import (
     render_insert_source_freshness_records_sql,
 )
@@ -80,6 +83,16 @@ from sqlbuild.sql_values.models import SqlValue
 
 class PostgresAdapter(MicrobatchMixin, BaseAdapter):
     """PostgreSQL adapter backed by psycopg."""
+
+    def get_columns_for_relations(
+        self,
+        *,
+        connection: Any,
+        relations: tuple[RelationInfo, ...],
+    ) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+        return get_columns_for_relations_bulk(
+            adapter=self, connection=connection, relations=relations
+        )
 
     adapter_name: ClassVar[str] = BuiltinAdapter.POSTGRES.value
     sql_analysis_dialect_name: ClassVar[str | None] = "postgres"

--- a/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
+++ b/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
@@ -27,6 +27,7 @@ from sqlbuild.adapter.contract.models import (
     FunctionDefinition,
     FunctionInfo,
     QueryResult,
+    RelationInfo,
     RowDiffColumnResult,
     RowDiffResult,
     RowDiffSampleCell,
@@ -66,6 +67,7 @@ from sqlbuild.adapters.snowflake.constants import (
     SUCCESS_STATUS_TOKENS,
     TEXT_TYPE_NAMES,
     TRUE_METADATA_VALUE,
+    VIEW_RELATION_TYPE_TOKEN,
 )
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.planner.types import InitialValidFrom, SnapshotStrategy
@@ -77,6 +79,9 @@ from sqlbuild.diagnostics.main.log_sql import log_sql
 from sqlbuild.spec.contracts.constants import DEFAULT_SEED_CSV_SETTINGS
 from sqlbuild.spec.contracts.models import SeedCsvSettings
 from sqlbuild.sql_values.models import SqlValue
+
+_EXACT_COLUMN_INSPECTION_LIMIT: int = 32
+_BULK_COLUMN_RELATION_CHUNK_SIZE: int = 200
 
 
 class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
@@ -154,6 +159,11 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
     @staticmethod
     def _information_schema_identifier(value: str) -> str:
         return value.upper()
+
+    def _information_schema_relation(self, *, database: str | None, name: str) -> str:
+        if database is None:
+            return f"information_schema.{name}"
+        return f"{self.render_identifier(database)}.information_schema.{name}"
 
     @staticmethod
     def _freshness_request_key(
@@ -367,7 +377,9 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
         cursor: Any = connection.cursor()
         try:
             cursor.execute(
-                "SELECT table_type, last_altered FROM information_schema.tables WHERE "
+                "SELECT table_type, last_altered FROM "
+                + self._information_schema_relation(database=database, name="tables")
+                + " WHERE "
                 + " AND ".join(clauses),
                 tuple(params),
             )
@@ -441,7 +453,12 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
             try:
                 cursor.execute(
                     "SELECT table_catalog, table_schema, table_name, table_type, last_altered "
-                    "FROM information_schema.tables WHERE " + " AND ".join(clauses),
+                    "FROM "
+                    + self._information_schema_relation(
+                        database=scoped_requests[0].database, name="tables"
+                    )
+                    + " WHERE "
+                    + " AND ".join(clauses),
                     tuple(params),
                 )
                 rows: list[tuple[Any, ...]] = list(cursor.fetchall())
@@ -1539,7 +1556,10 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
         cursor: Any = connection.cursor()
         try:
             cursor.execute(
-                "SELECT 1 FROM information_schema.tables WHERE " + " AND ".join(clauses),
+                "SELECT 1 FROM "
+                + self._information_schema_relation(database=database, name="tables")
+                + " WHERE "
+                + " AND ".join(clauses),
                 tuple(params),
             )
             return cursor.fetchone() is not None
@@ -1556,7 +1576,7 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
     ) -> tuple[Any, ...]:
         query: str = (
             "SELECT table_name, table_schema, table_type, is_transient "
-            "FROM information_schema.tables WHERE 1=1"
+            f"FROM {self._information_schema_relation(database=database, name='tables')} WHERE 1=1"
         )
         params: list[str] = []
         if schemas:
@@ -1641,7 +1661,9 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
     ) -> tuple[ColumnInfo, ...]:
         query: str = (
             "SELECT column_name, data_type, numeric_precision, numeric_scale, "
-            "character_maximum_length FROM information_schema.columns "
+            "character_maximum_length FROM "
+            + self._information_schema_relation(database=database, name="columns")
+            + " "
             "WHERE table_name = %s"
         )
         params: list[str] = [self._information_schema_identifier(name)]
@@ -1681,7 +1703,9 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
     ) -> dict[str, tuple[ColumnInfo, ...]]:
         query: str = (
             "SELECT table_name, column_name, data_type, numeric_precision, numeric_scale, "
-            "character_maximum_length FROM information_schema.columns WHERE 1=1"
+            "character_maximum_length FROM "
+            + self._information_schema_relation(database=database, name="columns")
+            + " WHERE 1=1"
         )
         params: list[str] = []
         if schemas:
@@ -1718,6 +1742,160 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
                 )
             )
         return {key: tuple(value) for key, value in result.items()}
+
+    def get_columns_for_relations(
+        self,
+        *,
+        connection: _SnowflakeConnection,
+        relations: tuple[RelationInfo, ...],
+    ) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+        """Use exact SHOW calls for sparse plans and qualified bulk metadata for broad plans."""
+
+        ordered_relations: tuple[RelationInfo, ...] = tuple(
+            sorted(
+                relations,
+                key=lambda relation: tuple(part or "" for part in relation.identity),
+            )
+        )
+        if len(ordered_relations) <= _EXACT_COLUMN_INSPECTION_LIMIT:
+            return {
+                relation.identity: self._show_columns_for_relation(
+                    connection=connection, relation=relation
+                )
+                for relation in ordered_relations
+            }
+        return self._get_columns_for_relations_bulk(
+            connection=connection, relations=ordered_relations
+        )
+
+    def _show_columns_for_relation(
+        self,
+        *,
+        connection: _SnowflakeConnection,
+        relation: RelationInfo,
+    ) -> tuple[ColumnInfo, ...]:
+        qualified_name: str | None = self.render_qualified_name(
+            database=relation.database,
+            schema=relation.schema,
+            name=relation.name,
+        )
+        if qualified_name is None:
+            raise AdapterUserError(message=f"Snowflake relation is not qualified: {relation.name}")
+        relation_kind: str = (
+            "VIEW" if VIEW_RELATION_TYPE_TOKEN in relation.relation_type.lower() else "TABLE"
+        )
+        cursor: Any = connection.cursor()
+        try:
+            cursor.execute(f"SHOW COLUMNS IN {relation_kind} {qualified_name}")
+            rows: list[tuple[Any, ...]] = list(cursor.fetchall())
+        finally:
+            cursor.close()
+        return tuple(
+            ColumnInfo(
+                name=str(row[2]).lower(),
+                type=self._build_show_columns_type(raw_data_type=row[3]),
+            )
+            for row in rows
+        )
+
+    def _get_columns_for_relations_bulk(
+        self,
+        *,
+        connection: _SnowflakeConnection,
+        relations: tuple[RelationInfo, ...],
+    ) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+        by_database: dict[str | None, list[RelationInfo]] = {}
+        for relation in relations:
+            by_database.setdefault(relation.database, []).append(relation)
+        result: dict[tuple[str | None, str | None, str], list[ColumnInfo]] = {}
+        for database, database_relations in by_database.items():
+            chunk_start: int
+            for chunk_start in range(
+                0, len(database_relations), _BULK_COLUMN_RELATION_CHUNK_SIZE
+            ):
+                chunk: list[RelationInfo] = database_relations[
+                    chunk_start : chunk_start + _BULK_COLUMN_RELATION_CHUNK_SIZE
+                ]
+                rows: list[tuple[Any, ...]] = self._get_columns_for_relations_bulk_chunk(
+                    connection=connection, database=database, relations=chunk
+                )
+                for row in rows:
+                    identity: tuple[str | None, str | None, str] = (
+                        None if database is None else str(row[0]).lower(),
+                        None if row[1] is None else str(row[1]).lower(),
+                        str(row[2]).lower(),
+                    )
+                    result.setdefault(identity, []).append(
+                        ColumnInfo(
+                            name=str(row[3]).lower(),
+                            type=self._build_information_schema_type(
+                                data_type=str(row[4]),
+                                numeric_precision=row[5],
+                                numeric_scale=row[6],
+                                character_maximum_length=row[7],
+                            ),
+                        )
+                    )
+        return {identity: tuple(columns) for identity, columns in result.items()}
+
+    def _get_columns_for_relations_bulk_chunk(
+        self,
+        *,
+        connection: _SnowflakeConnection,
+        database: str | None,
+        relations: list[RelationInfo],
+    ) -> list[tuple[Any, ...]]:
+        scopes: dict[str | None, list[str]] = {}
+        for relation in relations:
+            scopes.setdefault(relation.schema, []).append(relation.name)
+        clauses: list[str] = []
+        params: list[str] = []
+        for schema, names in sorted(scopes.items(), key=lambda item: item[0] or ""):
+            name_placeholders: str = ", ".join(["%s"] * len(names))
+            if schema is None:
+                clauses.append(f"table_name IN ({name_placeholders})")
+            else:
+                clauses.append(f"(table_schema = %s AND table_name IN ({name_placeholders}))")
+                params.append(self._information_schema_identifier(schema))
+            params.extend(self._information_schema_identifier(name) for name in names)
+        metadata_table: str = self._information_schema_relation(
+            database=database, name="columns"
+        )
+        query: str = (
+            "SELECT table_catalog, table_schema, table_name, column_name, data_type, "
+            "numeric_precision, numeric_scale, character_maximum_length "
+            f"FROM {metadata_table} WHERE " + " OR ".join(clauses)
+            + " ORDER BY table_catalog, table_schema, table_name, ordinal_position"
+        )
+        cursor: Any = connection.cursor()
+        try:
+            cursor.execute(query, tuple(params))
+            return list(cursor.fetchall())
+        finally:
+            cursor.close()
+
+    def _build_show_columns_type(self, *, raw_data_type: object) -> str:
+        try:
+            decoded_data_type: object = json.loads(str(raw_data_type))
+        except (json.JSONDecodeError, TypeError) as error:
+            raise AdapterUserError(
+                message="Snowflake SHOW COLUMNS returned invalid type metadata"
+            ) from error
+        if not isinstance(decoded_data_type, dict):
+            raise AdapterUserError(message="Snowflake SHOW COLUMNS returned invalid type metadata")
+        data_type: dict[str, object] = decoded_data_type
+        raw_name: str = str(data_type.get("type", ""))
+        normalized_name: str = {
+            "FIXED": NUMBER_TYPE_NAME,
+            "TEXT": "VARCHAR",
+            "REAL": "FLOAT",
+        }.get(raw_name.upper(), raw_name.upper())
+        return self._build_information_schema_type(
+            data_type=normalized_name,
+            numeric_precision=data_type.get("precision"),
+            numeric_scale=data_type.get("scale"),
+            character_maximum_length=data_type.get("length"),
+        )
 
     def close(self, connection: _SnowflakeConnection) -> None:
         """Close a Snowflake connection."""

--- a/src/sqlbuild/adapters/snowflake/constants.py
+++ b/src/sqlbuild/adapters/snowflake/constants.py
@@ -1,6 +1,7 @@
 """Snowflake adapter constants."""
 
 BASE_TABLE_METADATA_TYPE: str = "BASE TABLE"
+VIEW_RELATION_TYPE_TOKEN: str = "view"
 EXTERNAL_BROWSER_AUTHENTICATOR: str = "externalbrowser"
 MFA_AUTHENTICATOR: str = "username_password_mfa"
 OAUTH_AUTHORIZATION_CODE_AUTHENTICATOR: str = "oauth_authorization_code"

--- a/src/sqlbuild/adapters/sqlserver/classes/sqlserver_adapter.py
+++ b/src/sqlbuild/adapters/sqlserver/classes/sqlserver_adapter.py
@@ -58,6 +58,9 @@ from sqlbuild.adapter.contract.types import (
     PromotionStrategy,
     TablePromotionMode,
 )
+from sqlbuild.adapter.relations.main.get_columns_for_relations import (
+    get_columns_for_relations_bulk,
+)
 from sqlbuild.adapter.state_sql.main.render_insert_source_freshness_records_sql import (
     render_insert_source_freshness_records_sql,
 )
@@ -83,6 +86,16 @@ from sqlbuild.sql_values.types import SqlValueKind
 
 class SqlServerAdapter(MicrobatchMixin, BaseAdapter):
     """Microsoft SQL Server adapter backed by pymssql."""
+
+    def get_columns_for_relations(
+        self,
+        *,
+        connection: Any,
+        relations: tuple[RelationInfo, ...],
+    ) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+        return get_columns_for_relations_bulk(
+            adapter=self, connection=connection, relations=relations
+        )
 
     adapter_name: ClassVar[str] = BuiltinAdapter.SQLSERVER.value
     sql_analysis_dialect_name: ClassVar[str | None] = "tsql"

--- a/src/sqlbuild/cli/commands/_helpers/build_python_nodes/python_lifecycle.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_python_nodes/python_lifecycle.py
@@ -21,9 +21,7 @@ from sqlbuild.cli.commands.models import DirectLifecycleCallbacks
 from sqlbuild.compiler.compile.models import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
-from sqlbuild.compiler.pipeline.main.relation_targets import (
-    build_python_relation_targets,
-)
+from sqlbuild.compiler.pipeline.main.relation_targets import build_python_relation_targets
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.main.selection.loader_dag import build_intermediate_source_map
 from sqlbuild.compiler.planner.models import PlanOutput
@@ -95,6 +93,12 @@ def prepare_direct_python_lifecycle(
         adapter=adapter,
         project=pipeline_result.project,
         plan_output=plan_output,
+        required_refs=python_graph.selected_sql_refs(
+            selected_names=(
+                lifecycle_plan.ingress_python_node_names
+                | lifecycle_plan.read_side_python_node_names
+            ),
+        ),
     )
     default_database: str | None = pipeline_result.project.effective_target_database
     if default_database is None:

--- a/src/sqlbuild/cli/commands/_helpers/check/core.py
+++ b/src/sqlbuild/cli/commands/_helpers/check/core.py
@@ -15,9 +15,7 @@ from sqlbuild.adapter.relations.main.resolve_relation_location_qualified_name im
 from sqlbuild.cli.commands.exceptions import CliUserError
 from sqlbuild.compiler.compile.models import CompiledRelationLocation
 from sqlbuild.compiler.discovery.models import DiscoveredCheckFunction, DiscoveredProjectInputs
-from sqlbuild.compiler.pipeline.main.relation_targets import (
-    build_python_relation_targets,
-)
+from sqlbuild.compiler.pipeline.main.relation_targets import build_python_relation_targets
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.main.selection.selector_parse import parse_project_selector
@@ -141,7 +139,11 @@ def record_python_run_state_results(
 
 
 def build_check_relation_targets(
-    *, adapter: BaseAdapter, pipeline_result: CompilePipelineResult
+    *,
+    adapter: BaseAdapter,
+    pipeline_result: CompilePipelineResult,
+    python_graph: PythonNodeGraph,
+    selected_python_names: frozenset[str],
 ) -> dict[SqlResourceRef, str]:
     """Return SQL relation locations available to Python check dependencies."""
 
@@ -149,6 +151,9 @@ def build_check_relation_targets(
         adapter=adapter,
         project=pipeline_result.project,
         plan_output=pipeline_result.plan_output,
+        required_refs=python_graph.selected_sql_refs(
+            selected_names=selected_python_names,
+        ),
     )
 
 

--- a/src/sqlbuild/cli/commands/_helpers/check/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/check/execution.py
@@ -67,6 +67,8 @@ def prepare_check_execution(
     relation_targets: dict[SqlResourceRef, str] = build_check_relation_targets(
         adapter=invocation.adapter,
         pipeline_result=pipeline_result,
+        python_graph=python_graph,
+        selected_python_names=check_names,
     )
     return CheckExecutionPreparation(
         python_graph=python_graph,

--- a/src/sqlbuild/compiler/fingerprints/main/read.py
+++ b/src/sqlbuild/compiler/fingerprints/main/read.py
@@ -27,6 +27,8 @@ def read_latest_fingerprints(
     render_qualified_name: Callable[..., str | None],
     render_read_latest_sql: Callable[..., str],
     require_table: bool = False,
+    node_names: tuple[str, ...] | None = None,
+    filtered_node_types: tuple[str, ...] = (),
 ) -> FingerprintSet:
     """Read the latest fingerprint per node identity from adapter-rendered SQL."""
 
@@ -44,6 +46,30 @@ def read_latest_fingerprints(
         database=database,
         schema=schema,
     )
+    if node_names is not None:
+        if not node_names and not filtered_node_types:
+            return FingerprintSet(schema=schema, fingerprints={})
+        relevant_predicate: str = ""
+        if node_names:
+            literals: str = ", ".join(
+                "'" + node_name.replace("'", "''") + "'" for node_name in node_names
+            )
+            relevant_predicate = f"node_name IN ({literals})"
+        if filtered_node_types:
+            type_literals: str = ", ".join(
+                "'" + node_type.replace("'", "''") + "'"
+                for node_type in filtered_node_types
+            )
+            python_identity_predicate: str = f"node_type NOT IN ({type_literals})"
+            relevant_predicate = (
+                f"{relevant_predicate} OR {python_identity_predicate}"
+                if relevant_predicate
+                else python_identity_predicate
+            )
+        read_sql = (
+            f"SELECT * FROM ({read_sql}) AS __sqlbuild_relevant "
+            f"WHERE {relevant_predicate}"
+        )
     try:
         result: Any = execute(connection=connection, sql=read_sql)
     except Exception as error:

--- a/src/sqlbuild/compiler/pipeline/main/relation_targets.py
+++ b/src/sqlbuild/compiler/pipeline/main/relation_targets.py
@@ -6,33 +6,80 @@ from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.relations.main.resolve_relation_location_qualified_name import (
     resolve_relation_location_qualified_name,
 )
-from sqlbuild.compiler.compile.models import CompiledProject, CompiledRelationLocation
+from sqlbuild.compiler.compile.models import (
+    CompiledModel,
+    CompiledProject,
+    CompiledRelationLocation,
+)
 from sqlbuild.compiler.planner.models import PlanOutput
 from sqlbuild.compiler.references.main._render_source_relation import render_source_relation
+from sqlbuild.errors.contracts.exceptions import SharedInputError
 from sqlbuild.python_nodes.models import SqlResourceRef
 from sqlbuild.python_nodes.types import SqlResourceRefKind
 from sqlbuild.spec.contracts.models import SourceEntry
 
 
 def build_python_relation_targets(
-    *, adapter: BaseAdapter, project: CompiledProject, plan_output: PlanOutput
+    *,
+    adapter: BaseAdapter,
+    project: CompiledProject,
+    plan_output: PlanOutput,
+    required_refs: frozenset[SqlResourceRef] | None = None,
 ) -> dict[SqlResourceRef, str]:
-    """Return adapter-qualified runtime relation strings for model/source refs."""
+    """Return adapter-qualified runtime relations required by selected Python nodes."""
 
     targets: dict[SqlResourceRef, str] = {}
-    model_name: str
-    target: CompiledRelationLocation
-    for model_name, target in plan_output.model_locations.items():
-        targets[SqlResourceRef(kind=SqlResourceRefKind.MODEL, name=model_name)] = (
-            resolve_relation_location_qualified_name(adapter=adapter, location=target)
-        )
-    for source in project.sources:
-        targets[SqlResourceRef(kind=SqlResourceRefKind.SOURCE, name=source.name)] = (
-            _source_relation(adapter=adapter, source_name=source.name, plan_output=plan_output)
+    refs: frozenset[SqlResourceRef] = (
+        required_refs
+        if required_refs is not None
+        else _planned_relation_refs(plan_output=plan_output)
+    )
+    ref: SqlResourceRef
+    for ref in refs:
+        targets[ref] = _resolve_relation(
+            adapter=adapter,
+            project=project,
+            plan_output=plan_output,
+            ref=ref,
         )
     return targets
 
 
-def _source_relation(*, adapter: BaseAdapter, source_name: str, plan_output: PlanOutput) -> str:
-    source_entry: SourceEntry = (plan_output.source_read_map or plan_output.source_map)[source_name]
-    return render_source_relation(entry=source_entry, adapter=adapter)
+def _planned_relation_refs(*, plan_output: PlanOutput) -> frozenset[SqlResourceRef]:
+    refs: set[SqlResourceRef] = {
+        SqlResourceRef(kind=SqlResourceRefKind.MODEL, name=name)
+        for name in plan_output.model_locations
+    }
+    source_name: str
+    for source_name in (plan_output.source_read_map or plan_output.source_map):
+        refs.add(SqlResourceRef(kind=SqlResourceRefKind.SOURCE, name=source_name))
+    return frozenset(refs)
+
+
+def _resolve_relation(
+    *,
+    adapter: BaseAdapter,
+    project: CompiledProject,
+    plan_output: PlanOutput,
+    ref: SqlResourceRef,
+) -> str:
+    if ref.kind == SqlResourceRefKind.MODEL:
+        planned_model: CompiledRelationLocation | None = plan_output.model_locations.get(ref.name)
+        if planned_model is not None:
+            return resolve_relation_location_qualified_name(
+                adapter=adapter, location=planned_model
+            )
+        model: CompiledModel
+        for model in project.models:
+            if model.name == ref.name:
+                return resolve_relation_location_qualified_name(
+                    adapter=adapter, location=model.destination
+                )
+        raise SharedInputError(f"Python node references unknown model '{ref.name}'")
+    planned_sources: dict[str, SourceEntry] = plan_output.source_read_map or plan_output.source_map
+    planned_source: SourceEntry | None = planned_sources.get(ref.name)
+    if planned_source is not None:
+        return render_source_relation(entry=planned_source, adapter=adapter)
+    raise SharedInputError(
+        f"Python node source '{ref.name}' is missing from the resolved plan source map"
+    )

--- a/src/sqlbuild/compiler/planner/_helpers/graph/source_load_nodes.py
+++ b/src/sqlbuild/compiler/planner/_helpers/graph/source_load_nodes.py
@@ -14,18 +14,45 @@ from sqlbuild.spec.contracts.models import SourceEntry
 
 
 def build_source_load_map(
-    *, project: CompiledProject, selected_keys: frozenset[CompiledObjectKey]
+    *,
+    project: CompiledProject,
+    selected_keys: frozenset[CompiledObjectKey],
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] | None = None,
 ) -> dict[str, SourceEntry]:
     """Return source entries available to source-load and source-read planning."""
 
+    relevant_keys: frozenset[CompiledObjectKey] | None = (
+        _upstream_closure(selected_keys=selected_keys, upstream_deps=upstream_deps)
+        if upstream_deps is not None
+        else None
+    )
     source_map: dict[str, SourceEntry] = {
         source.source_entry.name: source.source_entry for source in project.sources
+        if relevant_keys is None or source.key in relevant_keys
     }
     source_map.update(build_intermediate_source_map(project=project, selected_keys=selected_keys))
     source_map.update(
         build_upstream_intermediate_source_map(project=project, selected_keys=selected_keys)
     )
     return source_map
+
+
+def _upstream_closure(
+    *,
+    selected_keys: frozenset[CompiledObjectKey],
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+) -> frozenset[CompiledObjectKey]:
+    """Return an adapter-neutral dependency closure for selected metadata reads."""
+
+    closure: set[CompiledObjectKey] = set(selected_keys)
+    pending: list[CompiledObjectKey] = list(selected_keys)
+    while pending:
+        key: CompiledObjectKey = pending.pop()
+        for upstream_key in upstream_deps.get(key, ()):
+            if upstream_key not in closure:
+                closure.add(upstream_key)
+                pending.append(upstream_key)
+    return frozenset(closure)
 
 
 def build_source_load_entries(

--- a/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
@@ -7,7 +7,7 @@ from datetime import date, datetime
 from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
-from sqlbuild.adapter.contract.models import ColumnInfo
+from sqlbuild.adapter.contract.models import ColumnInfo, RelationInfo
 from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.models import (
     CompiledModel,
@@ -121,6 +121,7 @@ def build_planner_relations_context(
     source_map: dict[str, SourceEntry] = build_source_load_map(
         project=project,
         selected_keys=scope.selected_keys,
+        upstream_deps=scope.upstream_deps if scope.all_keys else None,
     )
     source_read_map: dict[str, SourceEntry] = (
         build_source_read_map(
@@ -672,18 +673,33 @@ def gather_source_columns(
             schemas=schemas,
             source_entries=entries,
         )
-        all_columns: dict[str, tuple[ColumnInfo, ...]] = adapter.get_all_columns(
+        relations: tuple[RelationInfo, ...] = adapter.list_relations(
             connection=connection,
             database=database,
             schemas=tuple(sorted(schemas)),
             names=names,
         )
+        all_columns: dict[
+            tuple[str | None, str | None, str], tuple[ColumnInfo, ...]
+        ] = adapter.get_columns_for_relations(
+            connection=connection,
+            relations=relations,
+        )
         entry_iter: SourceEntry
         for entry_iter in entries:
-            if entry_iter.expression is not None:
+            if (
+                entry_iter.expression is not None
+                or (entry_iter.database or None) != database
+                or entry_iter.schema not in schemas
+            ):
                 continue
             table_name: str = entry_iter.table if entry_iter.table is not None else entry_iter.name
-            cols: tuple[ColumnInfo, ...] | None = all_columns.get(table_name)
+            identity: tuple[str | None, str | None, str] = (
+                None if database is None else database.lower(),
+                None if entry_iter.schema is None else entry_iter.schema.lower(),
+                table_name.lower(),
+            )
+            cols: tuple[ColumnInfo, ...] | None = all_columns.get(identity)
             if cols is not None:
                 result[entry_iter.name] = cols
 

--- a/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
+++ b/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
@@ -137,8 +137,10 @@ def gather_warehouse_snapshot(
 ) -> WarehouseSnapshot:
     """Gather relations, columns, and fingerprints for all target schemas."""
 
-    database: str | None = _resolve_database(project)
-    schemas: tuple[str, ...] = _collect_target_schemas(project)
+    database: str | None = _resolve_database(project=project, selected_keys=selected_keys)
+    schemas: tuple[str, ...] = _collect_target_schemas(
+        project=project, selected_keys=selected_keys
+    )
     metadata_names: tuple[str, ...] | None = _build_metadata_name_filter(
         project=project,
         selected_keys=selected_keys,
@@ -151,6 +153,7 @@ def gather_warehouse_snapshot(
     fingerprint_state_schemas: frozenset[str]
     freshness_state_schemas: frozenset[str]
     relations, fingerprint_state_schemas, freshness_state_schemas = _gather_relations(
+        project=project,
         adapter=adapter,
         connection=connection,
         database=database,
@@ -160,9 +163,7 @@ def gather_warehouse_snapshot(
     columns: dict[str, tuple[ColumnInfo, ...]] = _gather_columns(
         adapter=adapter,
         connection=connection,
-        database=database,
-        schemas=query_schemas,
-        names=metadata_names,
+        relations=relations,
     )
     fingerprints: WarehouseFingerprints = _gather_fingerprints(
         adapter=adapter,
@@ -171,6 +172,7 @@ def gather_warehouse_snapshot(
         database=database,
         schemas=query_schemas,
         fingerprint_state_schemas=fingerprint_state_schemas,
+        node_names=_selected_node_names(selected_keys),
     )
 
     cursor_snapshots: dict[str, ModelCursorSnapshot] = {}
@@ -195,44 +197,62 @@ def gather_warehouse_snapshot(
     )
 
 
-def _resolve_database(project: CompiledProject) -> str | None:
+def _resolve_database(
+    *,
+    project: CompiledProject,
+    selected_keys: frozenset[CompiledObjectKey] | None,
+) -> str | None:
     """Extract the database from the first model target that declares one."""
 
-    if project.effective_target_database is not None:
-        return project.effective_target_database
     model: CompiledModel
     for model in project.models:
+        if selected_keys is not None and model.key not in selected_keys:
+            continue
         if model.destination.database is not None:
             return model.destination.database
     seed: CompiledSeed
     for seed in project.seeds:
+        if selected_keys is not None and seed.key not in selected_keys:
+            continue
         if seed.destination.database is not None:
             return seed.destination.database
     function: CompiledFunction
     for function in project.functions:
+        if selected_keys is not None and function.key not in selected_keys:
+            continue
         if function.destination.database is not None:
             return function.destination.database
-    return None
+    return project.effective_target_database
 
 
-def _collect_target_schemas(project: CompiledProject) -> tuple[str, ...]:
+def _collect_target_schemas(
+    *,
+    project: CompiledProject,
+    selected_keys: frozenset[CompiledObjectKey] | None,
+) -> tuple[str, ...]:
     """Collect distinct non-null target schemas from models, seeds, and functions."""
 
     schemas: set[str] = set()
-    if project.effective_target_schema is not None:
-        schemas.add(project.effective_target_schema)
     model: CompiledModel
     for model in project.models:
+        if selected_keys is not None and model.key not in selected_keys:
+            continue
         if model.destination.schema is not None:
             schemas.add(model.destination.schema)
     seed: CompiledSeed
     for seed in project.seeds:
+        if selected_keys is not None and seed.key not in selected_keys:
+            continue
         if seed.destination.schema is not None:
             schemas.add(seed.destination.schema)
     function: CompiledFunction
     for function in project.functions:
+        if selected_keys is not None and function.key not in selected_keys:
+            continue
         if function.destination.schema is not None:
             schemas.add(function.destination.schema)
+    if not schemas and project.effective_target_schema is not None:
+        schemas.add(project.effective_target_schema)
     return tuple(sorted(schemas))
 
 
@@ -324,6 +344,7 @@ def _model_upstream_names(
 
 def _gather_relations(
     *,
+    project: CompiledProject,
     adapter: BaseAdapter,
     connection: Any,
     database: str | None,
@@ -336,6 +357,16 @@ def _gather_relations(
         connection=connection, database=database, schemas=schemas, names=names
     )
     result: dict[str, RelationInfo] = {}
+    logical_names_by_identity: dict[tuple[str | None, str | None, str], str] = {}
+    model: CompiledModel
+    for model in project.models:
+        logical_names_by_identity[_location_identity(model.destination)] = model.name
+    seed: CompiledSeed
+    for seed in project.seeds:
+        logical_names_by_identity[_location_identity(seed.destination)] = seed.name
+    function: CompiledFunction
+    for function in project.functions:
+        logical_names_by_identity[_location_identity(function.destination)] = function.name
     fingerprint_schemas: set[str] = set()
     freshness_schemas: set[str] = set()
     relation: RelationInfo
@@ -348,24 +379,39 @@ def _gather_relations(
             if relation.schema is not None:
                 freshness_schemas.add(relation.schema.lower())
             continue
-        result[relation.name] = relation
+        result[logical_names_by_identity.get(relation.identity, relation.name)] = relation
     return result, frozenset(fingerprint_schemas), frozenset(freshness_schemas)
+
+
+def _location_identity(
+    location: CompiledRelationLocation,
+) -> tuple[str | None, str | None, str]:
+    return (
+        None if location.database is None else location.database.lower(),
+        None if location.schema is None else location.schema.lower(),
+        location.name.lower(),
+    )
 
 
 def _gather_columns(
     *,
     adapter: BaseAdapter,
     connection: Any,
-    database: str | None,
-    schemas: tuple[str, ...] | None,
-    names: tuple[str, ...] | None,
+    relations: dict[str, RelationInfo],
 ) -> dict[str, tuple[ColumnInfo, ...]]:
     """Fetch column metadata for all relations across target schemas."""
 
-    all_columns: dict[str, tuple[ColumnInfo, ...]] = adapter.get_all_columns(
-        connection=connection, database=database, schemas=schemas, names=names
+    physical_relations: tuple[RelationInfo, ...] = tuple(relations.values())
+    all_columns: dict[
+        tuple[str | None, str | None, str], tuple[ColumnInfo, ...]
+    ] = adapter.get_columns_for_relations(
+        connection=connection, relations=physical_relations
     )
-    return {name: cols for name, cols in all_columns.items() if name != FINGERPRINT_TABLE_NAME}
+    return {
+        logical_name: all_columns[relation.identity]
+        for logical_name, relation in relations.items()
+        if relation.identity in all_columns
+    }
 
 
 def _gather_fingerprints(
@@ -376,6 +422,7 @@ def _gather_fingerprints(
     database: str | None,
     schemas: tuple[str, ...] | None,
     fingerprint_state_schemas: frozenset[str],
+    node_names: tuple[str, ...] | None,
 ) -> WarehouseFingerprints:
     """Read latest fingerprints across all target schemas grouped by node type."""
 
@@ -395,6 +442,8 @@ def _gather_fingerprints(
             schema=schema,
             render_qualified_name=adapter.render_qualified_name,
             render_read_latest_sql=adapter.render_read_latest_fingerprints_sql,
+            node_names=node_names,
+            filtered_node_types=(NODE_TYPE_MODEL, *FUNCTION_NODE_TYPES, NODE_TYPE_SEED),
         )
         node_name: str
         fingerprint: Fingerprint
@@ -420,6 +469,14 @@ def _gather_fingerprints(
         seeds=seed_fingerprints,
         python_nodes=python_fingerprints,
     )
+
+
+def _selected_node_names(
+    selected_keys: frozenset[CompiledObjectKey] | None,
+) -> tuple[str, ...] | None:
+    if selected_keys is None:
+        return None
+    return tuple(sorted({key.name for key in selected_keys}))
 
 
 def _gather_cursor_snapshots(

--- a/src/sqlbuild/compiler/planner/_helpers/warehouse/source_freshness.py
+++ b/src/sqlbuild/compiler/planner/_helpers/warehouse/source_freshness.py
@@ -52,6 +52,7 @@ def build_planner_source_freshness_result(
                 state_schema: state_schema.lower() in freshness_state_schemas
                 for state_schema in state_schemas
             },
+            filter_previous_to_sources=True,
         )
     )
     return replace(

--- a/src/sqlbuild/compiler/python_nodes/models.py
+++ b/src/sqlbuild/compiler/python_nodes/models.py
@@ -98,6 +98,23 @@ class PythonNodeGraph:
     nodes_by_name: dict[str, DiscoveredPythonNode]
     nodes_by_typed_selector: dict[str, DiscoveredPythonNode]
 
+    def selected_sql_refs(self, *, selected_names: frozenset[str]) -> frozenset[SqlResourceRef]:
+        """Return SQL references required by a selected Python-node closure."""
+
+        refs: set[SqlResourceRef] = set()
+        pending: list[str] = list(selected_names)
+        visited: set[str] = set()
+        while pending:
+            node_name: str = pending.pop()
+            if node_name in visited:
+                continue
+            visited.add(node_name)
+            node: DiscoveredPythonNode | None = self.nodes_by_name.get(node_name)
+            if node is not None:
+                refs.update(node.sql_deps)
+            pending.extend(self.upstream_deps.get(node_name, ()))
+        return frozenset(refs)
+
 
 @dataclass(frozen=True)
 class PythonSqlSelection:

--- a/src/sqlbuild/compiler/source_freshness/_helpers/planning.py
+++ b/src/sqlbuild/compiler/source_freshness/_helpers/planning.py
@@ -55,6 +55,7 @@ def build_direct_source_freshness_planning_result(
     run_id: str,
     render_qualified_name: Callable[..., str | None],
     state_table_exists_by_schema: dict[str, bool],
+    filter_previous_to_sources: bool = False,
 ) -> DirectSourceFreshnessPlanningResult:
     previous_records_by_identity: dict[SourceFreshnessIdentity, SourceFreshnessRecord] = (
         _read_previous_records(
@@ -64,6 +65,11 @@ def build_direct_source_freshness_planning_result(
             state_schemas=state_schemas,
             render_qualified_name=render_qualified_name,
             state_table_exists_by_schema=state_table_exists_by_schema,
+            source_names=(
+                tuple(sorted(source.name for source in sources))
+                if filter_previous_to_sources
+                else None
+            ),
         )
     )
     observed_records: list[SourceFreshnessRecord] = []
@@ -214,6 +220,7 @@ def _read_previous_records(
     state_schemas: tuple[str, ...],
     render_qualified_name: Callable[..., str | None],
     state_table_exists_by_schema: dict[str, bool],
+    source_names: tuple[str, ...] | None,
 ) -> dict[SourceFreshnessIdentity, SourceFreshnessRecord]:
     previous_records_by_identity: dict[SourceFreshnessIdentity, SourceFreshnessRecord] = {}
     state_schema: str
@@ -227,6 +234,7 @@ def _read_previous_records(
             schema=state_schema,
             render_qualified_name=render_qualified_name,
             render_read_latest_sql=adapter.render_read_latest_source_freshness_sql,
+            source_names=source_names,
         )
         previous_records_by_identity = _merged_latest_previous_records(
             previous_records_by_identity=previous_records_by_identity,

--- a/src/sqlbuild/compiler/source_freshness/main/_planning.py
+++ b/src/sqlbuild/compiler/source_freshness/main/_planning.py
@@ -25,6 +25,7 @@ def build_direct_source_freshness_planning_result(
     run_id: str,
     render_qualified_name: Callable[..., str | None],
     state_table_exists_by_schema: dict[str, bool],
+    filter_previous_to_sources: bool = False,
 ) -> DirectSourceFreshnessPlanningResult:
     """Observe direct source freshness and compare it to latest append-only state."""
 
@@ -38,4 +39,5 @@ def build_direct_source_freshness_planning_result(
         run_id=run_id,
         render_qualified_name=render_qualified_name,
         state_table_exists_by_schema=state_table_exists_by_schema,
+        filter_previous_to_sources=filter_previous_to_sources,
     )

--- a/src/sqlbuild/compiler/source_freshness/main/read.py
+++ b/src/sqlbuild/compiler/source_freshness/main/read.py
@@ -27,6 +27,7 @@ def read_latest_source_freshness(
     schema: str,
     render_qualified_name: Callable[..., str | None],
     render_read_latest_sql: Callable[..., str],
+    source_names: tuple[str, ...] | None = None,
 ) -> SourceFreshnessSet:
     """Read latest source freshness rows, trusting the caller-resolved table existence."""
 
@@ -42,6 +43,16 @@ def read_latest_source_freshness(
         database=database,
         schema=schema,
     )
+    if source_names is not None:
+        if not source_names:
+            return SourceFreshnessSet(schema=schema, records={})
+        literals: str = ", ".join(
+            "'" + source_name.replace("'", "''") + "'" for source_name in source_names
+        )
+        read_sql = (
+            f"SELECT * FROM ({read_sql}) AS __sqlbuild_relevant "
+            f"WHERE source_name IN ({literals})"
+        )
     try:
         result: Any = execute(connection=connection, sql=read_sql)
     except Exception as error:

--- a/src/sqlbuild/executor/pipeline/_helpers/connections.py
+++ b/src/sqlbuild/executor/pipeline/_helpers/connections.py
@@ -1,0 +1,59 @@
+"""Concurrent executor connection setup."""
+
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+
+
+def open_worker_connections(
+    *,
+    adapter: BaseAdapter,
+    connection_config: dict[str, object],
+    connection_count: int,
+) -> tuple[Any, ...]:
+    """Open worker connections concurrently and clean up partial success on failure."""
+
+    opened_connections: list[Any] = []
+    first_error: BaseException | None = None
+    with ThreadPoolExecutor(max_workers=connection_count) as executor:
+        futures: tuple[Future[Any], ...] = tuple(
+            executor.submit(adapter.connect, connection_config) for _ in range(connection_count)
+        )
+        future: Future[Any]
+        for future in futures:
+            try:
+                opened_connections.append(future.result())
+            except BaseException as error:
+                if first_error is None:
+                    first_error = error
+    if first_error is not None:
+        close_connections(
+            adapter=adapter,
+            connections=tuple(opened_connections),
+            active_error=first_error,
+        )
+        raise first_error
+    return tuple(opened_connections)
+
+
+def close_connections(
+    *,
+    adapter: BaseAdapter,
+    connections: tuple[Any, ...],
+    active_error: BaseException | None = None,
+) -> None:
+    """Attempt every close, raising cleanup failure only when no error is already active."""
+
+    first_close_error: BaseException | None = None
+    connection: Any
+    for connection in connections:
+        try:
+            adapter.close(connection)
+        except BaseException as error:
+            if first_close_error is None:
+                first_close_error = error
+    if active_error is None and first_close_error is not None:
+        raise first_close_error

--- a/src/sqlbuild/executor/pipeline/_helpers/graph_width.py
+++ b/src/sqlbuild/executor/pipeline/_helpers/graph_width.py
@@ -1,0 +1,12 @@
+"""Execution graph concurrency sizing."""
+
+from __future__ import annotations
+
+from sqlbuild.compiler.planner.models import PlanOutput
+
+
+def runnable_graph_width(*, plan: PlanOutput) -> int:
+    """Return a safe worker cap that cannot underestimate asynchronous overlap."""
+
+    executable_node_count: int = len(plan.execution_order)
+    return max(1, executable_node_count)

--- a/src/sqlbuild/executor/pipeline/main/run.py
+++ b/src/sqlbuild/executor/pipeline/main/run.py
@@ -26,6 +26,11 @@ from sqlbuild.executor.build.models import (
 from sqlbuild.executor.pipeline._helpers.auditing import (
     run_audit_pipeline as run_audit_pipeline,
 )
+from sqlbuild.executor.pipeline._helpers.connections import (
+    close_connections,
+    open_worker_connections,
+)
+from sqlbuild.executor.pipeline._helpers.graph_width import runnable_graph_width
 from sqlbuild.executor.pipeline._helpers.scenario import (
     run_scenario_capture_pipeline as run_scenario_capture_pipeline,
 )
@@ -102,7 +107,9 @@ def _run_build_pipeline(
         customizations=customizations,
         initial_state=initial_state,
     )
-    effective_concurrency: int = max(1, runtime.max_concurrency)
+    effective_concurrency: int = min(
+        max(1, runtime.max_concurrency), runnable_graph_width(plan=plan)
+    )
     logger: logging.Logger = logging.getLogger("sqlbuild.executor.pipeline")
     external_source_load_results: ExternalSourceLoadResults = (
         run_external_source_loads_before_connections(
@@ -126,40 +133,47 @@ def _run_build_pipeline(
         initial_failed_keys=inputs.initial_state.initial_failed_keys
         | external_source_load_results.failed_keys,
     )
-    _ = _prepare_build_schemas(
-        plan=plan,
-        adapter=adapter,
-        connection_config=connection_config,
-    )
     worker_connections: list[Any] = []
     scheduler_connection: Any | None = None
+    physical_connection_count: int = effective_concurrency + 1
     if inputs.callbacks.on_connection_start is not None:
-        inputs.callbacks.on_connection_start(effective_concurrency)
+        inputs.callbacks.on_connection_start(physical_connection_count)
     start: float = time.monotonic()
     try:
         logger.debug("open scheduler connection")
         scheduler_connection = adapter.connect(connection_config)
-        _i: int
-        for _i in range(effective_concurrency):
-            logger.debug("open worker connection index=%s", _i)
-            worker_connections.append(adapter.connect(connection_config))
-    except Exception:
+        _ = _prepare_build_schemas(
+            plan=plan,
+            adapter=adapter,
+            connection_config=connection_config,
+            connection=scheduler_connection,
+        )
+        worker_connections = list(
+            open_worker_connections(
+            adapter=adapter,
+            connection_config=connection_config,
+            connection_count=effective_concurrency,
+            )
+        )
+    except BaseException as error:
         if inputs.callbacks.on_connection_error is not None:
             inputs.callbacks.on_connection_error(
-                effective_concurrency, elapsed_seconds=time.monotonic() - start
+                physical_connection_count, elapsed_seconds=time.monotonic() - start
             )
-        conn: Any
-        for _i, conn in enumerate(worker_connections):
-            logger.debug("close worker connection index=%s", _i)
-            adapter.close(conn)
-        if scheduler_connection is not None:
-            logger.debug("close scheduler connection")
-            adapter.close(scheduler_connection)
+        cleanup_connections: tuple[Any, ...] = tuple(worker_connections) + (
+            () if scheduler_connection is None else (scheduler_connection,)
+        )
+        _ = close_connections(
+            adapter=adapter,
+            connections=cleanup_connections,
+            active_error=error,
+        )
         raise
     if inputs.callbacks.on_connection_complete is not None:
         inputs.callbacks.on_connection_complete(
-            effective_concurrency, elapsed_seconds=time.monotonic() - start
+            physical_connection_count, elapsed_seconds=time.monotonic() - start
         )
+    execution_error: BaseException | None = None
     try:
         return execute_build_plan(
             plan=plan,
@@ -172,14 +186,18 @@ def _run_build_pipeline(
             customizations=inputs.customizations,
             initial_state=merged_initial_state,
         )
+    except BaseException as error:
+        execution_error = error
+        raise
     finally:
-        conn: Any
-        for _i, conn in enumerate(worker_connections):
-            logger.debug("close worker connection index=%s", _i)
-            adapter.close(conn)
-        logger.debug("close scheduler connection")
-        if scheduler_connection is not None:
-            adapter.close(scheduler_connection)
+        cleanup_connections: tuple[Any, ...] = tuple(worker_connections) + (
+            () if scheduler_connection is None else (scheduler_connection,)
+        )
+        _ = close_connections(
+            adapter=adapter,
+            connections=cleanup_connections,
+            active_error=execution_error,
+        )
 
 
 def _prepare_build_schemas(
@@ -187,6 +205,7 @@ def _prepare_build_schemas(
     plan: PlanOutput,
     adapter: BaseAdapter,
     connection_config: dict[str, object],
+    connection: Any | None = None,
 ) -> None:
     schemas: set[tuple[str | None, str]] = set()
     for entry in (*plan.model_entries, *plan.seed_entries, *plan.function_entries):
@@ -199,15 +218,19 @@ def _prepare_build_schemas(
     if not schemas:
         return
 
-    connection: Any = adapter.connect(connection_config)
+    owned_connection: bool = connection is None
+    schema_connection: Any = (
+        connection if connection is not None else adapter.connect(connection_config)
+    )
     recorder: StatementRecorder = StatementRecorder()
     try:
         for database, schema in sorted(schemas, key=lambda item: (item[0] or "", item[1])):
             adapter.ensure_schema(
-                connection=connection,
+                connection=schema_connection,
                 database=database,
                 schema=schema,
                 statement_recorder=recorder,
             )
     finally:
-        adapter.close(connection)
+        if owned_connection:
+            adapter.close(schema_connection)

--- a/src/sqlbuild/virtual/executor/_helpers/build.py
+++ b/src/sqlbuild/virtual/executor/_helpers/build.py
@@ -34,9 +34,7 @@ from sqlbuild.compiler.pipeline.main.materializations import load_custom_materia
 from sqlbuild.compiler.pipeline.main.prepare_versions import (
     load_custom_prepare_version_functions,
 )
-from sqlbuild.compiler.pipeline.main.relation_targets import (
-    build_python_relation_targets,
-)
+from sqlbuild.compiler.pipeline.main.relation_targets import build_python_relation_targets
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult, ProjectGraph, PythonPlanEntry
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.main.changes.replay_on_change import resolve_replay_on_change
@@ -988,6 +986,12 @@ def _prepare_virtual_python_execution(
             adapter=runtime.adapter,
             project=project,
             plan_output=plan_output,
+            required_refs=python_graph.selected_sql_refs(
+                selected_names=(
+                    lifecycle_plan.ingress_python_node_names
+                    | lifecycle_plan.read_side_python_node_names
+                ),
+            ),
         ),
         selected_python_node_names=python_selection.python_node_names,
     )

--- a/tests/unit/src/sqlbuild/adapter/relations/main/get_columns_for_relations/_test_types.py
+++ b/tests/unit/src/sqlbuild/adapter/relations/main/get_columns_for_relations/_test_types.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class QualifiedBulkColumnsTestCase:
+    description: str
+    expected_query_count: int
+    expected_identity_count: int
+    expected_names_filter_is_none: bool = False

--- a/tests/unit/src/sqlbuild/adapter/relations/main/get_columns_for_relations/test_get_columns_for_relations.py
+++ b/tests/unit/src/sqlbuild/adapter/relations/main/get_columns_for_relations/test_get_columns_for_relations.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.adapter.contract.models import ColumnInfo, RelationInfo
+from tests.unit.src.sqlbuild.adapter.relations.main.get_columns_for_relations._test_types import (
+    QualifiedBulkColumnsTestCase,
+)
+
+
+class _BulkRecordingAdapter(BaseAdapter):
+    def __init__(self) -> None:
+        self.queries: list[tuple[str | None, tuple[str, ...] | None, tuple[str, ...] | None]] = []
+        self.inventory_names: dict[tuple[str | None, str], tuple[str, ...]] = {}
+
+    def connect(self, config: dict[str, object]) -> object:
+        del config
+        return object()
+
+    def close(self, connection: object) -> None:
+        del connection
+
+    def execute(self, connection: Any, sql: str) -> object:
+        del connection
+        return sql
+
+    def get_all_columns(
+        self,
+        *,
+        connection: Any,
+        database: str | None,
+        schemas: tuple[str, ...] | None,
+        names: tuple[str, ...] | None = None,
+    ) -> dict[str, tuple[ColumnInfo, ...]]:
+        del connection
+        self.queries.append((database, schemas, names))
+        schema: str = "none" if schemas is None else schemas[0]
+        requested_names: tuple[str, ...] = (
+            self.inventory_names.get((database, schema), ()) if names is None else names
+        )
+        return {
+            name: (ColumnInfo(name="id", type=f"{database}.{schema}.{name}"),)
+            for name in requested_names
+        }
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        QualifiedBulkColumnsTestCase(
+            description="groups bulk reads by database and schema without identity collisions",
+            expected_query_count=3,
+            expected_identity_count=4,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_qualified_relations_when_getting_columns_then_groups_bulk_queries_and_keys_results(
+    test_case: QualifiedBulkColumnsTestCase,
+) -> None:
+    relations: tuple[RelationInfo, ...] = (
+        RelationInfo(database="DB_A", schema="SCHEMA_A", name="SHARED", relation_type="table"),
+        RelationInfo(database="DB_A", schema="SCHEMA_A", name="ORDERS", relation_type="table"),
+        RelationInfo(database="DB_A", schema="SCHEMA_B", name="SHARED", relation_type="view"),
+        RelationInfo(database="DB_B", schema="SCHEMA_A", name="SHARED", relation_type="table"),
+    )
+    adapter: _BulkRecordingAdapter = _BulkRecordingAdapter()
+
+    columns: dict[
+        tuple[str | None, str | None, str], tuple[ColumnInfo, ...]
+    ] = adapter.get_columns_for_relations(connection=object(), relations=relations)
+
+    assert len(adapter.queries) == test_case.expected_query_count
+    assert len(columns) == test_case.expected_identity_count
+    assert columns[("db_a", "schema_a", "shared")][0].type == "DB_A.SCHEMA_A.SHARED"
+    assert columns[("db_a", "schema_b", "shared")][0].type == "DB_A.SCHEMA_B.SHARED"
+    assert columns[("db_b", "schema_a", "shared")][0].type == "DB_B.SCHEMA_A.SHARED"
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        QualifiedBulkColumnsTestCase(
+            description="broad scope above 250 relations uses unrestricted bulk metadata query",
+            expected_query_count=1,
+            expected_identity_count=251,
+            expected_names_filter_is_none=True,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_broad_relation_scope_when_getting_columns_then_preserves_unrestricted_bulk_query(
+    test_case: QualifiedBulkColumnsTestCase,
+) -> None:
+    relation_names: tuple[str, ...] = tuple(f"RELATION_{index}" for index in range(251))
+    relations: tuple[RelationInfo, ...] = tuple(
+        RelationInfo(
+            database="DB_A",
+            schema="SCHEMA_A",
+            name=name,
+            relation_type="table",
+        )
+        for name in relation_names
+    )
+    adapter: _BulkRecordingAdapter = _BulkRecordingAdapter()
+    adapter.inventory_names[("DB_A", "SCHEMA_A")] = relation_names
+
+    columns: dict[
+        tuple[str | None, str | None, str], tuple[ColumnInfo, ...]
+    ] = adapter.get_columns_for_relations(connection=object(), relations=relations)
+
+    assert len(adapter.queries) == test_case.expected_query_count
+    assert len(columns) == test_case.expected_identity_count
+    assert (adapter.queries[0][2] is None) is test_case.expected_names_filter_is_none

--- a/tests/unit/src/sqlbuild/adapters/snowflake/_test_types.py
+++ b/tests/unit/src/sqlbuild/adapters/snowflake/_test_types.py
@@ -144,3 +144,10 @@ class SnowflakeInformationSchemaFilterTestCase:
     schemas: tuple[str, ...]
     names: tuple[str, ...]
     expected_params: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SnowflakeQualifiedColumnInspectionTestCase:
+    description: str
+    relation_count: int
+    expected_statement_count: int

--- a/tests/unit/src/sqlbuild/adapters/snowflake/helpers.py
+++ b/tests/unit/src/sqlbuild/adapters/snowflake/helpers.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import sys
+from itertools import cycle, islice
 from types import ModuleType
 from typing import Any
 
-from sqlbuild.adapter.contract.models import ColumnInfo
+from sqlbuild.adapter.contract.models import ColumnInfo, RelationInfo
 
 
 class FakeSnowflakeDescribeCursor:
@@ -59,7 +60,7 @@ class FakeSnowflakeMetadataCursor:
         self.executed_params: tuple[object, ...] | None = None
         self.closed: bool = False
 
-    def execute(self, sql: str, params: tuple[object, ...]) -> None:
+    def execute(self, sql: str, params: tuple[object, ...] | None = None) -> None:
         self.executed_sql = sql
         self.executed_params = params
 
@@ -81,6 +82,128 @@ class FakeSnowflakeMetadataConnection:
 
     def cursor(self) -> FakeSnowflakeMetadataCursor:
         return self._cursor
+
+
+class FakeSnowflakeMetadataSequenceConnection:
+    """Connection double returning one metadata cursor per exact relation query."""
+
+    def __init__(self, cursors: tuple[FakeSnowflakeMetadataCursor, ...]) -> None:
+        self._cursors: list[FakeSnowflakeMetadataCursor] = list(cursors)
+        self.returned_cursors: list[FakeSnowflakeMetadataCursor] = []
+
+    def cursor(self) -> FakeSnowflakeMetadataCursor:
+        cursor: FakeSnowflakeMetadataCursor = self._cursors.pop(0)
+        self.returned_cursors.append(cursor)
+        return cursor
+
+
+def build_qualified_column_relations(*, count: int) -> tuple[RelationInfo, ...]:
+    """Build mixed table/view relations with a duplicate name across two schemas."""
+
+    names: tuple[str, ...] = (
+        "SHARED",
+        "SHARED",
+        *(f"RELATION_{index}" for index in range(2, count)),
+    )
+    schemas: tuple[str, ...] = tuple(islice(cycle(("SCHEMA_A", "SCHEMA_B")), count))
+    relation_types: tuple[str, ...] = tuple(
+        islice(cycle(("BASE TABLE", "VIEW")), count)
+    )
+    return tuple(
+        RelationInfo(
+            database="RACING",
+            schema=schema,
+            name=name,
+            relation_type=relation_type,
+        )
+        for name, schema, relation_type in zip(names, schemas, relation_types, strict=True)
+    )
+
+
+def build_show_columns_rows(*, relation: RelationInfo) -> list[tuple[object, ...]]:
+    """Build documented SHOW COLUMNS rows for numeric and text columns."""
+
+    return [
+        (
+            relation.name,
+            relation.schema,
+            "ID",
+            '{"type":"FIXED","precision":20,"scale":4,"nullable":false}',
+            False,
+            None,
+            "COLUMN",
+            None,
+            None,
+            relation.database,
+        ),
+        (
+            relation.name,
+            relation.schema,
+            "LABEL",
+            '{"type":"TEXT","length":128,"byteLength":512,"nullable":true}',
+            True,
+            None,
+            "COLUMN",
+            None,
+            None,
+            relation.database,
+        ),
+    ]
+
+
+def build_bulk_columns_rows(
+    *, relations: tuple[RelationInfo, ...]
+) -> list[tuple[object, ...]]:
+    """Build INFORMATION_SCHEMA rows equivalent to the exact SHOW fixtures."""
+
+    rows: list[tuple[object, ...]] = []
+    relation: RelationInfo
+    for relation in relations:
+        rows.extend(
+            (
+                (relation.database, relation.schema, relation.name, "ID", "NUMBER", 20, 4, None),
+                (
+                    relation.database,
+                    relation.schema,
+                    relation.name,
+                    "LABEL",
+                    "TEXT",
+                    None,
+                    None,
+                    128,
+                ),
+            )
+        )
+    return rows
+
+
+def expected_qualified_columns(
+    *, relations: tuple[RelationInfo, ...]
+) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+    """Build normalized expected columns keyed by physical identity."""
+
+    return {
+        relation.identity: (
+            ColumnInfo(name="id", type="NUMBER(20,4)"),
+            ColumnInfo(name="label", type="VARCHAR(128)"),
+        )
+        for relation in relations
+    }
+
+
+def build_bulk_sequence_connection(
+    *, relations: tuple[RelationInfo, ...], chunk_size: int
+) -> FakeSnowflakeMetadataSequenceConnection:
+    """Build one bulk metadata cursor per expected relation chunk."""
+
+    cursors: list[FakeSnowflakeMetadataCursor] = []
+    chunk_start: int
+    for chunk_start in range(0, len(relations), chunk_size):
+        chunk: tuple[RelationInfo, ...] = relations[chunk_start : chunk_start + chunk_size]
+        cursors.append(
+            FakeSnowflakeMetadataCursor(rows=build_bulk_columns_rows(relations=chunk))
+        )
+    return FakeSnowflakeMetadataSequenceConnection(tuple(cursors))
 
 
 def describe_equivalent_numeric_relation(

--- a/tests/unit/src/sqlbuild/adapters/snowflake/test_client.py
+++ b/tests/unit/src/sqlbuild/adapters/snowflake/test_client.py
@@ -11,6 +11,7 @@ from sqlbuild.adapter.contract.exceptions import AdapterUserError
 from sqlbuild.adapter.contract.models import (
     ColumnInfo,
     ExpressionInferenceProfile,
+    RelationInfo,
     SchemaDiffResult,
     TableFreshnessMetadata,
     TableFreshnessRequest,
@@ -31,6 +32,7 @@ from tests.unit.src.sqlbuild.adapters.snowflake._test_types import (
     SnowflakeMergeExclusionTestCase,
     SnowflakeMoveOrCopyRelationTestCase,
     SnowflakePruneSqlTestCase,
+    SnowflakeQualifiedColumnInspectionTestCase,
     SnowflakeQueryColumnNamesTestCase,
     SnowflakeRenderCloneTestCase,
     SnowflakeRenderCursorBoundLiteralTestCase,
@@ -47,7 +49,13 @@ from tests.unit.src.sqlbuild.adapters.snowflake.helpers import (
     FakeSnowflakeDescribeCursor,
     FakeSnowflakeMetadataConnection,
     FakeSnowflakeMetadataCursor,
+    FakeSnowflakeMetadataSequenceConnection,
+    build_bulk_columns_rows,
+    build_bulk_sequence_connection,
+    build_qualified_column_relations,
+    build_show_columns_rows,
     describe_equivalent_numeric_relation,
+    expected_qualified_columns,
     install_fake_snowflake_connector,
 )
 
@@ -296,6 +304,137 @@ def test_given_lowercase_schema_when_getting_all_columns_then_uppercases_filter_
     assert "UPPER(table_" not in cursor.executed_sql
     assert tuple(columns) == ("race__stg_horse",)
     assert columns["race__stg_horse"][0].name == "id"
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SnowflakeQualifiedColumnInspectionTestCase(
+            description="32 mixed relations use exact SHOW and match bulk normalization",
+            relation_count=32,
+            expected_statement_count=32,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_32_mixed_relations_when_getting_columns_then_exact_and_bulk_are_equivalent(
+    test_case: SnowflakeQualifiedColumnInspectionTestCase,
+) -> None:
+    relations: tuple[RelationInfo, ...] = build_qualified_column_relations(
+        count=test_case.relation_count
+    )
+    ordered_relations: tuple[RelationInfo, ...] = tuple(
+        sorted(relations, key=lambda relation: tuple(part or "" for part in relation.identity))
+    )
+    exact_connection: FakeSnowflakeMetadataSequenceConnection = (
+        FakeSnowflakeMetadataSequenceConnection(
+            tuple(
+                FakeSnowflakeMetadataCursor(rows=build_show_columns_rows(relation=relation))
+                for relation in ordered_relations
+            )
+        )
+    )
+    bulk_cursor: FakeSnowflakeMetadataCursor = FakeSnowflakeMetadataCursor(
+        rows=build_bulk_columns_rows(relations=relations)
+    )
+    adapter: SnowflakeAdapter = SnowflakeAdapter()
+
+    exact_columns: dict[
+        tuple[str | None, str | None, str], tuple[ColumnInfo, ...]
+    ] = adapter.get_columns_for_relations(
+        connection=cast(Any, exact_connection), relations=relations
+    )
+    bulk_columns: dict[
+        tuple[str | None, str | None, str], tuple[ColumnInfo, ...]
+    ] = adapter._get_columns_for_relations_bulk(
+        connection=cast(Any, FakeSnowflakeMetadataConnection(bulk_cursor)),
+        relations=relations,
+    )
+
+    executed_sql: tuple[str, ...] = tuple(
+        cursor.executed_sql or "" for cursor in exact_connection.returned_cursors
+    )
+    assert len(executed_sql) == test_case.expected_statement_count
+    assert any("SHOW COLUMNS IN TABLE" in sql for sql in executed_sql)
+    assert any("SHOW COLUMNS IN VIEW" in sql for sql in executed_sql)
+    assert exact_columns == expected_qualified_columns(relations=relations)
+    assert bulk_columns == exact_columns
+    assert ("racing", "schema_a", "shared") in exact_columns
+    assert ("racing", "schema_b", "shared") in exact_columns
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SnowflakeQualifiedColumnInspectionTestCase(
+            description="33 mixed relations use one database-qualified bulk query",
+            relation_count=33,
+            expected_statement_count=1,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_33_mixed_relations_when_getting_columns_then_uses_bulk_query(
+    test_case: SnowflakeQualifiedColumnInspectionTestCase,
+) -> None:
+    relations: tuple[RelationInfo, ...] = build_qualified_column_relations(
+        count=test_case.relation_count
+    )
+    cursor: FakeSnowflakeMetadataCursor = FakeSnowflakeMetadataCursor(
+        rows=build_bulk_columns_rows(relations=relations)
+    )
+    adapter: SnowflakeAdapter = SnowflakeAdapter()
+
+    columns: dict[
+        tuple[str | None, str | None, str], tuple[ColumnInfo, ...]
+    ] = adapter.get_columns_for_relations(
+        connection=cast(Any, FakeSnowflakeMetadataConnection(cursor)), relations=relations
+    )
+
+    assert cursor.executed_sql is not None
+    assert test_case.expected_statement_count == 1
+    assert 'FROM "RACING".information_schema.columns' in cursor.executed_sql
+    assert "table_schema = %s AND table_name IN" in cursor.executed_sql
+    assert columns == expected_qualified_columns(relations=relations)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SnowflakeQualifiedColumnInspectionTestCase(
+            description="251 relations use two bounded bulk queries and merge all results",
+            relation_count=251,
+            expected_statement_count=2,
+        ),
+        SnowflakeQualifiedColumnInspectionTestCase(
+            description="1000 relations use five bounded bulk queries and merge all results",
+            relation_count=1000,
+            expected_statement_count=5,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_large_relation_set_when_getting_columns_then_chunks_and_merges_bulk_results(
+    test_case: SnowflakeQualifiedColumnInspectionTestCase,
+) -> None:
+    relations: tuple[RelationInfo, ...] = build_qualified_column_relations(
+        count=test_case.relation_count
+    )
+    ordered_relations: tuple[RelationInfo, ...] = tuple(
+        sorted(relations, key=lambda relation: tuple(part or "" for part in relation.identity))
+    )
+    connection: FakeSnowflakeMetadataSequenceConnection = build_bulk_sequence_connection(
+        relations=ordered_relations, chunk_size=200
+    )
+
+    columns: dict[
+        tuple[str | None, str | None, str], tuple[ColumnInfo, ...]
+    ] = SnowflakeAdapter().get_columns_for_relations(
+        connection=cast(Any, connection), relations=relations
+    )
+
+    assert len(connection.returned_cursors) == test_case.expected_statement_count
+    assert columns == expected_qualified_columns(relations=relations)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/fingerprints/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/fingerprints/main/_test_types.py
@@ -25,6 +25,13 @@ class ReadLatestFingerprintsRendererTestCase:
 
 
 @dataclass(frozen=True)
+class ReadLatestFingerprintsFilterTestCase:
+    description: str
+    node_names: tuple[str, ...]
+    expected_sql_fragment: str
+
+
+@dataclass(frozen=True)
 class WriteFingerprintIndexTestCase:
     description: str
     expected_index_sql: str

--- a/tests/unit/src/sqlbuild/compiler/fingerprints/main/test_read.py
+++ b/tests/unit/src/sqlbuild/compiler/fingerprints/main/test_read.py
@@ -12,6 +12,7 @@ from sqlbuild.compiler.fingerprints.main.write import write_fingerprint
 from sqlbuild.compiler.fingerprints.models import Fingerprint, FingerprintSet
 from tests.unit.src.sqlbuild.compiler.fingerprints.main._test_types import (
     ReadLatestFingerprintsErrorTestCase,
+    ReadLatestFingerprintsFilterTestCase,
     ReadLatestFingerprintsRendererTestCase,
     ReadLatestFingerprintsTestCase,
     WriteFingerprintIndexTestCase,
@@ -106,6 +107,37 @@ def test_given_latest_sql_renderer_when_reading_then_executes_renderer_sql(
     )
 
     assert execute.executed_sql == [test_case.expected_executed_sql]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ReadLatestFingerprintsFilterTestCase(
+            description="filters latest state to escaped relevant node names",
+            node_names=("country_codes", "quoted'name"),
+            expected_sql_fragment="WHERE node_name IN ('country_codes', 'quoted''name')",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_relevant_node_names_when_reading_then_filters_state_query(
+    test_case: ReadLatestFingerprintsFilterTestCase,
+) -> None:
+    execute: FakeFingerprintExecute = FakeFingerprintExecute(rows=[])
+
+    read_latest_fingerprints(
+        connection=object(),
+        execute=execute,
+        table_exists=True,
+        database=None,
+        schema="main",
+        render_qualified_name=render_qualified_name,
+        render_read_latest_sql=render_sentinel_read_latest_sql,
+        node_names=test_case.node_names,
+    )
+
+    assert len(execute.executed_sql) == 1
+    assert test_case.expected_sql_fragment in execute.executed_sql[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/test_python_plan_entries.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/test_python_plan_entries.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import base64
+from datetime import datetime
+
 import pytest
 
-from sqlbuild.compiler.fingerprints.models import Fingerprint
+from sqlbuild.compiler.fingerprints.main.read import read_latest_fingerprints
+from sqlbuild.compiler.fingerprints.models import Fingerprint, FingerprintSet
 from sqlbuild.compiler.pipeline._helpers.python_plan_entries import build_python_plan_entries
 from sqlbuild.compiler.pipeline.models import PythonPlanEntry
 from sqlbuild.compiler.python_nodes._helpers.run_lifecycle import (
@@ -16,6 +20,11 @@ from sqlbuild.compiler.python_nodes.models import (
     PythonSqlRunSelection,
 )
 from sqlbuild.compiler.python_nodes.types import PythonIdentityStatus
+from tests.unit.src.sqlbuild.compiler.fingerprints.main.helpers import (
+    FakeFingerprintExecute,
+    render_qualified_name,
+    render_read_latest_sql,
+)
 from tests.unit.src.sqlbuild.compiler.pipeline._helpers._test_types import (
     PythonPlanIdentityStatusTestCase,
 )
@@ -78,3 +87,74 @@ def test_given_previous_python_identity_when_building_plan_entries_then_sets_sta
     expected_previous_payloads: bool = test_case.previous_version_hash is not None
     assert (entries[0].previous_definition_json is not None) is expected_previous_payloads
     assert (entries[0].previous_metadata_json is not None) is expected_previous_payloads
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        PythonPlanIdentityStatusTestCase(
+            description="filtered warehouse read preserves unchanged direct Python identity",
+            previous_version_hash="current",
+            expected_status=PythonIdentityStatus.UNCHANGED,
+        ),
+        PythonPlanIdentityStatusTestCase(
+            description="filtered warehouse read preserves changed direct Python identity",
+            previous_version_hash="previous",
+            expected_status=PythonIdentityStatus.CHANGED,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_filtered_warehouse_fingerprints_when_planning_python_then_sets_identity_status(
+    test_case: PythonPlanIdentityStatusTestCase,
+) -> None:
+    graph: PythonNodeGraph = build_orders_python_node_graph()
+    current_identity: PythonNodeIdentity | None = graph.nodes_by_name["prepare_orders"].identity
+    assert current_identity is not None
+    previous_version_hash: str = {
+        "current": current_identity.version_hash,
+    }.get(str(test_case.previous_version_hash), test_case.previous_version_hash or "")
+    execute: FakeFingerprintExecute = FakeFingerprintExecute(
+        rows=[
+            (
+                current_identity.node_type,
+                current_identity.node_name,
+                None,
+                "main",
+                None,
+                "previous_run",
+                current_identity.definition_hash,
+                previous_version_hash,
+                "schema_hash",
+                base64.b64encode(current_identity.definition_json.encode()).decode(),
+                base64.b64encode(current_identity.metadata_json.encode()).decode(),
+                datetime(2026, 1, 1),
+            )
+        ]
+    )
+
+    fingerprints: FingerprintSet = read_latest_fingerprints(
+        connection=object(),
+        execute=execute,
+        table_exists=True,
+        database=None,
+        schema="main",
+        render_qualified_name=render_qualified_name,
+        render_read_latest_sql=render_read_latest_sql,
+        node_names=(),
+        filtered_node_types=("model", "seed", "sql_udf"),
+    )
+    entries: tuple[PythonPlanEntry, ...] = build_python_plan_entries(
+        lifecycle_plan=build_python_sql_run_lifecycle_plan(
+            selection=PythonSqlRunSelection(
+                sql_keys=frozenset(),
+                python_node_names=frozenset({"prepare_orders"}),
+            ),
+            python_graph=graph,
+        ),
+        python_graph=graph,
+        previous_identities=fingerprints.fingerprints_by_identity,
+    )
+
+    assert "WHERE node_type NOT IN" in execute.executed_sql[0]
+    assert entries[0].identity_status == test_case.expected_status

--- a/tests/unit/src/sqlbuild/compiler/pipeline/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/main/_test_types.py
@@ -2,12 +2,27 @@ from dataclasses import dataclass
 
 from sqlbuild.compiler.pipeline.models import PythonPlanEntry
 from sqlbuild.compiler.planner.models import PlanOutput
+from sqlbuild.python_nodes.models import SqlResourceRef
 
 
 @dataclass(frozen=True)
 class PythonRelationTargetsTestCase:
     description: str
     expected_source_relation: str
+
+
+@dataclass(frozen=True)
+class PythonRelationTargetScopeTestCase:
+    description: str
+    required_refs: frozenset[SqlResourceRef]
+    expected_targets: dict[SqlResourceRef, str]
+
+
+@dataclass(frozen=True)
+class SelectedPythonRelationRefsTestCase:
+    description: str
+    selected_python_names: frozenset[str]
+    expected_refs: frozenset[SqlResourceRef]
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/pipeline/main/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/main/helpers.py
@@ -4,10 +4,17 @@ from pathlib import Path
 from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationLocation
+from sqlbuild.compiler.compile.models import (
+    CompiledObjectKey,
+    CompiledProject,
+    CompiledRelationLocation,
+    CompiledSource,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.discovery.models import DiscoveredSourceFile
 from sqlbuild.compiler.planner.models import ModelPlanEntry, PlanOutput
 from sqlbuild.compiler.planner.types import MaterializationType, PlanAction, PlanReason
+from sqlbuild.spec.contracts.models import SourceEntry
 
 
 class RelationTargetTestAdapter(BaseAdapter):
@@ -21,6 +28,40 @@ class RelationTargetTestAdapter(BaseAdapter):
     def execute(self, connection: Any, sql: str) -> object:
         del connection
         return sql
+
+
+def relation_target_python_node() -> None:
+    """No-op Python declaration used by relation target graph tests."""
+
+
+def build_relation_target_project() -> CompiledProject:
+    source_entry: SourceEntry = SourceEntry(
+        name="orders", schema="load_raw", table="orders"
+    )
+    source_file: DiscoveredSourceFile = DiscoveredSourceFile(
+        file_path=Path("sources/raw.yml"),
+        relative_path=Path("sources/raw.yml"),
+        contents="",
+        source_entries=(source_entry,),
+    )
+    return CompiledProject(
+        run_id="test_run",
+        effective_target_name="dev",
+        effective_connection={},
+        effective_vars={},
+        sources=(
+            CompiledSource(
+                key=CompiledObjectKey(
+                    resource_type=CompiledResourceType.SOURCE,
+                    name="orders",
+                ),
+                deps=(),
+                name="orders",
+                source_entry=source_entry,
+                source_file=source_file,
+            ),
+        ),
+    )
 
 
 def build_plan_output_with_model(name: str = "orders") -> PlanOutput:

--- a/tests/unit/src/sqlbuild/compiler/pipeline/main/test_relation_targets.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/main/test_relation_targets.py
@@ -4,20 +4,24 @@ from pathlib import Path
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject, CompiledSource
-from sqlbuild.compiler.compile.types import CompiledResourceType
-from sqlbuild.compiler.discovery.models import DiscoveredSourceFile
-from sqlbuild.compiler.pipeline.main.relation_targets import (
-    build_python_relation_targets,
-)
+from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.pipeline.main.relation_targets import build_python_relation_targets
 from sqlbuild.compiler.planner.models import PlanOutput
+from sqlbuild.compiler.python_nodes.models import DiscoveredPythonNode, PythonNodeGraph
+from sqlbuild.compiler.python_nodes.types import PythonNodeKind
 from sqlbuild.python_nodes.models import SqlResourceRef
-from sqlbuild.refs import source
+from sqlbuild.refs import model, source
 from sqlbuild.spec.contracts.models import SourceEntry
 from tests.unit.src.sqlbuild.compiler.pipeline.main._test_types import (
+    PythonRelationTargetScopeTestCase,
     PythonRelationTargetsTestCase,
+    SelectedPythonRelationRefsTestCase,
 )
-from tests.unit.src.sqlbuild.compiler.pipeline.main.helpers import RelationTargetTestAdapter
+from tests.unit.src.sqlbuild.compiler.pipeline.main.helpers import (
+    RelationTargetTestAdapter,
+    build_relation_target_project,
+    relation_target_python_node,
+)
 
 
 @pytest.mark.parametrize(
@@ -33,32 +37,9 @@ from tests.unit.src.sqlbuild.compiler.pipeline.main.helpers import RelationTarge
 def test_given_source_read_map_when_building_python_relation_targets_then_uses_read_relation(
     test_case: PythonRelationTargetsTestCase,
 ) -> None:
-    raw_source: SourceEntry = SourceEntry(name="orders", schema="load_raw", table="orders")
+    project: CompiledProject = build_relation_target_project()
+    raw_source: SourceEntry = project.sources[0].source_entry
     read_source: SourceEntry = SourceEntry(name="orders", schema="deferred_raw", table="orders")
-    source_file: DiscoveredSourceFile = DiscoveredSourceFile(
-        file_path=Path("sources/raw.yml"),
-        relative_path=Path("sources/raw.yml"),
-        contents="",
-        source_entries=(raw_source,),
-    )
-    project: CompiledProject = CompiledProject(
-        run_id="test_run",
-        effective_target_name="dev",
-        effective_connection={},
-        effective_vars={},
-        sources=(
-            CompiledSource(
-                key=CompiledObjectKey(
-                    resource_type=CompiledResourceType.SOURCE,
-                    name="orders",
-                ),
-                deps=(),
-                name="orders",
-                source_entry=raw_source,
-                source_file=source_file,
-            ),
-        ),
-    )
     plan_output: PlanOutput = PlanOutput(
         source_map={"orders": raw_source},
         source_read_map={"orders": read_source},
@@ -71,3 +52,119 @@ def test_given_source_read_map_when_building_python_relation_targets_then_uses_r
     )
 
     assert targets[source("orders")] == test_case.expected_source_relation
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        PythonRelationTargetScopeTestCase(
+            description="SQL-only seed ignores unrelated project source declarations",
+            required_refs=frozenset(),
+            expected_targets={},
+        ),
+        PythonRelationTargetScopeTestCase(
+            description="selected Python-only source ref preserves deferred plan mapping",
+            required_refs=frozenset({source("orders")}),
+            expected_targets={source("orders"): "deferred_raw.orders"},
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_narrow_plan_when_building_python_targets_then_only_required_refs_are_resolved(
+    test_case: PythonRelationTargetScopeTestCase,
+) -> None:
+    deferred_source: SourceEntry = SourceEntry(
+        name="orders", schema="deferred_raw", table="orders"
+    )
+    targets: dict[SqlResourceRef, str] = build_python_relation_targets(
+        adapter=RelationTargetTestAdapter(),
+        project=build_relation_target_project(),
+        plan_output=PlanOutput(source_read_map={"orders": deferred_source}),
+        required_refs=test_case.required_refs,
+    )
+
+    assert targets == test_case.expected_targets
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SelectedPythonRelationRefsTestCase(
+            description="selected loaders tasks assets and checks retain their SQL refs",
+            selected_python_names=frozenset({"orders_check"}),
+            expected_refs=frozenset(
+                {
+                    source("loader_source"),
+                    source("task_source"),
+                    model("asset_model"),
+                    model("check_model"),
+                }
+            ),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_selected_python_declarations_when_collecting_refs_then_all_kinds_are_retained(
+    test_case: SelectedPythonRelationRefsTestCase,
+) -> None:
+    project_path: Path = Path("python_nodes/orders.py")
+    nodes: tuple[DiscoveredPythonNode, ...] = (
+        DiscoveredPythonNode(
+            kind=PythonNodeKind.LOADER,
+            file_path=project_path,
+            relative_path=project_path,
+            name="load_orders",
+            function=relation_target_python_node,
+            sql_deps=(source("loader_source"),),
+        ),
+        DiscoveredPythonNode(
+            kind=PythonNodeKind.TASK,
+            file_path=project_path,
+            relative_path=project_path,
+            name="score_orders",
+            function=relation_target_python_node,
+            sql_deps=(source("task_source"),),
+        ),
+        DiscoveredPythonNode(
+            kind=PythonNodeKind.ASSET,
+            file_path=project_path,
+            relative_path=project_path,
+            name="orders_asset",
+            function=relation_target_python_node,
+            sql_deps=(model("asset_model"),),
+        ),
+        DiscoveredPythonNode(
+            kind=PythonNodeKind.CHECK,
+            file_path=project_path,
+            relative_path=project_path,
+            name="orders_check",
+            function=relation_target_python_node,
+            sql_deps=(model("check_model"),),
+        ),
+    )
+    graph: PythonNodeGraph = PythonNodeGraph(
+        nodes=nodes,
+        dependency_edges=(),
+        upstream_deps={
+            "load_orders": (),
+            "score_orders": ("load_orders",),
+            "orders_asset": ("score_orders",),
+            "orders_check": ("orders_asset",),
+        },
+        downstream_deps={
+            "load_orders": ("score_orders",),
+            "score_orders": ("orders_asset",),
+            "orders_asset": ("orders_check",),
+            "orders_check": (),
+        },
+        tag_index={},
+        path_index={},
+        nodes_by_name={node.name: node for node in nodes},
+        nodes_by_typed_selector={},
+    )
+
+    refs: frozenset[SqlResourceRef] = graph.selected_sql_refs(
+        selected_names=test_case.selected_python_names,
+    )
+
+    assert refs == test_case.expected_refs

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
@@ -68,12 +68,31 @@ class SourceColumnsTestCase:
 
 
 @dataclass(frozen=True)
+class MultiDatabaseSourceColumnsTestCase:
+    description: str
+    expected_source_types: dict[str, str]
+    expected_database_queries: tuple[str | None, ...]
+
+
+@dataclass(frozen=True)
 class KnownSourceColumnsReuseTestCase:
     description: str
     known_source_columns: dict[str, tuple[str, ...]] | None
     adapter_column_names: tuple[str, ...]
     expected_queried_sql_count: int
     expected_source_column_names: dict[str, tuple[str, ...]]
+
+
+@dataclass(frozen=True)
+class SourceMetadataClosureTestCase:
+    description: str
+    expected_source_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MetadataNameFilterTestCase:
+    description: str
+    expected_physical_names: frozenset[str]
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_source_columns.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_source_columns.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
-from sqlbuild.adapter.contract.models import ColumnInfo
+from sqlbuild.adapter.contract.models import ColumnInfo, RelationInfo
 from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject
 from sqlbuild.compiler.planner._helpers.output.plan_entry import (
     build_planner_relations_context,
@@ -20,6 +20,7 @@ from sqlbuild.compiler.references.types import SqlReferenceKind
 from sqlbuild.spec.contracts.models import SourceEntry
 from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
     KnownSourceColumnsReuseTestCase,
+    MultiDatabaseSourceColumnsTestCase,
     SourceColumnsTestCase,
     SourceCursorInputColumnsTestCase,
 )
@@ -64,6 +65,50 @@ class _RecordingAdapter(BaseAdapter):
         return {}
 
 
+class _QualifiedSourceAdapter(_RecordingAdapter):
+    def __init__(self) -> None:
+        super().__init__(())
+        self.database_queries: list[str | None] = []
+
+    def list_relations(
+        self,
+        *,
+        connection: Any,
+        database: str | None,
+        schemas: tuple[str, ...] | None,
+        names: tuple[str, ...] | None = None,
+    ) -> tuple[RelationInfo, ...]:
+        del connection, schemas, names
+        self.database_queries.append(database)
+        relations_by_database: dict[str | None, tuple[RelationInfo, ...]] = {
+            "DB_A": (
+                RelationInfo(
+                    database="DB_A", schema="RAW", name="SHARED", relation_type="table"
+                ),
+            ),
+            "DB_B": (
+                RelationInfo(
+                    database="DB_B", schema="RAW", name="SHARED", relation_type="table"
+                ),
+            ),
+        }
+        return relations_by_database.get(database, ())
+
+    def get_columns_for_relations(
+        self,
+        *,
+        connection: Any,
+        relations: tuple[RelationInfo, ...],
+    ) -> dict[tuple[str | None, str | None, str], tuple[ColumnInfo, ...]]:
+        del connection
+        return {
+            relation.identity: (
+                ColumnInfo(name="id", type=f"{relation.database}.{relation.schema}"),
+            )
+            for relation in relations
+        }
+
+
 @pytest.mark.parametrize(
     "test_case",
     [
@@ -106,6 +151,50 @@ def test_given_sources_when_gathering_columns_then_returns_expected_source_colum
     assert tuple(column.name for column in result.get("raw_payments", ())) == (
         test_case.expected_source_column_names
     )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MultiDatabaseSourceColumnsTestCase(
+            description="same physical name in two databases remains isolated and missing omitted",
+            expected_source_types={
+                "source_a": "DB_A.RAW",
+                "source_b": "DB_B.RAW",
+            },
+            expected_database_queries=("DB_A", "DB_B"),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_multi_database_sources_when_gathering_columns_then_matches_current_database_only(
+    test_case: MultiDatabaseSourceColumnsTestCase,
+) -> None:
+    project: CompiledProject = CompiledProject(
+        run_id="test",
+        effective_target_name=None,
+        effective_connection={},
+        effective_vars={},
+    )
+    adapter: _QualifiedSourceAdapter = _QualifiedSourceAdapter()
+    source_entries: tuple[SourceEntry, ...] = (
+        SourceEntry(name="source_a", database="DB_A", schema="RAW", table="SHARED"),
+        SourceEntry(name="source_b", database="DB_B", schema="RAW", table="SHARED"),
+        SourceEntry(name="missing", database="DB_A", schema="RAW", table="MISSING"),
+    )
+
+    result: dict[str, tuple[ColumnInfo, ...]] = gather_source_columns(
+        project=project,
+        adapter=adapter,
+        connection=None,
+        source_entries=source_entries,
+    )
+
+    actual_types: dict[str, str] = {
+        name: columns[0].type for name, columns in result.items()
+    }
+    assert actual_types == test_case.expected_source_types
+    assert tuple(adapter.database_queries) == test_case.expected_database_queries
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_source_load_nodes.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_source_load_nodes.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.compile.models import (
+    CompiledModel,
+    CompiledObjectKey,
+    CompiledProject,
+    CompiledRelationLocation,
+    CompileModelConfig,
+)
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner._helpers.graph.loader_dag import (
     build_intermediate_source_map,
@@ -14,13 +22,16 @@ from sqlbuild.compiler.planner._helpers.graph.source_load_nodes import (
     build_source_load_entries,
     build_source_load_map,
 )
+from sqlbuild.compiler.planner._helpers.warehouse.snapshot import _build_metadata_name_filter
 from sqlbuild.compiler.planner.models import SourceLoadPlanEntry
 from sqlbuild.runtime.contracts.types import ExecutionResourceKind
 from sqlbuild.spec.contracts.models import SourceEntry
 from sqlbuild.spec.contracts.types import SourceWriteStrategy
 from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
     LoaderDagExpansionTestCase,
+    MetadataNameFilterTestCase,
     SourceLoadNodesTestCase,
+    SourceMetadataClosureTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.planner._helpers.helpers import (
     build_source_load_nodes_project,
@@ -85,6 +96,134 @@ def test_given_selected_source_load_keys_when_building_entries_then_returns_orde
 
     assert tuple(sorted(source_map)) == test_case.expected_map_names
     assert entries == test_case.expected_entries
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SourceMetadataClosureTestCase(
+            description="unrelated selected seed excludes all project sources",
+            expected_source_names=(),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_unrelated_selected_seed_when_building_source_map_then_sources_are_excluded(
+    test_case: SourceMetadataClosureTestCase,
+) -> None:
+    project: CompiledProject = build_source_load_nodes_project()
+    seed_key: CompiledObjectKey = CompiledObjectKey(
+        CompiledResourceType.SEED, "country_codes"
+    )
+
+    source_map: dict[str, SourceEntry] = build_source_load_map(
+        project=project,
+        selected_keys=frozenset({seed_key}),
+        upstream_deps={seed_key: ()},
+    )
+
+    assert tuple(sorted(source_map)) == test_case.expected_source_names
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SourceMetadataClosureTestCase(
+            description="reachable source through unselected upstream model is retained",
+            expected_source_names=("raw_orders",),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_transitive_unselected_upstream_when_building_source_map_then_source_is_retained(
+    test_case: SourceMetadataClosureTestCase,
+) -> None:
+    project: CompiledProject = build_source_load_nodes_project()
+    selected_key: CompiledObjectKey = CompiledObjectKey(
+        CompiledResourceType.MODEL, "fact_orders"
+    )
+    upstream_key: CompiledObjectKey = CompiledObjectKey(
+        CompiledResourceType.MODEL, "stg_orders"
+    )
+    source_key: CompiledObjectKey = CompiledObjectKey(
+        CompiledResourceType.SOURCE, "raw_orders"
+    )
+
+    source_map: dict[str, SourceEntry] = build_source_load_map(
+        project=project,
+        selected_keys=frozenset({selected_key}),
+        upstream_deps={
+            selected_key: (upstream_key,),
+            upstream_key: (source_key,),
+            source_key: (),
+        },
+    )
+
+    assert tuple(sorted(source_map)) == test_case.expected_source_names
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MetadataNameFilterTestCase(
+            description="selected closure inventories logical aliases by physical destination",
+            expected_physical_names=frozenset({"FACT_ORDERS_PHYSICAL", "STG_ORDERS_PHYSICAL"}),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_unselected_upstream_in_closure_when_filtering_metadata_then_uses_physical_names(
+    test_case: MetadataNameFilterTestCase,
+) -> None:
+    selected_key: CompiledObjectKey = CompiledObjectKey(
+        CompiledResourceType.MODEL, "fact_orders"
+    )
+    upstream_key: CompiledObjectKey = CompiledObjectKey(
+        CompiledResourceType.MODEL, "stg_orders"
+    )
+    selected_model: CompiledModel = CompiledModel(
+        key=selected_key,
+        deps=(upstream_key,),
+        name="fact_orders",
+        relative_path=Path("models/fact_orders.sql"),
+        query_sql="SELECT * FROM __ref('stg_orders')",
+        config=CompileModelConfig(),
+        destination=CompiledRelationLocation(
+            database="RACING",
+            schema="ANALYTICS",
+            name="FACT_ORDERS_PHYSICAL",
+            qualified_name="RACING.ANALYTICS.FACT_ORDERS_PHYSICAL",
+        ),
+    )
+    upstream_model: CompiledModel = CompiledModel(
+        key=upstream_key,
+        deps=(),
+        name="stg_orders",
+        relative_path=Path("models/stg_orders.sql"),
+        query_sql="SELECT 1 AS id",
+        config=CompileModelConfig(),
+        destination=CompiledRelationLocation(
+            database="RACING",
+            schema="STAGING",
+            name="STG_ORDERS_PHYSICAL",
+            qualified_name="RACING.STAGING.STG_ORDERS_PHYSICAL",
+        ),
+    )
+    project: CompiledProject = CompiledProject(
+        run_id="test",
+        effective_target_name=None,
+        effective_connection={},
+        effective_vars={},
+        models=(selected_model, upstream_model),
+    )
+
+    names: tuple[str, ...] | None = _build_metadata_name_filter(
+        project=project,
+        selected_keys=frozenset({selected_key, upstream_key}),
+    )
+
+    assert names is not None
+    assert test_case.expected_physical_names.issubset(names)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/_test_types.py
@@ -63,3 +63,11 @@ class SeedPipelineConcurrencyTestCase:
     expected_connection_count: int
     expected_seed_order: tuple[str, ...]
     expected_json_asset_order: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class WorkerConnectionTestCase:
+    description: str
+    connection_count: int
+    expected_connection_count: int
+    expected_close_attempts: int = 0

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/test_connections.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/test_connections.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.executor.pipeline._helpers.connections import (
+    close_connections,
+    open_worker_connections,
+)
+from tests.unit.src.sqlbuild.executor.pipeline._helpers._test_types import WorkerConnectionTestCase
+
+
+class _ConnectionAdapter(BaseAdapter):
+    def __init__(self, *, fail_connect_index: int | None = None) -> None:
+        self._lock: threading.Lock = threading.Lock()
+        self._fail_connect_index: int | None = fail_connect_index
+        self.connect_calls: list[dict[str, object]] = []
+        self.close_attempts: list[object] = []
+
+    def connect(self, config: dict[str, object]) -> object:
+        with self._lock:
+            call_index: int = len(self.connect_calls)
+            self.connect_calls.append(config)
+        if call_index == self._fail_connect_index:
+            raise RuntimeError("original connection failure")
+        return object()
+
+    def close(self, connection: object) -> None:
+        self.close_attempts.append(connection)
+        if len(self.close_attempts) == 1:
+            raise RuntimeError("close failure")
+
+    def execute(self, connection: object, sql: str) -> object:
+        del connection
+        return sql
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        WorkerConnectionTestCase(
+            description="each worker opens an independent connection call",
+            connection_count=3,
+            expected_connection_count=3,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_worker_count_when_opening_connections_then_each_call_returns_independent_connection(
+    test_case: WorkerConnectionTestCase,
+) -> None:
+    adapter: _ConnectionAdapter = _ConnectionAdapter()
+
+    connections: tuple[object, ...] = open_worker_connections(
+        adapter=adapter,
+        connection_config={"authenticator": "oauth"},
+        connection_count=test_case.connection_count,
+    )
+
+    assert len(connections) == test_case.expected_connection_count
+    assert len({id(connection) for connection in connections}) == test_case.expected_connection_count
+    assert len(adapter.connect_calls) == test_case.connection_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        WorkerConnectionTestCase(
+            description="partial connect failure attempts every successful close",
+            connection_count=3,
+            expected_connection_count=0,
+            expected_close_attempts=2,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_partial_failure_when_opening_connections_then_cleanup_preserves_original_error(
+    test_case: WorkerConnectionTestCase,
+) -> None:
+    adapter: _ConnectionAdapter = _ConnectionAdapter(fail_connect_index=1)
+
+    with pytest.raises(RuntimeError, match="original connection failure"):
+        open_worker_connections(
+            adapter=adapter,
+            connection_config={},
+            connection_count=test_case.connection_count,
+        )
+
+    assert len(adapter.close_attempts) == test_case.expected_close_attempts
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        WorkerConnectionTestCase(
+            description="successful execution propagates first close failure after all attempts",
+            connection_count=2,
+            expected_connection_count=0,
+            expected_close_attempts=2,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_no_active_error_when_closing_connections_then_propagates_close_failure(
+    test_case: WorkerConnectionTestCase,
+) -> None:
+    adapter: _ConnectionAdapter = _ConnectionAdapter()
+
+    with pytest.raises(RuntimeError, match="close failure"):
+        close_connections(
+            adapter=adapter,
+            connections=tuple(object() for _ in range(test_case.connection_count)),
+        )
+
+    assert len(adapter.close_attempts) == test_case.expected_close_attempts
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        WorkerConnectionTestCase(
+            description="active execution error remains primary while all closes are attempted",
+            connection_count=2,
+            expected_connection_count=0,
+            expected_close_attempts=2,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_active_error_when_closing_connections_then_preserves_original_error(
+    test_case: WorkerConnectionTestCase,
+) -> None:
+    adapter: _ConnectionAdapter = _ConnectionAdapter()
+    original_error: RuntimeError = RuntimeError("original execution failure")
+
+    close_connections(
+        adapter=adapter,
+        connections=tuple(object() for _ in range(test_case.connection_count)),
+        active_error=original_error,
+    )
+    with pytest.raises(RuntimeError, match="original execution failure") as raised:
+        raise original_error
+
+    assert raised.value is original_error
+    assert len(adapter.close_attempts) == test_case.expected_close_attempts

--- a/tests/unit/src/sqlbuild/executor/pipeline/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/main/_test_types.py
@@ -5,3 +5,9 @@ from dataclasses import dataclass
 class BuildSchemaPreflightTestCase:
     description: str
     expected_schemas: tuple[tuple[str | None, str], ...]
+
+
+@dataclass(frozen=True)
+class RunnableGraphWidthTestCase:
+    description: str
+    expected_width: int

--- a/tests/unit/src/sqlbuild/executor/pipeline/main/test_schema_preflight.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/main/test_schema_preflight.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import pytest
 
+from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.planner.models import PlanOutput
+from sqlbuild.executor.pipeline._helpers.graph_width import runnable_graph_width
 from sqlbuild.executor.pipeline.main.run import _prepare_build_schemas
 from tests.unit.src.sqlbuild.executor.pipeline.main._test_types import (
     BuildSchemaPreflightTestCase,
+    RunnableGraphWidthTestCase,
 )
 from tests.unit.src.sqlbuild.executor.pipeline.main.helpers import (
     BuildSchemaPreflightAdapter,
@@ -36,3 +41,57 @@ def test_given_build_plan_when_preparing_schemas_then_all_destination_schemas_ar
     assert tuple(adapter.prepared_schemas) == test_case.expected_schemas
     assert len(adapter.connections) == 1
     assert adapter.closed_connections == adapter.connections
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [RunnableGraphWidthTestCase(description="four executable graph nodes", expected_width=4)],
+    ids=lambda case: case.description,
+)
+def test_given_layered_execution_graph_when_sizing_workers_then_uses_largest_frontier(
+    test_case: RunnableGraphWidthTestCase,
+) -> None:
+    root: CompiledObjectKey = CompiledObjectKey(CompiledResourceType.SEED, "root")
+    left: CompiledObjectKey = CompiledObjectKey(CompiledResourceType.MODEL, "left")
+    right: CompiledObjectKey = CompiledObjectKey(CompiledResourceType.MODEL, "right")
+    final: CompiledObjectKey = CompiledObjectKey(CompiledResourceType.MODEL, "final")
+    plan: PlanOutput = PlanOutput(
+        execution_order=(root, left, right, final),
+        upstream_deps={root: (), left: (root,), right: (root,), final: (left, right)},
+    )
+
+    assert runnable_graph_width(plan=plan) == test_case.expected_width
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        RunnableGraphWidthTestCase(
+            description="asymmetric branches retain possible asynchronous overlap",
+            expected_width=5,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_asymmetric_dag_when_sizing_workers_then_does_not_underestimate_overlap(
+    test_case: RunnableGraphWidthTestCase,
+) -> None:
+    root: CompiledObjectKey = CompiledObjectKey(CompiledResourceType.MODEL, "root")
+    slow: CompiledObjectKey = CompiledObjectKey(CompiledResourceType.MODEL, "slow")
+    fast: CompiledObjectKey = CompiledObjectKey(CompiledResourceType.MODEL, "fast")
+    fast_child: CompiledObjectKey = CompiledObjectKey(
+        CompiledResourceType.MODEL, "fast_child"
+    )
+    final: CompiledObjectKey = CompiledObjectKey(CompiledResourceType.MODEL, "final")
+    plan: PlanOutput = PlanOutput(
+        execution_order=(root, slow, fast, fast_child, final),
+        upstream_deps={
+            root: (),
+            slow: (root,),
+            fast: (root,),
+            fast_child: (fast,),
+            final: (slow, fast_child),
+        },
+    )
+
+    assert runnable_graph_width(plan=plan) == test_case.expected_width


### PR DESCRIPTION
## Why

Narrow SQLBuild selections scanned unrelated warehouse metadata and opened more Snowflake connections than runnable work required. A real five-object seed plan spent 23.12 seconds inspecting warehouse state.

Linear: https://linear.app/chio-labs/issue/CHI-132/reduce-warehouse-planning-and-connection-latency-without-weakening

## Changes

- Scope metadata, freshness, and SQL fingerprints to the selected dependency closure.
- Use qualified relation identities and adaptive Snowflake column inspection.
- Right-size/open worker connections concurrently while preserving preflight, Python identities, source deferral, cleanup, and generic bulk adapter behavior.

## Verification

- Unit suite: 4,038 passed with xdist.
- Ruff, Ty with PostgreSQL/SQL Server extras, Fensu, lockfile, and diff checks passed.
- Real Snowflake seed succeeded; inspection improved from 23.12s to 1.09s and planning from 1.40s to 0.10s.
- This PR remains independent of CHI-131, so released 0.63.1 cost collection may report partial.
