### PR TITLE
fix: require explicit warehouse write schemas

### DIFF
--- a/src/sqlbuild/adapter/contract/classes/base_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/base_adapter.py
@@ -80,6 +80,7 @@ class BaseAdapter(StrictAdapter):
     sql_analysis_dialect_name: ClassVar[str | None] = None
     max_identifier_length: ClassVar[int] = 63
     state_tables_transient: ClassVar[bool] = False
+    allows_implicit_managed_write_schema: ClassVar[bool] = False
 
     def supports_zero_copy_clone(self) -> bool:
         return False

--- a/src/sqlbuild/adapters/duckdb/classes/duckdb_adapter.py
+++ b/src/sqlbuild/adapters/duckdb/classes/duckdb_adapter.py
@@ -17,6 +17,7 @@ class DuckDbAdapter(MicrobatchMixin, DuckDbBackedAdapter):
     """First-class DuckDB adapter with full method coverage."""
 
     adapter_name: ClassVar[str] = BuiltinAdapter.DUCKDB.value
+    allows_implicit_managed_write_schema: ClassVar[bool] = True
 
     def supports_concurrent_microbatch_dml(self) -> bool:
         return True

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -24,6 +24,9 @@ from sqlbuild.compiler.compile._helpers.analysis.validation import (
     validate_hook_sql_syntax,
     validate_sql_syntax,
 )
+from sqlbuild.compiler.compile._helpers.attachment.namespace_validation import (
+    validate_preserved_logical_namespace,
+)
 from sqlbuild.compiler.compile._helpers.deps.dependencies import (
     audit_scope_deps,
     function_build_deps,
@@ -800,6 +803,16 @@ def _build_source_relation_entry(
 ) -> SourceEntry:
     if source_entry.loader is None or target_config is None:
         return source_entry
+    loader_target_config: TargetConfig = replace(
+        target_config,
+        schema=target_config.loader_schema or target_config.schema,
+    )
+    validate_preserved_logical_namespace(
+        resource_label=f"Managed source '{source_entry.name}'",
+        logical_database=source_entry.database,
+        logical_schema=source_entry.schema,
+        target_config=loader_target_config,
+    )
     return replace(
         source_entry,
         database=(
@@ -1249,6 +1262,12 @@ def _build_seed_relation_target(
             effective_vars=effective_vars,
             context_label=f"seed '{seed_entry.name}' schema",
         )
+    validate_preserved_logical_namespace(
+        resource_label=f"Seed '{seed_entry.name}'",
+        logical_database=logical_database,
+        logical_schema=logical_schema,
+        target_config=target_config,
+    )
     database, schema = _apply_seed_target_overrides(
         logical_database=logical_database,
         logical_schema=logical_schema,

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
@@ -14,6 +14,9 @@ from uuid import uuid4
 
 from sqlbuild.compiler.auditing.main._parse_audit_instance import parse_audit_instance
 from sqlbuild.compiler.compile._helpers.analysis.validation import validate_sql_syntax
+from sqlbuild.compiler.compile._helpers.attachment.namespace_validation import (
+    validate_preserved_logical_namespace,
+)
 from sqlbuild.compiler.compile._helpers.attachment.references import (
     build_known_function_names,
     build_known_ref_names,
@@ -716,6 +719,12 @@ def build_model_config(
     logical_schema: str | None = raw_logical_schema if isinstance(raw_logical_schema, str) else None
     logical_database: str | None = (
         raw_logical_database if isinstance(raw_logical_database, str) else None
+    )
+    validate_preserved_logical_namespace(
+        resource_label=f"Model '{model_name}'",
+        logical_database=logical_database,
+        logical_schema=logical_schema,
+        target_config=target_config,
     )
     model_resolved_values = apply_environment_database_schema_overrides(
         values=model_resolved_values,

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/functions.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/functions.py
@@ -11,6 +11,9 @@ from sqlbuild.compiler.compile._helpers.analysis.columns import infer_columns_wi
 from sqlbuild.compiler.compile._helpers.analysis.validation import (
     validate_function_sql_syntax,
 )
+from sqlbuild.compiler.compile._helpers.attachment.namespace_validation import (
+    validate_preserved_logical_namespace,
+)
 from sqlbuild.compiler.compile._helpers.attachment.references import (
     build_known_function_names,
     build_known_ref_names,
@@ -72,6 +75,7 @@ class _PythonFunctionBuildContext:
     logical_schema: str | None
     target_database: str | None
     target_schema: str | None
+    target_config: TargetConfig | None
     python_functions_inherit_default_namespace: bool
 
 
@@ -155,6 +159,12 @@ def build_sql_function_inputs(
             )
             if isinstance(raw_schema, str)
             else logical_schema
+        )
+        validate_preserved_logical_namespace(
+            resource_label=f"SQL function '{function_name}'",
+            logical_database=function_logical_database,
+            logical_schema=function_logical_schema,
+            target_config=target_config,
         )
         function_database: str | None = (
             function_logical_database if target_database is None else target_database
@@ -271,6 +281,7 @@ def build_sql_function_inputs(
         logical_schema=logical_schema,
         target_database=target_database,
         target_schema=target_schema,
+        target_config=target_config,
         python_functions_inherit_default_namespace=(python_functions_inherit_default_namespace),
     )
     python_function_file: DiscoveredPythonFunctionFile
@@ -386,6 +397,12 @@ def _build_python_function_input(
     )
     fingerprint_logical_schema: str | None = (
         function_logical_schema if isinstance(raw_schema, str) else context.logical_schema
+    )
+    validate_preserved_logical_namespace(
+        resource_label=f"Python function '{function_name}'",
+        logical_database=fingerprint_logical_database,
+        logical_schema=fingerprint_logical_schema,
+        target_config=context.target_config,
     )
     fingerprint_database: str | None = (
         fingerprint_logical_database if context.target_database is None else context.target_database

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/namespace_validation.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/namespace_validation.py
@@ -1,0 +1,36 @@
+"""Validate logical namespaces required by preserve target values."""
+
+from __future__ import annotations
+
+from sqlbuild.compiler.compile.constants import PRESERVE_TARGET_VALUE
+from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.spec.contracts.models import TargetConfig
+
+
+def validate_preserved_logical_namespace(
+    *,
+    resource_label: str,
+    logical_database: str | None,
+    logical_schema: str | None,
+    target_config: TargetConfig | None,
+) -> None:
+    """Fail when preserve cannot retain a resource-owned logical namespace."""
+
+    if target_config is None:
+        return
+    missing: list[str] = []
+    if target_config.database == PRESERVE_TARGET_VALUE and logical_database is None:
+        missing.append("database")
+    if target_config.schema == PRESERVE_TARGET_VALUE and logical_schema is None:
+        missing.append("schema")
+    if not missing:
+        return
+    dimensions: str = " and ".join(missing)
+    raise CompileInputError(
+        f"{resource_label} has no logical {dimensions}, but the selected target sets "
+        f"{dimensions} to 'preserve'",
+        help=(
+            f"Set {dimensions} on the resource or its defaults, or configure a literal target "
+            f"{dimensions}."
+        ),
+    )

--- a/src/sqlbuild/compiler/pipeline/_helpers/target_validation.py
+++ b/src/sqlbuild/compiler/pipeline/_helpers/target_validation.py
@@ -6,6 +6,7 @@ from typing import cast
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.types import BuiltinAdapter
+from sqlbuild.compiler.compile.constants import PRESERVE_TARGET_VALUE
 from sqlbuild.compiler.compile.main.effective_config import build_effective_connection_config
 from sqlbuild.compiler.compile.main.effective_runtime import build_effective_runtime_config
 from sqlbuild.compiler.compile.main.expand_template_data import expand_template_data
@@ -159,6 +160,63 @@ def validate_project_targets(*, adapter_name: str, project: CompiledProject) -> 
         resource_kind="seed",
         targets={seed.name: seed.destination for seed in project.seeds},
     )
+
+
+def validate_managed_write_schemas(*, adapter: BaseAdapter, project: CompiledProject) -> None:
+    """Require an explicitly resolved physical schema for every managed warehouse write."""
+
+    if adapter.allows_implicit_managed_write_schema:
+        return
+    connection_schema: str | None = _optional_explicit_schema(
+        project.effective_connection.get("schema")
+    )
+    for model in project.models:
+        _validate_managed_write_schema(
+            resource_label=f"Model '{model.name}'",
+            schema=model.destination.schema,
+            connection_schema=connection_schema,
+        )
+    for seed in project.seeds:
+        _validate_managed_write_schema(
+            resource_label=f"Seed '{seed.name}'",
+            schema=seed.destination.schema,
+            connection_schema=connection_schema,
+        )
+    for function in project.functions:
+        _validate_managed_write_schema(
+            resource_label=f"Function '{function.name}'",
+            schema=function.destination.schema,
+            connection_schema=connection_schema,
+        )
+    for source in project.sources:
+        if not source.source_entry.managed:
+            continue
+        _validate_managed_write_schema(
+            resource_label=f"Managed source '{source.name}'",
+            schema=source.source_entry.schema,
+            connection_schema=connection_schema,
+        )
+
+
+def _validate_managed_write_schema(
+    *, resource_label: str, schema: str | None, connection_schema: str | None
+) -> None:
+    if _optional_explicit_schema(schema) is not None or connection_schema is not None:
+        return
+    raise PlannerInputError(
+        f"{resource_label} has no explicitly resolved physical write schema. Set schema on the "
+        "resource or its defaults, selected target, loader_schema, or connection.",
+        code="S103",
+    )
+
+
+def _optional_explicit_schema(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    schema: str = value.strip()
+    if not schema or schema == PRESERVE_TARGET_VALUE:
+        return None
+    return schema
 
 
 def _validate_required_target_parts(

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -17,6 +17,7 @@ from sqlbuild.compiler.lineage.types import ColumnLineageMode
 from sqlbuild.compiler.pipeline._helpers.target_defaults import apply_target_defaults
 from sqlbuild.compiler.pipeline._helpers.target_validation import (
     validate_managed_loader_target_isolation,
+    validate_managed_write_schemas,
     validate_project_targets,
 )
 from sqlbuild.compiler.planner.main.selection._resolve_planner_scopes import (
@@ -82,17 +83,19 @@ def build_compiled_project(
         inference_profile=inference_profile,
         selection=analysis_selection,
     )
-    project: CompiledProject = apply_target_defaults(
-        project=assemble_project(
-            inputs=compile_inputs,
-            inference_profile=inference_profile,
-            skip_column_inference=skip_column_inference,
-            column_lineage_mode=column_lineage_mode,
-            analysis_cache_dir=compile_inputs.compile_cache_dir,
-            analysis_model_names=analysis_model_names,
-        ),
-        default_schema=adapter.default_schema(),
-        default_database=adapter.default_database(),
+    project: CompiledProject = assemble_project(
+        inputs=compile_inputs,
+        inference_profile=inference_profile,
+        skip_column_inference=skip_column_inference,
+        column_lineage_mode=column_lineage_mode,
+        analysis_cache_dir=compile_inputs.compile_cache_dir,
+        analysis_model_names=analysis_model_names,
+    )
+    validate_managed_write_schemas(adapter=adapter, project=project)
+    project = apply_target_defaults(
+        project=project,
+        default_schema=project.effective_target_schema or adapter.default_schema(),
+        default_database=project.effective_target_database or adapter.default_database(),
         render_qualified_name=adapter.render_qualified_name,
         python_functions_inherit_default_namespace=(
             adapter.python_functions_inherit_default_namespace()

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -95,7 +95,7 @@ def build_compiled_project(
     project = apply_target_defaults(
         project=project,
         default_schema=project.effective_target_schema or adapter.default_schema(),
-        default_database=project.effective_target_database or adapter.default_database(),
+        default_database=adapter.default_database(),
         render_qualified_name=adapter.render_qualified_name,
         python_functions_inherit_default_namespace=(
             adapter.python_functions_inherit_default_namespace()

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
@@ -34,3 +34,11 @@ class DbtShapedCompilePerformanceGuardTestCase:
     expected_max_sql_bytes: int
     expected_max_seconds: float
     expected_warm_max_seconds: float
+
+
+@dataclass(frozen=True)
+class NamespaceCompileTestCase:
+    description: str
+    repo_files: dict[str, str]
+    expected_exit_code: int
+    expected_stderr_fragment: str

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_namespace_validation.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_namespace_validation.py
@@ -1,0 +1,372 @@
+"""E2E tests for managed resource namespace validation during compile."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from tests.e2e.src.sqlbuild.cli.commands.main.compile._test_types import (
+    NamespaceCompileTestCase,
+)
+from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import prepare_inline_project, run_sqb
+
+_PRESERVE_CONFIG: str = (
+    dedent(
+        """
+    name = "namespace_validation"
+    adapter = "duckdb"
+    default_target = "dev"
+
+    [connection]
+    database = ":memory:"
+
+    [targets.dev]
+    schema = "preserve"
+    """
+    ).strip()
+    + "\n"
+)
+_SEED_SCHEMA: str = (
+    dedent(
+        """
+    seeds:
+      - name: countries
+        columns:
+          - name: code
+            type: VARCHAR
+    """
+    ).strip()
+    + "\n"
+)
+_POSTGRES_CONFIG_WITHOUT_SCHEMA: str = (
+    'name = "namespace_validation"\nadapter = "postgres"\n\n[connection]\ndatabase = "analytics"\n'
+)
+_PYTHON_FUNCTION: str = (
+    "from sqlbuild.functions import udf\n\n"
+    '@udf(arguments={}, returns="INTEGER", runtime_version="3.11")\n'
+    "def main():\n"
+    "    return 42\n"
+)
+_MANAGED_SOURCE: str = (
+    "sources:\n"
+    "  - name: raw_events\n"
+    "    managed: true\n"
+    "    write_strategy: table\n"
+    "    columns:\n"
+    "      - name: event_id\n"
+    "        type: INTEGER\n"
+)
+_MANAGED_SOURCE_LOADER: str = (
+    "from sqlbuild.loaders import loader\n\n"
+    "@loader\n"
+    "def raw_events(ctx):\n"
+    "    return [{'event_id': 1}]\n"
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        NamespaceCompileTestCase(
+            description="model without logical schema fails under preserve",
+            repo_files={
+                "sqlbuild_project.toml": _PRESERVE_CONFIG,
+                "models/orders.sql": "MODEL ();\n\nSELECT 1 AS id\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="Model 'orders' has no logical schema",
+        ),
+        NamespaceCompileTestCase(
+            description="seed without logical schema fails under preserve",
+            repo_files={
+                "sqlbuild_project.toml": _PRESERVE_CONFIG,
+                "seeds/schema.yml": _SEED_SCHEMA,
+                "seeds/countries.csv": "code\nGB\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="Seed 'countries' has no logical schema",
+        ),
+        NamespaceCompileTestCase(
+            description="SQL scalar function without logical schema fails under preserve",
+            repo_files={
+                "sqlbuild_project.toml": _PRESERVE_CONFIG,
+                "functions/sql/answer.sql": "FUNCTION (returns INTEGER);\n\n42\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="SQL function 'answer' has no logical schema",
+        ),
+        NamespaceCompileTestCase(
+            description="SQL table function without logical schema fails under preserve",
+            repo_files={
+                "sqlbuild_project.toml": _PRESERVE_CONFIG,
+                "functions/sql/answers.sql": dedent(
+                    """
+                FUNCTION (
+                  returns table (
+                    answer INTEGER
+                  )
+                );
+
+                SELECT 42 AS answer
+                """
+                ).strip()
+                + "\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="SQL function 'answers' has no logical schema",
+        ),
+        NamespaceCompileTestCase(
+            description="non inheriting Python UDF without logical schema fails under preserve",
+            repo_files={
+                "sqlbuild_project.toml": _PRESERVE_CONFIG,
+                "functions/python/answer.py": dedent(
+                    """
+                from sqlbuild.functions import udf
+
+                @udf(arguments={}, returns="INTEGER", runtime_version="3.11")
+                def main():
+                    return 42
+                """
+                ).strip()
+                + "\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="Python function 'answer' has no logical schema",
+        ),
+        NamespaceCompileTestCase(
+            description="managed source without logical schema fails under preserve",
+            repo_files={
+                "sqlbuild_project.toml": _PRESERVE_CONFIG,
+                "sources/raw.yml": _MANAGED_SOURCE,
+                "loaders/raw_events.py": _MANAGED_SOURCE_LOADER,
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="Managed source 'raw_events' has no logical schema",
+        ),
+        NamespaceCompileTestCase(
+            description="resource specific defaults resolve preserved schemas",
+            repo_files={
+                "sqlbuild_project.toml": dedent(
+                    """
+                name = "namespace_validation"
+                adapter = "duckdb"
+                default_target = "dev"
+
+                [connection]
+                database = ":memory:"
+
+                [defaults]
+                seed_schema = "seed_data"
+                function_schema = "functions"
+
+                [path_defaults.marts]
+                schema = "analytics"
+
+                [targets.dev]
+                schema = "preserve"
+                """
+                ).strip()
+                + "\n",
+                "models/marts/orders.sql": "MODEL ();\n\nSELECT 1 AS id\n",
+                "seeds/schema.yml": _SEED_SCHEMA,
+                "seeds/countries.csv": "code\nGB\n",
+                "functions/sql/answer.sql": "FUNCTION (returns INTEGER);\n\n42\n",
+                "functions/python/python_answer.py": dedent(
+                    """
+                from sqlbuild.functions import udf
+
+                @udf(arguments={}, returns="INTEGER", runtime_version="3.11")
+                def main():
+                    return 42
+                """
+                ).strip()
+                + "\n",
+            },
+            expected_exit_code=0,
+            expected_stderr_fragment="",
+        ),
+        NamespaceCompileTestCase(
+            description="literal target schema supplies physical namespace",
+            repo_files={
+                "sqlbuild_project.toml": _PRESERVE_CONFIG.replace(
+                    'schema = "preserve"', 'schema = "physical"'
+                ),
+                "models/orders.sql": "MODEL ();\n\nSELECT 1 AS id\n",
+                "seeds/schema.yml": _SEED_SCHEMA,
+                "seeds/countries.csv": "code\nGB\n",
+                "functions/sql/answer.sql": "FUNCTION (returns INTEGER);\n\n42\n",
+                "functions/python/python_answer.py": dedent(
+                    """
+                from sqlbuild.functions import udf
+
+                @udf(arguments={}, returns="INTEGER", runtime_version="3.11")
+                def main():
+                    return 42
+                """
+                ).strip()
+                + "\n",
+            },
+            expected_exit_code=0,
+            expected_stderr_fragment="",
+        ),
+        NamespaceCompileTestCase(
+            description="warehouse model without explicit schema fails offline",
+            repo_files={
+                "sqlbuild_project.toml": _POSTGRES_CONFIG_WITHOUT_SCHEMA,
+                "models/orders.sql": "MODEL ();\n\nSELECT 1 AS id\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="Model 'orders' has no explicitly resolved physical write schema",
+        ),
+        NamespaceCompileTestCase(
+            description="warehouse seed without explicit schema fails offline",
+            repo_files={
+                "sqlbuild_project.toml": _POSTGRES_CONFIG_WITHOUT_SCHEMA,
+                "seeds/schema.yml": _SEED_SCHEMA,
+                "seeds/countries.csv": "code\nGB\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="Seed 'countries' has no explicitly resolved physical write schema",
+        ),
+        NamespaceCompileTestCase(
+            description="warehouse SQL scalar function without explicit schema fails offline",
+            repo_files={
+                "sqlbuild_project.toml": _POSTGRES_CONFIG_WITHOUT_SCHEMA,
+                "functions/sql/answer.sql": "FUNCTION (returns INTEGER);\n\n42\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="Function 'answer' has no explicitly resolved physical write schema",
+        ),
+        NamespaceCompileTestCase(
+            description="warehouse SQL table function without explicit schema fails offline",
+            repo_files={
+                "sqlbuild_project.toml": _POSTGRES_CONFIG_WITHOUT_SCHEMA,
+                "functions/sql/answers.sql": (
+                    "FUNCTION (returns table (answer INTEGER));\n\nSELECT 42 AS answer\n"
+                ),
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="Function 'answers' has no explicitly resolved physical write schema",
+        ),
+        NamespaceCompileTestCase(
+            description="warehouse Python UDF without explicit schema fails offline",
+            repo_files={
+                "sqlbuild_project.toml": _POSTGRES_CONFIG_WITHOUT_SCHEMA,
+                "functions/python/answer.py": _PYTHON_FUNCTION,
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="Function 'answer' has no explicitly resolved physical write schema",
+        ),
+        NamespaceCompileTestCase(
+            description="warehouse managed source without explicit schema fails offline",
+            repo_files={
+                "sqlbuild_project.toml": _POSTGRES_CONFIG_WITHOUT_SCHEMA,
+                "sources/raw.yml": _MANAGED_SOURCE,
+                "loaders/raw_events.py": _MANAGED_SOURCE_LOADER,
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment=(
+                "Managed source 'raw_events' has no explicitly resolved physical write schema"
+            ),
+        ),
+        NamespaceCompileTestCase(
+            description="resource schema supplies physical namespace",
+            repo_files={
+                "sqlbuild_project.toml": _POSTGRES_CONFIG_WITHOUT_SCHEMA,
+                "models/orders.sql": "MODEL (schema analytics);\n\nSELECT 1 AS id\n",
+            },
+            expected_exit_code=0,
+            expected_stderr_fragment="",
+        ),
+        NamespaceCompileTestCase(
+            description="default schema supplies physical namespace",
+            repo_files={
+                "sqlbuild_project.toml": (
+                    _POSTGRES_CONFIG_WITHOUT_SCHEMA + '\n[defaults]\nschema = "analytics"\n'
+                ),
+                "models/orders.sql": "MODEL ();\n\nSELECT 1 AS id\n",
+            },
+            expected_exit_code=0,
+            expected_stderr_fragment="",
+        ),
+        NamespaceCompileTestCase(
+            description="literal target schema supplies warehouse physical namespace",
+            repo_files={
+                "sqlbuild_project.toml": (
+                    _POSTGRES_CONFIG_WITHOUT_SCHEMA.replace(
+                        "\n[connection]\n", '\ndefault_target = "dev"\n\n[connection]\n'
+                    )
+                    + '\n[targets.dev]\nschema = "analytics"\n'
+                ),
+                "models/orders.sql": "MODEL ();\n\nSELECT 1 AS id\n",
+            },
+            expected_exit_code=0,
+            expected_stderr_fragment="",
+        ),
+        NamespaceCompileTestCase(
+            description="connection schema supplies physical namespace",
+            repo_files={
+                "sqlbuild_project.toml": (
+                    _POSTGRES_CONFIG_WITHOUT_SCHEMA + 'schema = "analytics"\n'
+                ),
+                "models/orders.sql": "MODEL ();\n\nSELECT 1 AS id\n",
+            },
+            expected_exit_code=0,
+            expected_stderr_fragment="",
+        ),
+        NamespaceCompileTestCase(
+            description="loader schema supplies managed source physical namespace",
+            repo_files={
+                "sqlbuild_project.toml": (
+                    _POSTGRES_CONFIG_WITHOUT_SCHEMA.replace(
+                        "\n[connection]\n", '\ndefault_target = "dev"\n\n[connection]\n'
+                    )
+                    + '\n[targets.dev]\nloader_schema = "raw"\n'
+                ),
+                "sources/raw.yml": _MANAGED_SOURCE,
+                "loaders/raw_events.py": _MANAGED_SOURCE_LOADER,
+            },
+            expected_exit_code=0,
+            expected_stderr_fragment="",
+        ),
+        NamespaceCompileTestCase(
+            description="DuckDB may compile managed writes with implicit main schema",
+            repo_files={
+                "sqlbuild_project.toml": (
+                    'name = "namespace_validation"\nadapter = "duckdb"\n\n'
+                    "[connection]\n"
+                    'database = ":memory:"\n'
+                ),
+                "models/orders.sql": "MODEL ();\n\nSELECT 1 AS id\n",
+                "seeds/schema.yml": _SEED_SCHEMA,
+                "seeds/countries.csv": "code\nGB\n",
+                "functions/sql/answer.sql": "FUNCTION (returns INTEGER);\n\n42\n",
+                "sources/raw.yml": _MANAGED_SOURCE,
+                "loaders/raw_events.py": _MANAGED_SOURCE_LOADER,
+            },
+            expected_exit_code=0,
+            expected_stderr_fragment="",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_managed_resources_when_compiling_namespace_targets_then_validation_is_fail_closed(
+    test_case: NamespaceCompileTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_inline_project(
+        tmp_path=tmp_path,
+        project_name="namespace_validation",
+        repo_files=test_case.repo_files,
+    )
+
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "compile"),
+        project_dir=project_dir,
+    )
+
+    assert result.returncode == test_case.expected_exit_code, result.stdout + result.stderr
+    assert test_case.expected_stderr_fragment in result.stderr

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
@@ -330,7 +330,7 @@ def test_given_progress_callback_when_building_project_graph_then_reports_compil
     "test_case",
     [
         SnowflakeTargetValidationIntegrationTestCase(
-            description="snowflake compile accepts explicit connection database and schema",
+            description="snowflake compile requires explicit target database and schema",
             project_files={
                 "sqlbuild_project.toml": (
                     'name = "demo"\nadapter = "duckdb"\n\n[connection]\ndatabase = "demo.duckdb"\n'
@@ -345,13 +345,12 @@ def test_given_progress_callback_when_building_project_graph_then_reports_compil
                 ),
                 "models/stg_orders.sql": "MODEL (materialized view);\n\nSELECT 1 AS order_id\n",
             },
-            expected_database="TEST_DB",
-            expected_schema="TEST_SCHEMA",
+            expected_error_fragment="snowflake execution requires explicit target database",
         )
     ],
     ids=lambda case: case.description,
 )
-def test_given_snowflake_local_override_with_connection_namespace_when_compiling_then_targets_resolve(
+def test_given_snowflake_local_override_without_target_namespace_when_compiling_then_it_fails_early(
     test_case: SnowflakeTargetValidationIntegrationTestCase,
     tmp_path: Path,
     write_repo_files: Callable[[Path, dict[str, str]], None],
@@ -361,13 +360,12 @@ def test_given_snowflake_local_override_with_connection_namespace_when_compiling
     write_repo_files(tmp_path, test_case.project_files)
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
 
-    project: CompiledProject = compile_project(
-        discovered_inputs=discovered_inputs,
-        adapter=SnowflakeAdapter(),
-        no_sql_validation=True,
-    )
-    assert project.models[0].destination.database == test_case.expected_database
-    assert project.models[0].destination.schema == test_case.expected_schema
+    with pytest.raises(ValueError, match=test_case.expected_error_fragment):
+        compile_project(
+            discovered_inputs=discovered_inputs,
+            adapter=SnowflakeAdapter(),
+            no_sql_validation=True,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
@@ -330,7 +330,7 @@ def test_given_progress_callback_when_building_project_graph_then_reports_compil
     "test_case",
     [
         SnowflakeTargetValidationIntegrationTestCase(
-            description="snowflake compile requires explicit target database and schema",
+            description="snowflake compile accepts explicit connection database and schema",
             project_files={
                 "sqlbuild_project.toml": (
                     'name = "demo"\nadapter = "duckdb"\n\n[connection]\ndatabase = "demo.duckdb"\n'
@@ -345,12 +345,13 @@ def test_given_progress_callback_when_building_project_graph_then_reports_compil
                 ),
                 "models/stg_orders.sql": "MODEL (materialized view);\n\nSELECT 1 AS order_id\n",
             },
-            expected_error_fragment="snowflake execution requires explicit target database, schema",
+            expected_database="TEST_DB",
+            expected_schema="TEST_SCHEMA",
         )
     ],
     ids=lambda case: case.description,
 )
-def test_given_snowflake_local_override_without_target_namespace_when_compiling_then_it_fails_early(
+def test_given_snowflake_local_override_with_connection_namespace_when_compiling_then_targets_resolve(
     test_case: SnowflakeTargetValidationIntegrationTestCase,
     tmp_path: Path,
     write_repo_files: Callable[[Path, dict[str, str]], None],
@@ -360,12 +361,13 @@ def test_given_snowflake_local_override_without_target_namespace_when_compiling_
     write_repo_files(tmp_path, test_case.project_files)
     discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
 
-    with pytest.raises(ValueError, match=test_case.expected_error_fragment):
-        compile_project(
-            discovered_inputs=discovered_inputs,
-            adapter=SnowflakeAdapter(),
-            no_sql_validation=True,
-        )
+    project: CompiledProject = compile_project(
+        discovered_inputs=discovered_inputs,
+        adapter=SnowflakeAdapter(),
+        no_sql_validation=True,
+    )
+    assert project.models[0].destination.database == test_case.expected_database
+    assert project.models[0].destination.schema == test_case.expected_schema
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/adapters/_test_types.py
+++ b/tests/unit/src/sqlbuild/adapters/_test_types.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.classes.strict_adapter import StrictAdapter
 
 
@@ -44,3 +45,10 @@ class AdapterSeedSelectAfterCursorTestCase:
     cursor_start_exclusive: str
     cursor_type: str | None
     expected_sql: str
+
+
+@dataclass(frozen=True)
+class AdapterManagedWriteSchemaCapabilityTestCase:
+    description: str
+    adapter: BaseAdapter
+    expected_allows_implicit_schema: bool

--- a/tests/unit/src/sqlbuild/adapters/test_managed_write_schema_capability.py
+++ b/tests/unit/src/sqlbuild/adapters/test_managed_write_schema_capability.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import pytest
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.adapters.bigquery.classes.bigquery_adapter import BigQueryAdapter
+from sqlbuild.adapters.databricks.classes.databricks_adapter import DatabricksAdapter
+from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.adapters.motherduck.classes.motherduck_adapter import MotherDuckAdapter
+from sqlbuild.adapters.postgres.classes.postgres_adapter import PostgresAdapter
+from sqlbuild.adapters.snowflake.classes.snowflake_adapter import SnowflakeAdapter
+from sqlbuild.adapters.sqlserver.classes.sqlserver_adapter import SqlServerAdapter
+from tests.unit.src.sqlbuild.adapters._test_types import (
+    AdapterManagedWriteSchemaCapabilityTestCase,
+)
+
+
+class _CustomAdapter(BaseAdapter):
+    adapter_name: ClassVar[str] = "custom"
+
+    def connect(self, config: dict[str, Any]) -> Any:
+        del config
+        return None
+
+    def close(self, connection: Any) -> None:
+        del connection
+
+    def execute(self, connection: Any, sql: str) -> Any:
+        del connection, sql
+        return None
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AdapterManagedWriteSchemaCapabilityTestCase(
+            description="DuckDB permits its implicit main schema",
+            adapter=DuckDbAdapter(),
+            expected_allows_implicit_schema=True,
+        ),
+        AdapterManagedWriteSchemaCapabilityTestCase(
+            description="MotherDuck requires an explicit schema",
+            adapter=MotherDuckAdapter(),
+            expected_allows_implicit_schema=False,
+        ),
+        AdapterManagedWriteSchemaCapabilityTestCase(
+            description="Snowflake requires an explicit schema",
+            adapter=SnowflakeAdapter(),
+            expected_allows_implicit_schema=False,
+        ),
+        AdapterManagedWriteSchemaCapabilityTestCase(
+            description="BigQuery requires an explicit schema",
+            adapter=BigQueryAdapter(),
+            expected_allows_implicit_schema=False,
+        ),
+        AdapterManagedWriteSchemaCapabilityTestCase(
+            description="Databricks requires an explicit schema",
+            adapter=DatabricksAdapter(),
+            expected_allows_implicit_schema=False,
+        ),
+        AdapterManagedWriteSchemaCapabilityTestCase(
+            description="Postgres requires an explicit schema despite public default",
+            adapter=PostgresAdapter(),
+            expected_allows_implicit_schema=False,
+        ),
+        AdapterManagedWriteSchemaCapabilityTestCase(
+            description="SQL Server requires an explicit schema despite dbo default",
+            adapter=SqlServerAdapter(),
+            expected_allows_implicit_schema=False,
+        ),
+        AdapterManagedWriteSchemaCapabilityTestCase(
+            description="custom adapters inherit the conservative default",
+            adapter=_CustomAdapter(),
+            expected_allows_implicit_schema=False,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_adapter_when_checking_managed_write_schema_capability_then_policy_is_conservative(
+    test_case: AdapterManagedWriteSchemaCapabilityTestCase,
+) -> None:
+    assert (
+        test_case.adapter.allows_implicit_managed_write_schema
+        is test_case.expected_allows_implicit_schema
+    )

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
@@ -456,6 +456,16 @@ class ValidateSqlSyntaxTestCase:
 
 
 @dataclass(frozen=True)
+class PreservedLogicalNamespaceTestCase:
+    description: str
+    logical_database: str | None
+    logical_schema: str | None
+    target_database: str | None
+    target_schema: str | None
+    expected_error_fragment: str | None
+
+
+@dataclass(frozen=True)
 class ValidateHookSqlSyntaxTestCase:
     description: str
     hook_sql: str

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_namespace_validation.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_namespace_validation.py
@@ -1,0 +1,99 @@
+"""Tests for preserve target logical namespace validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from sqlbuild.compiler.compile._helpers.attachment.namespace_validation import (
+    validate_preserved_logical_namespace,
+)
+from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.spec.contracts.models import TargetConfig
+from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
+    PreservedLogicalNamespaceTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        PreservedLogicalNamespaceTestCase(
+            description="preserved schema without logical schema fails closed",
+            logical_database="analytics",
+            logical_schema=None,
+            target_database=None,
+            target_schema="preserve",
+            expected_error_fragment="Model 'orders' has no logical schema",
+        ),
+        PreservedLogicalNamespaceTestCase(
+            description="preserved database without logical database fails closed",
+            logical_database=None,
+            logical_schema="marts",
+            target_database="preserve",
+            target_schema=None,
+            expected_error_fragment="Model 'orders' has no logical database",
+        ),
+        PreservedLogicalNamespaceTestCase(
+            description="both preserved dimensions report one structured error",
+            logical_database=None,
+            logical_schema=None,
+            target_database="preserve",
+            target_schema="preserve",
+            expected_error_fragment="no logical database and schema",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_missing_logical_namespace_when_validating_preserve_then_structured_error_is_raised(
+    test_case: PreservedLogicalNamespaceTestCase,
+) -> None:
+    target: TargetConfig = TargetConfig(
+        database=test_case.target_database,
+        schema=test_case.target_schema,
+    )
+    with pytest.raises(CompileInputError, match=str(test_case.expected_error_fragment)) as error:
+        validate_preserved_logical_namespace(
+            resource_label="Model 'orders'",
+            logical_database=test_case.logical_database,
+            logical_schema=test_case.logical_schema,
+            target_config=target,
+        )
+    assert error.value.help is not None
+    assert "defaults" in error.value.help
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        PreservedLogicalNamespaceTestCase(
+            description="literal target supplies namespace without logical values",
+            logical_database=None,
+            logical_schema=None,
+            target_database="physical_db",
+            target_schema="physical_schema",
+            expected_error_fragment=None,
+        ),
+        PreservedLogicalNamespaceTestCase(
+            description="missing target fields retain adapter fallback",
+            logical_database=None,
+            logical_schema=None,
+            target_database=None,
+            target_schema=None,
+            expected_error_fragment=None,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_non_preserved_target_when_validating_namespace_then_adapter_fallback_remains_allowed(
+    test_case: PreservedLogicalNamespaceTestCase,
+) -> None:
+    validate_preserved_logical_namespace(
+        resource_label="Model 'orders'",
+        logical_database=test_case.logical_database,
+        logical_schema=test_case.logical_schema,
+        target_config=TargetConfig(
+            database=test_case.target_database,
+            schema=test_case.target_schema,
+        ),
+    )
+    assert test_case.expected_error_fragment is None

--- a/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/_test_types.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.compile.models import CompiledRelationLocation
 
 
@@ -9,3 +10,12 @@ class ValidateProjectTargetsTestCase:
     adapter_name: str
     target: CompiledRelationLocation
     expected_error_fragment: str
+
+
+@dataclass(frozen=True)
+class ValidateManagedWriteSchemaTestCase:
+    description: str
+    adapter: BaseAdapter
+    target_schema: str | None
+    effective_connection: dict[str, object]
+    expected_error_fragment: str | None

--- a/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/helpers.py
@@ -14,13 +14,15 @@ from sqlbuild.compiler.compile.models import (
 from sqlbuild.compiler.compile.types import CompiledResourceType
 
 
-def build_project(*, target: CompiledRelationLocation) -> CompiledProject:
+def build_project(
+    *, target: CompiledRelationLocation, effective_connection: dict[str, object]
+) -> CompiledProject:
     """Build a minimal compiled project for target validation tests."""
 
     return CompiledProject(
         run_id="run_123",
         effective_target_name=None,
-        effective_connection={},
+        effective_connection=effective_connection,
         effective_vars={},
         models=(
             CompiledModel(

--- a/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/test_main.py
@@ -3,12 +3,23 @@ from __future__ import annotations
 import pytest
 
 from sqlbuild.adapter.contract.types import BuiltinAdapter
+from sqlbuild.adapters.bigquery.classes.bigquery_adapter import BigQueryAdapter
+from sqlbuild.adapters.databricks.classes.databricks_adapter import DatabricksAdapter
+from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.adapters.motherduck.classes.motherduck_adapter import MotherDuckAdapter
+from sqlbuild.adapters.postgres.classes.postgres_adapter import PostgresAdapter
+from sqlbuild.adapters.snowflake.classes.snowflake_adapter import SnowflakeAdapter
+from sqlbuild.adapters.sqlserver.classes.sqlserver_adapter import SqlServerAdapter
 from sqlbuild.compiler.compile.models import (
     CompiledProject,
     CompiledRelationLocation,
 )
-from sqlbuild.compiler.pipeline._helpers.target_validation import validate_project_targets
+from sqlbuild.compiler.pipeline._helpers.target_validation import (
+    validate_managed_write_schemas,
+    validate_project_targets,
+)
 from tests.unit.src.sqlbuild.compiler.pipeline._helpers.target_validation._test_types import (
+    ValidateManagedWriteSchemaTestCase,
     ValidateProjectTargetsTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.pipeline._helpers.target_validation.helpers import (
@@ -41,7 +52,7 @@ from tests.unit.src.sqlbuild.compiler.pipeline._helpers.target_validation.helper
 def test_given_adapter_with_missing_target_namespace_when_validating_then_raises_clear_error(
     test_case: ValidateProjectTargetsTestCase,
 ) -> None:
-    project: CompiledProject = build_project(target=test_case.target)
+    project: CompiledProject = build_project(target=test_case.target, effective_connection={})
 
     with pytest.raises(ValueError, match=test_case.expected_error_fragment):
         validate_project_targets(adapter_name=test_case.adapter_name, project=project)
@@ -67,7 +78,116 @@ def test_given_adapter_with_missing_target_namespace_when_validating_then_raises
 def test_given_duckdb_with_missing_target_namespace_when_validating_then_it_passes(
     test_case: ValidateProjectTargetsTestCase,
 ) -> None:
-    project: CompiledProject = build_project(target=test_case.target)
+    project: CompiledProject = build_project(target=test_case.target, effective_connection={})
 
     validate_project_targets(adapter_name=test_case.adapter_name, project=project)
     assert test_case.expected_error_fragment == ""
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        ValidateManagedWriteSchemaTestCase(
+            description="Postgres adapter default does not satisfy write policy",
+            adapter=PostgresAdapter(),
+            target_schema=None,
+            effective_connection={},
+            expected_error_fragment="Model 'stg_customers' has no explicitly resolved",
+        ),
+        ValidateManagedWriteSchemaTestCase(
+            description="MotherDuck adapter default does not satisfy write policy",
+            adapter=MotherDuckAdapter(),
+            target_schema=None,
+            effective_connection={},
+            expected_error_fragment="Model 'stg_customers' has no explicitly resolved",
+        ),
+        ValidateManagedWriteSchemaTestCase(
+            description="Snowflake rejects an implicit write schema",
+            adapter=SnowflakeAdapter(),
+            target_schema=None,
+            effective_connection={},
+            expected_error_fragment="Model 'stg_customers' has no explicitly resolved",
+        ),
+        ValidateManagedWriteSchemaTestCase(
+            description="BigQuery rejects an implicit write schema",
+            adapter=BigQueryAdapter(),
+            target_schema=None,
+            effective_connection={},
+            expected_error_fragment="Model 'stg_customers' has no explicitly resolved",
+        ),
+        ValidateManagedWriteSchemaTestCase(
+            description="Databricks rejects an implicit write schema",
+            adapter=DatabricksAdapter(),
+            target_schema=None,
+            effective_connection={},
+            expected_error_fragment="Model 'stg_customers' has no explicitly resolved",
+        ),
+        ValidateManagedWriteSchemaTestCase(
+            description="SQL Server default does not satisfy write policy",
+            adapter=SqlServerAdapter(),
+            target_schema=None,
+            effective_connection={},
+            expected_error_fragment="Model 'stg_customers' has no explicitly resolved",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_warehouse_managed_write_without_schema_when_validating_then_error_is_raised(
+    test_case: ValidateManagedWriteSchemaTestCase,
+) -> None:
+    project: CompiledProject = build_project(
+        target=CompiledRelationLocation(
+            database=None,
+            schema=test_case.target_schema,
+            name="stg_customers",
+            qualified_name=None,
+        ),
+        effective_connection=test_case.effective_connection,
+    )
+
+    with pytest.raises(ValueError, match=str(test_case.expected_error_fragment)):
+        validate_managed_write_schemas(adapter=test_case.adapter, project=project)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        ValidateManagedWriteSchemaTestCase(
+            description="literal resolved schema satisfies write policy",
+            adapter=PostgresAdapter(),
+            target_schema="analytics",
+            effective_connection={},
+            expected_error_fragment=None,
+        ),
+        ValidateManagedWriteSchemaTestCase(
+            description="connection schema satisfies write policy",
+            adapter=PostgresAdapter(),
+            target_schema=None,
+            effective_connection={"schema": "analytics"},
+            expected_error_fragment=None,
+        ),
+        ValidateManagedWriteSchemaTestCase(
+            description="DuckDB permits implicit main schema",
+            adapter=DuckDbAdapter(),
+            target_schema=None,
+            effective_connection={},
+            expected_error_fragment=None,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_explicit_or_permitted_schema_when_validating_managed_write_then_it_passes(
+    test_case: ValidateManagedWriteSchemaTestCase,
+) -> None:
+    project: CompiledProject = build_project(
+        target=CompiledRelationLocation(
+            database=None,
+            schema=test_case.target_schema,
+            name="stg_customers",
+            qualified_name=None,
+        ),
+        effective_connection=test_case.effective_connection,
+    )
+
+    validate_managed_write_schemas(adapter=test_case.adapter, project=project)
+    assert test_case.expected_error_fragment is None


### PR DESCRIPTION
## Why
Shared warehouse adapters could silently fall back to session defaults such as `public`, `dbo`, or `main` when a managed resource had no resolved schema. This risks writing to an unintended schema.

## Changes
- Require explicit physical write schemas for models, seeds, functions, and managed source loaders on warehouse/custom adapters.
- Fail unresolved `preserve` namespaces during offline compilation.
- Permit implicit `main` only for first-class local DuckDB; MotherDuck remains fail-closed.
- Accept explicit resource, defaults/path defaults, target/loader, and connection namespaces.
- Add structured `S103` diagnostics and propagate explicit connection namespaces into compiled targets.
- Cover all built-in adapters, custom adapters, every managed resource kind, preserve behavior, and DuckDB fallback.

## Verification
- `make check-ci`
- Full unit/integration suite: 4,700 passed
- Focused adapter/namespace suite: 60 passed