### PR TITLE
fix: require named targets to declare schema strategy

### DIFF
--- a/src/sqlbuild/adapters/duckdb/classes/duckdb_adapter.py
+++ b/src/sqlbuild/adapters/duckdb/classes/duckdb_adapter.py
@@ -14,7 +14,7 @@ from sqlbuild.microbatches.constants import MICROBATCH_GENERATION_COMMENT_PREFIX
 
 
 class DuckDbAdapter(MicrobatchMixin, DuckDbBackedAdapter):
-    """First-class DuckDB adapter with full method coverage."""
+    """DuckDB adapter allowing implicit main for targetless and named local targets."""
 
     adapter_name: ClassVar[str] = BuiltinAdapter.DUCKDB.value
     allows_implicit_managed_write_schema: ClassVar[bool] = True

--- a/src/sqlbuild/compiler/pipeline/_helpers/target_validation.py
+++ b/src/sqlbuild/compiler/pipeline/_helpers/target_validation.py
@@ -17,6 +17,7 @@ from sqlbuild.compiler.compile.models import (
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.spec.contracts.main.resolve_target_config import resolve_target_config
+from sqlbuild.spec.contracts.main.resolve_target_name import resolve_target_name
 from sqlbuild.spec.contracts.models import SourceEntry, TargetConfig
 
 _CONNECTION_IDENTITY_KEYS: frozenset[str] = frozenset(
@@ -82,6 +83,38 @@ def validate_managed_loader_target_isolation(
                 f"targets.{right_target}.loader_schema values.",
                 code="S102",
             )
+
+
+def validate_named_target_schema_strategy(
+    *,
+    discovered_inputs: DiscoveredProjectInputs,
+    adapter: BaseAdapter,
+    selected_target: str | None,
+) -> None:
+    """Require shared-warehouse named targets to choose a schema strategy."""
+
+    if adapter.allows_implicit_managed_write_schema:
+        return
+    target_name: str | None = resolve_target_name(
+        project_config=discovered_inputs.project_config,
+        local_config=discovered_inputs.local_config,
+        selected_target=selected_target,
+    )
+    if target_name is None:
+        return
+    target_config: TargetConfig = resolve_target_config(
+        project_config=discovered_inputs.project_config,
+        local_config=discovered_inputs.local_config,
+        target_name=target_name,
+    )
+    if isinstance(target_config.schema, str) and target_config.schema.strip():
+        return
+    raise PlannerInputError(
+        f"Named target '{target_name}' must explicitly set schema to a nonblank literal or "
+        f"'{PRESERVE_TARGET_VALUE}'. Resource schemas, defaults, and connection schemas do not "
+        "select a named target schema strategy.",
+        code="S104",
+    )
 
 
 def _connection_identity(connection: dict[str, object]) -> tuple[tuple[str, str], ...]:

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -18,6 +18,7 @@ from sqlbuild.compiler.pipeline._helpers.target_defaults import apply_target_def
 from sqlbuild.compiler.pipeline._helpers.target_validation import (
     validate_managed_loader_target_isolation,
     validate_managed_write_schemas,
+    validate_named_target_schema_strategy,
     validate_project_targets,
 )
 from sqlbuild.compiler.planner.main.selection._resolve_planner_scopes import (
@@ -52,6 +53,11 @@ def build_compiled_project(
 ) -> CompiledProject:
     """Build one compiled project with adapter defaults and target validation applied."""
 
+    validate_named_target_schema_strategy(
+        discovered_inputs=discovered_inputs,
+        adapter=adapter,
+        selected_target=selected_target,
+    )
     validate_managed_loader_target_isolation(
         discovered_inputs=discovered_inputs,
         adapter=adapter,

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_namespace_validation.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_namespace_validation.py
@@ -44,6 +44,10 @@ _SEED_SCHEMA: str = (
 _POSTGRES_CONFIG_WITHOUT_SCHEMA: str = (
     'name = "namespace_validation"\nadapter = "postgres"\n\n[connection]\ndatabase = "analytics"\n'
 )
+_NAMED_POSTGRES_CONFIG_WITHOUT_SCHEMA: str = (
+    'name = "namespace_validation"\nadapter = "postgres"\ndefault_target = "dev"\n\n'
+    '[connection]\ndatabase = "analytics"\n\n[targets.dev]\n'
+)
 _PYTHON_FUNCTION: str = (
     "from sqlbuild.functions import udf\n\n"
     '@udf(arguments={}, returns="INTEGER", runtime_version="3.11")\n'
@@ -307,6 +311,51 @@ _MANAGED_SOURCE_LOADER: str = (
             expected_stderr_fragment="",
         ),
         NamespaceCompileTestCase(
+            description="preserve target schema retains model logical namespace",
+            repo_files={
+                "sqlbuild_project.toml": (
+                    _NAMED_POSTGRES_CONFIG_WITHOUT_SCHEMA + 'schema = "preserve"\n'
+                ),
+                "models/orders.sql": "MODEL (schema analytics);\n\nSELECT 1 AS id\n",
+            },
+            expected_exit_code=0,
+            expected_stderr_fragment="",
+        ),
+        NamespaceCompileTestCase(
+            description="named target rejects model logical schema as strategy",
+            repo_files={
+                "sqlbuild_project.toml": _NAMED_POSTGRES_CONFIG_WITHOUT_SCHEMA,
+                "models/orders.sql": "MODEL (schema analytics);\n\nSELECT 1 AS id\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment=(
+                "Named target 'dev' must explicitly set schema to a nonblank literal or 'preserve'"
+            ),
+        ),
+        NamespaceCompileTestCase(
+            description="named target rejects defaults schema as strategy",
+            repo_files={
+                "sqlbuild_project.toml": (
+                    _NAMED_POSTGRES_CONFIG_WITHOUT_SCHEMA + '\n[defaults]\nschema = "analytics"\n'
+                ),
+                "models/orders.sql": "MODEL ();\n\nSELECT 1 AS id\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="Named target 'dev' must explicitly set schema",
+        ),
+        NamespaceCompileTestCase(
+            description="named target rejects connection schema as strategy",
+            repo_files={
+                "sqlbuild_project.toml": _NAMED_POSTGRES_CONFIG_WITHOUT_SCHEMA.replace(
+                    'database = "analytics"',
+                    'database = "analytics"\nschema = "connection_schema"',
+                ),
+                "models/orders.sql": "MODEL ();\n\nSELECT 1 AS id\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragment="Named target 'dev' must explicitly set schema",
+        ),
+        NamespaceCompileTestCase(
             description="connection schema supplies physical namespace",
             repo_files={
                 "sqlbuild_project.toml": (
@@ -318,7 +367,7 @@ _MANAGED_SOURCE_LOADER: str = (
             expected_stderr_fragment="",
         ),
         NamespaceCompileTestCase(
-            description="loader schema supplies managed source physical namespace",
+            description="named target rejects loader schema as target strategy",
             repo_files={
                 "sqlbuild_project.toml": (
                     _POSTGRES_CONFIG_WITHOUT_SCHEMA.replace(
@@ -329,8 +378,8 @@ _MANAGED_SOURCE_LOADER: str = (
                 "sources/raw.yml": _MANAGED_SOURCE,
                 "loaders/raw_events.py": _MANAGED_SOURCE_LOADER,
             },
-            expected_exit_code=0,
-            expected_stderr_fragment="",
+            expected_exit_code=1,
+            expected_stderr_fragment="Named target 'dev' must explicitly set schema",
         ),
         NamespaceCompileTestCase(
             description="DuckDB may compile managed writes with implicit main schema",
@@ -346,6 +395,20 @@ _MANAGED_SOURCE_LOADER: str = (
                 "functions/sql/answer.sql": "FUNCTION (returns INTEGER);\n\n42\n",
                 "sources/raw.yml": _MANAGED_SOURCE,
                 "loaders/raw_events.py": _MANAGED_SOURCE_LOADER,
+            },
+            expected_exit_code=0,
+            expected_stderr_fragment="",
+        ),
+        NamespaceCompileTestCase(
+            description="named DuckDB target may compile with implicit main schema",
+            repo_files={
+                "sqlbuild_project.toml": (
+                    'name = "namespace_validation"\nadapter = "duckdb"\ndefault_target = "dev"\n\n'
+                    "[connection]\n"
+                    'database = ":memory:"\n\n'
+                    "[targets.dev]\n"
+                ),
+                "models/orders.sql": "MODEL ();\n\nSELECT 1 AS id\n",
             },
             expected_exit_code=0,
             expected_stderr_fragment="",

--- a/tests/e2e/src/sqlbuild/cli/commands/main/state/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/state/helpers.py
@@ -37,6 +37,8 @@ def build_postgres_state_project_toml(
         f'dbname = "{config["dbname"]}"\n'
         f'user = "{config["user"]}"\n'
         f'password = "{config["password"]}"\n\n'
+        "[targets.dev]\n"
+        'schema = "preserve"\n\n'
         "[targets.dev.state]\n"
         'backend = "postgres"\n'
         f'schema = "{state_schema}"\n'

--- a/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/_test_types.py
@@ -29,3 +29,11 @@ class PythonPlanIdentityStatusTestCase:
     description: str
     previous_version_hash: str | None
     expected_status: PythonIdentityStatus
+
+
+@dataclass(frozen=True)
+class CloneTargetSchemaTestCase:
+    description: str
+    origin_schema: str | None
+    destination_schema: str | None
+    expected_target_name: str

--- a/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/_test_types.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.compile.models import CompiledRelationLocation
+from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig
 
 
 @dataclass(frozen=True)
@@ -18,4 +19,14 @@ class ValidateManagedWriteSchemaTestCase:
     adapter: BaseAdapter
     target_schema: str | None
     effective_connection: dict[str, object]
+    expected_error_fragment: str | None
+
+
+@dataclass(frozen=True)
+class ValidateNamedTargetSchemaTestCase:
+    description: str
+    adapter: BaseAdapter
+    project_config: ProjectConfig
+    local_config: LocalConfig
+    selected_target: str | None
     expected_error_fragment: str | None

--- a/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/helpers.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, ClassVar
 
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.compile.models import (
     CompiledModel,
     CompiledObjectKey,
@@ -12,6 +14,23 @@ from sqlbuild.compiler.compile.models import (
     CompileModelConfig,
 )
 from sqlbuild.compiler.compile.types import CompiledResourceType
+
+
+class ConservativeCustomAdapter(BaseAdapter):
+    """Custom adapter retaining the conservative schema capability default."""
+
+    adapter_name: ClassVar[str] = "custom"
+
+    def connect(self, config: dict[str, Any]) -> Any:
+        del config
+        return None
+
+    def close(self, connection: Any) -> None:
+        del connection
+
+    def execute(self, connection: Any, sql: str) -> Any:
+        del connection, sql
+        return None
 
 
 def build_project(

--- a/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/target_validation/test_main.py
@@ -14,15 +14,25 @@ from sqlbuild.compiler.compile.models import (
     CompiledProject,
     CompiledRelationLocation,
 )
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline._helpers.target_validation import (
     validate_managed_write_schemas,
+    validate_named_target_schema_strategy,
     validate_project_targets,
+)
+from sqlbuild.spec.contracts.models import (
+    LocalConfig,
+    LocalTargetConfig,
+    ProjectConfig,
+    TargetConfig,
 )
 from tests.unit.src.sqlbuild.compiler.pipeline._helpers.target_validation._test_types import (
     ValidateManagedWriteSchemaTestCase,
+    ValidateNamedTargetSchemaTestCase,
     ValidateProjectTargetsTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.pipeline._helpers.target_validation.helpers import (
+    ConservativeCustomAdapter,
     build_project,
 )
 
@@ -190,4 +200,179 @@ def test_given_explicit_or_permitted_schema_when_validating_managed_write_then_i
     )
 
     validate_managed_write_schemas(adapter=test_case.adapter, project=project)
+    assert test_case.expected_error_fragment is None
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        ValidateNamedTargetSchemaTestCase(
+            description="shared warehouse named target omits schema",
+            adapter=PostgresAdapter(),
+            project_config=ProjectConfig(
+                name="test",
+                adapter="postgres",
+                default_target="dev",
+                targets={"dev": TargetConfig()},
+            ),
+            local_config=LocalConfig(),
+            selected_target=None,
+            expected_error_fragment=(
+                "Named target 'dev' must explicitly set schema to a nonblank literal or 'preserve'"
+            ),
+        ),
+        ValidateNamedTargetSchemaTestCase(
+            description="local override leaves merged named target schema blank",
+            adapter=SnowflakeAdapter(),
+            project_config=ProjectConfig(
+                name="test", adapter="snowflake", targets={"ci": TargetConfig()}
+            ),
+            local_config=LocalConfig(targets={"ci": LocalTargetConfig(schema="   ")}),
+            selected_target="ci",
+            expected_error_fragment="Named target 'ci' must explicitly set schema",
+        ),
+        ValidateNamedTargetSchemaTestCase(
+            description="MotherDuck named target omits schema",
+            adapter=MotherDuckAdapter(),
+            project_config=ProjectConfig(
+                name="test",
+                adapter="motherduck",
+                default_target="dev",
+                targets={"dev": TargetConfig()},
+            ),
+            local_config=LocalConfig(),
+            selected_target=None,
+            expected_error_fragment="Named target 'dev' must explicitly set schema",
+        ),
+        ValidateNamedTargetSchemaTestCase(
+            description="BigQuery named target omits schema",
+            adapter=BigQueryAdapter(),
+            project_config=ProjectConfig(
+                name="test",
+                adapter="bigquery",
+                default_target="dev",
+                targets={"dev": TargetConfig()},
+            ),
+            local_config=LocalConfig(),
+            selected_target=None,
+            expected_error_fragment="Named target 'dev' must explicitly set schema",
+        ),
+        ValidateNamedTargetSchemaTestCase(
+            description="Databricks named target omits schema",
+            adapter=DatabricksAdapter(),
+            project_config=ProjectConfig(
+                name="test",
+                adapter="databricks",
+                default_target="dev",
+                targets={"dev": TargetConfig()},
+            ),
+            local_config=LocalConfig(),
+            selected_target=None,
+            expected_error_fragment="Named target 'dev' must explicitly set schema",
+        ),
+        ValidateNamedTargetSchemaTestCase(
+            description="SQL Server named target omits schema",
+            adapter=SqlServerAdapter(),
+            project_config=ProjectConfig(
+                name="test",
+                adapter="sqlserver",
+                default_target="dev",
+                targets={"dev": TargetConfig()},
+            ),
+            local_config=LocalConfig(),
+            selected_target=None,
+            expected_error_fragment="Named target 'dev' must explicitly set schema",
+        ),
+        ValidateNamedTargetSchemaTestCase(
+            description="custom adapter named target omits schema conservatively",
+            adapter=ConservativeCustomAdapter(),
+            project_config=ProjectConfig(
+                name="test", adapter="custom", default_target="dev", targets={"dev": TargetConfig()}
+            ),
+            local_config=LocalConfig(),
+            selected_target=None,
+            expected_error_fragment="Named target 'dev' must explicitly set schema",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_named_target_without_schema_when_validating_strategy_then_error_is_raised(
+    test_case: ValidateNamedTargetSchemaTestCase,
+) -> None:
+    discovered_inputs: DiscoveredProjectInputs = DiscoveredProjectInputs(
+        project_config=test_case.project_config,
+        local_config=test_case.local_config,
+    )
+
+    with pytest.raises(ValueError, match=str(test_case.expected_error_fragment)):
+        validate_named_target_schema_strategy(
+            discovered_inputs=discovered_inputs,
+            adapter=test_case.adapter,
+            selected_target=test_case.selected_target,
+        )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        ValidateNamedTargetSchemaTestCase(
+            description="literal named target schema is explicit",
+            adapter=BigQueryAdapter(),
+            project_config=ProjectConfig(
+                name="test",
+                adapter="bigquery",
+                default_target="dev",
+                targets={"dev": TargetConfig(schema="analytics")},
+            ),
+            local_config=LocalConfig(),
+            selected_target=None,
+            expected_error_fragment=None,
+        ),
+        ValidateNamedTargetSchemaTestCase(
+            description="preserve named target schema is explicit",
+            adapter=DatabricksAdapter(),
+            project_config=ProjectConfig(
+                name="test",
+                adapter="databricks",
+                default_target="dev",
+                targets={"dev": TargetConfig(schema="preserve")},
+            ),
+            local_config=LocalConfig(),
+            selected_target=None,
+            expected_error_fragment=None,
+        ),
+        ValidateNamedTargetSchemaTestCase(
+            description="named local DuckDB retains implicit main capability",
+            adapter=DuckDbAdapter(),
+            project_config=ProjectConfig(
+                name="test", adapter="duckdb", default_target="dev", targets={"dev": TargetConfig()}
+            ),
+            local_config=LocalConfig(),
+            selected_target=None,
+            expected_error_fragment=None,
+        ),
+        ValidateNamedTargetSchemaTestCase(
+            description="targetless shared warehouse remains under resource write policy",
+            adapter=SqlServerAdapter(),
+            project_config=ProjectConfig(name="test", adapter="sqlserver"),
+            local_config=LocalConfig(),
+            selected_target=None,
+            expected_error_fragment=None,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_explicit_or_exempt_target_when_validating_schema_strategy_then_it_passes(
+    test_case: ValidateNamedTargetSchemaTestCase,
+) -> None:
+    discovered_inputs: DiscoveredProjectInputs = DiscoveredProjectInputs(
+        project_config=test_case.project_config,
+        local_config=test_case.local_config,
+    )
+
+    validate_named_target_schema_strategy(
+        discovered_inputs=discovered_inputs,
+        adapter=test_case.adapter,
+        selected_target=test_case.selected_target,
+    )
     assert test_case.expected_error_fragment is None

--- a/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/test_clone.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/_helpers/test_clone.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from sqlbuild.adapters.postgres.classes.postgres_adapter import PostgresAdapter
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.compiler.pipeline._helpers.clone import prepare_clone_pipeline
+from sqlbuild.compiler.pipeline.models import ClonePipelineOptions
+from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig, TargetConfig
+from tests.unit.src.sqlbuild.compiler.pipeline._helpers._test_types import (
+    CloneTargetSchemaTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        CloneTargetSchemaTestCase(
+            description="clone origin named target omits schema strategy",
+            origin_schema=None,
+            destination_schema="destination",
+            expected_target_name="prod",
+        ),
+        CloneTargetSchemaTestCase(
+            description="clone destination named target omits schema strategy",
+            origin_schema="origin",
+            destination_schema=None,
+            expected_target_name="dev",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_clone_target_without_schema_when_compiling_then_fails_before_planning(
+    test_case: CloneTargetSchemaTestCase,
+) -> None:
+    discovered_inputs: DiscoveredProjectInputs = DiscoveredProjectInputs(
+        project_config=ProjectConfig(
+            name="test",
+            adapter="postgres",
+            targets={
+                "prod": TargetConfig(schema=test_case.origin_schema),
+                "dev": TargetConfig(schema=test_case.destination_schema),
+            },
+        ),
+        local_config=LocalConfig(),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=f"Named target '{test_case.expected_target_name}' must explicitly set schema",
+    ):
+        prepare_clone_pipeline(
+            discovered_inputs=discovered_inputs,
+            adapter=PostgresAdapter(),
+            origin_target_name="prod",
+            destination_target_name="dev",
+            destination_connection=None,
+            options=ClonePipelineOptions(),
+        )


### PR DESCRIPTION
## Why
A named warehouse target could omit `schema` and silently write managed resources to their logical schemas. That makes an incompletely configured development target capable of resolving to production-shaped namespaces.

## Changes
- Require every effective named shared-warehouse target to explicitly set a nonblank literal schema or `preserve`.
- Reject omission offline before resource compilation or connection.
- Prevent resource defaults, logical schemas, loader schemas, connection schemas, and adapter defaults from bypassing the target-level decision.
- Cover Snowflake, BigQuery, Databricks, MotherDuck, PostgreSQL, SQL Server, conservative custom adapters, and clone origin/destination compilation.
- Retain local DuckDB implicit `main` behavior through its existing explicit capability.

## Verification
- Focused namespace and CLI suites: 50 passed
- Full unit/integration suite: 4,713 passed
- `make check-ci`
- Fensu: 0 faults