### PR TITLE
ci: validate PR metadata before hosted checks

### DIFF
--- a/.github/workflows/pull-request-metadata.yml
+++ b/.github/workflows/pull-request-metadata.yml
@@ -19,6 +19,7 @@ jobs:
     name: Pull Request Metadata
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
+      - uses: actions/checkout@v4
       - name: Resolve pull request metadata
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -35,75 +36,4 @@ jobs:
       - name: Validate branch, title, and description
         env:
           PR_METADATA_PATH: ${{ runner.temp }}/pull-request.json
-        run: |
-          python - <<'PY'
-          import json
-          import os
-          import re
-          import sys
-
-          with open(os.environ["PR_METADATA_PATH"], encoding="utf-8") as metadata_file:
-              payload = json.load(metadata_file)
-          pull_request = payload.get("pull_request", payload)
-          branch = pull_request["head"]["ref"]
-          title = pull_request["title"]
-          body = pull_request.get("body") or ""
-
-          branch_pattern = re.compile(
-              r"^(feat|fix|perf|refactor|test|docs|build|ci|chore|revert)/"
-              r"(?:chi-[0-9]+-)?[a-z0-9]+(?:-[a-z0-9]+)*$"
-          )
-          automation_pattern = re.compile(
-              r"^(release-please--|dependabot/|renovate/|github-actions/|blacksmith-migration-)"
-          )
-          title_pattern = re.compile(
-              r"^(feat|fix|perf|refactor|test|docs|build|ci|chore|revert)"
-              r"(?:\([a-z0-9][a-z0-9-]*\))?!?: [^ ].+$"
-          )
-
-          errors: list[str] = []
-          automated = automation_pattern.match(branch) is not None
-          if not automated and branch_pattern.fullmatch(branch) is None:
-              errors.append(
-                  "Branch must use <type>/<kebab-case> or "
-                  "<type>/chi-<number>-<kebab-case>."
-              )
-          if title_pattern.fullmatch(title) is None:
-              errors.append("PR title must follow Conventional Commits.")
-
-          if not automated:
-              if len(body) > 2_000:
-                  errors.append("PR description must not exceed 2,000 characters.")
-              sections = list(
-                  re.finditer(r"^## (Why|Changes|Verification)\s*$", body, re.MULTILINE)
-              )
-              found = [match.group(1) for match in sections]
-              expected = ["Why", "Changes", "Verification"]
-              if found != expected:
-                  errors.append(
-                      "PR description must contain Why, Changes, and Verification "
-                      "sections in that order."
-                  )
-              else:
-                  for index, match in enumerate(sections):
-                      end = (
-                          sections[index + 1].start()
-                          if index + 1 < len(sections)
-                          else len(body)
-                      )
-                      content = re.sub(
-                          r"<!--.*?-->", "", body[match.end() : end], flags=re.DOTALL
-                      )
-                      if not content.strip():
-                          errors.append(
-                              f"PR description section {match.group(1)} is empty."
-                          )
-
-          if errors:
-              print(f"Invalid pull request metadata for {branch}:", file=sys.stderr)
-              for error in errors:
-                  print(f"- {error}", file=sys.stderr)
-              sys.exit(1)
-
-          print(f"Pull request metadata is valid for {branch}.")
-          PY
+        run: python -m scripts.validate_pr_metadata --metadata-file "${PR_METADATA_PATH}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,10 @@ pytest tests/unit/src/sqlbuild/compiler/compile/test_main.py
 - Use concise conventional commit messages, such as `fix: ...`, `feat: ...`, `test: ...`, or `docs: ...`.
 - In pull requests, summarize the behavior change and list the checks you ran.
 - Call out breaking changes, migrations, or compatibility decisions explicitly.
+
+Before creating or editing a pull request, write its description to a file and validate the
+current branch, proposed title, and description locally:
+
+```bash
+make check-pr-metadata PR_TITLE='type: concise summary' PR_BODY_FILE=/path/to/pr-body.md
+```

--- a/Makefile
+++ b/Makefile
@@ -381,6 +381,14 @@ check-ci:
 	uv run fensu check
 
 
+check-pr-metadata:
+	@test -n "$(PR_TITLE)" || { echo "PR_TITLE is required" >&2; exit 2; }
+	@test -n "$(PR_BODY_FILE)" || { echo "PR_BODY_FILE is required" >&2; exit 2; }
+	uv run python -m scripts.validate_pr_metadata \
+		--title "$(PR_TITLE)" \
+		--body-file "$(PR_BODY_FILE)"
+
+
 verify-ci:
 	uv run ruff format --check .
 	uv run ruff check .

--- a/scripts/pr_metadata/__init__.py
+++ b/scripts/pr_metadata/__init__.py
@@ -1,0 +1,1 @@
+"""Pull request metadata validation tooling."""

--- a/scripts/pr_metadata/_helpers/__init__.py
+++ b/scripts/pr_metadata/_helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Pull request metadata validation helpers."""

--- a/scripts/pr_metadata/_helpers/inputs.py
+++ b/scripts/pr_metadata/_helpers/inputs.py
@@ -1,0 +1,29 @@
+"""Pull request metadata input resolution."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def load_event_metadata(path: Path) -> tuple[str, str, str]:
+    """Load branch, title, and body from a GitHub pull request payload."""
+    payload: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    pull_request: dict[str, Any] = payload.get("pull_request", payload)
+    return (
+        pull_request["head"]["ref"],
+        pull_request["title"],
+        pull_request.get("body") or "",
+    )
+
+
+def get_current_branch() -> str:
+    """Return the current Git branch name."""
+    return subprocess.run(
+        ["git", "branch", "--show-current"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()

--- a/scripts/pr_metadata/_helpers/validation.py
+++ b/scripts/pr_metadata/_helpers/validation.py
@@ -1,0 +1,43 @@
+"""Pull request metadata policy validation."""
+
+from __future__ import annotations
+
+import re
+
+from scripts.pr_metadata.constants import (
+    AUTOMATION_PATTERN,
+    BRANCH_PATTERN,
+    EXPECTED_SECTIONS,
+    MAX_BODY_LENGTH,
+    SECTION_PATTERN,
+    TITLE_PATTERN,
+)
+
+
+def get_pr_metadata_errors(*, branch: str, title: str, body: str) -> tuple[str, ...]:
+    """Return every pull request metadata policy violation."""
+    errors: list[str] = []
+    automated: bool = AUTOMATION_PATTERN.match(branch) is not None
+    if not automated and BRANCH_PATTERN.fullmatch(branch) is None:
+        errors.append("Branch must use <type>/<kebab-case> or <type>/chi-<number>-<kebab-case>.")
+    if TITLE_PATTERN.fullmatch(title) is None:
+        errors.append("PR title must follow Conventional Commits.")
+
+    if automated:
+        return tuple(errors)
+    if len(body) > MAX_BODY_LENGTH:
+        errors.append("PR description must not exceed 2,000 characters.")
+
+    sections: list[re.Match[str]] = list(SECTION_PATTERN.finditer(body))
+    if tuple(match.group(1) for match in sections) != EXPECTED_SECTIONS:
+        errors.append(
+            "PR description must contain Why, Changes, and Verification sections in that order."
+        )
+        return tuple(errors)
+
+    for index, match in enumerate(sections):
+        end: int = sections[index + 1].start() if index + 1 < len(sections) else len(body)
+        content: str = re.sub(r"<!--.*?-->", "", body[match.end() : end], flags=re.DOTALL)
+        if not content.strip():
+            errors.append(f"PR description section {match.group(1)} is empty.")
+    return tuple(errors)

--- a/scripts/pr_metadata/constants.py
+++ b/scripts/pr_metadata/constants.py
@@ -1,0 +1,18 @@
+"""Stable pull request metadata policy constants."""
+
+import re
+
+BRANCH_PATTERN: re.Pattern[str] = re.compile(
+    r"^(feat|fix|perf|refactor|test|docs|build|ci|chore|revert)/"
+    r"(?:chi-[0-9]+-)?[a-z0-9]+(?:-[a-z0-9]+)*$"
+)
+AUTOMATION_PATTERN: re.Pattern[str] = re.compile(
+    r"^(release-please--|dependabot/|renovate/|github-actions/|blacksmith-migration-)"
+)
+TITLE_PATTERN: re.Pattern[str] = re.compile(
+    r"^(feat|fix|perf|refactor|test|docs|build|ci|chore|revert)"
+    r"(?:\([a-z0-9][a-z0-9-]*\))?!?: [^ ].+$"
+)
+SECTION_PATTERN: re.Pattern[str] = re.compile(r"^## (Why|Changes|Verification)\s*$", re.MULTILINE)
+EXPECTED_SECTIONS: tuple[str, ...] = ("Why", "Changes", "Verification")
+MAX_BODY_LENGTH: int = 2_000

--- a/scripts/pr_metadata/main/__init__.py
+++ b/scripts/pr_metadata/main/__init__.py
@@ -1,0 +1,1 @@
+"""Pull request metadata command entrypoints."""

--- a/scripts/pr_metadata/main/validate.py
+++ b/scripts/pr_metadata/main/validate.py
@@ -1,0 +1,46 @@
+"""Pull request metadata command entrypoint."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from scripts.pr_metadata._helpers.inputs import get_current_branch, load_event_metadata
+from scripts.pr_metadata._helpers.validation import get_pr_metadata_errors
+
+
+def run_pr_metadata_validation(argv: list[str] | None = None) -> int:
+    """Validate metadata supplied directly or through a GitHub event payload."""
+    parser: argparse.ArgumentParser = _build_parser()
+    arguments: argparse.Namespace = parser.parse_args(argv)
+    branch: str
+    title: str
+    body: str
+    if arguments.metadata_file is not None:
+        branch, title, body = load_event_metadata(arguments.metadata_file)
+    else:
+        if arguments.title is None or arguments.body_file is None:
+            parser.error("--title and --body-file are required without --metadata-file")
+        branch = arguments.branch or get_current_branch()
+        title = arguments.title
+        body = arguments.body_file.read_text(encoding="utf-8")
+
+    errors: tuple[str, ...] = get_pr_metadata_errors(branch=branch, title=title, body=body)
+    if errors:
+        print(f"Invalid pull request metadata for {branch}:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"Pull request metadata is valid for {branch}.")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metadata-file", type=Path)
+    parser.add_argument("--branch")
+    parser.add_argument("--title")
+    parser.add_argument("--body-file", type=Path)
+    return parser

--- a/scripts/validate_pr_metadata.py
+++ b/scripts/validate_pr_metadata.py
@@ -1,0 +1,14 @@
+"""Direct wrapper for pull request metadata validation."""
+
+from __future__ import annotations
+
+from scripts.pr_metadata.main.validate import run_pr_metadata_validation
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate pull request metadata."""
+    return run_pr_metadata_validation(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/pr_metadata/__init__.py
+++ b/tests/unit/scripts/pr_metadata/__init__.py
@@ -1,0 +1,1 @@
+"""Pull request metadata tooling tests."""

--- a/tests/unit/scripts/pr_metadata/_helpers/__init__.py
+++ b/tests/unit/scripts/pr_metadata/_helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Pull request metadata helper tests."""

--- a/tests/unit/scripts/pr_metadata/_helpers/_test_types.py
+++ b/tests/unit/scripts/pr_metadata/_helpers/_test_types.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PrMetadataValidationTestCase:
+    description: str
+    branch: str
+    title: str
+    body: str
+    expected_errors: tuple[str, ...]

--- a/tests/unit/scripts/pr_metadata/_helpers/test_validation.py
+++ b/tests/unit/scripts/pr_metadata/_helpers/test_validation.py
@@ -1,0 +1,106 @@
+import pytest
+
+from scripts.pr_metadata._helpers.validation import get_pr_metadata_errors
+from tests.unit.scripts.pr_metadata._helpers._test_types import PrMetadataValidationTestCase
+
+VALID_BODY: str = "## Why\nReason\n\n## Changes\nChange\n\n## Verification\nTested\n"
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        PrMetadataValidationTestCase(
+            description="valid issue branch and complete body",
+            branch="feat/chi-137-named-connections",
+            title="feat: add named connections",
+            body=VALID_BODY,
+            expected_errors=(),
+        ),
+        PrMetadataValidationTestCase(
+            description="body exactly at maximum length",
+            branch="ci/local-pr-check",
+            title="ci: add local PR check",
+            body=VALID_BODY + "x" * (2_000 - len(VALID_BODY)),
+            expected_errors=(),
+        ),
+        PrMetadataValidationTestCase(
+            description="automation branch skips human body requirements",
+            branch="dependabot/pip/ruff-1.0",
+            title="chore(deps): update ruff",
+            body="",
+            expected_errors=(),
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_valid_metadata_when_validating_then_returns_no_errors(
+    test_case: PrMetadataValidationTestCase,
+) -> None:
+    errors: tuple[str, ...] = get_pr_metadata_errors(
+        branch=test_case.branch,
+        title=test_case.title,
+        body=test_case.body,
+    )
+
+    assert errors == test_case.expected_errors
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        PrMetadataValidationTestCase(
+            description="invalid branch",
+            branch="kvlonge/chi-137-named-connections",
+            title="feat: add named connections",
+            body=VALID_BODY,
+            expected_errors=(
+                "Branch must use <type>/<kebab-case> or <type>/chi-<number>-<kebab-case>.",
+            ),
+        ),
+        PrMetadataValidationTestCase(
+            description="non-conventional title",
+            branch="feat/named-connections",
+            title="Add named connections",
+            body=VALID_BODY,
+            expected_errors=("PR title must follow Conventional Commits.",),
+        ),
+        PrMetadataValidationTestCase(
+            description="body exceeds maximum length",
+            branch="feat/named-connections",
+            title="feat: add named connections",
+            body=VALID_BODY + "x" * (2_001 - len(VALID_BODY)),
+            expected_errors=("PR description must not exceed 2,000 characters.",),
+        ),
+        PrMetadataValidationTestCase(
+            description="sections are out of order",
+            branch="feat/named-connections",
+            title="feat: add named connections",
+            body="## Changes\nChange\n## Why\nReason\n## Verification\nTested\n",
+            expected_errors=(
+                "PR description must contain Why, Changes, and Verification sections in that order.",
+            ),
+        ),
+        PrMetadataValidationTestCase(
+            description="comment-only section is empty",
+            branch="feat/named-connections",
+            title="feat: add named connections",
+            body=("## Why\n<!-- reason -->\n\n## Changes\nChange\n\n## Verification\nTested\n"),
+            expected_errors=("PR description section Why is empty.",),
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_invalid_metadata_when_validating_then_returns_policy_errors(
+    test_case: PrMetadataValidationTestCase,
+) -> None:
+    errors: tuple[str, ...] = get_pr_metadata_errors(
+        branch=test_case.branch,
+        title=test_case.title,
+        body=test_case.body,
+    )
+
+    assert errors == test_case.expected_errors
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])


### PR DESCRIPTION
## Why
PR metadata policy previously existed only as inline workflow code, so invalid descriptions could be discovered after expensive hosted suites had already completed.

## Changes
- Extract branch, title, section, and length policy into tested Python tooling.
- Use the same validator from GitHub Actions and a local Make target.
- Document the preflight for contributors and agents.

## Verification
- `uv run pytest tests/unit/scripts/pr_metadata -n auto --dist loadfile -q` (8 passed)
- `make check-ci`
- Fensu: 0 faults
- Local direct and GitHub event-payload invocations
- `git diff --check`
