### PR TITLE
fix: support restricted Snowflake role sessions

### DIFF
--- a/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
+++ b/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
@@ -1476,7 +1476,6 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
             connect_config.setdefault("oauth_enable_refresh_tokens", True)
         elif authenticator == EXTERNAL_BROWSER_AUTHENTICATOR:
             connect_config.setdefault("client_store_temporary_credential", True)
-        role: object | None = connect_config.get("role")
         warehouse: object | None = connect_config.get("warehouse")
         database: object | None = connect_config.get("database")
         schema: object | None = connect_config.get("schema")
@@ -1488,7 +1487,6 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
         self._initialize_session(
             connection=connection,
             secondary_roles=secondary_roles,
-            role=role,
             warehouse=warehouse,
             database=database,
             schema=schema,
@@ -2883,18 +2881,14 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
         *,
         connection: _SnowflakeConnection,
         secondary_roles: str,
-        role: object | None,
         warehouse: object | None,
         database: object | None,
         schema: object | None,
     ) -> None:
         statements: list[str] = [f"USE SECONDARY ROLES {secondary_roles}"]
-        normalized_role: str | None = self._normalize_session_value(role)
         normalized_warehouse: str | None = self._normalize_session_value(warehouse)
         normalized_database: str | None = self._normalize_session_value(database)
         normalized_schema: str | None = self._normalize_session_value(schema)
-        if normalized_role is not None:
-            statements.append(f"USE ROLE {normalized_role}")
         if normalized_warehouse is not None:
             statements.append(f"USE WAREHOUSE {normalized_warehouse}")
         if normalized_database is not None:

--- a/tests/unit/src/sqlbuild/adapters/snowflake/test_client.py
+++ b/tests/unit/src/sqlbuild/adapters/snowflake/test_client.py
@@ -202,22 +202,25 @@ def test_given_snowflake_adapter_when_getting_inference_profile_then_returns_exp
             expected_session_statements=("USE SECONDARY ROLES ALL",),
         ),
         SnowflakeConnectConfigTestCase(
-            description="disables secondary roles before selecting primary session context",
+            description="programmatic token selects role during authentication without switching it",
             config={
                 "account": "acct",
+                "authenticator": "programmatic_access_token",
+                "token": "secret-token",
                 "role": "DEVELOPER",
                 "warehouse": "DEV_WH",
                 "database": "ANALYTICS",
             },
             expected_connect_kwargs={
                 "account": "acct",
+                "authenticator": "programmatic_access_token",
+                "token": "secret-token",
                 "role": "DEVELOPER",
                 "warehouse": "DEV_WH",
                 "database": "ANALYTICS",
             },
             expected_session_statements=(
                 "USE SECONDARY ROLES NONE",
-                "USE ROLE DEVELOPER",
                 "USE WAREHOUSE DEV_WH",
                 "USE DATABASE ANALYTICS",
             ),


### PR DESCRIPTION
## Why
Snowflake programmatic-access-token sessions reject `USE ROLE`. SQLBuild already supplies the configured role during connector authentication, but then redundantly issued `USE ROLE` during session initialization, causing destination-only automation clones to fail before planning.

## Changes
- Keep `role` in Snowflake connector authentication arguments.
- Stop issuing the redundant post-login `USE ROLE` statement.
- Add programmatic-token regression coverage for connector and session statements.

## Verification
- Snowflake adapter unit suite: 37 passed
- `uv sync --all-extras`
- `make check-ci`
- Fensu: 0 faults
- `git diff --check`
