### PR TITLE
fix: avoid implicit Snowflake role switching

### DIFF
--- a/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
+++ b/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
@@ -1479,7 +1479,7 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
         warehouse: object | None = connect_config.get("warehouse")
         database: object | None = connect_config.get("database")
         schema: object | None = connect_config.get("schema")
-        secondary_roles: str = self._normalize_secondary_roles(
+        secondary_roles: str | None = self._normalize_secondary_roles(
             connect_config.pop("secondary_roles", None)
         )
         raw_connection: Any = snowflake.connector.connect(**connect_config)
@@ -2880,12 +2880,14 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
         self,
         *,
         connection: _SnowflakeConnection,
-        secondary_roles: str,
+        secondary_roles: str | None,
         warehouse: object | None,
         database: object | None,
         schema: object | None,
     ) -> None:
-        statements: list[str] = [f"USE SECONDARY ROLES {secondary_roles}"]
+        statements: list[str] = []
+        if secondary_roles is not None:
+            statements.append(f"USE SECONDARY ROLES {secondary_roles}")
         normalized_warehouse: str | None = self._normalize_session_value(warehouse)
         normalized_database: str | None = self._normalize_session_value(database)
         normalized_schema: str | None = self._normalize_session_value(schema)
@@ -2904,9 +2906,9 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
             self.execute(connection=connection, sql=statement)
 
     @staticmethod
-    def _normalize_secondary_roles(value: object | None) -> str:
+    def _normalize_secondary_roles(value: object | None) -> str | None:
         if value is None:
-            return SECONDARY_ROLES_NONE
+            return None
         normalized: str = str(value).strip().upper()
         if normalized not in {SECONDARY_ROLES_ALL, SECONDARY_ROLES_NONE}:
             raise AdapterUserError(

--- a/tests/unit/src/sqlbuild/adapters/snowflake/_test_types.py
+++ b/tests/unit/src/sqlbuild/adapters/snowflake/_test_types.py
@@ -135,7 +135,7 @@ class SnowflakeConnectConfigTestCase:
     description: str
     config: dict[str, object]
     expected_connect_kwargs: dict[str, object]
-    expected_session_statements: tuple[str, ...] = ("USE SECONDARY ROLES NONE",)
+    expected_session_statements: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/adapters/snowflake/test_client.py
+++ b/tests/unit/src/sqlbuild/adapters/snowflake/test_client.py
@@ -220,7 +220,6 @@ def test_given_snowflake_adapter_when_getting_inference_profile_then_returns_exp
                 "database": "ANALYTICS",
             },
             expected_session_statements=(
-                "USE SECONDARY ROLES NONE",
                 "USE WAREHOUSE DEV_WH",
                 "USE DATABASE ANALYTICS",
             ),


### PR DESCRIPTION
## Why
Restricted Snowflake programmatic-token sessions reject role-switching statements. SQLBuild implicitly issued `USE SECONDARY ROLES NONE` for every connection even when secondary roles were not configured, causing automation clones to fail before planning.

## Changes
- Do not emit a secondary-role statement when the setting is absent.
- Preserve explicit `secondary_roles = "ALL"` or `"NONE"` behavior.
- Update programmatic-token session regression coverage.

## Verification
- Snowflake adapter unit suite: 37 passed
- `uv sync --all-extras`
- `make check-ci`
- Fensu: 0 faults
- `git diff --check`
