### PR TITLE
fix: stream SQLBuild output to Dagster logs

### DIFF
--- a/src/sqlbuild/integrations/dagster/_helpers/invocation.py
+++ b/src/sqlbuild/integrations/dagster/_helpers/invocation.py
@@ -233,9 +233,9 @@ def _forward_stream(*, source: IO[str], sink: TextIO, context: Any, stream_name:
     try:
         for chunk in iter(source.readline, ""):
             captured.append(chunk)
+            sink.write(chunk)
+            sink.flush()
             if logger is None:
-                sink.write(chunk)
-                sink.flush()
                 continue
             line: str = chunk.rstrip("\r\n")
             if stream_name == STDERR_STREAM_NAME:

--- a/src/sqlbuild/integrations/dagster/_helpers/invocation.py
+++ b/src/sqlbuild/integrations/dagster/_helpers/invocation.py
@@ -27,6 +27,7 @@ from sqlbuild.integrations.dagster.constants import (
     SCENARIO_VALUE_FLAGS,
     SELECT_FILE_FLAG,
     SOURCE_NODE_KIND,
+    STDERR_STREAM_NAME,
     WARNING_CHECK_SEVERITY,
 )
 
@@ -208,20 +209,39 @@ def _create_execution_json_path() -> Path:
 
 
 def _start_stream_future(
-    *, executor: ThreadPoolExecutor, source: IO[str] | None, sink: TextIO
+    *,
+    executor: ThreadPoolExecutor,
+    source: IO[str] | None,
+    sink: TextIO,
+    context: Any,
+    stream_name: str,
 ) -> Future[str] | None:
     if source is None:
         return None
-    return executor.submit(_forward_stream, source=source, sink=sink)
+    return executor.submit(
+        _forward_stream,
+        source=source,
+        sink=sink,
+        context=context,
+        stream_name=stream_name,
+    )
 
 
-def _forward_stream(*, source: IO[str], sink: TextIO) -> str:
+def _forward_stream(*, source: IO[str], sink: TextIO, context: Any, stream_name: str) -> str:
     captured: list[str] = []
+    logger: Any | None = getattr(context, "log", None) if context is not None else None
     try:
         for chunk in iter(source.readline, ""):
             captured.append(chunk)
-            sink.write(chunk)
-            sink.flush()
+            if logger is None:
+                sink.write(chunk)
+                sink.flush()
+                continue
+            line: str = chunk.rstrip("\r\n")
+            if stream_name == STDERR_STREAM_NAME:
+                logger.warning("SQLBuild: %s", line)
+            else:
+                logger.info("SQLBuild: %s", line)
     finally:
         source.close()
     return "".join(captured)

--- a/src/sqlbuild/integrations/dagster/_helpers/invocation_factory.py
+++ b/src/sqlbuild/integrations/dagster/_helpers/invocation_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -41,9 +42,12 @@ def start_sqlbuild_cli_invocation(
         dag=dag,
     )
     command: tuple[str, ...] = (*tuple(sqb_command), *resolved_args)
+    process_environment: dict[str, str] = dict(os.environ)
+    process_environment["PYTHONUNBUFFERED"] = "1"
     process: subprocess.Popen[str] = subprocess.Popen(
         command,
         cwd=project_dir,
+        env=process_environment,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
+++ b/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
@@ -60,11 +60,15 @@ class SqlBuildCliInvocation:
                 executor=executor,
                 source=self.process.stdout,
                 sink=sys.stdout,
+                context=self.context,
+                stream_name="stdout",
             )
             stderr_future: Future[str] | None = _start_stream_future(
                 executor=executor,
                 source=self.process.stderr,
                 sink=sys.stderr,
+                context=self.context,
+                stream_name="stderr",
             )
             self.returncode = self.process.wait()
             self.stdout = stdout_future.result() if stdout_future is not None else ""

--- a/src/sqlbuild/integrations/dagster/constants.py
+++ b/src/sqlbuild/integrations/dagster/constants.py
@@ -44,3 +44,4 @@ CHECK_METADATA_EXCLUDED_KEYS: frozenset[str] = frozenset(
     {"passed", "steps", "expected_results", "assertion_results"}
 )
 WARNING_CHECK_SEVERITY: str = "warn"
+STDERR_STREAM_NAME: str = "stderr"

--- a/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
@@ -70,6 +70,13 @@ class DagsterCliInvocationTestCase:
 
 
 @dataclass(frozen=True)
+class DagsterCliLiveLogTestCase:
+    description: str
+    expected_stdout_lines: tuple[str, ...]
+    expected_stderr_lines: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class DagsterCliStreamTestCase:
     description: str
     command_stdout: str

--- a/tests/unit/src/sqlbuild/integrations/dagster/helpers.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/helpers.py
@@ -201,6 +201,28 @@ def write_fake_sqb_command(
     return ["python", str(script_path)]
 
 
+def write_blocking_fake_sqb_command(*, root: Path, release_path: Path) -> list[str]:
+    script_path: Path = root / "blocking_fake_sqb.py"
+    script_path.write_text(
+        "\n".join(
+            (
+                "from pathlib import Path",
+                "import sys",
+                "import time",
+                "sys.stdout.write('started without explicit flush\\n')",
+                "sys.stderr.write('warning without explicit flush\\n')",
+                f"release_path = Path({str(release_path)!r})",
+                "while not release_path.exists():",
+                "    time.sleep(0.01)",
+                "sys.stdout.write('completed\\n')",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return ["python", str(script_path)]
+
+
 def write_dagster_test_dag(*, root: Path) -> Path:
     root.mkdir(parents=True, exist_ok=True)
     dag_path: Path = root / "sqlbuild_dag.json"

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
+from threading import Event
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
@@ -12,6 +15,7 @@ from tests.unit.src.sqlbuild.integrations.dagster._test_types import (
     DagsterCliFailureTestCase,
     DagsterCliInvocationTestCase,
     DagsterCliJsonStreamTestCase,
+    DagsterCliLiveLogTestCase,
     DagsterCliSelectionTestCase,
     DagsterCliStreamTestCase,
 )
@@ -19,6 +23,7 @@ from tests.unit.src.sqlbuild.integrations.dagster.helpers import (
     assert_json_output_file_behavior,
     assert_positional_selector_behavior,
     assert_select_file_selector_behavior,
+    write_blocking_fake_sqb_command,
     write_dagster_test_dag,
     write_fake_sqb_command,
 )
@@ -71,6 +76,58 @@ def test_given_sqlbuild_cli_resource_when_waiting_invocation_then_captures_proce
     assert invocation.is_successful() is test_case.expected_success
     assert invocation.stdout == test_case.expected_stdout
     assert invocation.stderr == test_case.expected_stderr
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagsterCliLiveLogTestCase(
+            description="unflushed subprocess output reaches Dagster before process completion",
+            expected_stdout_lines=("started without explicit flush", "completed"),
+            expected_stderr_lines=("warning without explicit flush",),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_running_sqlbuild_command_when_output_arrives_then_dagster_logs_it_immediately(
+    test_case: DagsterCliLiveLogTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    release_path: Path = tmp_path / "release"
+    first_log_received: Event = Event()
+    logger: Mock = Mock()
+    logger.info.side_effect = lambda *_args: first_log_received.set()
+    context: Any = type("LoggingContext", (), {"log": logger})()
+    resource: SqlBuildCliResource = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_blocking_fake_sqb_command(
+            root=tmp_path,
+            release_path=release_path,
+        ),
+    )
+    invocation: SqlBuildCliInvocation = resource.cli(
+        ["build"], context=context, raise_on_error=False
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        wait_future: Future[SqlBuildCliInvocation] = executor.submit(invocation.wait)
+        assert first_log_received.wait(timeout=3)
+        assert not wait_future.done()
+        release_path.write_text("continue", encoding="utf-8")
+        completed_invocation: SqlBuildCliInvocation = wait_future.result(timeout=3)
+
+    for line in test_case.expected_stdout_lines:
+        logger.info.assert_any_call("SQLBuild: %s", line)
+    for line in test_case.expected_stderr_lines:
+        logger.warning.assert_any_call("SQLBuild: %s", line)
+    assert completed_invocation.stdout == "".join(
+        f"{line}\n" for line in test_case.expected_stdout_lines
+    )
+    assert completed_invocation.stderr == "".join(
+        f"{line}\n" for line in test_case.expected_stderr_lines
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why
SQLBuild Dagster subprocesses wrote piped output to process stdout/stderr instead of Dagster structured logs and did not force unbuffered child output. Long-running commands therefore appeared silent in the Dagster event timeline until completion.

## Changes
- Start every SQLBuild Dagster subprocess with `PYTHONUNBUFFERED=1`.
- Forward stdout and stderr line by line to `context.log` while retaining complete captured diagnostics.
- Apply the behavior through the shared invocation path for every SQLBuild command.
- Add a deterministic blocked-subprocess regression proving an unflushed line is logged before process completion.

## Verification
- Dagster integration unit suite: 24 passed
- `make check-ci`
- Ruff and `ty`: passed
- Fensu: 0 faults
- `git diff --check`
