### PR TITLE
fix: make clone dependency outcomes explicit

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/clone/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/clone/execution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from typing import TextIO
 
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.cli.commands._helpers.clone.output import render_clone_item_line
 from sqlbuild.cli.commands.models import (
     CloneCommandRequest,
@@ -12,6 +13,14 @@ from sqlbuild.cli.commands.models import (
     CloneExecutionPreparation,
     CloneInvocation,
     CloneRunOutcome,
+)
+from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationLocation
+from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.planner.models import (
+    CloneSourcePlanEntry,
+    FunctionPlanEntry,
+    ModelPlanEntry,
+    SeedPlanEntry,
 )
 from sqlbuild.executor.clone.main.execute import execute_clone
 from sqlbuild.executor.clone.main.fingerprinting import copy_clone_fingerprints
@@ -22,6 +31,7 @@ from sqlbuild.executor.clone.models import (
     CloneSourceEntries,
 )
 from sqlbuild.executor.clone.types import CloneItemCallback
+from sqlbuild.spec.contracts.models import SourceEntry
 
 
 def execute_clone_plan(
@@ -55,6 +65,11 @@ def execute_clone_plan(
             hard_copy=request.hard_copy,
             run_id=preparation.pipeline_result.destination_project.run_id,
             query_change_tracking=preparation.pipeline_result.destination_project.settings.query_change_tracking,
+            upstream_deps=preparation.pipeline_result.clone_plan.upstream_deps,
+            dependency_locations=_clone_dependency_locations(
+                preparation=preparation,
+                adapter=invocation.adapter,
+            ),
             on_item=on_item,
         )
     )
@@ -70,6 +85,44 @@ def execute_clone_plan(
         query_change_tracking=preparation.pipeline_result.destination_project.settings.query_change_tracking,
     )
     return CloneRunOutcome(result=result, elapsed=time.monotonic() - clone_start)
+
+
+def _clone_dependency_locations(
+    *, preparation: CloneExecutionPreparation, adapter: BaseAdapter
+) -> dict[CompiledObjectKey, CompiledRelationLocation]:
+    entries: tuple[
+        CloneSourcePlanEntry | ModelPlanEntry | SeedPlanEntry | FunctionPlanEntry, ...
+    ] = (
+        *preparation.pipeline_result.destination_source_entries,
+        *preparation.pipeline_result.destination_model_entries,
+        *preparation.pipeline_result.destination_seed_entries,
+        *preparation.pipeline_result.destination_function_entries,
+    )
+    locations: dict[CompiledObjectKey, CompiledRelationLocation] = {
+        entry.key: entry.destination for entry in entries
+    }
+    source_map: dict[str, SourceEntry] = (
+        preparation.pipeline_result.clone_plan.source_read_map
+        or preparation.pipeline_result.clone_plan.source_map
+    )
+    for name, source in source_map.items():
+        if source.table is None:
+            continue
+        key: CompiledObjectKey = CompiledObjectKey(CompiledResourceType.SOURCE, name)
+        locations[key] = CompiledRelationLocation(
+            database=source.database,
+            schema=source.schema,
+            name=source.table,
+            qualified_name=(
+                adapter.render_qualified_name(
+                    database=source.database,
+                    schema=source.schema,
+                    name=source.table,
+                )
+                or source.table
+            ),
+        )
+    return locations
 
 
 def _build_on_clone_item(*, stream: TextIO, use_color: bool) -> CloneItemCallback:

--- a/src/sqlbuild/cli/commands/_helpers/clone/output.py
+++ b/src/sqlbuild/cli/commands/_helpers/clone/output.py
@@ -118,4 +118,4 @@ def render_clone_output(
 
 
 def is_clone_success(result: CloneExecutionResult) -> bool:
-    return all(item.status == CloneStatus.SUCCESS for item in result.item_results)
+    return all(item.status != CloneStatus.FAILED for item in result.item_results)

--- a/src/sqlbuild/cli/commands/_helpers/clone/outputs.py
+++ b/src/sqlbuild/cli/commands/_helpers/clone/outputs.py
@@ -13,6 +13,14 @@ from sqlbuild.cli.commands.models import (
     CloneInvocation,
     CloneRunOutcome,
 )
+from sqlbuild.cli.output.main._clone_execution_json import format_clone_execution_json
+from sqlbuild.cli.output.main._write_execution_json_output import write_execution_json_output
+from sqlbuild.compiler.planner.models import (
+    CloneSourcePlanEntry,
+    FunctionPlanEntry,
+    ModelPlanEntry,
+    SeedPlanEntry,
+)
 
 
 def write_clone_execution_header(
@@ -48,6 +56,35 @@ def write_clone_completion_output(*, invocation: CloneInvocation, outcome: Clone
         result=outcome.result,
         elapsed_seconds=outcome.elapsed,
         use_color=invocation.use_color,
+    )
+
+
+def write_clone_execution_json_output(
+    *,
+    request: CloneCommandRequest,
+    preparation: CloneExecutionPreparation,
+    outcome: CloneRunOutcome,
+) -> None:
+    """Write structured direct clone outcomes when requested."""
+
+    entries: tuple[
+        CloneSourcePlanEntry | ModelPlanEntry | SeedPlanEntry | FunctionPlanEntry, ...
+    ] = (
+        *preparation.pipeline_result.destination_source_entries,
+        *preparation.pipeline_result.destination_model_entries,
+        *preparation.pipeline_result.destination_seed_entries,
+        *preparation.pipeline_result.destination_function_entries,
+    )
+    resource_types_by_name: dict[str, str] = {
+        entry.name: str(entry.key.resource_type) for entry in entries
+    }
+    write_execution_json_output(
+        payload=format_clone_execution_json(
+            result=outcome.result,
+            resource_types_by_name=resource_types_by_name,
+        ),
+        json_output=False,
+        json_output_path=request.json_output_path,
     )
 
 

--- a/src/sqlbuild/cli/commands/_helpers/clone/virtual.py
+++ b/src/sqlbuild/cli/commands/_helpers/clone/virtual.py
@@ -15,6 +15,10 @@ from sqlbuild.cli.commands._helpers.runtime.connection import (
     resolve_target_connection_config,
 )
 from sqlbuild.cli.commands.models import CloneCommandRequest, CloneInvocation
+from sqlbuild.cli.output.main._virtual_clone_execution_json import (
+    format_virtual_clone_execution_json,
+)
+from sqlbuild.cli.output.main._write_execution_json_output import write_execution_json_output
 from sqlbuild.cli.progress.classes.planning_progress_reporter import PlanningProgressReporter
 from sqlbuild.virtual.executor.main.clone import run_virtual_clone
 from sqlbuild.virtual.executor.models import CloneOptions, VirtualCloneResult
@@ -60,5 +64,10 @@ def execute_virtual_clone(*, request: CloneCommandRequest, invocation: CloneInvo
         result=result,
         use_color=invocation.use_color,
         verbose=request.verbose,
+    )
+    write_execution_json_output(
+        payload=format_virtual_clone_execution_json(result=result),
+        json_output=False,
+        json_output_path=request.json_output_path,
     )
     return 0 if is_virtual_clone_success(result) else 1

--- a/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
@@ -316,6 +316,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
                 exclude=tuple(args.exclude),
                 verbose=args.verbose,
                 cli_vars=args.vars,
+                json_output_path=args.json_output,
             )
         )
     if args.command == CliCommand.DIFF:

--- a/src/sqlbuild/cli/commands/_helpers/entry/parser.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parser.py
@@ -267,6 +267,7 @@ def _add_data_parsers(
     _ = add_select_args(clone_parser)
     _ = add_vars_args(clone_parser)
     _ = add_dbt_config_args(parser=clone_parser)
+    _ = add_execution_json_output_arg(clone_parser)
 
     diff_parser: argparse.ArgumentParser = subparsers.add_parser(CliCommand.DIFF)
     diff_parser.add_argument("target_range", metavar="FROM:TO")

--- a/src/sqlbuild/cli/commands/main/inspection/_clone.py
+++ b/src/sqlbuild/cli/commands/main/inspection/_clone.py
@@ -12,6 +12,7 @@ from sqlbuild.cli.commands._helpers.clone.outputs import (
     resolve_clone_exit_code,
     write_clone_completion_output,
     write_clone_execution_header,
+    write_clone_execution_json_output,
 )
 from sqlbuild.cli.commands._helpers.clone.planning import prepare_clone_execution
 from sqlbuild.cli.commands._helpers.clone.virtual import execute_virtual_clone
@@ -54,4 +55,9 @@ def run_clone(request: CloneCommandRequest) -> int:
     finally:
         _ = close_clone_targets(invocation=invocation, connection_context=connection_context)
     write_clone_completion_output(invocation=invocation, outcome=outcome)
+    write_clone_execution_json_output(
+        request=request,
+        preparation=preparation,
+        outcome=outcome,
+    )
     return resolve_clone_exit_code(outcome)

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -389,6 +389,7 @@ class CloneCommandRequest:
     exclude: tuple[str, ...] = ()
     verbose: bool = False
     cli_vars: dict[str, object] | None = None
+    json_output_path: Path | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
+++ b/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import cast
 
@@ -20,6 +21,8 @@ from sqlbuild.executor.build.models import (
     SeedExecutionResult,
 )
 from sqlbuild.executor.build.types import BuildStatus, ExecutionStatus
+from sqlbuild.executor.clone.models import CloneExecutionResult
+from sqlbuild.executor.clone.types import CloneStatus
 from sqlbuild.executor.load.models import LoadExecutionResult
 from sqlbuild.executor.python_nodes.models import (
     PythonCheckExecutionResult,
@@ -38,6 +41,12 @@ from sqlbuild.executor.testing.models import SqlTestExecutionResult, StepResult
 from sqlbuild.executor.testing.types import SqlTestOutcome
 from sqlbuild.sql_values.models import SqlValue
 from sqlbuild.sql_values.types import SqlValueKind
+from sqlbuild.virtual.executor.constants import (
+    VIRTUAL_CLONE_FOUND_ACTIONS,
+    VIRTUAL_CLONE_MISSING_ACTION,
+    VIRTUAL_CLONE_SKIPPED_LOCKED_ACTION,
+)
+from sqlbuild.virtual.executor.models import VirtualCloneResult
 
 _JSON_VERSION: int = 1
 
@@ -200,6 +209,88 @@ def format_load_execution_json(*, results: tuple[LoadExecutionResult, ...]) -> s
             "total_count": len(results),
         },
     )
+
+
+def format_clone_execution_json(
+    *, result: CloneExecutionResult, resource_types_by_name: Mapping[str, str]
+) -> str:
+    """Format direct clone command execution results as JSON."""
+
+    failure_count: int = sum(1 for item in result.item_results if item.status == CloneStatus.FAILED)
+    warning_count: int = sum(
+        1 for item in result.item_results if item.status == CloneStatus.WARNING
+    )
+    return _format_execution_json(
+        command="clone",
+        status=(BuildStatus.SUCCESS.value if failure_count == 0 else BuildStatus.FAILED.value),
+        assets=tuple(
+            _drop_none(
+                {
+                    "kind": resource_types_by_name[item.name],
+                    "name": item.name,
+                    "status": item.status.value,
+                    "action": item.action.value,
+                    "duration_ms": (
+                        round(item.duration_seconds * 1000)
+                        if item.duration_seconds is not None
+                        else None
+                    ),
+                    "origin_relation": item.origin_relation,
+                    "target": item.destination_relation,
+                    "message": item.message,
+                }
+            )
+            for item in result.item_results
+        ),
+        checks=(),
+        summary={
+            "success_count": len(result.item_results) - failure_count - warning_count,
+            "failure_count": failure_count,
+            "warning_count": warning_count,
+            "total_count": len(result.item_results),
+        },
+    )
+
+
+def format_virtual_clone_execution_json(*, result: VirtualCloneResult) -> str:
+    """Format virtual clone command execution results as JSON."""
+
+    return _format_execution_json(
+        command="clone",
+        status=(
+            BuildStatus.SUCCESS.value if result.missing_count == 0 else BuildStatus.FAILED.value
+        ),
+        assets=tuple(
+            _drop_none(
+                {
+                    "kind": item.artifact_type.value,
+                    "name": item.artifact_name,
+                    "status": _virtual_clone_item_status(action=item.action),
+                    "action": item.action,
+                    "version_hash": item.version_hash,
+                    "message": item.message,
+                }
+            )
+            for item in result.item_results
+        ),
+        checks=(),
+        summary={
+            "success_count": result.found_count,
+            "failure_count": result.missing_count,
+            "skipped_count": result.skipped_locked_count,
+            "total_count": result.selected_count,
+        },
+    )
+
+
+def _virtual_clone_item_status(*, action: str) -> str:
+    if action in VIRTUAL_CLONE_FOUND_ACTIONS:
+        return "success"
+    if action == VIRTUAL_CLONE_SKIPPED_LOCKED_ACTION:
+        return "skipped"
+    if action == VIRTUAL_CLONE_MISSING_ACTION:
+        return "warning"
+    return "failed"
 
 
 def format_test_execution_json(*, results: tuple[SqlTestExecutionResult, ...]) -> str:

--- a/src/sqlbuild/cli/output/main/_clone_execution_json.py
+++ b/src/sqlbuild/cli/output/main/_clone_execution_json.py
@@ -1,0 +1,21 @@
+"""Public clone execution JSON formatting entrypoint."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from sqlbuild.cli.output._helpers.execution_protocol_v1 import (
+    format_clone_execution_json as _format_clone_execution_json,
+)
+from sqlbuild.executor.clone.models import CloneExecutionResult
+
+
+def format_clone_execution_json(
+    *, result: CloneExecutionResult, resource_types_by_name: Mapping[str, str]
+) -> str:
+    """Format clone command execution results as JSON."""
+
+    return _format_clone_execution_json(
+        result=result,
+        resource_types_by_name=resource_types_by_name,
+    )

--- a/src/sqlbuild/cli/output/main/_virtual_clone_execution_json.py
+++ b/src/sqlbuild/cli/output/main/_virtual_clone_execution_json.py
@@ -1,0 +1,14 @@
+"""Public virtual clone execution JSON formatting entrypoint."""
+
+from __future__ import annotations
+
+from sqlbuild.cli.output._helpers.execution_protocol_v1 import (
+    format_virtual_clone_execution_json as _format_virtual_clone_execution_json,
+)
+from sqlbuild.virtual.executor.models import VirtualCloneResult
+
+
+def format_virtual_clone_execution_json(*, result: VirtualCloneResult) -> str:
+    """Format virtual clone command execution results as JSON."""
+
+    return _format_virtual_clone_execution_json(result=result)

--- a/src/sqlbuild/executor/clone/_helpers/execution_items.py
+++ b/src/sqlbuild/executor/clone/_helpers/execution_items.py
@@ -23,10 +23,25 @@ from sqlbuild.executor.scheduling.types import ExecutionStatus
 
 
 def execute_clone_function_item(
-    *, destination_entry: FunctionPlanEntry, inputs: CloneExecutionInput
+    *,
+    destination_entry: FunctionPlanEntry,
+    inputs: CloneExecutionInput,
+    available_keys: set[CompiledObjectKey],
 ) -> CloneItemResult:
     """Recreate one function and normalize its clone outcome."""
 
+    missing_dependencies: tuple[CompiledObjectKey, ...] = _missing_destination_dependencies(
+        key=destination_entry.key,
+        inputs=inputs,
+        available_keys=available_keys,
+    )
+    if missing_dependencies:
+        return _missing_dependency_result(
+            name=destination_entry.name,
+            destination_relation=destination_entry.destination.qualified_name,
+            missing_dependencies=missing_dependencies,
+            inputs=inputs,
+        )
     start: float = time.monotonic()
     recorder: StatementRecorder = StatementRecorder()
     function_result: FunctionExecutionResult = execute_function(
@@ -76,28 +91,58 @@ def execute_clone_relation_item(
             hard_copy=inputs.hard_copy,
             origin_lookup=relation_lookup,
         )
-    missing_dependencies: tuple[CompiledObjectKey, ...] = tuple(
-        dependency
-        for dependency in inputs.upstream_deps.get(destination_entry.key, ())
-        if dependency in inputs.dependency_locations and dependency not in available_keys
+    missing_dependencies: tuple[CompiledObjectKey, ...] = _missing_destination_dependencies(
+        key=destination_entry.key,
+        inputs=inputs,
+        available_keys=available_keys,
     )
     if missing_dependencies:
-        return CloneItemResult(
+        return _missing_dependency_result(
             name=destination_entry.name,
-            action=CloneAction.SKIPPED_MISSING_DEPENDENCY,
-            status=CloneStatus.WARNING,
-            message="missing destination dependencies: "
-            + ", ".join(
-                inputs.dependency_locations[dependency].qualified_name
-                or inputs.dependency_locations[dependency].name
-                for dependency in missing_dependencies
-            ),
             origin_relation=origin_entry.destination.qualified_name,
             destination_relation=destination_entry.destination.qualified_name,
+            missing_dependencies=missing_dependencies,
+            inputs=inputs,
         )
     return recreate_view(
         destination_entry=destination_entry,
         origin_entry=origin_entry,
         adapter=inputs.adapter,
         destination_connection=inputs.destination_connection,
+    )
+
+
+def _missing_destination_dependencies(
+    *,
+    key: CompiledObjectKey,
+    inputs: CloneExecutionInput,
+    available_keys: set[CompiledObjectKey],
+) -> tuple[CompiledObjectKey, ...]:
+    return tuple(
+        dependency
+        for dependency in inputs.upstream_deps.get(key, ())
+        if dependency in inputs.dependency_locations and dependency not in available_keys
+    )
+
+
+def _missing_dependency_result(
+    *,
+    name: str,
+    destination_relation: str | None,
+    missing_dependencies: tuple[CompiledObjectKey, ...],
+    inputs: CloneExecutionInput,
+    origin_relation: str | None = None,
+) -> CloneItemResult:
+    return CloneItemResult(
+        name=name,
+        action=CloneAction.SKIPPED_MISSING_DEPENDENCY,
+        status=CloneStatus.WARNING,
+        message="missing destination dependencies: "
+        + ", ".join(
+            inputs.dependency_locations[dependency].qualified_name
+            or inputs.dependency_locations[dependency].name
+            for dependency in missing_dependencies
+        ),
+        origin_relation=origin_relation,
+        destination_relation=destination_relation,
     )

--- a/src/sqlbuild/executor/clone/_helpers/execution_items.py
+++ b/src/sqlbuild/executor/clone/_helpers/execution_items.py
@@ -1,0 +1,103 @@
+"""Per-item clone execution decisions."""
+
+from __future__ import annotations
+
+import time
+
+from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
+from sqlbuild.adapter.contract.models import RelationLookup
+from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.planner.models import (
+    CloneSourcePlanEntry,
+    FunctionPlanEntry,
+    ModelPlanEntry,
+    SeedPlanEntry,
+)
+from sqlbuild.compiler.planner.types import MaterializationType
+from sqlbuild.executor.build.models import FunctionExecutionResult
+from sqlbuild.executor.clone._helpers.operations import clone_relation, recreate_view
+from sqlbuild.executor.clone.models import CloneExecutionInput, CloneItemResult
+from sqlbuild.executor.clone.types import CloneAction, CloneStatus
+from sqlbuild.executor.functions.main._execute import execute_function
+from sqlbuild.executor.scheduling.types import ExecutionStatus
+
+
+def execute_clone_function_item(
+    *, destination_entry: FunctionPlanEntry, inputs: CloneExecutionInput
+) -> CloneItemResult:
+    """Recreate one function and normalize its clone outcome."""
+
+    start: float = time.monotonic()
+    recorder: StatementRecorder = StatementRecorder()
+    function_result: FunctionExecutionResult = execute_function(
+        function_entry=destination_entry,
+        adapter=inputs.adapter,
+        connection=inputs.destination_connection,
+        statement_recorder=recorder,
+        run_id=inputs.run_id,
+        query_change_tracking=inputs.query_change_tracking,
+    )
+    succeeded: bool = function_result.status == ExecutionStatus.SUCCESS
+    return CloneItemResult(
+        name=destination_entry.name,
+        action=CloneAction.RECREATED_FUNCTION if succeeded else CloneAction.FAILED,
+        status=CloneStatus.SUCCESS if succeeded else CloneStatus.FAILED,
+        message=(
+            "; ".join(function_result.warning_messages)
+            if succeeded and function_result.warning_messages
+            else function_result.error_message
+        ),
+        destination_relation=destination_entry.destination.qualified_name,
+        duration_seconds=time.monotonic() - start,
+        executed_statements=function_result.lifecycle_events,
+    )
+
+
+def execute_clone_relation_item(
+    *,
+    destination_entry: CloneSourcePlanEntry | SeedPlanEntry | ModelPlanEntry,
+    origin_entry: CloneSourcePlanEntry | SeedPlanEntry | ModelPlanEntry,
+    inputs: CloneExecutionInput,
+    relation_lookup: RelationLookup,
+    available_keys: set[CompiledObjectKey],
+) -> CloneItemResult:
+    """Clone a physical relation or conditionally recreate one view."""
+
+    if (
+        not isinstance(destination_entry, ModelPlanEntry)
+        or not isinstance(origin_entry, ModelPlanEntry)
+        or destination_entry.materialization_type != MaterializationType.VIEW
+    ):
+        return clone_relation(
+            destination_entry=destination_entry,
+            origin_entry=origin_entry,
+            adapter=inputs.adapter,
+            destination_connection=inputs.destination_connection,
+            hard_copy=inputs.hard_copy,
+            origin_lookup=relation_lookup,
+        )
+    missing_dependencies: tuple[CompiledObjectKey, ...] = tuple(
+        dependency
+        for dependency in inputs.upstream_deps.get(destination_entry.key, ())
+        if dependency in inputs.dependency_locations and dependency not in available_keys
+    )
+    if missing_dependencies:
+        return CloneItemResult(
+            name=destination_entry.name,
+            action=CloneAction.SKIPPED_MISSING_DEPENDENCY,
+            status=CloneStatus.WARNING,
+            message="missing destination dependencies: "
+            + ", ".join(
+                inputs.dependency_locations[dependency].qualified_name
+                or inputs.dependency_locations[dependency].name
+                for dependency in missing_dependencies
+            ),
+            origin_relation=origin_entry.destination.qualified_name,
+            destination_relation=destination_entry.destination.qualified_name,
+        )
+    return recreate_view(
+        destination_entry=destination_entry,
+        origin_entry=origin_entry,
+        adapter=inputs.adapter,
+        destination_connection=inputs.destination_connection,
+    )

--- a/src/sqlbuild/executor/clone/_helpers/operations.py
+++ b/src/sqlbuild/executor/clone/_helpers/operations.py
@@ -50,18 +50,12 @@ def recreate_view(
     origin_entry: SeedPlanEntry | ModelPlanEntry,
     adapter: BaseAdapter,
     destination_connection: Any,
-    origin_lookup: RelationLookup,
 ) -> CloneItemResult:
     return recreate_view_by_names(
         name=destination_entry.name,
         origin_relation=qualified_name(adapter=adapter, entry=origin_entry),
         destination_relation=qualified_name(adapter=adapter, entry=destination_entry),
         view_sql=destination_entry.resolved_sql,
-        origin_exists=origin_lookup.exists(
-            database=origin_entry.destination.database,
-            schema=origin_entry.destination.schema,
-            name=origin_entry.destination.name,
-        ),
         adapter=adapter,
         connection=destination_connection,
     )

--- a/src/sqlbuild/executor/clone/main/_recreate_view_operation.py
+++ b/src/sqlbuild/executor/clone/main/_recreate_view_operation.py
@@ -17,21 +17,11 @@ def recreate_view_by_names(
     origin_relation: str,
     destination_relation: str,
     view_sql: str,
-    origin_exists: bool,
     adapter: BaseAdapter,
     connection: Any,
 ) -> CloneItemResult:
     """Recreate the destination view from SQL, returning a timed item result."""
 
-    if not origin_exists:
-        return CloneItemResult(
-            name=name,
-            action=CloneAction.WARNING_MISSING_SOURCE,
-            status=CloneStatus.WARNING,
-            message="missing in origin environment",
-            origin_relation=origin_relation,
-            destination_relation=destination_relation,
-        )
     recorder: StatementRecorder = StatementRecorder()
     start: float = time.monotonic()
     try:

--- a/src/sqlbuild/executor/clone/main/execute.py
+++ b/src/sqlbuild/executor/clone/main/execute.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
@@ -16,17 +15,16 @@ from sqlbuild.compiler.planner.models import (
     ModelPlanEntry,
     SeedPlanEntry,
 )
-from sqlbuild.compiler.planner.types import MaterializationType
-from sqlbuild.executor.build.models import FunctionExecutionResult
-from sqlbuild.executor.clone._helpers.operations import clone_relation, recreate_view
+from sqlbuild.executor.clone._helpers.execution_items import (
+    execute_clone_function_item,
+    execute_clone_relation_item,
+)
 from sqlbuild.executor.clone.models import (
     CloneExecutionInput,
     CloneExecutionResult,
     CloneItemResult,
 )
-from sqlbuild.executor.clone.types import CloneAction, CloneStatus
-from sqlbuild.executor.functions.main._execute import execute_function
-from sqlbuild.executor.scheduling.types import ExecutionStatus
+from sqlbuild.executor.clone.types import CloneStatus
 
 
 def _ensure_destination_schemas(
@@ -106,7 +104,7 @@ def execute_clone(*, inputs: CloneExecutionInput) -> CloneExecutionResult:
         )
         is not None
     )
-    origin_lookup: RelationLookup = build_relation_lookup(
+    relation_lookup: RelationLookup = build_relation_lookup(
         adapter=inputs.adapter,
         connection=inputs.destination_connection,
         locations=tuple(
@@ -116,67 +114,54 @@ def execute_clone(*, inputs: CloneExecutionInput) -> CloneExecutionResult:
                 origin_entry.destination.name,
             )
             for _, origin_entry in clonable_entries
+        )
+        + tuple(
+            (location.database, location.schema, location.name)
+            for location in inputs.dependency_locations.values()
         ),
     )
+    available_keys: set[CompiledObjectKey] = {
+        key
+        for key, location in inputs.dependency_locations.items()
+        if relation_lookup.exists(
+            database=location.database,
+            schema=location.schema,
+            name=location.name,
+        )
+    }
     origins_by_key: dict[
         CompiledObjectKey, CloneSourcePlanEntry | SeedPlanEntry | ModelPlanEntry
     ] = {destination.key: origin for destination, origin in clonable_entries}
     total: int = len(ordered_destination_entries)
     for index, destination_entry in enumerate(ordered_destination_entries, start=1):
         if isinstance(destination_entry, FunctionPlanEntry):
-            start: float = time.monotonic()
-            recorder: StatementRecorder = StatementRecorder()
-            function_result: FunctionExecutionResult = execute_function(
-                function_entry=destination_entry,
-                adapter=inputs.adapter,
-                connection=inputs.destination_connection,
-                statement_recorder=recorder,
-                run_id=inputs.run_id,
-                query_change_tracking=inputs.query_change_tracking,
-            )
-            succeeded: bool = function_result.status == ExecutionStatus.SUCCESS
-            item_result: CloneItemResult = CloneItemResult(
-                name=destination_entry.name,
-                action=(CloneAction.RECREATED_FUNCTION if succeeded else CloneAction.FAILED),
-                status=(CloneStatus.SUCCESS if succeeded else CloneStatus.FAILED),
-                message=(
-                    "; ".join(function_result.warning_messages)
-                    if succeeded and function_result.warning_messages
-                    else function_result.error_message
-                ),
-                destination_relation=destination_entry.destination.qualified_name,
-                duration_seconds=time.monotonic() - start,
-                executed_statements=function_result.lifecycle_events,
+            item_result: CloneItemResult = execute_clone_function_item(
+                destination_entry=destination_entry,
+                inputs=inputs,
             )
             results.append(item_result)
             if inputs.on_item is not None:
                 inputs.on_item(index=index, total=total, item=item_result)
+            if item_result.status == CloneStatus.SUCCESS:
+                available_keys.add(destination_entry.key)
+            else:
+                available_keys.discard(destination_entry.key)
             continue
         origin_entry: CloneSourcePlanEntry | SeedPlanEntry | ModelPlanEntry = origins_by_key[
             destination_entry.key
         ]
-        if (
-            isinstance(destination_entry, ModelPlanEntry)
-            and isinstance(origin_entry, ModelPlanEntry)
-            and destination_entry.materialization_type == MaterializationType.VIEW
-        ):
-            item_result: CloneItemResult = recreate_view(
-                destination_entry=destination_entry,
-                origin_entry=origin_entry,
-                adapter=inputs.adapter,
-                destination_connection=inputs.destination_connection,
-                origin_lookup=origin_lookup,
-            )
-        else:
-            item_result = clone_relation(
-                destination_entry=destination_entry,
-                origin_entry=origin_entry,
-                adapter=inputs.adapter,
-                destination_connection=inputs.destination_connection,
-                hard_copy=inputs.hard_copy,
-                origin_lookup=origin_lookup,
-            )
+        item_result = execute_clone_relation_item(
+            destination_entry=destination_entry,
+            origin_entry=origin_entry,
+            inputs=inputs,
+            relation_lookup=relation_lookup,
+            available_keys=available_keys,
+        )
         results.append(item_result)
+        if item_result.status == CloneStatus.SUCCESS:
+            available_keys.add(destination_entry.key)
+        elif item_result.status == CloneStatus.FAILED:
+            available_keys.discard(destination_entry.key)
         if inputs.on_item is not None:
             inputs.on_item(index=index, total=total, item=item_result)
 

--- a/src/sqlbuild/executor/clone/main/execute.py
+++ b/src/sqlbuild/executor/clone/main/execute.py
@@ -138,6 +138,7 @@ def execute_clone(*, inputs: CloneExecutionInput) -> CloneExecutionResult:
             item_result: CloneItemResult = execute_clone_function_item(
                 destination_entry=destination_entry,
                 inputs=inputs,
+                available_keys=available_keys,
             )
             results.append(item_result)
             if inputs.on_item is not None:

--- a/src/sqlbuild/executor/clone/models.py
+++ b/src/sqlbuild/executor/clone/models.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.models import LifeCycleEvent
-from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationLocation
 from sqlbuild.compiler.planner.models import (
     CloneSourcePlanEntry,
     FunctionPlanEntry,
@@ -41,6 +41,12 @@ class CloneExecutionInput:
     hard_copy: bool
     run_id: str
     query_change_tracking: bool
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] = field(
+        default_factory=dict
+    )
+    dependency_locations: dict[CompiledObjectKey, CompiledRelationLocation] = field(
+        default_factory=dict
+    )
     on_item: CloneItemCallback | None = None
 
 

--- a/src/sqlbuild/executor/clone/types.py
+++ b/src/sqlbuild/executor/clone/types.py
@@ -31,4 +31,5 @@ class CloneAction(StrEnum):
     RECREATED_VIEW = "recreated_view"
     RECREATED_FUNCTION = "recreated_function"
     WARNING_MISSING_SOURCE = "warning_missing_source"
+    SKIPPED_MISSING_DEPENDENCY = "skipped_missing_dependency"
     FAILED = "failed"

--- a/src/sqlbuild/integrations/dagster/_helpers/invocation.py
+++ b/src/sqlbuild/integrations/dagster/_helpers/invocation.py
@@ -13,6 +13,7 @@ from sqlbuild.integrations.dagster.constants import (
     ASSET_SELECTION_COMMANDS,
     CHECK_METADATA_EXCLUDED_KEYS,
     CHECK_NAME_SEPARATOR_CHARACTER,
+    CLONE_COMMAND,
     COMPLETED_EXECUTION_STATUSES,
     DEFAULT_SELECTABLE_NODE_KINDS,
     EXPLICIT_SELECTION_FLAGS,
@@ -336,6 +337,9 @@ def _build_results_from_execution_payload(
     context: Any,
 ) -> tuple[Any, ...]:
     selected_paths: set[tuple[str, ...]] = _selected_asset_paths(context=context)
+    is_clone: bool = str(payload.get("command")) == CLONE_COMMAND
+    if is_clone:
+        selected_paths = set()
     nodes_by_name: dict[tuple[str, str], Mapping[str, Any]] = {
         (str(node.get("kind")), str(node.get("name"))): node for node in dag.get("nodes", ())
     }
@@ -365,7 +369,7 @@ def _build_results_from_execution_payload(
     for node in _sort_nodes_topologically(dag=dag):
         node_id: str = str(node.get("id"))
         execution_asset: Mapping[str, Any] | None = asset_results_by_id.get(node_id)
-        if execution_asset is None and str(node.get("kind")) != SOURCE_NODE_KIND:
+        if execution_asset is None and (is_clone or str(node.get("kind")) != SOURCE_NODE_KIND):
             continue
         asset_key: Any = dg.AssetKey([str(part) for part in node["asset_key"]])
         if selected_paths and tuple(asset_key.path) not in selected_paths:
@@ -375,8 +379,9 @@ def _build_results_from_execution_payload(
             if execution_asset is not None
             else {"kind": "source", "name": node.get("name"), "status": "observed"}
         )
+        materialization_type: Any = dg.AssetMaterialization if is_clone else dg.MaterializeResult
         results.append(
-            dg.MaterializeResult(
+            materialization_type(
                 asset_key=asset_key,
                 metadata={
                     "command": " ".join(command),

--- a/src/sqlbuild/integrations/dagster/_helpers/invocation.py
+++ b/src/sqlbuild/integrations/dagster/_helpers/invocation.py
@@ -29,6 +29,7 @@ from sqlbuild.integrations.dagster.constants import (
     SELECT_FILE_FLAG,
     SOURCE_NODE_KIND,
     STDERR_STREAM_NAME,
+    SUCCESS_EXECUTION_STATUS,
     WARNING_CHECK_SEVERITY,
 )
 
@@ -349,7 +350,10 @@ def _build_results_from_execution_payload(
     asset_results_by_id: dict[str, Mapping[str, Any]] = {}
     payload_asset: Mapping[str, Any]
     for payload_asset in payload.get("assets", ()):  # type: ignore[assignment]
-        if str(payload_asset.get("status")) not in COMPLETED_EXECUTION_STATUSES:
+        execution_status: str = str(payload_asset.get("status"))
+        if execution_status not in COMPLETED_EXECUTION_STATUSES:
+            continue
+        if is_clone and execution_status != SUCCESS_EXECUTION_STATUS:
             continue
         node: Mapping[str, Any] | None = nodes_by_name.get(
             (str(payload_asset.get("kind")), str(payload_asset.get("name")))

--- a/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
+++ b/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
@@ -19,6 +19,7 @@ from sqlbuild.integrations.dagster._helpers.invocation import (
     _log_invocation,
     _start_stream_future,
 )
+from sqlbuild.integrations.dagster.constants import COMPLETED_EXECUTION_STATUSES
 
 
 class SqlBuildCliInvocation:
@@ -108,19 +109,29 @@ class SqlBuildCliInvocation:
         if self.returncode is None or self.returncode == 0:
             return None
         dg: Any = load_dagster()
+        metadata: dict[str, Any] = {
+            "command": " ".join(self.command),
+            "project_dir": str(self.project_dir),
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "selection": " ".join(self.selection),
+            "selector_file": self.selector_file_path,
+        }
+        if self.execution_payload is not None:
+            incomplete_assets: list[str] = []
+            for asset in self.execution_payload.get("assets", ()):
+                status: str = str(asset.get("status"))
+                if status in COMPLETED_EXECUTION_STATUSES:
+                    continue
+                incomplete_assets.append(f"{asset.get('kind')}:{asset.get('name')} ({status})")
+            metadata["execution_status"] = str(self.execution_payload.get("status"))
+            metadata["incomplete_assets"] = ", ".join(incomplete_assets)
         return dg.Failure(
             description=(
                 "SQLBuild CLI command failed with exit code "
                 f"{self.returncode}: {' '.join(self.command)}"
             ),
-            metadata={
-                "command": " ".join(self.command),
-                "project_dir": str(self.project_dir),
-                "stdout": self.stdout,
-                "stderr": self.stderr,
-                "selection": " ".join(self.selection),
-                "selector_file": self.selector_file_path,
-            },
+            metadata=metadata,
         )
 
     def get_artifact(self, artifact: str) -> dict[str, Any]:
@@ -154,11 +165,11 @@ class SqlBuildCliInvocation:
                 if error is not None and self.raise_on_error:
                     raise error
                 return
+        error = self.get_error()
+        if error is not None and self.raise_on_error:
+            raise error
         if self.dag is None:
             yield dg.MaterializeResult(metadata={"command": " ".join(self.command)})
-            error = self.get_error()
-            if error is not None and self.raise_on_error:
-                raise error
             return
         yield from _build_results_for_selected_assets(
             dg=dg,
@@ -166,6 +177,3 @@ class SqlBuildCliInvocation:
             command=self.command,
             context=self.context,
         )
-        error = self.get_error()
-        if error is not None and self.raise_on_error:
-            raise error

--- a/src/sqlbuild/integrations/dagster/constants.py
+++ b/src/sqlbuild/integrations/dagster/constants.py
@@ -40,6 +40,7 @@ MATERIALIZABLE_NODE_KINDS: frozenset[str] = frozenset(
     {"source", "loader", "seed", "model", "udf", "table_fn"}
 )
 COMPLETED_EXECUTION_STATUSES: frozenset[str] = frozenset({"success", "skipped"})
+SUCCESS_EXECUTION_STATUS: str = "success"
 CHECK_NAME_SEPARATOR_CHARACTER: str = "_"
 CHECK_METADATA_EXCLUDED_KEYS: frozenset[str] = frozenset(
     {"passed", "steps", "expected_results", "assertion_results"}

--- a/src/sqlbuild/integrations/dagster/constants.py
+++ b/src/sqlbuild/integrations/dagster/constants.py
@@ -14,8 +14,9 @@ LOADER_NODE_KIND: str = "loader"
 VIEW_MATERIALIZATION_TYPE: str = "view"
 
 ASSET_SELECTION_COMMANDS: frozenset[str] = frozenset(
-    {"build", "run", "test", "audit", "seed", "load"}
+    {"build", "run", "test", "audit", "seed", "load", "clone"}
 )
+CLONE_COMMAND: str = "clone"
 EXPLICIT_SELECTION_FLAGS: frozenset[str] = frozenset({"--select", "-s", "--select-file"})
 JSON_OUTPUT_FLAGS: frozenset[str] = frozenset({"--json", "--json-output"})
 JSON_OUTPUT_FLAG: str = "--json-output"

--- a/tests/e2e/src/sqlbuild/cli/commands/main/clone/test_clone.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/clone/test_clone.py
@@ -103,7 +103,7 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
                 "orders_enriched",
                 "missing_snapshot",
             ),
-            expected_exit_code=1,
+            expected_exit_code=0,
             expected_stdout_fragments=(
                 "fact_orders",
                 "copied",

--- a/tests/unit/src/sqlbuild/cli/output/main/clone_execution_json/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/clone_execution_json/_test_types.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+from sqlbuild.executor.clone.models import CloneItemResult
+
+
+@dataclass(frozen=True)
+class CloneExecutionJsonTestCase:
+    description: str
+    item_results: tuple[CloneItemResult, ...]
+    expected_status: str
+    expected_asset_statuses: tuple[str, ...]
+    expected_asset_actions: tuple[str, ...]
+    expected_summary: dict[str, int]
+
+
+@dataclass(frozen=True)
+class VirtualCloneExecutionJsonTestCase:
+    description: str
+    expected_status: str
+    expected_asset_statuses: tuple[str, ...]
+    expected_summary: dict[str, int]

--- a/tests/unit/src/sqlbuild/cli/output/main/clone_execution_json/test_execution_protocol_v1.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/clone_execution_json/test_execution_protocol_v1.py
@@ -1,0 +1,122 @@
+import json
+from typing import Any
+
+import pytest
+
+from sqlbuild.cli.output.main._clone_execution_json import (
+    format_clone_execution_json,
+)
+from sqlbuild.cli.output.main._virtual_clone_execution_json import (
+    format_virtual_clone_execution_json,
+)
+from sqlbuild.executor.clone.models import CloneExecutionResult, CloneItemResult
+from sqlbuild.executor.clone.types import CloneAction, CloneStatus
+from sqlbuild.virtual.executor.models import VirtualCloneItemResult, VirtualCloneResult
+from sqlbuild.virtual.state.types import PhysicalArtifactType
+from tests.unit.src.sqlbuild.cli.output.main.clone_execution_json._test_types import (
+    CloneExecutionJsonTestCase,
+    VirtualCloneExecutionJsonTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        CloneExecutionJsonTestCase(
+            description="clone outcomes retain actions and tolerate missing origins",
+            item_results=(
+                CloneItemResult(
+                    name="orders",
+                    action=CloneAction.CLONED,
+                    status=CloneStatus.SUCCESS,
+                    origin_relation="prod.orders",
+                    destination_relation="test.orders",
+                    duration_seconds=0.012,
+                ),
+                CloneItemResult(
+                    name="customers",
+                    action=CloneAction.WARNING_MISSING_SOURCE,
+                    status=CloneStatus.WARNING,
+                    message="missing in origin environment",
+                    origin_relation="prod.customers",
+                    destination_relation="test.customers",
+                ),
+            ),
+            expected_status="success",
+            expected_asset_statuses=("success", "warning"),
+            expected_asset_actions=("cloned", "warning_missing_source"),
+            expected_summary={
+                "success_count": 1,
+                "failure_count": 0,
+                "warning_count": 1,
+                "total_count": 2,
+            },
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_clone_results_when_formatting_execution_json_then_preserves_asset_outcomes(
+    test_case: CloneExecutionJsonTestCase,
+) -> None:
+    result: str = format_clone_execution_json(
+        result=CloneExecutionResult(item_results=test_case.item_results),
+        resource_types_by_name={"orders": "model", "customers": "model"},
+    )
+
+    payload: dict[str, Any] = json.loads(result)
+    assets: list[dict[str, Any]] = payload["assets"]
+    assert payload["version"] == 1
+    assert payload["command"] == "clone"
+    assert payload["status"] == test_case.expected_status
+    assert tuple(asset["status"] for asset in assets) == test_case.expected_asset_statuses
+    assert tuple(asset["action"] for asset in assets) == test_case.expected_asset_actions
+    assert payload["summary"] == test_case.expected_summary
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        VirtualCloneExecutionJsonTestCase(
+            description="virtual clone reports reused and locked assets as completed",
+            expected_status="success",
+            expected_asset_statuses=("success", "skipped"),
+            expected_summary={
+                "success_count": 1,
+                "failure_count": 0,
+                "skipped_count": 1,
+                "total_count": 2,
+            },
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_virtual_clone_results_when_formatting_json_then_preserves_asset_outcomes(
+    test_case: VirtualCloneExecutionJsonTestCase,
+) -> None:
+    result: str = format_virtual_clone_execution_json(
+        result=VirtualCloneResult(
+            mode="target",
+            origin_environment="prod",
+            destination_environment="test",
+            item_results=(
+                VirtualCloneItemResult(
+                    artifact_type=PhysicalArtifactType.MODEL,
+                    artifact_name="orders",
+                    version_hash="abc",
+                    action="reused",
+                ),
+                VirtualCloneItemResult(
+                    artifact_type=PhysicalArtifactType.SEED,
+                    artifact_name="countries",
+                    version_hash="def",
+                    action="skipped_locked",
+                ),
+            ),
+        )
+    )
+
+    payload: dict[str, Any] = json.loads(result)
+    assets: list[dict[str, Any]] = payload["assets"]
+    assert payload["status"] == test_case.expected_status
+    assert tuple(asset["status"] for asset in assets) == test_case.expected_asset_statuses
+    assert payload["summary"] == test_case.expected_summary

--- a/tests/unit/src/sqlbuild/executor/clone/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/clone/main/_test_types.py
@@ -25,6 +25,16 @@ class InterleavedCloneGraphTestCase:
 
 
 @dataclass(frozen=True)
+class CloneViewDependencyTestCase:
+    description: str
+    origin_names: tuple[str, ...]
+    expected_actions: tuple[CloneAction, ...]
+    expected_view_statement_count: int
+    expected_view_statement_fragment: str
+    expected_view_message: str | None
+
+
+@dataclass(frozen=True)
 class PrephaseCloneItemRowTestCase:
     description: str
     action: str

--- a/tests/unit/src/sqlbuild/executor/clone/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/clone/main/_test_types.py
@@ -35,6 +35,14 @@ class CloneViewDependencyTestCase:
 
 
 @dataclass(frozen=True)
+class CloneFunctionDependencyTestCase:
+    description: str
+    expected_actions: tuple[CloneAction, ...]
+    expected_function_statement_count: int
+    expected_function_message: str
+
+
+@dataclass(frozen=True)
 class PrephaseCloneItemRowTestCase:
     description: str
     action: str

--- a/tests/unit/src/sqlbuild/executor/clone/main/test_execute.py
+++ b/tests/unit/src/sqlbuild/executor/clone/main/test_execute.py
@@ -20,6 +20,7 @@ from tests.unit.src.sqlbuild.executor.clone._helpers.helpers import (
     build_clone_model_entry,
 )
 from tests.unit.src.sqlbuild.executor.clone.main._test_types import (
+    CloneFunctionDependencyTestCase,
     CloneStreamTestCase,
     CloneViewDependencyTestCase,
     InterleavedCloneGraphTestCase,
@@ -230,3 +231,56 @@ def test_given_view_clone_when_checking_destination_dependencies_then_recreates_
     assert view_statement_count == test_case.expected_view_statement_count
     assert test_case.expected_view_statement_fragment in executed_sql
     assert result.item_results[-1].message == test_case.expected_view_message
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        CloneFunctionDependencyTestCase(
+            description="function with missing destination dependency is skipped clearly",
+            expected_actions=(
+                CloneAction.WARNING_MISSING_SOURCE,
+                CloneAction.SKIPPED_MISSING_DEPENDENCY,
+            ),
+            expected_function_statement_count=0,
+            expected_function_message="missing destination dependencies: dev.orders",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_function_clone_when_dependency_is_missing_then_skips_function_execution(
+    test_case: CloneFunctionDependencyTestCase,
+) -> None:
+    adapter: FakeCloneAdapter = FakeCloneAdapter(supports_zero_copy=True, origin_names=())
+    origin_table: ModelPlanEntry = build_clone_model_entry(schema="prod", name="orders")
+    destination_table: ModelPlanEntry = build_clone_model_entry(schema="dev", name="orders")
+    function: FunctionPlanEntry = build_clone_function_entry(schema="dev", name="order_count")
+
+    result: CloneExecutionResult = execute_clone(
+        inputs=CloneExecutionInput(
+            source_entries=CloneSourceEntries(),
+            origin_model_entries=(origin_table,),
+            destination_model_entries=(destination_table,),
+            origin_seed_entries=(),
+            destination_seed_entries=(),
+            destination_function_entries=(function,),
+            execution_order=(destination_table.key, function.key),
+            adapter=adapter,
+            destination_connection=object(),
+            hard_copy=False,
+            run_id="clone-run",
+            query_change_tracking=False,
+            upstream_deps={function.key: (destination_table.key,)},
+            dependency_locations={
+                destination_table.key: destination_table.destination,
+                function.key: function.destination,
+            },
+        )
+    )
+
+    function_statement_count: int = sum(
+        statement.startswith("CREATE FUNCTION") for statement in adapter.executed_statements
+    )
+    assert tuple(item.action for item in result.item_results) == test_case.expected_actions
+    assert function_statement_count == test_case.expected_function_statement_count
+    assert result.item_results[-1].message == test_case.expected_function_message

--- a/tests/unit/src/sqlbuild/executor/clone/main/test_execute.py
+++ b/tests/unit/src/sqlbuild/executor/clone/main/test_execute.py
@@ -21,6 +21,7 @@ from tests.unit.src.sqlbuild.executor.clone._helpers.helpers import (
 )
 from tests.unit.src.sqlbuild.executor.clone.main._test_types import (
     CloneStreamTestCase,
+    CloneViewDependencyTestCase,
     InterleavedCloneGraphTestCase,
 )
 
@@ -151,3 +152,81 @@ def test_given_interleaved_clone_graph_when_executing_then_uses_plan_order(
     function_statement_index: int = executed_sql.index(test_case.expected_function_statement)
     view_statement_index: int = executed_sql.index(test_case.expected_view_statement_fragment)
     assert function_statement_index < view_statement_index
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        CloneViewDependencyTestCase(
+            description="missing origin view with available destination dependency is recreated",
+            origin_names=("orders",),
+            expected_actions=(CloneAction.CLONED, CloneAction.RECREATED_VIEW),
+            expected_view_statement_count=1,
+            expected_view_statement_fragment=(
+                "CREATE OR REPLACE VIEW dev.order_summary AS SELECT * FROM dev.orders"
+            ),
+            expected_view_message=None,
+        ),
+        CloneViewDependencyTestCase(
+            description="view with missing destination dependency is skipped clearly",
+            origin_names=(),
+            expected_actions=(
+                CloneAction.WARNING_MISSING_SOURCE,
+                CloneAction.SKIPPED_MISSING_DEPENDENCY,
+            ),
+            expected_view_statement_count=0,
+            expected_view_statement_fragment="",
+            expected_view_message="missing destination dependencies: dev.orders",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_view_clone_when_checking_destination_dependencies_then_recreates_only_when_ready(
+    test_case: CloneViewDependencyTestCase,
+) -> None:
+    adapter: FakeCloneAdapter = FakeCloneAdapter(
+        supports_zero_copy=True,
+        origin_names=test_case.origin_names,
+    )
+    origin_table: ModelPlanEntry = build_clone_model_entry(schema="prod", name="orders")
+    origin_view: ModelPlanEntry = replace(
+        build_clone_model_entry(schema="prod", name="order_summary"),
+        materialization_type=MaterializationType.VIEW,
+    )
+    destination_table: ModelPlanEntry = build_clone_model_entry(schema="dev", name="orders")
+    destination_view: ModelPlanEntry = replace(
+        build_clone_model_entry(schema="dev", name="order_summary"),
+        materialization_type=MaterializationType.VIEW,
+        resolved_sql="SELECT * FROM dev.orders",
+    )
+
+    result: CloneExecutionResult = execute_clone(
+        inputs=CloneExecutionInput(
+            source_entries=CloneSourceEntries(),
+            origin_model_entries=(origin_table, origin_view),
+            destination_model_entries=(destination_table, destination_view),
+            origin_seed_entries=(),
+            destination_seed_entries=(),
+            destination_function_entries=(),
+            execution_order=(destination_table.key, destination_view.key),
+            adapter=adapter,
+            destination_connection=object(),
+            hard_copy=False,
+            run_id="clone-run",
+            query_change_tracking=False,
+            upstream_deps={destination_view.key: (destination_table.key,)},
+            dependency_locations={
+                destination_table.key: destination_table.destination,
+                destination_view.key: destination_view.destination,
+            },
+        )
+    )
+
+    assert tuple(item.action for item in result.item_results) == test_case.expected_actions
+    executed_sql: str = "\n".join(adapter.executed_statements)
+    view_statement_count: int = sum(
+        statement.startswith("CREATE OR REPLACE VIEW") for statement in adapter.executed_statements
+    )
+    assert view_statement_count == test_case.expected_view_statement_count
+    assert test_case.expected_view_statement_fragment in executed_sql
+    assert result.item_results[-1].message == test_case.expected_view_message

--- a/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
@@ -95,6 +95,22 @@ class DagsterCliJsonStreamTestCase:
 
 
 @dataclass(frozen=True)
+class DagsterCliCloneStreamTestCase:
+    description: str
+    command_stdout: str
+    expected_asset_keys: tuple[tuple[str, ...], ...]
+    expected_actions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DagsterCliCloneFailureTestCase:
+    description: str
+    command_stdout: str
+    expected_materialized_asset_key: tuple[str, ...]
+    expected_incomplete_assets: str
+
+
+@dataclass(frozen=True)
 class DagsterCliFailureTestCase:
     description: str
     command_stderr: str

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from threading import Event
@@ -12,6 +13,8 @@ import pytest
 from sqlbuild.integrations.dagster import SqlBuildCliResource
 from sqlbuild.integrations.dagster.classes.sqlbuild_cli_invocation import SqlBuildCliInvocation
 from tests.unit.src.sqlbuild.integrations.dagster._test_types import (
+    DagsterCliCloneFailureTestCase,
+    DagsterCliCloneStreamTestCase,
     DagsterCliFailureTestCase,
     DagsterCliInvocationTestCase,
     DagsterCliJsonStreamTestCase,
@@ -233,6 +236,136 @@ def test_given_execution_json_when_streaming_then_yields_structured_dagster_even
     assert tuple(result.severity.value for result in check_results) == (
         test_case.expected_check_severities
     )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagsterCliCloneStreamTestCase(
+            description="clone execution yields materializations for successful items only",
+            command_stdout=(
+                '{"version": 1, "command": "clone", "status": "success", '
+                '"summary": {"success_count": 2}, '
+                '"assets": [{"kind": "model", "name": "orders", '
+                '"status": "success", "action": "cloned"}, '
+                '{"kind": "seed", "name": "waffle_types", '
+                '"status": "success", "action": "copied"}], "checks": []}'
+            ),
+            expected_asset_keys=(("analytics", "waffle_types"), ("analytics", "orders")),
+            expected_actions=("copied", "cloned"),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_clone_execution_json_when_streaming_then_yields_asset_materializations(
+    test_case: DagsterCliCloneStreamTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    context: Any = type(
+        "AggregateCloneContext",
+        (),
+        {"selected_asset_keys": {dg.AssetKey(["aggregate_clone"])}},
+    )()
+    resource: SqlBuildCliResource = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_fake_sqb_command(root=tmp_path, stdout=test_case.command_stdout),
+        dag_path=str(write_dagster_test_dag(root=tmp_path)),
+    )
+
+    results: list[Any] = list(
+        resource.cli(args=["clone", "--from", "prod"], context=context).stream()
+    )
+
+    assert all(isinstance(result, dg.AssetMaterialization) for result in results)
+    assert (
+        tuple(tuple(result.asset_key.path) for result in results) == test_case.expected_asset_keys
+    )
+    assert (
+        tuple(result.metadata["action"].value for result in results) == test_case.expected_actions
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagsterCliCloneFailureTestCase(
+            description="partial clone failure preserves confirmed materializations",
+            command_stdout=(
+                '{"version": 1, "command": "clone", "status": "failed", '
+                '"summary": {"success_count": 1, "failure_count": 1}, '
+                '"assets": [{"kind": "model", "name": "orders", '
+                '"status": "success", "action": "cloned"}, '
+                '{"kind": "model", "name": "customers", '
+                '"status": "failed", "action": "failed"}], "checks": []}'
+            ),
+            expected_materialized_asset_key=("analytics", "orders"),
+            expected_incomplete_assets="model:customers (failed)",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_partial_clone_failure_when_streaming_then_preserves_confirmed_materializations(
+    test_case: DagsterCliCloneFailureTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    context: Any = type("CloneContext", (), {"selected_asset_keys": set()})()
+    resource: SqlBuildCliResource = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_fake_sqb_command(
+            root=tmp_path,
+            stdout=test_case.command_stdout,
+            exit_code=1,
+        ),
+        dag_path=str(write_dagster_test_dag(root=tmp_path)),
+    )
+    stream: Iterator[Any] = resource.cli(args=["clone", "--from", "prod"], context=context).stream()
+
+    materialization: Any = next(stream)
+    assert tuple(materialization.asset_key.path) == test_case.expected_materialized_asset_key
+    with pytest.raises(dg.Failure) as exc_info:
+        next(stream)
+
+    incomplete_assets: Any = exc_info.value.metadata["incomplete_assets"]
+    assert incomplete_assets.value == test_case.expected_incomplete_assets
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagsterCliFailureTestCase(
+            description="clone failure without payload emits no materializations",
+            command_stderr="clone crashed\n",
+            command_exit_code=1,
+            expected_error_fragment="SQLBuild CLI command failed with exit code 1",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_clone_failure_without_payload_when_streaming_then_emits_no_materializations(
+    test_case: DagsterCliFailureTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    context: Any = type("CloneContext", (), {"selected_asset_keys": set()})()
+    resource: SqlBuildCliResource = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_fake_sqb_command(
+            root=tmp_path,
+            stderr=test_case.command_stderr,
+            exit_code=test_case.command_exit_code,
+        ),
+        dag_path=str(write_dagster_test_dag(root=tmp_path)),
+    )
+
+    with pytest.raises(dg.Failure) as exc_info:
+        next(resource.cli(args=["clone", "--from", "prod"], context=context).stream())
+
+    assert test_case.expected_error_fragment in str(exc_info.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Dagster run `20b593b3` exposed three clone observability/correctness problems: missing production relations made the command fail despite being warnings, missing views were not recreated even when destination dependencies existed, and unavailable dependencies cascaded into noisy DDL failures. Clone outcomes also lacked structured JSON, so Dagster could not materialize confirmed successes or summarize incomplete assets.

Tracks [CHI-138](https://linear.app/chio-labs/issue/CHI-138/fix-clone-dependency-skips-and-dagster-materializations).

## Changes

- Treat missing-origin and missing-dependency outcomes as nonfatal warnings; genuine execution failures still exit nonzero.
- Recreate production-missing views only when all physical destination dependencies are available.
- Skip unavailable views before DDL with qualified missing-dependency metadata.
- Add versioned direct/virtual clone execution JSON with action, status, relations, duration, and summary.
- Add clone to Dagster structured streaming and emit `AssetMaterialization` only for confirmed successful outcomes.
- Preserve partial-success materializations before raising a compact failed-step summary; emit none when a failed command produced no trustworthy payload.

## Verification

- `uv sync --all-extras && make check-ci`
- Focused unit/integration suites: `148 passed`
- DuckDB clone E2E suite: `15 passed`
- Fensu: `0 faults`
- `git diff --check`
