### PR TITLE
fix: stream SQLBuild execution events live

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/audit/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/audit/execution.py
@@ -8,6 +8,8 @@ from sqlbuild.cli.commands.models import (
     AuditExecutionPreparation,
     AuditInvocation,
 )
+from sqlbuild.cli.output.classes.execution_event_writer import ExecutionEventWriter
+from sqlbuild.cli.output.main._build_item_execution_event import format_build_item_execution_event
 from sqlbuild.cli.progress.classes.connection_progress_reporter import (
     ConnectionProgressReporter,
 )
@@ -67,34 +69,43 @@ def execute_audit_plan(
 ) -> tuple[AuditExecutionResult, ...]:
     """Execute the audit plan with nested progress reporting."""
 
+    event_writer: ExecutionEventWriter = ExecutionEventWriter()
     on_complete: Callable[[AuditExecutionResult], None] = _build_on_complete(
-        progress=preparation.progress
+        progress=preparation.progress,
+        event_writer=event_writer,
+        pipeline_result=pipeline_result,
     )
-    return run_audit_pipeline(
-        plan=pipeline_result.plan_output,
-        connection_config=invocation.connection_config,
-        adapter=invocation.adapter,
-        on_connection_start=preparation.execution_connection_progress.on_connection_start,
-        on_connection_complete=lambda connection_count, elapsed_seconds: (
-            preparation.execution_connection_progress.on_connection_complete(
-                connection_count=connection_count, elapsed_seconds=elapsed_seconds
-            )
-        ),
-        on_connection_error=lambda connection_count, elapsed_seconds: (
-            preparation.execution_connection_progress.on_connection_error(
-                connection_count=connection_count, elapsed_seconds=elapsed_seconds
-            )
-        ),
-        on_audit_start=lambda entry: preparation.progress.on_item_start(
-            group_name=entry.attached_target_name or "(unattached)",
-            item_name=_audit_display_name_from_entry(entry),
-        ),
-        on_audit_complete=on_complete,
-    )
+    try:
+        return run_audit_pipeline(
+            plan=pipeline_result.plan_output,
+            connection_config=invocation.connection_config,
+            adapter=invocation.adapter,
+            on_connection_start=preparation.execution_connection_progress.on_connection_start,
+            on_connection_complete=lambda connection_count, elapsed_seconds: (
+                preparation.execution_connection_progress.on_connection_complete(
+                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
+                )
+            ),
+            on_connection_error=lambda connection_count, elapsed_seconds: (
+                preparation.execution_connection_progress.on_connection_error(
+                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
+                )
+            ),
+            on_audit_start=lambda entry: preparation.progress.on_item_start(
+                group_name=entry.attached_target_name or "(unattached)",
+                item_name=_audit_display_name_from_entry(entry),
+            ),
+            on_audit_complete=on_complete,
+        )
+    finally:
+        event_writer.close()
 
 
 def _build_on_complete(
-    *, progress: NestedCommandProgressCallbacks
+    *,
+    progress: NestedCommandProgressCallbacks,
+    event_writer: ExecutionEventWriter,
+    pipeline_result: CompilePipelineResult,
 ) -> Callable[[AuditExecutionResult], None]:
     def _on_complete(result: AuditExecutionResult) -> None:
         group_name: str = result.attached_target_name or "(unattached)"
@@ -117,6 +128,13 @@ def _build_on_complete(
             item_name=audit_name,
             status_text=status_text,
             detail=detail,
+        )
+        event_writer.write(
+            format_build_item_execution_event(
+                result=result,
+                plan=pipeline_result.plan_output,
+                command="audit",
+            )
         )
 
     return _on_complete

--- a/src/sqlbuild/cli/commands/_helpers/build_execution/checks.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_execution/checks.py
@@ -12,6 +12,7 @@ from sqlbuild.cli.commands._helpers.check.core import (
 )
 from sqlbuild.cli.commands.models import (
     BuildCommandRequest,
+    BuildExecutionPreparation,
     BuildInvocation,
     BuildRunOutcome,
 )
@@ -22,6 +23,7 @@ from sqlbuild.compiler.python_nodes.models import PythonNodeGraph
 from sqlbuild.executor.build.types import BuildStatus
 from sqlbuild.executor.python_nodes.main.checks import execute_python_checks
 from sqlbuild.executor.python_nodes.models import (
+    PythonCheckCallbacks,
     PythonCheckExecutionResult,
     PythonNodeRunState,
     PythonNodeRuntime,
@@ -35,6 +37,7 @@ def run_post_build_python_checks(
     pipeline_result: CompilePipelineResult,
     outcome: BuildRunOutcome,
     providers: Any,
+    preparation: BuildExecutionPreparation,
 ) -> tuple[PythonCheckExecutionResult, ...]:
     """Execute relevant python check functions after a successful build."""
 
@@ -90,6 +93,9 @@ def run_post_build_python_checks(
                 providers=providers,
             ),
             run_state=check_run_state,
+            callbacks=PythonCheckCallbacks(
+                on_check_complete=preparation.callbacks.write_execution_event,
+            ),
         )
     finally:
         invocation.adapter.close(check_connection)

--- a/src/sqlbuild/cli/commands/_helpers/build_execution/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_execution/execution.py
@@ -53,6 +53,7 @@ def prepare_build_execution(
         use_color=invocation.use_color,
         verbose=request.verbose,
         debug=request.debug or request.json_output,
+        event_output_path=request.event_output_path,
     )
     effective_concurrency: int = (
         request.concurrency

--- a/src/sqlbuild/cli/commands/_helpers/check/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/check/execution.py
@@ -16,6 +16,8 @@ from sqlbuild.cli.commands.models import (
     CheckExecutionPreparation,
     CheckInvocation,
 )
+from sqlbuild.cli.output.classes.execution_event_writer import ExecutionEventWriter
+from sqlbuild.cli.output.main._build_item_execution_event import format_build_item_execution_event
 from sqlbuild.compiler.discovery.models import DiscoveredCheckFunction
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.python_nodes.main.graph import build_discovered_python_node_graph
@@ -29,6 +31,7 @@ from sqlbuild.executor.python_nodes.main.checks import execute_python_checks
 from sqlbuild.executor.python_nodes.main.ingress import execute_ingress_python_loader_nodes
 from sqlbuild.executor.python_nodes.models import (
     IngressCallbacks,
+    PythonCheckCallbacks,
     PythonCheckExecutionResult,
     PythonIngressLoaderExecutorResult,
     PythonNodeExecutionResult,
@@ -90,6 +93,7 @@ def execute_check_plan(
     """Execute selected Python checks with their Python dependencies."""
 
     connection: Any = invocation.adapter.connect(invocation.connection_config)
+    event_writer: ExecutionEventWriter = ExecutionEventWriter()
     try:
         ingress_result: PythonIngressLoaderExecutorResult = _execute_check_ingress(
             invocation=invocation,
@@ -130,8 +134,18 @@ def execute_check_plan(
             ),
             run_state=ingress_result.run_state,
             require_upstream_results=False,
+            callbacks=PythonCheckCallbacks(
+                on_check_complete=lambda result: event_writer.write(
+                    format_build_item_execution_event(
+                        result=result,
+                        plan=pipeline_result.plan_output,
+                        command="check",
+                    )
+                )
+            ),
         )
     finally:
+        event_writer.close()
         invocation.adapter.close(connection)
 
 

--- a/src/sqlbuild/cli/commands/_helpers/clone/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/clone/execution.py
@@ -14,6 +14,10 @@ from sqlbuild.cli.commands.models import (
     CloneInvocation,
     CloneRunOutcome,
 )
+from sqlbuild.cli.output.classes.execution_event_writer import ExecutionEventWriter
+from sqlbuild.cli.output.main._clone_item_execution_event import (
+    format_clone_item_execution_event,
+)
 from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationLocation
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import (
@@ -44,35 +48,42 @@ def execute_clone_plan(
     """Execute the direct clone plan and copy fingerprints."""
 
     clone_start: float = time.monotonic()
+    resource_types_by_name: dict[str, str] = _clone_resource_types_by_name(preparation=preparation)
+    event_writer: ExecutionEventWriter = ExecutionEventWriter(path=request.event_output_path)
     on_item: CloneItemCallback = _build_on_clone_item(
         stream=invocation.progress_stream,
         use_color=invocation.use_color,
+        event_writer=event_writer,
+        resource_types_by_name=resource_types_by_name,
     )
-    result: CloneExecutionResult = execute_clone(
-        inputs=CloneExecutionInput(
-            source_entries=CloneSourceEntries(
-                origin=preparation.pipeline_result.origin_source_entries,
-                destination=preparation.pipeline_result.destination_source_entries,
-            ),
-            origin_model_entries=preparation.pipeline_result.origin_model_entries,
-            destination_model_entries=preparation.pipeline_result.destination_model_entries,
-            origin_seed_entries=preparation.pipeline_result.origin_seed_entries,
-            destination_seed_entries=preparation.pipeline_result.destination_seed_entries,
-            destination_function_entries=preparation.pipeline_result.destination_function_entries,
-            execution_order=preparation.pipeline_result.clone_plan.execution_order,
-            adapter=invocation.adapter,
-            destination_connection=connection_context.destination_connection,
-            hard_copy=request.hard_copy,
-            run_id=preparation.pipeline_result.destination_project.run_id,
-            query_change_tracking=preparation.pipeline_result.destination_project.settings.query_change_tracking,
-            upstream_deps=preparation.pipeline_result.clone_plan.upstream_deps,
-            dependency_locations=_clone_dependency_locations(
-                preparation=preparation,
+    try:
+        result: CloneExecutionResult = execute_clone(
+            inputs=CloneExecutionInput(
+                source_entries=CloneSourceEntries(
+                    origin=preparation.pipeline_result.origin_source_entries,
+                    destination=preparation.pipeline_result.destination_source_entries,
+                ),
+                origin_model_entries=preparation.pipeline_result.origin_model_entries,
+                destination_model_entries=preparation.pipeline_result.destination_model_entries,
+                origin_seed_entries=preparation.pipeline_result.origin_seed_entries,
+                destination_seed_entries=preparation.pipeline_result.destination_seed_entries,
+                destination_function_entries=preparation.pipeline_result.destination_function_entries,
+                execution_order=preparation.pipeline_result.clone_plan.execution_order,
                 adapter=invocation.adapter,
-            ),
-            on_item=on_item,
+                destination_connection=connection_context.destination_connection,
+                hard_copy=request.hard_copy,
+                run_id=preparation.pipeline_result.destination_project.run_id,
+                query_change_tracking=preparation.pipeline_result.destination_project.settings.query_change_tracking,
+                upstream_deps=preparation.pipeline_result.clone_plan.upstream_deps,
+                dependency_locations=_clone_dependency_locations(
+                    preparation=preparation,
+                    adapter=invocation.adapter,
+                ),
+                on_item=on_item,
+            )
         )
-    )
+    finally:
+        event_writer.close()
     copy_clone_fingerprints(
         result=result,
         origin_model_entries=preparation.pipeline_result.origin_model_entries,
@@ -125,11 +136,35 @@ def _clone_dependency_locations(
     return locations
 
 
-def _build_on_clone_item(*, stream: TextIO, use_color: bool) -> CloneItemCallback:
+def _clone_resource_types_by_name(*, preparation: CloneExecutionPreparation) -> dict[str, str]:
+    entries: tuple[
+        CloneSourcePlanEntry | ModelPlanEntry | SeedPlanEntry | FunctionPlanEntry, ...
+    ] = (
+        *preparation.pipeline_result.destination_source_entries,
+        *preparation.pipeline_result.destination_model_entries,
+        *preparation.pipeline_result.destination_seed_entries,
+        *preparation.pipeline_result.destination_function_entries,
+    )
+    return {entry.name: str(entry.key.resource_type) for entry in entries}
+
+
+def _build_on_clone_item(
+    *,
+    stream: TextIO,
+    use_color: bool,
+    event_writer: ExecutionEventWriter,
+    resource_types_by_name: dict[str, str],
+) -> CloneItemCallback:
     def _on_clone_item(*, index: int, total: int, item: CloneItemResult) -> None:
         stream.write(
             render_clone_item_line(index=index, total=total, item=item, use_color=use_color) + "\n"
         )
         stream.flush()
+        event_writer.write(
+            format_clone_item_execution_event(
+                item=item,
+                resource_type=resource_types_by_name[item.name],
+            )
+        )
 
     return _on_clone_item

--- a/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
@@ -188,6 +188,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
                 manifest=args.manifest,
                 json_output=args.json,
                 json_output_path=args.json_output,
+                event_output_path=args.event_output,
             )
         )
     if args.command == CliCommand.FRESHNESS:
@@ -317,6 +318,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
                 verbose=args.verbose,
                 cli_vars=args.vars,
                 json_output_path=args.json_output,
+                event_output_path=args.event_output,
             )
         )
     if args.command == CliCommand.DIFF:

--- a/src/sqlbuild/cli/commands/_helpers/entry/parser.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from sqlbuild.cli.commands._helpers.entry.errors import build_argument_parser_class
 from sqlbuild.cli.commands._helpers.entry.parser_arguments import (
@@ -173,6 +174,7 @@ def _add_plan_and_build_parsers(
     build_parser.add_argument("--no-audits", dest="run_audits", action="store_false", default=True)
     build_parser.add_argument("--manifest", action="store_true", default=False)
     _ = add_execution_json_output_arg(build_parser)
+    build_parser.add_argument("--event-output", type=Path, default=None, help=argparse.SUPPRESS)
     _ = add_cursor_override_args(build_parser)
     build_load_group: argparse._MutuallyExclusiveGroup = build_parser.add_mutually_exclusive_group()
     build_load_group.add_argument("--load", dest="load_sources", action="store_true", default=None)
@@ -268,6 +270,7 @@ def _add_data_parsers(
     _ = add_vars_args(clone_parser)
     _ = add_dbt_config_args(parser=clone_parser)
     _ = add_execution_json_output_arg(clone_parser)
+    clone_parser.add_argument("--event-output", type=Path, default=None, help=argparse.SUPPRESS)
 
     diff_parser: argparse.ArgumentParser = subparsers.add_parser(CliCommand.DIFF)
     diff_parser.add_argument("target_range", metavar="FROM:TO")

--- a/src/sqlbuild/cli/commands/_helpers/load/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/load/execution.py
@@ -15,6 +15,8 @@ from sqlbuild.cli.commands.models import (
     LoadInvocation,
     LoadRunOutcome,
 )
+from sqlbuild.cli.output.classes.execution_event_writer import ExecutionEventWriter
+from sqlbuild.cli.output.main._build_item_execution_event import format_build_item_execution_event
 from sqlbuild.cli.progress.classes.connection_progress_reporter import ConnectionProgressReporter
 from sqlbuild.executor.load.main.run import run_load_pipeline
 from sqlbuild.executor.load.models import (
@@ -34,6 +36,7 @@ def execute_load_plan(
     """Execute selected source loads."""
 
     start: float = time.monotonic()
+    event_writer: ExecutionEventWriter = ExecutionEventWriter()
     load_progress: LoadProgressReporter = LoadProgressReporter(
         stream=invocation.progress_stream,
         use_color=invocation.use_color,
@@ -48,45 +51,59 @@ def execute_load_plan(
         blank_line_after_complete=True,
         use_color=invocation.use_color,
     )
-    results: tuple[LoadExecutionResult, ...] = run_load_pipeline(
-        sources=invocation.selected_sources,
-        reference_sources=invocation.reference_sources,
-        loader_functions=invocation.discovered_inputs.loader_functions,
-        connection_config=preparation.connection_config,
-        adapter=preparation.adapter,
-        max_concurrency=preparation.effective_concurrency,
-        runtime=LoadRuntimeParams(
-            run_id=preparation.run_id,
-            runtime_dir=invocation.effective_project_dir / "target",
-            target=preparation.target_name,
-            vars=preparation.effective_vars,
-            is_reload=request.reload,
-            start_cursor_ts=parse_cursor_timestamp(preparation.effective_cursor_overrides.start_ts),
-            end_cursor_ts=parse_cursor_timestamp(preparation.effective_cursor_overrides.end_ts),
-            start_cursor_int=parse_cursor_integer(preparation.effective_cursor_overrides.start_int),
-            end_cursor_int=parse_cursor_integer(preparation.effective_cursor_overrides.end_int),
-            use_color=invocation.use_color,
-            providers=preparation.provider_session.providers,
-        ),
-        callbacks=LoadCallbacks(
-            on_load_start=load_progress.on_start,
-            on_load_progress=lambda source, message: load_progress.on_progress(
-                source=source, message=message
+
+    def on_load_complete(result: LoadExecutionResult) -> None:
+        load_progress.on_complete(result)
+        event_writer.write(
+            format_build_item_execution_event(result=result, plan=None, command="load")
+        )
+
+    try:
+        results: tuple[LoadExecutionResult, ...] = run_load_pipeline(
+            sources=invocation.selected_sources,
+            reference_sources=invocation.reference_sources,
+            loader_functions=invocation.discovered_inputs.loader_functions,
+            connection_config=preparation.connection_config,
+            adapter=preparation.adapter,
+            max_concurrency=preparation.effective_concurrency,
+            runtime=LoadRuntimeParams(
+                run_id=preparation.run_id,
+                runtime_dir=invocation.effective_project_dir / "target",
+                target=preparation.target_name,
+                vars=preparation.effective_vars,
+                is_reload=request.reload,
+                start_cursor_ts=parse_cursor_timestamp(
+                    preparation.effective_cursor_overrides.start_ts
+                ),
+                end_cursor_ts=parse_cursor_timestamp(preparation.effective_cursor_overrides.end_ts),
+                start_cursor_int=parse_cursor_integer(
+                    preparation.effective_cursor_overrides.start_int
+                ),
+                end_cursor_int=parse_cursor_integer(preparation.effective_cursor_overrides.end_int),
+                use_color=invocation.use_color,
+                providers=preparation.provider_session.providers,
             ),
-            on_load_complete=load_progress.on_complete,
-            on_connection_start=connection_progress.on_connection_start,
-            on_connection_complete=lambda connection_count, elapsed_seconds: (
-                connection_progress.on_connection_complete(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
+            callbacks=LoadCallbacks(
+                on_load_start=load_progress.on_start,
+                on_load_progress=lambda source, message: load_progress.on_progress(
+                    source=source, message=message
+                ),
+                on_load_complete=on_load_complete,
+                on_connection_start=connection_progress.on_connection_start,
+                on_connection_complete=lambda connection_count, elapsed_seconds: (
+                    connection_progress.on_connection_complete(
+                        connection_count=connection_count, elapsed_seconds=elapsed_seconds
+                    )
+                ),
+                on_connection_error=lambda connection_count, elapsed_seconds: (
+                    connection_progress.on_connection_error(
+                        connection_count=connection_count, elapsed_seconds=elapsed_seconds
+                    )
+                ),
             ),
-            on_connection_error=lambda connection_count, elapsed_seconds: (
-                connection_progress.on_connection_error(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
-        ),
-    )
+        )
+    finally:
+        event_writer.close()
     return LoadRunOutcome(
         results=results,
         elapsed=time.monotonic() - start,

--- a/src/sqlbuild/cli/commands/_helpers/seed/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/seed/execution.py
@@ -11,7 +11,10 @@ from sqlbuild.cli.commands.models import (
     SeedInvocation,
     SeedRunOutcome,
 )
+from sqlbuild.cli.output.classes.execution_event_writer import ExecutionEventWriter
+from sqlbuild.cli.output.main._build_item_execution_event import format_build_item_execution_event
 from sqlbuild.cli.progress.classes.connection_progress_reporter import ConnectionProgressReporter
+from sqlbuild.compiler.planner.models import PlanOutput
 from sqlbuild.executor.build.models import SeedExecutionResult
 from sqlbuild.executor.build.types import ExecutionStatus
 from sqlbuild.executor.pipeline.main.run import run_seed_pipeline
@@ -25,6 +28,7 @@ def execute_seed_plan(
     """Execute compiled seed entries."""
 
     start: float = time.monotonic()
+    event_writer: ExecutionEventWriter = ExecutionEventWriter()
     on_complete: Callable[[SeedExecutionResult], None] = _build_on_complete(
         stream=invocation.progress_stream,
         use_color=invocation.use_color,
@@ -35,6 +39,8 @@ def execute_seed_plan(
             )
         },
         total_count=len(preparation.pipeline_result.plan_output.seed_entries),
+        event_writer=event_writer,
+        plan=preparation.pipeline_result.plan_output,
     )
     execution_connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
         adapter_name=invocation.adapter_name,
@@ -42,31 +48,40 @@ def execute_seed_plan(
         blank_line_after_complete=True,
         use_color=invocation.use_color,
     )
-    results: tuple[SeedExecutionResult, ...] = run_seed_pipeline(
-        plan=preparation.pipeline_result.plan_output,
-        connection_config=invocation.connection_config,
-        adapter=invocation.adapter,
-        max_concurrency=preparation.effective_concurrency,
-        run_id=preparation.pipeline_result.project.run_id,
-        query_change_tracking=preparation.pipeline_result.project.settings.query_change_tracking,
-        on_seed_complete=on_complete,
-        on_connection_start=execution_connection_progress.on_connection_start,
-        on_connection_complete=lambda connection_count, elapsed_seconds: (
-            execution_connection_progress.on_connection_complete(
-                connection_count=connection_count, elapsed_seconds=elapsed_seconds
-            )
-        ),
-        on_connection_error=lambda connection_count, elapsed_seconds: (
-            execution_connection_progress.on_connection_error(
-                connection_count=connection_count, elapsed_seconds=elapsed_seconds
-            )
-        ),
-    )
+    try:
+        results: tuple[SeedExecutionResult, ...] = run_seed_pipeline(
+            plan=preparation.pipeline_result.plan_output,
+            connection_config=invocation.connection_config,
+            adapter=invocation.adapter,
+            max_concurrency=preparation.effective_concurrency,
+            run_id=preparation.pipeline_result.project.run_id,
+            query_change_tracking=preparation.pipeline_result.project.settings.query_change_tracking,
+            on_seed_complete=on_complete,
+            on_connection_start=execution_connection_progress.on_connection_start,
+            on_connection_complete=lambda connection_count, elapsed_seconds: (
+                execution_connection_progress.on_connection_complete(
+                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
+                )
+            ),
+            on_connection_error=lambda connection_count, elapsed_seconds: (
+                execution_connection_progress.on_connection_error(
+                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
+                )
+            ),
+        )
+    finally:
+        event_writer.close()
     return SeedRunOutcome(results=results, elapsed=time.monotonic() - start)
 
 
 def _build_on_complete(
-    *, stream: TextIO, use_color: bool, seed_order: dict[str, int], total_count: int
+    *,
+    stream: TextIO,
+    use_color: bool,
+    seed_order: dict[str, int],
+    total_count: int,
+    event_writer: ExecutionEventWriter,
+    plan: PlanOutput,
 ) -> Callable[[SeedExecutionResult], None]:
     def _on_complete(result: SeedExecutionResult) -> None:
         status_text: str = "OK" if result.status == ExecutionStatus.SUCCESS else "FAIL"
@@ -83,6 +98,9 @@ def _build_on_complete(
         if result.error_message is not None:
             stream.write(f"    {_format_seed_error(result=result, use_color=use_color)}\n")
         stream.flush()
+        event_writer.write(
+            format_build_item_execution_event(result=result, plan=plan, command="seed")
+        )
 
     return _on_complete
 

--- a/src/sqlbuild/cli/commands/_helpers/test/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/test/execution.py
@@ -14,6 +14,8 @@ from sqlbuild.cli.commands.models import (
     TestExecutionPreparation,
     TestInvocation,
 )
+from sqlbuild.cli.output.classes.execution_event_writer import ExecutionEventWriter
+from sqlbuild.cli.output.main._build_item_execution_event import format_build_item_execution_event
 from sqlbuild.cli.progress.classes.connection_progress_reporter import (
     ConnectionProgressReporter,
 )
@@ -81,40 +83,49 @@ def execute_test_plan(
 ) -> tuple[SqlTestExecutionResult, ...]:
     """Execute the test plan with nested progress reporting."""
 
+    event_writer: ExecutionEventWriter = ExecutionEventWriter()
     on_complete: Callable[[SqlTestExecutionResult], None] = _build_on_complete(
-        progress=preparation.progress
+        progress=preparation.progress,
+        event_writer=event_writer,
+        pipeline_result=pipeline_result,
     )
-    return run_test_pipeline(
-        plan=pipeline_result.plan_output,
-        connection_config=invocation.connection_config,
-        adapter=invocation.adapter,
-        on_connection_start=preparation.execution_connection_progress.on_connection_start,
-        on_connection_complete=lambda connection_count, elapsed_seconds: (
-            preparation.execution_connection_progress.on_connection_complete(
-                connection_count=connection_count, elapsed_seconds=elapsed_seconds
-            )
-        ),
-        on_connection_error=lambda connection_count, elapsed_seconds: (
-            preparation.execution_connection_progress.on_connection_error(
-                connection_count=connection_count, elapsed_seconds=elapsed_seconds
-            )
-        ),
-        on_progress=preparation.preflight_progress.report_preflight_progress,
-        on_test_start=lambda entry: preparation.progress.on_item_start(
-            group_name=_test_group_name_from_entry(entry),
-            item_name=format_parameterized_test_label(
-                name=entry.name,
-                source_path=entry.source_path,
-                parameter_schema=entry.parameter_schema,
-                parameter_values=entry.parameter_values,
+    try:
+        return run_test_pipeline(
+            plan=pipeline_result.plan_output,
+            connection_config=invocation.connection_config,
+            adapter=invocation.adapter,
+            on_connection_start=preparation.execution_connection_progress.on_connection_start,
+            on_connection_complete=lambda connection_count, elapsed_seconds: (
+                preparation.execution_connection_progress.on_connection_complete(
+                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
+                )
             ),
-        ),
-        on_test_complete=on_complete,
-    )
+            on_connection_error=lambda connection_count, elapsed_seconds: (
+                preparation.execution_connection_progress.on_connection_error(
+                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
+                )
+            ),
+            on_progress=preparation.preflight_progress.report_preflight_progress,
+            on_test_start=lambda entry: preparation.progress.on_item_start(
+                group_name=_test_group_name_from_entry(entry),
+                item_name=format_parameterized_test_label(
+                    name=entry.name,
+                    source_path=entry.source_path,
+                    parameter_schema=entry.parameter_schema,
+                    parameter_values=entry.parameter_values,
+                ),
+            ),
+            on_test_complete=on_complete,
+        )
+    finally:
+        event_writer.close()
 
 
 def _build_on_complete(
-    *, progress: NestedCommandProgressCallbacks
+    *,
+    progress: NestedCommandProgressCallbacks,
+    event_writer: ExecutionEventWriter,
+    pipeline_result: CompilePipelineResult,
 ) -> Callable[[SqlTestExecutionResult], None]:
     def _on_complete(result: SqlTestExecutionResult) -> None:
         model_name: str = ""
@@ -135,6 +146,13 @@ def _build_on_complete(
             error_code=result.error_code,
             error_help=result.error_help,
             error_message=result.error_message,
+        )
+        event_writer.write(
+            format_build_item_execution_event(
+                result=result,
+                plan=pipeline_result.plan_output,
+                command="test",
+            )
         )
 
     return _on_complete

--- a/src/sqlbuild/cli/commands/classes/build_progress_callbacks.py
+++ b/src/sqlbuild/cli/commands/classes/build_progress_callbacks.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import sys
 import threading
 import time
+from pathlib import Path
 
 from sqlbuild.adapter.contract.models import LifeCycleEvent
 from sqlbuild.adapter.contract.types import LifeCycleEventKind
 from sqlbuild.cli.commands._helpers.test.sql_progress import format_parameterized_test_label
+from sqlbuild.cli.output.classes.execution_event_writer import ExecutionEventWriter
+from sqlbuild.cli.output.main._build_item_execution_event import format_build_item_execution_event
 from sqlbuild.cli.progress.main._expectation_detail import format_expectation_detail
 from sqlbuild.cli.progress.main._expectation_name import format_expectation_name
 from sqlbuild.compiler.auditing.types import AuditOutcome, AuditRunScope
@@ -87,7 +90,9 @@ class BuildProgressCallbacks:
         use_color: bool,
         verbose: bool = False,
         debug: bool = False,
+        event_output_path: Path | None = None,
     ) -> None:
+        self._plan: PlanOutput = plan
         self._model_entry_map: dict[str, ModelPlanEntry] = {
             entry.name: entry for entry in plan.model_entries
         }
@@ -120,6 +125,7 @@ class BuildProgressCallbacks:
         self._spinner_stop_event: threading.Event | None = None
         self._spinner_thread: threading.Thread | None = None
         self._cursor_hidden: bool = False
+        self._event_writer: ExecutionEventWriter = ExecutionEventWriter(path=event_output_path)
 
         ctr_width: int = len(str(self._total)) * 2 + 1
         self._prefix_width: int = 2 + ctr_width + 2
@@ -258,6 +264,12 @@ class BuildProgressCallbacks:
         self._cursor_hidden = False
 
     def on_node_complete(self, node_result: object) -> None:
+        try:
+            self._write_node_result(node_result)
+        finally:
+            self._write_execution_event(node_result)
+
+    def _write_node_result(self, node_result: object) -> None:
         if isinstance(node_result, SqlTestExecutionResult):
             if node_result.outcome != SqlTestOutcome.PASS:
                 self._write_failed_test_result(test_result=node_result)
@@ -350,6 +362,23 @@ class BuildProgressCallbacks:
 
         if isinstance(node_result, ModelExecutionResult):
             self._write_model_result(ctr=ctr, model_result=node_result)
+
+    def _write_execution_event(self, node_result: object) -> None:
+        payload: str | None = format_build_item_execution_event(
+            result=node_result,
+            plan=self._plan,
+        )
+        self._event_writer.write(payload)
+
+    def write_execution_event(self, result: object) -> None:
+        """Write one result to the shared structured event channel."""
+
+        self._write_execution_event(result)
+
+    def close(self) -> None:
+        """Close the optional structured execution event stream."""
+
+        self._event_writer.close()
 
     def _write_model_result(self, *, ctr: str, model_result: ModelExecutionResult) -> None:
         plan_entry: ModelPlanEntry | None = self._model_entry_map.get(model_result.model_name)

--- a/src/sqlbuild/cli/commands/classes/cli_namespace.py
+++ b/src/sqlbuild/cli/commands/classes/cli_namespace.py
@@ -175,6 +175,7 @@ class CliNamespace:
     hard_copy: bool
     json: bool
     json_output: Path | None
+    event_output: Path | None
     manifest: bool
     dag: str | None
     compile_lineage_mode: CompileLineageMode

--- a/src/sqlbuild/cli/commands/classes/direct_python_lifecycle_state.py
+++ b/src/sqlbuild/cli/commands/classes/direct_python_lifecycle_state.py
@@ -94,6 +94,8 @@ class DirectPythonLifecycleState:
             if result.node_name not in previous_names
         )
         if new_results:
+            for result in new_results:
+                self.base_on_node_complete(result)
             write_python_node_results(
                 stream=self.progress_stream,
                 results=new_results,
@@ -110,6 +112,8 @@ class DirectPythonLifecycleState:
             self.read_side_tracker.finalize_unrun_python_nodes()
         )
         if finalized_results:
+            for result in finalized_results:
+                self.base_on_node_complete(result)
             write_python_node_results(
                 stream=self.progress_stream,
                 results=finalized_results,

--- a/src/sqlbuild/cli/commands/main/execution/_build.py
+++ b/src/sqlbuild/cli/commands/main/execution/_build.py
@@ -239,27 +239,33 @@ def _execute_direct_build(
             pipeline_result=pipeline_result,
             providers=providers,
         )
-        outcome: BuildRunOutcome = execute_build_plan(
-            request=request,
-            invocation=invocation,
-            pipeline_result=pipeline_result,
-            preparation=preparation,
-            providers=providers,
-        )
-        with CostContext.resource_scope(
-            resource_type="run",
-            resource_name=(
-                pipeline_result.project.effective_target_name or invocation.adapter_name
-            ),
-            phase="post_build_checks",
-        ):
-            check_results: tuple[PythonCheckExecutionResult, ...] = run_post_build_python_checks(
+        try:
+            outcome: BuildRunOutcome = execute_build_plan(
                 request=request,
                 invocation=invocation,
                 pipeline_result=pipeline_result,
-                outcome=outcome,
+                preparation=preparation,
                 providers=providers,
             )
+            with CostContext.resource_scope(
+                resource_type="run",
+                resource_name=(
+                    pipeline_result.project.effective_target_name or invocation.adapter_name
+                ),
+                phase="post_build_checks",
+            ):
+                check_results: tuple[PythonCheckExecutionResult, ...] = (
+                    run_post_build_python_checks(
+                        request=request,
+                        invocation=invocation,
+                        pipeline_result=pipeline_result,
+                        outcome=outcome,
+                        providers=providers,
+                        preparation=preparation,
+                    )
+                )
+        finally:
+            preparation.callbacks.close()
     return preparation, outcome, check_results
 
 

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -183,6 +183,7 @@ class BuildCommandRequest:
     manifest: bool = False
     json_output: bool = False
     json_output_path: Path | None = None
+    event_output_path: Path | None = None
     no_cache: bool = False
 
 
@@ -390,6 +391,7 @@ class CloneCommandRequest:
     verbose: bool = False
     cli_vars: dict[str, object] | None = None
     json_output_path: Path | None = None
+    event_output_path: Path | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
+++ b/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
@@ -21,7 +21,7 @@ from sqlbuild.executor.build.models import (
     SeedExecutionResult,
 )
 from sqlbuild.executor.build.types import BuildStatus, ExecutionStatus
-from sqlbuild.executor.clone.models import CloneExecutionResult
+from sqlbuild.executor.clone.models import CloneExecutionResult, CloneItemResult
 from sqlbuild.executor.clone.types import CloneStatus
 from sqlbuild.executor.load.models import LoadExecutionResult
 from sqlbuild.executor.python_nodes.models import (
@@ -126,6 +126,59 @@ def format_build_execution_json(
     )
 
 
+def format_build_item_execution_event(
+    *, result: object, plan: PlanOutput | None, command: str = "build"
+) -> str | None:
+    """Format one completed build asset or check as JSON Lines events."""
+
+    assets: tuple[dict[str, object], ...] = ()
+    checks: tuple[dict[str, object], ...] = ()
+    if isinstance(result, ModelExecutionResult):
+        assets = _format_model_assets(results=(result,), plan=plan)
+    elif isinstance(result, SeedExecutionResult):
+        assets = _format_seed_assets(results=(result,), plan=plan)
+    elif isinstance(result, FunctionExecutionResult):
+        assets = _format_function_assets(results=(result,), plan=plan)
+    elif isinstance(result, LoadExecutionResult):
+        assets = _format_load_assets(results=(result,))
+    elif isinstance(result, PythonNodeExecutionResult):
+        assets = _format_python_node_assets(results=(result,))
+    elif isinstance(result, SqlTestExecutionResult):
+        checks = _format_sql_test_checks((result,))
+    elif isinstance(result, AuditExecutionResult):
+        checks = _format_audit_checks((result,))
+    elif isinstance(result, PythonCheckExecutionResult):
+        checks = _format_python_check_results(results=(result,))
+    if isinstance(result, ModelExecutionResult):
+        checks = _format_audit_checks(result.audit_results)
+    if not assets and not checks:
+        return None
+    records: list[str] = []
+    for asset in assets:
+        records.append(
+            json.dumps(
+                {
+                    "version": _JSON_VERSION,
+                    "command": command,
+                    "event": "asset",
+                    "asset": asset,
+                }
+            )
+        )
+    for check in checks:
+        records.append(
+            json.dumps(
+                {
+                    "version": _JSON_VERSION,
+                    "command": command,
+                    "event": "check",
+                    "check": check,
+                }
+            )
+        )
+    return "\n".join(records) + "\n"
+
+
 def format_run_execution_json(
     *,
     result: BuildExecutionResult,
@@ -222,24 +275,9 @@ def format_clone_execution_json(
     )
     return _format_execution_json(
         command="clone",
-        status=(BuildStatus.SUCCESS.value if failure_count == 0 else BuildStatus.FAILED.value),
+        status=BuildStatus.SUCCESS.value if failure_count == 0 else BuildStatus.FAILED.value,
         assets=tuple(
-            _drop_none(
-                {
-                    "kind": resource_types_by_name[item.name],
-                    "name": item.name,
-                    "status": item.status.value,
-                    "action": item.action.value,
-                    "duration_ms": (
-                        round(item.duration_seconds * 1000)
-                        if item.duration_seconds is not None
-                        else None
-                    ),
-                    "origin_relation": item.origin_relation,
-                    "target": item.destination_relation,
-                    "message": item.message,
-                }
-            )
+            _format_clone_asset(item=item, resource_type=resource_types_by_name[item.name])
             for item in result.item_results
         ),
         checks=(),
@@ -249,6 +287,35 @@ def format_clone_execution_json(
             "warning_count": warning_count,
             "total_count": len(result.item_results),
         },
+    )
+
+
+def format_clone_item_execution_event(*, item: CloneItemResult, resource_type: str) -> str:
+    """Format one completed direct-clone item as a JSON Lines event."""
+
+    payload: dict[str, object] = {
+        "version": _JSON_VERSION,
+        "command": "clone",
+        "event": "asset",
+        "asset": _format_clone_asset(item=item, resource_type=resource_type),
+    }
+    return json.dumps(payload) + "\n"
+
+
+def _format_clone_asset(*, item: CloneItemResult, resource_type: str) -> dict[str, object]:
+    return _drop_none(
+        {
+            "kind": resource_type,
+            "name": item.name,
+            "status": item.status.value,
+            "action": item.action.value,
+            "duration_ms": (
+                round(item.duration_seconds * 1000) if item.duration_seconds is not None else None
+            ),
+            "origin_relation": item.origin_relation,
+            "target": item.destination_relation,
+            "message": item.message,
+        }
     )
 
 

--- a/src/sqlbuild/cli/output/classes/execution_event_writer.py
+++ b/src/sqlbuild/cli/output/classes/execution_event_writer.py
@@ -1,0 +1,39 @@
+"""Thread-safe JSON Lines execution event writer."""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from typing import TextIO
+
+from sqlbuild.cli.output.constants import EXECUTION_EVENT_PATH_ENV
+
+
+class ExecutionEventWriter:
+    """Append and flush structured execution events for a parent integration."""
+
+    def __init__(self, *, path: Path | None = None) -> None:
+        configured_path: str | None = os.environ.get(EXECUTION_EVENT_PATH_ENV)
+        self._path: Path | None = path or (Path(configured_path) if configured_path else None)
+        self._stream: TextIO | None = None
+        self._lock: threading.Lock = threading.Lock()
+        if self._path is not None:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._stream = self._path.open(mode="a", encoding="utf-8")
+
+    def write(self, payload: str | None) -> None:
+        """Write and flush one or more complete JSON Lines records."""
+
+        if self._stream is None or payload is None:
+            return
+        with self._lock:
+            self._stream.write(payload)
+            self._stream.flush()
+
+    def close(self) -> None:
+        """Close the event stream when configured."""
+
+        if self._stream is not None:
+            self._stream.close()
+            self._stream = None

--- a/src/sqlbuild/cli/output/constants.py
+++ b/src/sqlbuild/cli/output/constants.py
@@ -1,0 +1,3 @@
+"""CLI execution output constants."""
+
+EXECUTION_EVENT_PATH_ENV: str = "SQLBUILD_EXECUTION_EVENT_PATH"

--- a/src/sqlbuild/cli/output/main/_build_item_execution_event.py
+++ b/src/sqlbuild/cli/output/main/_build_item_execution_event.py
@@ -1,0 +1,16 @@
+"""Public direct build item event formatting entrypoint."""
+
+from __future__ import annotations
+
+from sqlbuild.cli.output._helpers.execution_protocol_v1 import (
+    format_build_item_execution_event as _format_build_item_execution_event,
+)
+from sqlbuild.compiler.planner.models import PlanOutput
+
+
+def format_build_item_execution_event(
+    *, result: object, plan: PlanOutput | None, command: str = "build"
+) -> str | None:
+    """Format one completed build item as a JSON Lines event when it is an asset result."""
+
+    return _format_build_item_execution_event(result=result, plan=plan, command=command)

--- a/src/sqlbuild/cli/output/main/_clone_item_execution_event.py
+++ b/src/sqlbuild/cli/output/main/_clone_item_execution_event.py
@@ -1,0 +1,14 @@
+"""Public direct clone item event formatting entrypoint."""
+
+from __future__ import annotations
+
+from sqlbuild.cli.output._helpers.execution_protocol_v1 import (
+    format_clone_item_execution_event as _format_clone_item_execution_event,
+)
+from sqlbuild.executor.clone.models import CloneItemResult
+
+
+def format_clone_item_execution_event(*, item: CloneItemResult, resource_type: str) -> str:
+    """Format one completed clone item as a JSON Lines event."""
+
+    return _format_clone_item_execution_event(item=item, resource_type=resource_type)

--- a/src/sqlbuild/executor/python_nodes/_helpers/python_checks.py
+++ b/src/sqlbuild/executor/python_nodes/_helpers/python_checks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
@@ -23,13 +23,13 @@ from sqlbuild.executor.python_nodes._helpers.fingerprinting import (
 from sqlbuild.executor.python_nodes._helpers.results import normalize_python_check_return
 from sqlbuild.executor.python_nodes.models import (
     CheckContext,
+    PythonCheckCallbacks,
     PythonCheckExecutionResult,
     PythonCheckResult,
     PythonNodeExecutionResult,
     PythonNodeRunState,
     PythonNodeRuntime,
 )
-from sqlbuild.executor.python_nodes.types import PythonIdentityRecorder
 from sqlbuild.executor.scheduling.types import ExecutionStatus
 from sqlbuild.provider.main.runtime import (
     ProviderContainer,
@@ -48,12 +48,16 @@ def execute_python_check_nodes(
     runtime: PythonNodeRuntime,
     run_state: PythonNodeRunState,
     upstream_load_results_by_loader_name: Mapping[str, LoadExecutionResult] | None = None,
-    logger: logging.Logger | None = None,
-    identity_recorder: PythonIdentityRecorder | None = None,
+    callbacks: PythonCheckCallbacks | None = None,
     require_upstream_results: bool = True,
+    **legacy_callbacks: Any,
 ) -> tuple[PythonCheckExecutionResult, ...]:
     """Execute check nodes after their selected Python dependencies have completed."""
 
+    resolved_callbacks: PythonCheckCallbacks = callbacks or PythonCheckCallbacks(
+        logger=cast("Any", legacy_callbacks.get("logger")),
+        identity_recorder=cast("Any", legacy_callbacks.get("identity_recorder")),
+    )
     adapter: BaseAdapter = runtime.adapter
     connection: Any = runtime.connection
     run_id: str = runtime.run_id
@@ -114,6 +118,8 @@ def execute_python_check_nodes(
                     run_id=run_id,
                 )
             results.append(blocked)
+            if resolved_callbacks.on_check_complete is not None:
+                resolved_callbacks.on_check_complete(blocked)
             continue
         with CostContext.resource_scope(
             resource_type=PythonNodeKind.CHECK.value,
@@ -127,7 +133,8 @@ def execute_python_check_nodes(
                 target=runtime.target,
                 vars=runtime.vars,
                 is_reload=runtime.is_reload,
-                logger=logger or logging.getLogger(f"sqlbuild.check.{check_function.name}"),
+                logger=resolved_callbacks.logger
+                or logging.getLogger(f"sqlbuild.check.{check_function.name}"),
                 statement_recorder=StatementRecorder(),
                 run_state=run_state,
                 result_store=resolved_result_store,
@@ -164,6 +171,8 @@ def execute_python_check_nodes(
                     run_id=run_id,
                 )
                 results.append(error_result)
+                if resolved_callbacks.on_check_complete is not None:
+                    resolved_callbacks.on_check_complete(error_result)
                 continue
             severity: PythonCheckSeverity = check_result.severity or check_function.severity
             result: PythonCheckExecutionResult = PythonCheckExecutionResult(
@@ -179,12 +188,14 @@ def execute_python_check_nodes(
                 run_id=run_id,
             )
             results.append(result)
+            if resolved_callbacks.on_check_complete is not None:
+                resolved_callbacks.on_check_complete(result)
             if not result.failed:
                 identity: PythonNodeIdentity | None = python_graph.nodes_by_name[
                     check_function.name
                 ].identity
-                if identity_recorder is not None:
-                    identity_recorder(identity=identity, _target_name=None)
+                if resolved_callbacks.identity_recorder is not None:
+                    resolved_callbacks.identity_recorder(identity=identity, _target_name=None)
                 else:
                     try_write_python_node_identity_fingerprint(
                         identity=identity,

--- a/src/sqlbuild/executor/python_nodes/main/checks.py
+++ b/src/sqlbuild/executor/python_nodes/main/checks.py
@@ -2,20 +2,20 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Mapping
+from typing import Any, cast
 
 from sqlbuild.compiler.discovery.models import DiscoveredCheckFunction
 from sqlbuild.compiler.python_nodes.models import PythonNodeGraph
 from sqlbuild.executor.load.models import LoadExecutionResult
 from sqlbuild.executor.python_nodes._helpers.python_checks import execute_python_check_nodes
 from sqlbuild.executor.python_nodes.models import (
+    PythonCheckCallbacks,
     PythonCheckExecutionResult,
     PythonNodeExecutionResult,
     PythonNodeRunState,
     PythonNodeRuntime,
 )
-from sqlbuild.executor.python_nodes.types import PythonIdentityRecorder
 
 
 def execute_python_checks(
@@ -27,12 +27,16 @@ def execute_python_checks(
     runtime: PythonNodeRuntime,
     run_state: PythonNodeRunState,
     upstream_load_results_by_loader_name: Mapping[str, LoadExecutionResult] | None = None,
-    logger: logging.Logger | None = None,
-    identity_recorder: PythonIdentityRecorder | None = None,
+    callbacks: PythonCheckCallbacks | None = None,
     require_upstream_results: bool = True,
+    **legacy_callbacks: Any,
 ) -> tuple[PythonCheckExecutionResult, ...]:
     """Execute check nodes after their selected Python dependencies have completed."""
 
+    resolved_callbacks: PythonCheckCallbacks = callbacks or PythonCheckCallbacks(
+        logger=cast("Any", legacy_callbacks.get("logger")),
+        identity_recorder=cast("Any", legacy_callbacks.get("identity_recorder")),
+    )
     return execute_python_check_nodes(
         check_functions=check_functions,
         python_graph=python_graph,
@@ -41,7 +45,6 @@ def execute_python_checks(
         runtime=runtime,
         run_state=run_state,
         upstream_load_results_by_loader_name=upstream_load_results_by_loader_name,
-        logger=logger,
-        identity_recorder=identity_recorder,
+        callbacks=resolved_callbacks,
         require_upstream_results=require_upstream_results,
     )

--- a/src/sqlbuild/executor/python_nodes/models.py
+++ b/src/sqlbuild/executor/python_nodes/models.py
@@ -402,3 +402,12 @@ class CheckContext(BasePythonNodeContext):
             metadata={} if metadata is None else metadata,
             severity=PythonCheckSeverity.WARN,
         )
+
+
+@dataclass(frozen=True)
+class PythonCheckCallbacks:
+    """Optional logging, identity, and completion callbacks for Python checks."""
+
+    logger: logging.Logger | None = None
+    identity_recorder: PythonIdentityRecorder | None = None
+    on_check_complete: Callable[[PythonCheckExecutionResult], None] | None = None

--- a/src/sqlbuild/integrations/dagster/_helpers/invocation.py
+++ b/src/sqlbuild/integrations/dagster/_helpers/invocation.py
@@ -13,12 +13,15 @@ from sqlbuild.integrations.dagster.constants import (
     ASSET_SELECTION_COMMANDS,
     CHECK_METADATA_EXCLUDED_KEYS,
     CHECK_NAME_SEPARATOR_CHARACTER,
+    CLONE_ASSET_EVENT,
     CLONE_COMMAND,
     COMPLETED_EXECUTION_STATUSES,
     DEFAULT_SELECTABLE_NODE_KINDS,
+    EVENT_OUTPUT_FLAG,
     EXPLICIT_SELECTION_FLAGS,
     JSON_OUTPUT_FLAG,
     JSON_OUTPUT_FLAGS,
+    LIVE_EVENT_COMMANDS,
     LOAD_COMMAND,
     LOAD_SELECTABLE_NODE_KINDS,
     LOADER_NODE_KIND,
@@ -30,6 +33,7 @@ from sqlbuild.integrations.dagster.constants import (
     SOURCE_NODE_KIND,
     STDERR_STREAM_NAME,
     SUCCESS_EXECUTION_STATUS,
+    VIRTUAL_ENV_FLAG,
     WARNING_CHECK_SEVERITY,
 )
 
@@ -210,6 +214,34 @@ def _create_execution_json_path() -> Path:
         return Path(handle.name)
 
 
+def _with_event_output_args(
+    *, args: tuple[str, ...], context: Any, dag: Mapping[str, Any] | None
+) -> tuple[tuple[str, ...], Path | None]:
+    if (
+        dag is None
+        or context is None
+        or not args
+        or args[0] not in LIVE_EVENT_COMMANDS
+        or VIRTUAL_ENV_FLAG in args
+        or EVENT_OUTPUT_FLAG in args
+    ):
+        return args, None
+    path: Path = _create_execution_event_path()
+    return args, path
+
+
+def _create_execution_event_path() -> Path:
+    handle: IO[str] = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix="sqlbuild-dagster-events-",
+        suffix=".jsonl",
+        delete=False,
+    )
+    with handle:
+        return Path(handle.name)
+
+
 def _start_stream_future(
     *,
     executor: ThreadPoolExecutor,
@@ -339,6 +371,7 @@ def _build_results_from_execution_payload(
 ) -> tuple[Any, ...]:
     selected_paths: set[tuple[str, ...]] = _selected_asset_paths(context=context)
     is_clone: bool = str(payload.get("command")) == CLONE_COMMAND
+    is_live_asset_event: bool = str(payload.get("event")) == CLONE_ASSET_EVENT
     if is_clone:
         selected_paths = set()
     nodes_by_name: dict[tuple[str, str], Mapping[str, Any]] = {
@@ -373,7 +406,9 @@ def _build_results_from_execution_payload(
     for node in _sort_nodes_topologically(dag=dag):
         node_id: str = str(node.get("id"))
         execution_asset: Mapping[str, Any] | None = asset_results_by_id.get(node_id)
-        if execution_asset is None and (is_clone or str(node.get("kind")) != SOURCE_NODE_KIND):
+        if execution_asset is None and (
+            is_clone or is_live_asset_event or str(node.get("kind")) != SOURCE_NODE_KIND
+        ):
             continue
         asset_key: Any = dg.AssetKey([str(part) for part in node["asset_key"]])
         if selected_paths and tuple(asset_key.path) not in selected_paths:

--- a/src/sqlbuild/integrations/dagster/_helpers/invocation_factory.py
+++ b/src/sqlbuild/integrations/dagster/_helpers/invocation_factory.py
@@ -8,7 +8,9 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from sqlbuild.cli.output.constants import EXECUTION_EVENT_PATH_ENV
 from sqlbuild.integrations.dagster._helpers.invocation import (
+    _with_event_output_args,
     _with_json_output_args,
     _with_selected_asset_args,
 )
@@ -41,9 +43,17 @@ def start_sqlbuild_cli_invocation(
         context=context,
         dag=dag,
     )
-    command: tuple[str, ...] = (*tuple(sqb_command), *resolved_args)
+    event_args: tuple[str, ...]
+    event_args, event_jsonl_path = _with_event_output_args(
+        args=resolved_args,
+        context=context,
+        dag=dag,
+    )
+    command: tuple[str, ...] = (*tuple(sqb_command), *event_args)
     process_environment: dict[str, str] = dict(os.environ)
     process_environment["PYTHONUNBUFFERED"] = "1"
+    if event_jsonl_path is not None:
+        process_environment[EXECUTION_EVENT_PATH_ENV] = str(event_jsonl_path)
     process: subprocess.Popen[str] = subprocess.Popen(
         command,
         cwd=project_dir,
@@ -62,4 +72,5 @@ def start_sqlbuild_cli_invocation(
         selection=selection,
         selector_file=selector_file,
         execution_json_path=execution_json_path,
+        event_jsonl_path=event_jsonl_path,
     )

--- a/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
+++ b/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import time
 from collections.abc import Iterator, Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 from sqlbuild.integrations.dagster._helpers.imports import load_dagster
 from sqlbuild.integrations.dagster._helpers.invocation import (
@@ -19,7 +20,12 @@ from sqlbuild.integrations.dagster._helpers.invocation import (
     _log_invocation,
     _start_stream_future,
 )
-from sqlbuild.integrations.dagster.constants import COMPLETED_EXECUTION_STATUSES
+from sqlbuild.integrations.dagster.constants import (
+    CHECK_EVENT,
+    CLONE_ASSET_EVENT,
+    COMPLETED_EXECUTION_STATUSES,
+    VERBOSE_FLAGS,
+)
 
 
 class SqlBuildCliInvocation:
@@ -37,6 +43,7 @@ class SqlBuildCliInvocation:
         selection: tuple[str, ...] = (),
         selector_file: Path | None = None,
         execution_json_path: Path | None = None,
+        event_jsonl_path: Path | None = None,
     ) -> None:
         self.process: subprocess.Popen[str] = process
         self.command: tuple[str, ...] = command
@@ -48,6 +55,7 @@ class SqlBuildCliInvocation:
         self.selector_file: Path | None = selector_file
         self.selector_file_path: str = str(selector_file) if selector_file is not None else ""
         self.execution_json_path: Path | None = execution_json_path
+        self.event_jsonl_path: Path | None = event_jsonl_path
         self.stdout: str = ""
         self.stderr: str = ""
         self.execution_payload: Mapping[str, Any] | None = None
@@ -61,7 +69,7 @@ class SqlBuildCliInvocation:
                 executor=executor,
                 source=self.process.stdout,
                 sink=sys.stdout,
-                context=self.context,
+                context=self._stdout_log_context(),
                 stream_name="stdout",
             )
             stderr_future: Future[str] | None = _start_stream_future(
@@ -90,11 +98,17 @@ class SqlBuildCliInvocation:
             finally:
                 self.selector_file = None
         if self.execution_json_path is None:
-            return
-        try:
-            self.execution_json_path.unlink(missing_ok=True)
-        finally:
-            self.execution_json_path = None
+            pass
+        else:
+            try:
+                self.execution_json_path.unlink(missing_ok=True)
+            finally:
+                self.execution_json_path = None
+        if self.event_jsonl_path is not None:
+            try:
+                self.event_jsonl_path.unlink(missing_ok=True)
+            finally:
+                self.event_jsonl_path = None
 
     def is_successful(self) -> bool:
         """Return whether the invocation completed successfully."""
@@ -102,6 +116,11 @@ class SqlBuildCliInvocation:
         if self.returncode is None:
             return False
         return self.returncode == 0
+
+    def _stdout_log_context(self) -> Any:
+        if VERBOSE_FLAGS.isdisjoint(self.command):
+            return self.context
+        return None
 
     def get_error(self) -> Exception | None:
         """Return a Dagster failure if the process failed."""
@@ -143,6 +162,9 @@ class SqlBuildCliInvocation:
     def stream(self) -> Iterator[Any]:
         """Wait for the process, log output, and yield Dagster events."""
 
+        if self.event_jsonl_path is not None and self.dag is not None:
+            yield from self._stream_with_live_events()
+            return
         original_raise_on_error: bool = self.raise_on_error
         self.raise_on_error = False
         self.wait()
@@ -177,3 +199,145 @@ class SqlBuildCliInvocation:
             command=self.command,
             context=self.context,
         )
+
+    def _stream_with_live_events(self) -> Iterator[Any]:
+        dg: Any = load_dagster()
+        emitted_asset_keys: set[tuple[str, ...]] = set()
+        emitted_check_keys: set[tuple[tuple[str, ...], str]] = set()
+        event_path: Path | None = self.event_jsonl_path
+        dag: Mapping[str, Any] | None = self.dag
+        if event_path is None or dag is None:
+            return
+        original_raise_on_error: bool = self.raise_on_error
+        self.raise_on_error = False
+        try:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                stdout_future: Future[str] | None = _start_stream_future(
+                    executor=executor,
+                    source=self.process.stdout,
+                    sink=sys.stdout,
+                    context=self._stdout_log_context(),
+                    stream_name="stdout",
+                )
+                stderr_future: Future[str] | None = _start_stream_future(
+                    executor=executor,
+                    source=self.process.stderr,
+                    sink=sys.stderr,
+                    context=self.context,
+                    stream_name="stderr",
+                )
+                try:
+                    with event_path.open(mode="r", encoding="utf-8") as event_stream:
+                        for result in self._yield_live_event_results(
+                            dg=dg,
+                            dag=dag,
+                            event_stream=event_stream,
+                        ):
+                            if isinstance(result, dg.AssetCheckResult):
+                                check_key: tuple[tuple[str, ...], str] = (
+                                    tuple(result.asset_key.path),
+                                    result.check_name,
+                                )
+                                if check_key in emitted_check_keys:
+                                    continue
+                                emitted_check_keys.add(check_key)
+                            else:
+                                asset_key: tuple[str, ...] = tuple(result.asset_key.path)
+                                if asset_key in emitted_asset_keys:
+                                    continue
+                                emitted_asset_keys.add(asset_key)
+                            yield result
+                finally:
+                    if self.process.poll() is None:
+                        self.process.terminate()
+                self.returncode = self.process.wait()
+                self.stdout = stdout_future.result() if stdout_future is not None else ""
+                self.stderr = stderr_future.result() if stderr_future is not None else ""
+            self.execution_payload = _load_execution_payload_from_path(self.execution_json_path)
+            _log_invocation(context=self.context, invocation=self)
+            if self.execution_payload is not None:
+                for result in _build_results_from_execution_payload(
+                    dg=dg,
+                    dag=dag,
+                    payload=self.execution_payload,
+                    command=self.command,
+                    context=self.context,
+                ):
+                    if isinstance(result, dg.AssetCheckResult):
+                        check_key = (tuple(result.asset_key.path), result.check_name)
+                        if check_key in emitted_check_keys:
+                            continue
+                        emitted_check_keys.add(check_key)
+                        yield result
+                        continue
+                    if isinstance(result, (dg.AssetMaterialization, dg.MaterializeResult)):
+                        asset_key: tuple[str, ...] = tuple(result.asset_key.path)
+                        if asset_key in emitted_asset_keys:
+                            continue
+                        emitted_asset_keys.add(asset_key)
+                    yield result
+            self.raise_on_error = original_raise_on_error
+            error: Exception | None = self.get_error()
+            if error is not None and self.raise_on_error:
+                raise error
+        finally:
+            self.raise_on_error = original_raise_on_error
+            self._cleanup_temp_files()
+
+    def _yield_live_event_results(
+        self,
+        *,
+        dg: Any,
+        dag: Mapping[str, Any],
+        event_stream: IO[str],
+    ) -> Iterator[Any]:
+        pending: str = ""
+        while True:
+            chunk: str = event_stream.read()
+            if chunk:
+                pending += chunk
+                lines: list[str] = pending.split("\n")
+                pending = lines.pop()
+                for line in lines:
+                    yield from self._results_from_live_event_line(dg=dg, dag=dag, line=line)
+                continue
+            if self.process.poll() is not None:
+                final_chunk: str = event_stream.read()
+                pending += final_chunk
+                for line in pending.splitlines():
+                    yield from self._results_from_live_event_line(dg=dg, dag=dag, line=line)
+                return
+            time.sleep(0.01)
+
+    def _results_from_live_event_line(
+        self, *, dg: Any, dag: Mapping[str, Any], line: str
+    ) -> Iterator[Any]:
+        if line:
+            event: Any
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                return
+            if not isinstance(event, Mapping) or event.get("event") not in {
+                CLONE_ASSET_EVENT,
+                CHECK_EVENT,
+            }:
+                return
+            asset: object = event.get("asset")
+            check: object = event.get("check")
+            if not isinstance(asset, Mapping) and not isinstance(check, Mapping):
+                return
+            payload: Mapping[str, Any] = {
+                "version": event.get("version"),
+                "command": event.get("command"),
+                "event": event.get("event"),
+                "assets": (asset,) if isinstance(asset, Mapping) else (),
+                "checks": (check,) if isinstance(check, Mapping) else (),
+            }
+            yield from _build_results_from_execution_payload(
+                dg=dg,
+                dag=dag,
+                payload=payload,
+                command=self.command,
+                context=self.context,
+            )

--- a/src/sqlbuild/integrations/dagster/constants.py
+++ b/src/sqlbuild/integrations/dagster/constants.py
@@ -14,9 +14,15 @@ LOADER_NODE_KIND: str = "loader"
 VIEW_MATERIALIZATION_TYPE: str = "view"
 
 ASSET_SELECTION_COMMANDS: frozenset[str] = frozenset(
-    {"build", "run", "test", "audit", "seed", "load", "clone"}
+    {"build", "run", "test", "check", "audit", "seed", "load", "clone"}
 )
 CLONE_COMMAND: str = "clone"
+CLONE_ASSET_EVENT: str = "asset"
+CHECK_EVENT: str = "check"
+EVENT_OUTPUT_FLAG: str = "--event-output"
+LIVE_EVENT_COMMANDS: frozenset[str] = ASSET_SELECTION_COMMANDS
+VIRTUAL_ENV_FLAG: str = "--virtual-env"
+VERBOSE_FLAGS: frozenset[str] = frozenset({"--verbose", "-v"})
 EXPLICIT_SELECTION_FLAGS: frozenset[str] = frozenset({"--select", "-s", "--select-file"})
 JSON_OUTPUT_FLAGS: frozenset[str] = frozenset({"--json", "--json-output"})
 JSON_OUTPUT_FLAG: str = "--json-output"

--- a/tests/unit/src/sqlbuild/cli/output/main/clone_execution_json/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/clone_execution_json/_test_types.py
@@ -14,6 +14,14 @@ class CloneExecutionJsonTestCase:
 
 
 @dataclass(frozen=True)
+class CloneItemExecutionEventTestCase:
+    description: str
+    item: CloneItemResult
+    resource_type: str
+    expected_asset: dict[str, object]
+
+
+@dataclass(frozen=True)
 class VirtualCloneExecutionJsonTestCase:
     description: str
     expected_status: str

--- a/tests/unit/src/sqlbuild/cli/output/main/clone_execution_json/test_execution_protocol_v1.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/clone_execution_json/test_execution_protocol_v1.py
@@ -6,6 +6,9 @@ import pytest
 from sqlbuild.cli.output.main._clone_execution_json import (
     format_clone_execution_json,
 )
+from sqlbuild.cli.output.main._clone_item_execution_event import (
+    format_clone_item_execution_event,
+)
 from sqlbuild.cli.output.main._virtual_clone_execution_json import (
     format_virtual_clone_execution_json,
 )
@@ -15,6 +18,7 @@ from sqlbuild.virtual.executor.models import VirtualCloneItemResult, VirtualClon
 from sqlbuild.virtual.state.types import PhysicalArtifactType
 from tests.unit.src.sqlbuild.cli.output.main.clone_execution_json._test_types import (
     CloneExecutionJsonTestCase,
+    CloneItemExecutionEventTestCase,
     VirtualCloneExecutionJsonTestCase,
 )
 
@@ -71,6 +75,49 @@ def test_given_clone_results_when_formatting_execution_json_then_preserves_asset
     assert tuple(asset["status"] for asset in assets) == test_case.expected_asset_statuses
     assert tuple(asset["action"] for asset in assets) == test_case.expected_asset_actions
     assert payload["summary"] == test_case.expected_summary
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        CloneItemExecutionEventTestCase(
+            description="completed clone item retains typed materialization metadata",
+            item=CloneItemResult(
+                name="orders",
+                action=CloneAction.CLONED,
+                status=CloneStatus.SUCCESS,
+                origin_relation="prod.orders",
+                destination_relation="test.orders",
+                duration_seconds=0.012,
+            ),
+            resource_type="model",
+            expected_asset={
+                "kind": "model",
+                "name": "orders",
+                "status": "success",
+                "action": "cloned",
+                "duration_ms": 12,
+                "origin_relation": "prod.orders",
+                "target": "test.orders",
+            },
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_completed_clone_item_when_formatting_event_then_emits_one_flushed_json_line(
+    test_case: CloneItemExecutionEventTestCase,
+) -> None:
+    result: str = format_clone_item_execution_event(
+        item=test_case.item,
+        resource_type=test_case.resource_type,
+    )
+
+    payload: dict[str, Any] = json.loads(result)
+    assert result.endswith("\n")
+    assert payload["version"] == 1
+    assert payload["command"] == "clone"
+    assert payload["event"] == "asset"
+    assert payload["asset"] == test_case.expected_asset
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
@@ -111,6 +111,15 @@ class DagsterCliCloneFailureTestCase:
 
 
 @dataclass(frozen=True)
+class DagsterCliLiveCloneEventTestCase:
+    description: str
+    command: str
+    command_args: tuple[str, ...]
+    expected_asset_key: tuple[str, ...]
+    expected_remaining_asset_keys: tuple[tuple[str, ...], ...] = ()
+
+
+@dataclass(frozen=True)
 class DagsterCliFailureTestCase:
     description: str
     command_stderr: str

--- a/tests/unit/src/sqlbuild/integrations/dagster/helpers.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/helpers.py
@@ -223,6 +223,124 @@ def write_blocking_fake_sqb_command(*, root: Path, release_path: Path) -> list[s
     return ["python", str(script_path)]
 
 
+def write_blocking_clone_event_command(
+    *, root: Path, release_path: Path, command: str = "clone"
+) -> list[str]:
+    event_payload: str = json.dumps(
+        {
+            "version": 1,
+            "command": command,
+            "event": "asset",
+            "asset": {
+                "kind": "model",
+                "name": "orders",
+                "status": "success",
+                "action": "cloned",
+            },
+        }
+    )
+    script_path: Path = root / "blocking_clone_event.py"
+    script_path.write_text(
+        "\n".join(
+            (
+                "from pathlib import Path",
+                "import os",
+                "import sys",
+                "import time",
+                "event_path = Path(os.environ['SQLBUILD_EXECUTION_EVENT_PATH'])",
+                "event_path.write_text("
+                '    \'{"version": 1, "command": "clone", "event": "asset", \''
+                '    \'{"asset": {"kind": "model", "name": "orders", \''
+                '    \'"status": "success", "action": "cloned"}}}\\n\','
+                "    encoding='utf-8',"
+                ")",
+                f"event_path.write_text({event_payload + chr(10)!r}, encoding='utf-8')",
+                f"release_path = Path({str(release_path)!r})",
+                "while not release_path.exists():",
+                "    time.sleep(0.01)",
+                "json_path = Path(sys.argv[sys.argv.index('--json-output') + 1])",
+                "json_path.write_text("
+                '    \'{"version": 1, "command": "clone", "status": "success", \''
+                '    \'"summary": {"success_count": 1}, "assets": \''
+                '    \'[{"kind": "model", "name": "orders", "status": "success", \''
+                '    \'"action": "cloned"}], "checks": []}\','
+                "    encoding='utf-8',"
+                ")",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return ["python", str(script_path)]
+
+
+def write_blocking_execution_event_command(
+    *, root: Path, release_path: Path, command: str
+) -> list[str]:
+    event_payload: str = (
+        json.dumps(
+            {
+                "version": 1,
+                "command": command,
+                "event": "asset",
+                "asset": {
+                    "kind": "model",
+                    "name": "orders",
+                    "status": "success",
+                    "action": "completed",
+                },
+            }
+        )
+        + "\n"
+    )
+    execution_payload: str = json.dumps(
+        {
+            "version": 1,
+            "command": command,
+            "status": "success",
+            "summary": {"success_count": 1},
+            "assets": [
+                {
+                    "kind": "model",
+                    "name": "orders",
+                    "status": "success",
+                    "action": "completed",
+                }
+            ],
+            "checks": [],
+        }
+    )
+    event_write_lines: tuple[str, ...] = (
+        "with event_path.open('a', encoding='utf-8') as stream:\n"
+        f"    stream.write({event_payload[: len(event_payload) // 2]!r})\n"
+        "    stream.flush()\n"
+        "    time.sleep(0.05)\n"
+        f"    stream.write({event_payload[len(event_payload) // 2 :]!r})\n"
+        "    stream.flush()",
+    )
+    script_path: Path = root / f"blocking_{command}_event.py"
+    script_path.write_text(
+        "\n".join(
+            (
+                "from pathlib import Path",
+                "import os",
+                "import sys",
+                "import time",
+                "event_path = Path(os.environ['SQLBUILD_EXECUTION_EVENT_PATH'])",
+                *event_write_lines,
+                f"release_path = Path({str(release_path)!r})",
+                "while not release_path.exists():",
+                "    time.sleep(0.01)",
+                "json_path = Path(sys.argv[sys.argv.index('--json-output') + 1])",
+                f"json_path.write_text({execution_payload!r}, encoding='utf-8')",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return ["python", str(script_path)]
+
+
 def write_dagster_test_dag(*, root: Path) -> Path:
     root.mkdir(parents=True, exist_ok=True)
     dag_path: Path = root / "sqlbuild_dag.json"

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from threading import Event
-from typing import Any
+from typing import Any, cast
 from unittest.mock import Mock
 
 import pytest
@@ -18,6 +18,7 @@ from tests.unit.src.sqlbuild.integrations.dagster._test_types import (
     DagsterCliFailureTestCase,
     DagsterCliInvocationTestCase,
     DagsterCliJsonStreamTestCase,
+    DagsterCliLiveCloneEventTestCase,
     DagsterCliLiveLogTestCase,
     DagsterCliSelectionTestCase,
     DagsterCliStreamTestCase,
@@ -26,6 +27,7 @@ from tests.unit.src.sqlbuild.integrations.dagster.helpers import (
     assert_json_output_file_behavior,
     assert_positional_selector_behavior,
     assert_select_file_selector_behavior,
+    write_blocking_execution_event_command,
     write_blocking_fake_sqb_command,
     write_dagster_test_dag,
     write_fake_sqb_command,
@@ -130,6 +132,43 @@ def test_given_running_sqlbuild_command_when_output_arrives_then_dagster_logs_it
     )
     assert completed_invocation.stderr == "".join(
         f"{line}\n" for line in test_case.expected_stderr_lines
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        DagsterCliLiveLogTestCase(
+            description="verbose SQL stays in compute stdout instead of Dagster event logs",
+            expected_stdout_lines=("    SELECT * FROM orders",),
+            expected_stderr_lines=(),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_verbose_command_when_streaming_output_then_keeps_sql_out_of_context_log(
+    test_case: DagsterCliLiveLogTestCase, tmp_path: Path
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    logger: Mock = Mock()
+    invocation: SqlBuildCliInvocation = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_fake_sqb_command(
+            root=tmp_path,
+            stdout="".join(f"{line}\n" for line in test_case.expected_stdout_lines),
+        ),
+    ).cli(
+        ["build", "--verbose"],
+        context=type("VerboseContext", (), {"log": logger})(),
+        raise_on_error=False,
+    )
+
+    invocation.wait()
+
+    assert invocation.stdout == "".join(f"{line}\n" for line in test_case.expected_stdout_lines)
+    assert not any(
+        call.args and call.args[0] == "SQLBuild: %s" for call in logger.info.call_args_list
     )
 
 
@@ -285,6 +324,143 @@ def test_given_clone_execution_json_when_streaming_then_yields_asset_materializa
     assert (
         tuple(result.metadata["action"].value for result in results) == test_case.expected_actions
     )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        DagsterCliLiveCloneEventTestCase(
+            description="completed clone item materializes while subprocess remains blocked",
+            command="clone",
+            command_args=("clone", "--from", "prod"),
+            expected_asset_key=("analytics", "orders"),
+        ),
+        DagsterCliLiveCloneEventTestCase(
+            description="completed build item materializes while subprocess remains blocked",
+            command="build",
+            command_args=("build",),
+            expected_asset_key=("analytics", "orders"),
+            expected_remaining_asset_keys=(("raw", "orders"),),
+        ),
+        DagsterCliLiveCloneEventTestCase(
+            description="partial JSONL writes are buffered until their record is complete",
+            command="build",
+            command_args=("build",),
+            expected_asset_key=("analytics", "orders"),
+            expected_remaining_asset_keys=(("raw", "orders"),),
+        ),
+        DagsterCliLiveCloneEventTestCase(
+            description="run uses the shared live execution event transport",
+            command="run",
+            command_args=("run",),
+            expected_asset_key=("analytics", "orders"),
+            expected_remaining_asset_keys=(("raw", "orders"),),
+        ),
+        DagsterCliLiveCloneEventTestCase(
+            description="test uses the shared live execution event transport",
+            command="test",
+            command_args=("test",),
+            expected_asset_key=("analytics", "orders"),
+            expected_remaining_asset_keys=(("raw", "orders"),),
+        ),
+        DagsterCliLiveCloneEventTestCase(
+            description="check uses the shared live execution event transport",
+            command="check",
+            command_args=("check",),
+            expected_asset_key=("analytics", "orders"),
+            expected_remaining_asset_keys=(("raw", "orders"),),
+        ),
+        DagsterCliLiveCloneEventTestCase(
+            description="audit uses the shared live execution event transport",
+            command="audit",
+            command_args=("audit",),
+            expected_asset_key=("analytics", "orders"),
+            expected_remaining_asset_keys=(("raw", "orders"),),
+        ),
+        DagsterCliLiveCloneEventTestCase(
+            description="seed uses the shared live execution event transport",
+            command="seed",
+            command_args=("seed",),
+            expected_asset_key=("analytics", "orders"),
+            expected_remaining_asset_keys=(("raw", "orders"),),
+        ),
+        DagsterCliLiveCloneEventTestCase(
+            description="load uses the shared live execution event transport",
+            command="load",
+            command_args=("load",),
+            expected_asset_key=("analytics", "orders"),
+            expected_remaining_asset_keys=(("raw", "orders"),),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_running_clone_when_item_completes_then_materializes_before_process_exit(
+    test_case: DagsterCliLiveCloneEventTestCase, tmp_path: Path
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    release_path: Path = tmp_path / "release"
+    context: Any = type("AggregateCloneContext", (), {"selected_asset_keys": set()})()
+    resource: SqlBuildCliResource = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_blocking_execution_event_command(
+            root=tmp_path,
+            release_path=release_path,
+            command=test_case.command,
+        ),
+        dag_path=str(write_dagster_test_dag(root=tmp_path)),
+    )
+    invocation: SqlBuildCliInvocation = resource.cli(args=test_case.command_args, context=context)
+    stream: Iterator[Any] = invocation.stream()
+
+    materialization: Any = next(stream)
+
+    assert tuple(materialization.asset_key.path) == test_case.expected_asset_key
+    assert invocation.process.poll() is None
+    release_path.touch()
+    remaining_results: list[Any] = list(stream)
+    assert tuple(tuple(result.asset_key.path) for result in remaining_results) == (
+        test_case.expected_remaining_asset_keys
+    )
+    assert invocation.returncode == 0
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        DagsterCliLiveCloneEventTestCase(
+            description="closing a live event stream terminates its blocked subprocess",
+            command="build",
+            command_args=("build",),
+            expected_asset_key=("analytics", "orders"),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_blocked_command_when_live_stream_closes_then_subprocess_terminates(
+    test_case: DagsterCliLiveCloneEventTestCase, tmp_path: Path
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    invocation: SqlBuildCliInvocation = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_blocking_execution_event_command(
+            root=tmp_path,
+            release_path=tmp_path / "never-release",
+            command=test_case.command,
+        ),
+        dag_path=str(write_dagster_test_dag(root=tmp_path)),
+    ).cli(
+        args=test_case.command_args,
+        context=type("LiveEventContext", (), {"selected_asset_keys": set()})(),
+    )
+    stream: Generator[Any, None, None] = cast(Generator[Any, None, None], invocation.stream())
+
+    materialization: Any = next(stream)
+    stream.close()
+
+    assert tuple(materialization.asset_key.path) == test_case.expected_asset_key
+    assert invocation.process.wait(timeout=3) is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

SQLBuild stdout was live in Dagster, but asset materializations and checks were delayed until final execution JSON was written. With `--verbose`, full SQL bodies were also duplicated line-by-line into Dagster's structured event log.

Tracks [CHI-138](https://linear.app/chio-labs/issue/CHI-138/fix-clone-dependency-skips-and-dagster-materializations).

## Changes

- Add one shared, thread-safe JSONL execution-event transport for SQLBuild integrations.
- Stream asset and check results for build, run, test, check, audit, seed, load, and direct clone commands.
- Include model/seed/function/source/Python asset results, embedded SQL tests/audits, standalone checks, and post-build Python checks.
- Tail events concurrently with stdout/stderr and yield Dagster events before subprocess completion.
- Buffer partial records, drain after process exit, suppress duplicate final events, and terminate blocked subprocesses when a consumer closes the generator.
- Keep verbose SQL in raw compute stdout instead of duplicating it into Dagster context logs.
- Retain final JSON for aggregate summaries, failure metadata, and fallback behavior.

## Verification

- Blocking subprocess matrix proves pre-exit delivery across every supported command.
- Regression coverage includes split JSONL writes, generator cancellation, partial failures, duplicate suppression, and verbose-log routing.
- Focused CLI, executor, protocol, and Dagster tests: `258 passed`.
- DuckDB clone E2E suite: `15 passed`.
- `make check-ci`.
- Ruff, `ty`, and Fensu (`0 faults`).
- Independent review performed twice; all high and medium findings addressed.
