### PR TITLE
fix: preserve Dagster compute stdout

### DIFF
--- a/src/sqlbuild/integrations/dagster/_helpers/invocation.py
+++ b/src/sqlbuild/integrations/dagster/_helpers/invocation.py
@@ -247,6 +247,7 @@ def _start_stream_future(
     executor: ThreadPoolExecutor,
     source: IO[str] | None,
     sink: TextIO,
+    mirror_sink: TextIO | None = None,
     context: Any,
     stream_name: str,
 ) -> Future[str] | None:
@@ -256,12 +257,20 @@ def _start_stream_future(
         _forward_stream,
         source=source,
         sink=sink,
+        mirror_sink=mirror_sink,
         context=context,
         stream_name=stream_name,
     )
 
 
-def _forward_stream(*, source: IO[str], sink: TextIO, context: Any, stream_name: str) -> str:
+def _forward_stream(
+    *,
+    source: IO[str],
+    sink: TextIO,
+    mirror_sink: TextIO | None,
+    context: Any,
+    stream_name: str,
+) -> str:
     captured: list[str] = []
     logger: Any | None = getattr(context, "log", None) if context is not None else None
     try:
@@ -269,6 +278,11 @@ def _forward_stream(*, source: IO[str], sink: TextIO, context: Any, stream_name:
             captured.append(chunk)
             sink.write(chunk)
             sink.flush()
+            if mirror_sink is not None and not _streams_share_file_descriptor(
+                first=sink, second=mirror_sink
+            ):
+                mirror_sink.write(chunk)
+                mirror_sink.flush()
             if logger is None:
                 continue
             line: str = chunk.rstrip("\r\n")
@@ -279,6 +293,15 @@ def _forward_stream(*, source: IO[str], sink: TextIO, context: Any, stream_name:
     finally:
         source.close()
     return "".join(captured)
+
+
+def _streams_share_file_descriptor(*, first: TextIO, second: TextIO) -> bool:
+    if first is second:
+        return True
+    try:
+        return first.fileno() == second.fileno()
+    except (AttributeError, OSError):
+        return False
 
 
 def _write_selector_file(selectors: tuple[str, ...]) -> Path:

--- a/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
+++ b/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
@@ -68,14 +68,16 @@ class SqlBuildCliInvocation:
             stdout_future: Future[str] | None = _start_stream_future(
                 executor=executor,
                 source=self.process.stdout,
-                sink=sys.__stdout__ or sys.stdout,
+                sink=sys.stdout,
+                mirror_sink=sys.__stdout__,
                 context=self._stdout_log_context(),
                 stream_name="stdout",
             )
             stderr_future: Future[str] | None = _start_stream_future(
                 executor=executor,
                 source=self.process.stderr,
-                sink=sys.__stderr__ or sys.stderr,
+                sink=sys.stderr,
+                mirror_sink=sys.__stderr__,
                 context=self.context,
                 stream_name="stderr",
             )
@@ -215,14 +217,16 @@ class SqlBuildCliInvocation:
                 stdout_future: Future[str] | None = _start_stream_future(
                     executor=executor,
                     source=self.process.stdout,
-                    sink=sys.__stdout__ or sys.stdout,
+                    sink=sys.stdout,
+                    mirror_sink=sys.__stdout__,
                     context=self._stdout_log_context(),
                     stream_name="stdout",
                 )
                 stderr_future: Future[str] | None = _start_stream_future(
                     executor=executor,
                     source=self.process.stderr,
-                    sink=sys.__stderr__ or sys.stderr,
+                    sink=sys.stderr,
+                    mirror_sink=sys.__stderr__,
                     context=self.context,
                     stream_name="stderr",
                 )

--- a/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
+++ b/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
@@ -68,14 +68,14 @@ class SqlBuildCliInvocation:
             stdout_future: Future[str] | None = _start_stream_future(
                 executor=executor,
                 source=self.process.stdout,
-                sink=sys.stdout,
+                sink=sys.__stdout__ or sys.stdout,
                 context=self._stdout_log_context(),
                 stream_name="stdout",
             )
             stderr_future: Future[str] | None = _start_stream_future(
                 executor=executor,
                 source=self.process.stderr,
-                sink=sys.stderr,
+                sink=sys.__stderr__ or sys.stderr,
                 context=self.context,
                 stream_name="stderr",
             )
@@ -215,14 +215,14 @@ class SqlBuildCliInvocation:
                 stdout_future: Future[str] | None = _start_stream_future(
                     executor=executor,
                     source=self.process.stdout,
-                    sink=sys.stdout,
+                    sink=sys.__stdout__ or sys.stdout,
                     context=self._stdout_log_context(),
                     stream_name="stdout",
                 )
                 stderr_future: Future[str] | None = _start_stream_future(
                     executor=executor,
                     source=self.process.stderr,
-                    sink=sys.stderr,
+                    sink=sys.__stderr__ or sys.stderr,
                     context=self.context,
                     stream_name="stderr",
                 )

--- a/tests/e2e/src/sqlbuild/integrations/dagster/_test_types.py
+++ b/tests/e2e/src/sqlbuild/integrations/dagster/_test_types.py
@@ -97,3 +97,13 @@ class DagsterPythonNodesArtifactE2ETestCase:
     expected_check_names: tuple[str, ...]
     expected_task_group: str
     expected_asset_group: str
+
+
+@dataclass(frozen=True)
+class DagsterComputeLogE2ETestCase:
+    """Test case for multiprocess Dagster compute-log capture."""
+
+    description: str
+    expected_stdout_fragments: tuple[str, ...]
+    unexpected_structured_log_fragment: str
+    expected_materialization_fragment: str

--- a/tests/e2e/src/sqlbuild/integrations/dagster/helpers.py
+++ b/tests/e2e/src/sqlbuild/integrations/dagster/helpers.py
@@ -310,3 +310,51 @@ _CHECK_EVALUATION_COLLECTORS: MappingProxyType[
     bool,
     Callable[[defaultdict[AssetKey, dict[str, AssetCheckSeverity]], AssetCheckEvaluation], None],
 ] = MappingProxyType({False: _record_failed_check, True: _ignore_passed_check})
+
+
+def dagster_compute_log_job_source(*, root: Path) -> str:
+    """Return a reconstructable multiprocess Dagster job for compute-log verification."""
+
+    return f"""from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import dagster as dg
+from sqlbuild.integrations.dagster import SqlBuildCliResource
+
+ROOT = Path({str(root)!r})
+DAG_PATH = ROOT / "sqlbuild_dag.json"
+DAG_PATH.write_text(json.dumps({{
+    "version": 1,
+    "project_name": "stdout_e2e",
+    "nodes": [{{"id": "model:orders", "kind": "model", "name": "orders", "asset_key": ["orders"]}}],
+    "edges": [],
+    "checks": [],
+}}))
+COMMAND = ROOT / "emit_output.py"
+COMMAND.write_text(
+    "import json, os, sys\\n"
+    "from pathlib import Path\\n"
+    "event = {{'version': 1, 'command': 'build', 'event': 'asset', "
+    "'asset': {{'kind': 'model', 'name': 'orders', 'status': 'success'}}}}\\n"
+    "Path(os.environ['SQLBUILD_EXECUTION_EVENT_PATH']).write_text(json.dumps(event) + '\\\\n')\\n"
+    "sys.stdout.write('PROGRESS LINE\\\\n    SELECT * FROM important_table;\\\\n')\\n"
+    "sys.stdout.flush()\\n"
+    "payload = {{'version': 1, 'command': 'build', 'status': 'success', "
+    "'summary': {{'success_count': 1}}, 'assets': [event['asset']], 'checks': []}}\\n"
+    "Path(sys.argv[sys.argv.index('--json-output') + 1]).write_text(json.dumps(payload))\\n"
+)
+
+@dg.multi_asset(specs=[dg.AssetSpec("orders")])
+def sqlbuild_assets(context):
+    resource = SqlBuildCliResource(
+        project_dir=str(ROOT),
+        dag_path=str(DAG_PATH),
+        sqb_command=[sys.executable, str(COMMAND)],
+    )
+    yield from resource.cli(["build", "--verbose"], context=context).stream()
+
+defs = dg.Definitions(assets=[sqlbuild_assets], jobs=[dg.define_asset_job("stdout_capture_job")])
+"""

--- a/tests/e2e/src/sqlbuild/integrations/dagster/test_compute_logs.py
+++ b/tests/e2e/src/sqlbuild/integrations/dagster/test_compute_logs.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.src.sqlbuild.integrations.dagster._test_types import (
+    DagsterComputeLogE2ETestCase,
+)
+from tests.e2e.src.sqlbuild.integrations.dagster.helpers import dagster_compute_log_job_source
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        DagsterComputeLogE2ETestCase(
+            description="live asset events preserve full multiprocess Dagster compute stdout",
+            expected_stdout_fragments=(
+                "PROGRESS LINE",
+                "SELECT * FROM important_table;",
+            ),
+            unexpected_structured_log_fragment="SQLBuild:     SELECT * FROM important_table;",
+            expected_materialization_fragment="Materialized value orders",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_verbose_sqlbuild_stream_when_dagster_captures_logs_then_stdout_remains_complete(
+    test_case: DagsterComputeLogE2ETestCase,
+    tmp_path: Path,
+) -> None:
+    dagster_home: Path = tmp_path / "dagster-home"
+    compute_dir: Path = dagster_home / "compute"
+    history_dir: Path = dagster_home / "history"
+    compute_dir.mkdir(parents=True)
+    history_dir.mkdir()
+    (dagster_home / "dagster.yaml").write_text(
+        "storage:\n"
+        "  sqlite:\n"
+        f"    base_dir: {history_dir}\n"
+        "compute_logs:\n"
+        "  module: dagster._core.storage.local_compute_log_manager\n"
+        "  class: LocalComputeLogManager\n"
+        "  config:\n"
+        f"    base_dir: {compute_dir}\n"
+        "telemetry:\n"
+        "  enabled: false\n",
+        encoding="utf-8",
+    )
+    job_file: Path = tmp_path / "stdout_job.py"
+    job_file.write_text(dagster_compute_log_job_source(root=tmp_path), encoding="utf-8")
+    environment: dict[str, str] = dict(os.environ)
+    environment["DAGSTER_HOME"] = str(dagster_home)
+
+    completed: subprocess.CompletedProcess[str] = subprocess.run(
+        [
+            str(Path(sys.executable).parent / "dagster"),
+            "job",
+            "execute",
+            "-f",
+            str(job_file),
+            "-a",
+            "defs",
+            "-j",
+            "stdout_capture_job",
+        ],
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    combined_output: str = completed.stdout + completed.stderr
+    assert completed.returncode == 0, combined_output
+    stdout_files: tuple[Path, ...] = tuple(compute_dir.glob("**/*.out"))
+    assert len(stdout_files) == 1
+    compute_stdout: str = stdout_files[0].read_text(encoding="utf-8")
+    for fragment in test_case.expected_stdout_fragments:
+        assert fragment in compute_stdout
+    assert test_case.unexpected_structured_log_fragment not in combined_output
+    assert test_case.expected_materialization_fragment in combined_output


### PR DESCRIPTION
## Why

After deploying SQLBuild 0.65.5, live Dagster materializations worked and verbose SQL no longer flooded the structured event timeline, but the multiprocess raw compute stdout file was empty.

Tracks [CHI-138](https://linear.app/chio-labs/issue/CHI-138/fix-clone-dependency-skips-and-dagster-materializations).

## Changes

- Tee subprocess output to both the current Python stream and process-level original stream when they are genuinely distinct.
- Deduplicate streams sharing the same file descriptor to avoid doubled output.
- Retain complete in-memory stdout/stderr capture and existing context-log filtering.
- Add a real reconstructable multiprocess Dagster `@multi_asset` E2E test using `.stream()` and persisted local compute logs.

## Verification

- Real multiprocess Dagster run confirms the persisted `.out` file contains progress and full SQL, the materialization is emitted, and SQL is absent from `context.log` events.
- Existing in-process pre-exit streaming E2E still passes.
- Full Dagster integration E2E suite: `13 passed`.
- Dagster integration unit tests: `38 passed`.
- `make check-ci`.
- Ruff, `ty`, and Fensu (`0 faults`).
- `git diff --check`.
