### PR TITLE
feat: make debug include verbose output

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/entry/parser.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parser.py
@@ -33,7 +33,12 @@ def build_cli_parser(*, use_color: bool = False) -> argparse.ArgumentParser:
     parser: argparse.ArgumentParser = parser_class(prog="sqb")
     parser.add_argument("--project-dir", "--sqb-project-dir", dest="project_dir", default=None)
     parser.add_argument("--no-color", action="store_true", default=False)
-    parser.add_argument("--debug", action="store_true", default=False)
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="enable verbose output and mirror internal diagnostics to stderr",
+    )
 
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser] = parser.add_subparsers(
         dest="command",

--- a/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
@@ -86,7 +86,7 @@ def parse_cli_invocation(
                     dbt_passthrough_started = True
                     dbt_passthrough_args.append(dbt_arg)
                     continue
-                if dbt_arg == NO_COLOR_OPTION:
+                if dbt_arg == NO_COLOR_OPTION and not dbt_passthrough_started:
                     args.no_color = True
                     continue
                 if dbt_arg == DEBUG_OPTION and not dbt_passthrough_started:

--- a/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from sqlbuild.cli.commands.classes.cli_namespace import CliNamespace
 from sqlbuild.cli.commands.constants import (
+    DBT_VERBOSE_OPTIONS,
     DEBUG_OPTION,
     EMPTY_ENV_VALUE,
     NO_COLOR_OPTION,
@@ -19,6 +20,7 @@ from sqlbuild.cli.commands.constants import (
 from sqlbuild.cli.commands.models import ParsedCliInvocation
 from sqlbuild.cli.commands.types import CliCommand
 from sqlbuild.compiler.scopes.types import DeclarationKind
+from sqlbuild.integrations.dbt.types import DbtInteropCommand
 
 _DBT_PASSTHROUGH_SUBCOMMANDS: frozenset[str] = frozenset(
     {
@@ -88,6 +90,14 @@ def parse_cli_invocation(
             args.dbt_args = dbt_passthrough_args
         elif unknown_args:
             parser.error(f"unrecognized arguments: {' '.join(unknown_args)}")
+        args.verbose = args.verbose or args.debug
+        if (
+            args.debug
+            and args.command == CliCommand.DBT
+            and args.dbt_command != DbtInteropCommand.DEBUG
+            and not any(option in args.dbt_args for option in DBT_VERBOSE_OPTIONS)
+        ):
+            args.dbt_args.append("--verbose")
         if args.command in {CliCommand.BUILD, CliCommand.LOAD, CliCommand.SEED}:
             try:
                 args.concurrency = resolve_env_default_concurrency(args.concurrency)

--- a/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 from sqlbuild.cli.commands.classes.cli_namespace import CliNamespace
 from sqlbuild.cli.commands.constants import (
+    DBT_PASSTHROUGH_SEPARATOR,
     DBT_VERBOSE_OPTIONS,
+    DEBUG_OPTION,
     EMPTY_ENV_VALUE,
     NO_COLOR_OPTION,
     SCOPE_DEFAULT_PAGE_SIZE,
@@ -77,10 +79,18 @@ def parse_cli_invocation(
         _, unknown_args = parser.parse_known_args(argv, namespace=args)
         if args.command == CliCommand.DBT and args.dbt_command in _DBT_PASSTHROUGH_SUBCOMMANDS:
             dbt_passthrough_args: list[str] = []
+            dbt_passthrough_started: bool = False
             dbt_arg: str
             for dbt_arg in unknown_args:
+                if dbt_arg == DBT_PASSTHROUGH_SEPARATOR:
+                    dbt_passthrough_started = True
+                    dbt_passthrough_args.append(dbt_arg)
+                    continue
                 if dbt_arg == NO_COLOR_OPTION:
                     args.no_color = True
+                    continue
+                if dbt_arg == DEBUG_OPTION and not dbt_passthrough_started:
+                    args.debug = True
                     continue
                 dbt_passthrough_args.append(dbt_arg)
             args.dbt_args = dbt_passthrough_args

--- a/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from sqlbuild.cli.commands.classes.cli_namespace import CliNamespace
 from sqlbuild.cli.commands.constants import (
     DBT_VERBOSE_OPTIONS,
-    DEBUG_OPTION,
     EMPTY_ENV_VALUE,
     NO_COLOR_OPTION,
     SCOPE_DEFAULT_PAGE_SIZE,
@@ -82,9 +81,6 @@ def parse_cli_invocation(
             for dbt_arg in unknown_args:
                 if dbt_arg == NO_COLOR_OPTION:
                     args.no_color = True
-                    continue
-                if dbt_arg == DEBUG_OPTION:
-                    args.debug = True
                     continue
                 dbt_passthrough_args.append(dbt_arg)
             args.dbt_args = dbt_passthrough_args

--- a/src/sqlbuild/cli/commands/constants.py
+++ b/src/sqlbuild/cli/commands/constants.py
@@ -59,6 +59,7 @@ SQL_VALIDATION_CONFIG_KEY: str = "sql_validation"
 GRAPH_SELECTOR_EXPANSION_MARKER: str = "+"
 GRAPH_SELECTOR_PATH_MARKER: str = "~"
 DBT_JSON_OUTPUT_OPTION: str = "--json"
+DBT_PASSTHROUGH_SEPARATOR: str = "--"
 DBT_VERBOSE_OPTIONS: frozenset[str] = frozenset({"--verbose", "-v"})
 DBT_CLI_OUTPUT_OPTIONS: frozenset[str] = frozenset({DBT_JSON_OUTPUT_OPTION, *DBT_VERBOSE_OPTIONS})
 DBT_NO_CONNECTION_OPTION: str = "--no-connection"

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/_test_types.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class VerboseCommandTestCase:
+    """One command that supports verbose output."""
+
+    description: str
+    expected_argv: tuple[str, ...]

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/test_parsing.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/test_parsing.py
@@ -1,0 +1,57 @@
+"""Tests for cross-command CLI output mode normalization."""
+
+from __future__ import annotations
+
+import pytest
+
+from sqlbuild.cli.commands._helpers.entry.parser import build_cli_parser
+from sqlbuild.cli.commands._helpers.entry.parsing import parse_cli_invocation
+from sqlbuild.cli.commands.models import ParsedCliInvocation
+from tests.unit.src.sqlbuild.cli.commands._helpers.entry._test_types import (
+    VerboseCommandTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        VerboseCommandTestCase(description="plan", expected_argv=("plan",)),
+        VerboseCommandTestCase(description="build", expected_argv=("build",)),
+        VerboseCommandTestCase(
+            description="clone",
+            expected_argv=("clone", "--from", "prod", "--to", "dev"),
+        ),
+        VerboseCommandTestCase(description="diff", expected_argv=("diff", "prod:dev")),
+        VerboseCommandTestCase(
+            description="promote",
+            expected_argv=("promote", "--from", "preview", "--to", "dev"),
+        ),
+        VerboseCommandTestCase(
+            description="rollback",
+            expected_argv=("rollback", "--virtual-env", "dev"),
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_output_mode_when_parsing_verbose_command_then_normalizes_consistently(
+    test_case: VerboseCommandTestCase,
+) -> None:
+    default: ParsedCliInvocation = parse_cli_invocation(
+        argv=test_case.expected_argv,
+        parser=build_cli_parser(),
+    )
+    verbose: ParsedCliInvocation = parse_cli_invocation(
+        argv=(*test_case.expected_argv, "--verbose"),
+        parser=build_cli_parser(),
+    )
+    debug: ParsedCliInvocation = parse_cli_invocation(
+        argv=("--debug", *test_case.expected_argv),
+        parser=build_cli_parser(),
+    )
+
+    assert default.args is not None
+    assert verbose.args is not None
+    assert debug.args is not None
+    assert (default.args.verbose, default.args.debug) == (False, False)
+    assert (verbose.args.verbose, verbose.args.debug) == (True, False)
+    assert (debug.args.verbose, debug.args.debug) == (True, True)

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/_test_types.py
@@ -48,6 +48,7 @@ class MainTestCase:
     expected_allow_snapshot_schema_change: bool = False
     expected_no_color: bool = False
     expected_debug: bool = False
+    expected_verbose: bool = False
     expected_json: bool = False
     expected_json_output_path: Path | None = None
     expected_run_tests: bool = True

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -328,10 +328,16 @@ def test_given_dbt_command_without_sqlbuild_project_when_dispatching_then_does_n
             expected_dbt_args=("--select", "tag:nightly", "--start-cursor-int", "10"),
         ),
         MainTestCase(
-            description="displaced global debug enables verbose dbt run output",
+            description="dbt debug argument remains owned by dbt",
             argv=["dbt", "run", "--debug", "--select", "tag:nightly"],
             expected_exit_code=17,
-            expected_dbt_args=("--select", "tag:nightly", "--verbose"),
+            expected_dbt_args=("--debug", "--select", "tag:nightly"),
+        ),
+        MainTestCase(
+            description="dbt debug argument after separator is preserved verbatim",
+            argv=["dbt", "run", "--", "--debug"],
+            expected_exit_code=17,
+            expected_dbt_args=("--", "--debug"),
         ),
         MainTestCase(
             description="dispatches dbt build and preserves dbt args",

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -187,7 +187,19 @@ def test_given_compile_command_arguments_when_running_with_dependencies_then_it_
                 "--start-cursor-int",
                 "10",
             ),
-        )
+        ),
+        MainTestCase(
+            description="global debug enables verbose dbt plan output",
+            argv=["--debug", "dbt", "plan", "--select", "orders"],
+            expected_exit_code=13,
+            expected_dbt_args=("--select", "orders", "--verbose"),
+        ),
+        MainTestCase(
+            description="global debug does not duplicate explicit dbt verbose output",
+            argv=["--debug", "dbt", "plan", "--verbose"],
+            expected_exit_code=13,
+            expected_dbt_args=("--verbose",),
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -316,6 +328,12 @@ def test_given_dbt_command_without_sqlbuild_project_when_dispatching_then_does_n
             expected_dbt_args=("--select", "tag:nightly", "--start-cursor-int", "10"),
         ),
         MainTestCase(
+            description="displaced global debug enables verbose dbt run output",
+            argv=["dbt", "run", "--debug", "--select", "tag:nightly"],
+            expected_exit_code=17,
+            expected_dbt_args=("--select", "tag:nightly", "--verbose"),
+        ),
+        MainTestCase(
             description="dispatches dbt build and preserves dbt args",
             argv=[
                 "--project-dir",
@@ -328,6 +346,12 @@ def test_given_dbt_command_without_sqlbuild_project_when_dispatching_then_does_n
             expected_exit_code=19,
             expected_project_dir=Path("/tmp/demo"),
             expected_dbt_args=("--select", "tag:nightly"),
+        ),
+        MainTestCase(
+            description="global debug enables verbose dbt build output",
+            argv=["--debug", "dbt", "build", "--select", "tag:nightly"],
+            expected_exit_code=19,
+            expected_dbt_args=("--select", "tag:nightly", "--verbose"),
         ),
         MainTestCase(
             description="dispatches dbt build with sqb project dir alias",
@@ -415,6 +439,12 @@ def test_given_dbt_command_without_sqlbuild_project_when_dispatching_then_does_n
                 "--profiles-dir",
                 "profiles",
             ),
+        ),
+        MainTestCase(
+            description="global debug does not alter dbt debug subcommand arguments",
+            argv=["--debug", "dbt", "debug", "--no-connection"],
+            expected_exit_code=29,
+            expected_dbt_args=("--no-connection",),
         ),
     ],
     ids=lambda case: case.description,
@@ -2077,6 +2107,7 @@ def test_given_dag_command_arguments_when_running_then_dispatches_expected_handl
             expected_allow_snapshot_schema_change=True,
             expected_no_color=True,
             expected_debug=True,
+            expected_verbose=True,
         ),
         MainTestCase(
             description="passes no load to build handler",
@@ -2148,6 +2179,7 @@ def test_given_build_full_refresh_when_running_then_dispatches_expected_flag(
             bool,
             bool,
             bool,
+            bool,
         ]
     ] = []
 
@@ -2165,6 +2197,7 @@ def test_given_build_full_refresh_when_running_then_dispatches_expected_flag(
                 request.run_tests,
                 request.run_audits,
                 request.debug,
+                request.verbose,
                 request.changes_only,
                 request.no_cache,
             )
@@ -2190,6 +2223,7 @@ def test_given_build_full_refresh_when_running_then_dispatches_expected_flag(
             test_case.expected_run_tests,
             test_case.expected_run_audits,
             test_case.expected_debug,
+            test_case.expected_verbose,
             test_case.expected_changes_only,
             test_case.expected_no_cache,
         )

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -328,10 +328,10 @@ def test_given_dbt_command_without_sqlbuild_project_when_dispatching_then_does_n
             expected_dbt_args=("--select", "tag:nightly", "--start-cursor-int", "10"),
         ),
         MainTestCase(
-            description="dbt debug argument remains owned by dbt",
+            description="displaced SQLBuild debug enables verbose dbt run output",
             argv=["dbt", "run", "--debug", "--select", "tag:nightly"],
             expected_exit_code=17,
-            expected_dbt_args=("--debug", "--select", "tag:nightly"),
+            expected_dbt_args=("--select", "tag:nightly", "--verbose"),
         ),
         MainTestCase(
             description="dbt debug argument after separator is preserved verbatim",

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -340,6 +340,12 @@ def test_given_dbt_command_without_sqlbuild_project_when_dispatching_then_does_n
             expected_dbt_args=("--", "--debug"),
         ),
         MainTestCase(
+            description="dbt no color argument after separator is preserved verbatim",
+            argv=["dbt", "run", "--", "--no-color"],
+            expected_exit_code=17,
+            expected_dbt_args=("--", "--no-color"),
+        ),
+        MainTestCase(
             description="dispatches dbt build and preserves dbt args",
             argv=[
                 "--project-dir",


### PR DESCRIPTION
## Why

SQLBuild's global `--debug` enabled internal diagnostics and deterministic stderr progress, but did not include the detailed resource output supplied by `--verbose`. This differed from dbt's operator expectation that debug is the most detailed mode and left Dagster users choosing between diagnostics and useful execution detail.

## Changes

- Normalize CLI modes centrally so `--debug` implies `--verbose` for every verbose-capable native command.
- Apply the same rule to `sqb dbt plan`, `run`, and `build` without duplicating an explicit verbose flag or changing the `sqb dbt debug` subcommand.
- Clarify root CLI help: debug enables verbose output and mirrors internal diagnostics to stderr.
- Add a cross-command mode matrix for plan, build, clone, diff, promote, and rollback, plus dbt passthrough coverage.
- Preserve the existing diagnostics contract: DEBUG events and adapter SQL always go to `target/sqlbuild.log`; debug additionally mirrors them to stderr.

dbt Core comparison: dbt debug lowers console/file thresholds to DEBUG while retaining structured event ownership and adapter event emission. SQLBuild intentionally keeps `verbose` as operator detail and `debug` as verbose plus internal diagnostics, rather than coupling formatting or adapter behavior to individual commands.

## Verification

- `make check-ci`
- `uv run pytest tests/unit/src/sqlbuild/cli/commands/_helpers/entry/test_parsing.py tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py tests/unit/src/sqlbuild/diagnostics/test_main.py -n auto --dist loadfile -q` (`104 passed`)
- `uv run sqb --help`
