### PR TITLE
fix: enrich Dagster non-SQL asset descriptions

### DIFF
--- a/src/sqlbuild/integrations/dagster/classes/sqlbuild_dagster_translator.py
+++ b/src/sqlbuild/integrations/dagster/classes/sqlbuild_dagster_translator.py
@@ -58,6 +58,9 @@ class SqlBuildDagsterTranslator:
         sql: object = node.get("sql")
         if isinstance(sql, str) and sql.strip():
             return f"{description}\n\n**SQLBuild SQL:**\n```sql\n{sql.strip()}\n```"
+        path: object = node.get("path")
+        if isinstance(path, str) and path.strip():
+            return f"{description}\n\n**Source file:** `{path.strip()}`"
         return description
 
     def get_check_name(self, check: Mapping[str, Any]) -> str:

--- a/src/sqlbuild/integrations/dagster/classes/sqlbuild_dagster_translator.py
+++ b/src/sqlbuild/integrations/dagster/classes/sqlbuild_dagster_translator.py
@@ -59,8 +59,8 @@ class SqlBuildDagsterTranslator:
         if isinstance(sql, str) and sql.strip():
             return f"{description}\n\n**SQLBuild SQL:**\n```sql\n{sql.strip()}\n```"
         path: object = node.get("path")
-        if isinstance(path, str) and path.strip():
-            return f"{description}\n\n**Source file:** `{path.strip()}`"
+        if isinstance(path, str) and path:
+            return f"{description}\n\n**Source file:** {_markdown_code_span(path)}"
         return description
 
     def get_check_name(self, check: Mapping[str, Any]) -> str:
@@ -88,6 +88,15 @@ def _normalize_tag_key(value: str) -> str:
 def _normalize_name(value: str) -> str:
     normalized: str = re.sub(r"[^A-Za-z0-9_]+", "_", value).strip("_")
     return normalized or "check"
+
+
+def _markdown_code_span(value: str) -> str:
+    longest_backtick_run: int = max(
+        (len(match.group()) for match in re.finditer(r"`+", value)), default=0
+    )
+    delimiter: str = "`" * (longest_backtick_run + 1)
+    padding: str = " " if value.startswith(("`", " ")) or value.endswith(("`", " ")) else ""
+    return f"{delimiter}{padding}{value}{padding}{delimiter}"
 
 
 def _fallback_description(node: Mapping[str, Any]) -> str:

--- a/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
@@ -19,6 +19,13 @@ class DagsterAssetSpecTestCase:
 
 
 @dataclass(frozen=True)
+class DagsterDescriptionTestCase:
+    description: str
+    node: dict[str, object]
+    expected_description: str
+
+
+@dataclass(frozen=True)
 class DagsterPythonArtifactCompatibilityTestCase:
     description: str
     expected_asset_keys: tuple[tuple[str, ...], ...]

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_assets.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_assets.py
@@ -72,7 +72,9 @@ dg: Any = pytest.importorskip("dagster")
                 "**SQLBuild SQL:**",
                 "MODEL (materialized table);",
             ),
-            expected_seed_description=("SQLBuild seed `waffle_types`."),
+            expected_seed_description=(
+                "SQLBuild seed `waffle_types`.\n\n**Source file:** `seeds/waffle_types.csv`"
+            ),
         )
     ],
     ids=lambda case: case.description,

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_assets.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_assets.py
@@ -23,6 +23,7 @@ from tests.unit.src.sqlbuild.integrations.dagster._test_types import (
     DagsterAssetSpecTestCase,
     DagsterConflictingInputTestCase,
     DagsterDecoratorTestCase,
+    DagsterDescriptionTestCase,
     DagsterPythonArtifactCompatibilityTestCase,
     DagsterScenarioCheckDecoratorTestCase,
 )
@@ -32,6 +33,59 @@ from tests.unit.src.sqlbuild.integrations.dagster.helpers import (
 )
 
 dg: Any = pytest.importorskip("dagster")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagsterDescriptionTestCase(
+            description="authored SQL takes precedence over the source path",
+            node={
+                "kind": "model",
+                "name": "orders",
+                "description": "Clean orders",
+                "path": "models/orders.sql",
+                "sql": "SELECT 1",
+            },
+            expected_description=(
+                "Clean orders\n\n**SQLBuild SQL:**\n```sql\nSELECT 1\n```"
+            ),
+        ),
+        DagsterDescriptionTestCase(
+            description="non-SQL asset includes its source path",
+            node={"kind": "seed", "name": "waffles", "path": "seeds/waffles.csv"},
+            expected_description=(
+                "SQLBuild seed `waffles`.\n\n**Source file:** `seeds/waffles.csv`"
+            ),
+        ),
+        DagsterDescriptionTestCase(
+            description="source path containing backticks remains one code span",
+            node={"kind": "seed", "name": "waffles", "path": "seeds/`waffles`.csv"},
+            expected_description=(
+                "SQLBuild seed `waffles`.\n\n**Source file:** ``seeds/`waffles`.csv``"
+            ),
+        ),
+        DagsterDescriptionTestCase(
+            description="source path whitespace is preserved",
+            node={"kind": "seed", "name": "waffles", "path": " seeds/waffles.csv "},
+            expected_description=(
+                "SQLBuild seed `waffles`.\n\n**Source file:** `  seeds/waffles.csv  `"
+            ),
+        ),
+        DagsterDescriptionTestCase(
+            description="missing source path retains the fallback description",
+            node={"kind": "seed", "name": "waffles"},
+            expected_description="SQLBuild seed `waffles`.",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_node_when_translating_description_then_renders_expected_markdown(
+    test_case: DagsterDescriptionTestCase,
+) -> None:
+    translator: SqlBuildDagsterTranslator = SqlBuildDagsterTranslator()
+
+    assert translator.get_description(test_case.node) == test_case.expected_description
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_assets.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_assets.py
@@ -47,9 +47,7 @@ dg: Any = pytest.importorskip("dagster")
                 "path": "models/orders.sql",
                 "sql": "SELECT 1",
             },
-            expected_description=(
-                "Clean orders\n\n**SQLBuild SQL:**\n```sql\nSELECT 1\n```"
-            ),
+            expected_description=("Clean orders\n\n**SQLBuild SQL:**\n```sql\nSELECT 1\n```"),
         ),
         DagsterDescriptionTestCase(
             description="non-SQL asset includes its source path",


### PR DESCRIPTION
## Why
SQLBuild models already show their authored description and SQL in Dagster, matching dagster-dbt. Non-SQL assets such as seeds have no SQL body and currently fall back to a terse generated warehouse-location sentence even though SQLBuild knows their source file.

## Changes
- append the source file path to Dagster descriptions when a SQLBuild node has no authored SQL
- preserve the existing description and SQL block for models and functions
- avoid embedding CSV contents in asset descriptions

## Verification
- `38 passed` in the SQLBuild Dagster integration suite
- Ruff passed
- ty passed
- `git diff --check` passed