### PR TITLE
fix: report resolved build run context

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/build_execution/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_execution/execution.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlbuild.cli.commands._helpers.build_execution.run_context import write_build_run_context
+from sqlbuild.cli.commands._helpers.build_execution.run_context import (
+    write_build_run_context,
+)
 from sqlbuild.cli.commands._helpers.build_python_nodes.python_lifecycle import (
     prepare_direct_python_lifecycle,
 )
@@ -20,6 +22,7 @@ from sqlbuild.cli.commands.models import (
     BuildCommandRequest,
     BuildExecutionPreparation,
     BuildInvocation,
+    BuildRunContext,
     BuildRunOutcome,
     DirectLifecycleCallbacks,
 )
@@ -64,13 +67,17 @@ def prepare_build_execution(
     if request.verbose or request.debug:
         write_build_run_context(
             stream=invocation.progress_stream,
-            command="sqb build",
-            project=pipeline_result.project,
-            plan=pipeline_result.plan_output,
-            connection_config=invocation.connection_config,
-            concurrency=effective_concurrency,
-            full_refresh=request.full_refresh,
-            selector_files=request.selector_files,
+            context=BuildRunContext(
+                command="sqb build",
+                project=pipeline_result.project,
+                plan=pipeline_result.plan_output,
+                discovered_inputs=invocation.discovered_inputs,
+                python_plan_entries=pipeline_result.python_plan_entries,
+                connection_config=invocation.connection_config,
+                concurrency=effective_concurrency,
+                full_refresh=request.full_refresh,
+                selector_files=request.selector_files,
+            ),
             use_color=invocation.use_color,
         )
     else:

--- a/src/sqlbuild/cli/commands/_helpers/build_execution/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_execution/execution.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from sqlbuild.cli.commands._helpers.build_execution.run_context import write_build_run_context
 from sqlbuild.cli.commands._helpers.build_python_nodes.python_lifecycle import (
     prepare_direct_python_lifecycle,
 )
@@ -60,13 +61,26 @@ def prepare_build_execution(
         if request.concurrency is not None
         else pipeline_result.project.settings.concurrency
     )
-    write_execution_header(
-        stream=invocation.progress_stream,
-        command="sqb build",
-        target=None,
-        concurrency=effective_concurrency,
-        use_color=invocation.use_color,
-    )
+    if request.verbose or request.debug:
+        write_build_run_context(
+            stream=invocation.progress_stream,
+            command="sqb build",
+            project=pipeline_result.project,
+            plan=pipeline_result.plan_output,
+            connection_config=invocation.connection_config,
+            concurrency=effective_concurrency,
+            full_refresh=request.full_refresh,
+            selector_files=request.selector_files,
+            use_color=invocation.use_color,
+        )
+    else:
+        write_execution_header(
+            stream=invocation.progress_stream,
+            command="sqb build",
+            target=None,
+            concurrency=effective_concurrency,
+            use_color=invocation.use_color,
+        )
     has_ingress_source_loads: bool = bool(pipeline_result.plan_output.source_load_entries)
     execution_connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
         adapter_name=invocation.adapter_name,

--- a/src/sqlbuild/cli/commands/_helpers/build_execution/no_work.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_execution/no_work.py
@@ -3,11 +3,15 @@
 from datetime import UTC, datetime
 
 from sqlbuild.cli.commands._helpers.build_execution.outputs import write_no_work_build_json
+from sqlbuild.cli.commands._helpers.build_execution.run_context import (
+    write_build_run_context,
+)
 from sqlbuild.cli.commands._helpers.cost.collection import finalize_build_cost
 from sqlbuild.cli.commands.models import (
     BuildCommandRequest,
     BuildCostFinalization,
     BuildInvocation,
+    BuildRunContext,
 )
 from sqlbuild.compiler.pipeline.main.plan_work import plan_has_executable_work
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
@@ -27,6 +31,27 @@ def finalize_no_work_build_if_needed(
         python_plan_entries=pipeline_result.python_plan_entries,
     ):
         return False
+    if request.verbose or request.debug:
+        effective_concurrency: int = (
+            request.concurrency
+            if request.concurrency is not None
+            else pipeline_result.project.settings.concurrency
+        )
+        write_build_run_context(
+            stream=invocation.progress_stream,
+            context=BuildRunContext(
+                command="sqb build",
+                project=pipeline_result.project,
+                plan=pipeline_result.plan_output,
+                discovered_inputs=invocation.discovered_inputs,
+                python_plan_entries=pipeline_result.python_plan_entries,
+                connection_config=invocation.connection_config,
+                concurrency=effective_concurrency,
+                full_refresh=request.full_refresh,
+                selector_files=request.selector_files,
+            ),
+            use_color=invocation.use_color,
+        )
     completed_at: datetime = datetime.now(UTC)
     cost_record: CostRunRecord | None = finalize_build_cost(
         BuildCostFinalization(

--- a/src/sqlbuild/cli/commands/_helpers/build_execution/run_context.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_execution/run_context.py
@@ -2,87 +2,83 @@
 
 from __future__ import annotations
 
+from datetime import date, datetime
+from pathlib import Path
 from typing import TextIO
 
-from sqlbuild.cli.commands.models import SelectorFileSummary
-from sqlbuild.compiler.compile.models import CompiledProject
-from sqlbuild.compiler.planner.models import PlanOutput
+from sqlbuild.cli.commands.constants import (
+    C0_CONTROL_CODE_LIMIT,
+    C1_CONTROL_CODE_LIMIT,
+    C1_CONTROL_CODE_START,
+)
+from sqlbuild.cli.commands.models import BuildRunContext
 from sqlbuild.presentation.classes.cli_document import CliDocument
 from sqlbuild.presentation.classes.cli_style import CliStyle
 
 
-def write_build_run_context(
-    *,
-    stream: TextIO,
-    command: str,
-    project: CompiledProject,
-    plan: PlanOutput,
-    connection_config: dict[str, object],
-    concurrency: int,
-    full_refresh: bool,
-    selector_files: tuple[SelectorFileSummary, ...],
-    use_color: bool,
-) -> None:
+def write_build_run_context(*, stream: TextIO, context: BuildRunContext, use_color: bool) -> None:
     """Write resolved non-secret build placement, mode, and selection context."""
 
-    stream.write(
-        _format_build_run_context(
-            command=command,
-            project=project,
-            plan=plan,
-            connection_config=connection_config,
-            concurrency=concurrency,
-            full_refresh=full_refresh,
-            selector_files=selector_files,
-            use_color=use_color,
-        )
-    )
+    stream.write(_format_build_run_context(context=context, use_color=use_color))
     stream.flush()
 
 
-def _format_build_run_context(
-    *,
-    command: str,
-    project: CompiledProject,
-    plan: PlanOutput,
-    connection_config: dict[str, object],
-    concurrency: int,
-    full_refresh: bool,
-    selector_files: tuple[SelectorFileSummary, ...],
-    use_color: bool,
-) -> str:
+def _format_build_run_context(*, context: BuildRunContext, use_color: bool) -> str:
     style: CliStyle = CliStyle(use_color=use_color)
     document: CliDocument = CliDocument(style)
     selected_count: int = (
-        len(plan.model_entries) + len(plan.seed_entries) + len(plan.function_entries)
+        len(context.plan.model_entries)
+        + len(context.plan.seed_entries)
+        + len(context.plan.function_entries)
+        + len(context.plan.source_load_entries)
+        + len(context.python_plan_entries)
     )
-    total_count: int = len(project.models) + len(project.seeds) + len(project.functions)
+    total_source_load_count: int = sum(
+        source.source_entry.loader is not None for source in context.project.sources
+    )
+    total_count: int = (
+        len(context.project.models)
+        + len(context.project.seeds)
+        + len(context.project.functions)
+        + total_source_load_count
+        + len(context.discovered_inputs.task_functions)
+        + len(context.discovered_inputs.asset_functions)
+    )
+    placement_rows: tuple[tuple[str, str], ...]
+    if context.virtual_logical_schema is not None or context.virtual_physical_schema is not None:
+        placement_rows = (
+            ("logical schema", _display_value(context.virtual_logical_schema)),
+            ("physical schema", _display_value(context.virtual_physical_schema)),
+        )
+    else:
+        placement_rows = (("schema", _display_value(context.project.effective_target_schema)),)
     document.header(text="Execution")
     document.fields(
         rows=(
-            ("command", command),
-            ("run_id", project.run_id),
-            ("target", _display_value(project.effective_target_name)),
-            ("database", _display_value(project.effective_target_database)),
-            ("schema", _display_value(project.effective_target_schema)),
-            ("warehouse", _display_value(connection_config.get("warehouse"))),
-            ("concurrency", f"{concurrency} configured limit"),
-            ("full_refresh", str(full_refresh).lower()),
-            ("selected", f"{selected_count:,} of {total_count:,} managed resources"),
-            ("date vars", _date_vars_display(project.effective_vars)),
+            ("command", _display_value(context.command)),
+            ("run_id", _display_value(context.project.run_id)),
+            ("target", _display_value(context.project.effective_target_name)),
+            ("database", _display_value(context.project.effective_target_database)),
+            *placement_rows,
+            ("warehouse", _display_value(context.connection_config.get("warehouse"))),
+            ("concurrency", f"{context.concurrency} configured limit"),
+            ("full_refresh", str(context.full_refresh).lower()),
+            ("selected", f"{selected_count:,} of {total_count:,} build resources"),
+            ("date vars", _date_vars_display(context.project.effective_vars)),
         ),
         label_width=12,
     )
-    if selector_files:
+    if context.selector_files:
         document.blank()
         document.header(text="Selection files")
-        for selector_file in selector_files:
+        for selector_file in context.selector_files:
             selector_noun: str = "selector" if selector_file.selector_count == 1 else "selectors"
             document.fields(
                 rows=(
                     (
                         "selector_file",
-                        f"{selector_file.path} ({selector_file.selector_count:,} {selector_noun})",
+                        f"{_safe_path(selector_file.path)} "
+                        f"({selector_file.selector_count:,} {selector_noun})",
                     ),
                 ),
                 label_width=12,
@@ -98,13 +94,40 @@ def _display_value(value: object) -> str:
 
 def _safe_display_value(value: object) -> str | None:
     if isinstance(value, str | int | float) and not isinstance(value, bool):
-        return str(value)
+        return _sanitize(str(value))
     return None
 
 
+def _safe_path(path: Path) -> str:
+    return _sanitize(str(path))
+
+
+def _sanitize(value: str) -> str:
+    return "".join(
+        f"\\x{ord(character):02x}"
+        if ord(character) < C0_CONTROL_CODE_LIMIT
+        or C1_CONTROL_CODE_START <= ord(character) < C1_CONTROL_CODE_LIMIT
+        else character
+        for character in value
+    )
+
+
+def _validated_iso_value(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        try:
+            datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return _sanitize(value)
+
+
 def _date_vars_display(effective_vars: dict[str, object]) -> str:
-    start_date: str | None = _safe_display_value(effective_vars.get("start_date"))
-    end_date: str | None = _safe_display_value(effective_vars.get("end_date"))
+    start_date: str | None = _validated_iso_value(effective_vars.get("start_date"))
+    end_date: str | None = _validated_iso_value(effective_vars.get("end_date"))
     if start_date is None and end_date is None:
         return "not set"
     if start_date is None:

--- a/src/sqlbuild/cli/commands/_helpers/build_execution/run_context.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_execution/run_context.py
@@ -1,0 +1,114 @@
+"""Resolved verbose build-start context output."""
+
+from __future__ import annotations
+
+from typing import TextIO
+
+from sqlbuild.cli.commands.models import SelectorFileSummary
+from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.planner.models import PlanOutput
+from sqlbuild.presentation.classes.cli_document import CliDocument
+from sqlbuild.presentation.classes.cli_style import CliStyle
+
+
+def write_build_run_context(
+    *,
+    stream: TextIO,
+    command: str,
+    project: CompiledProject,
+    plan: PlanOutput,
+    connection_config: dict[str, object],
+    concurrency: int,
+    full_refresh: bool,
+    selector_files: tuple[SelectorFileSummary, ...],
+    use_color: bool,
+) -> None:
+    """Write resolved non-secret build placement, mode, and selection context."""
+
+    stream.write(
+        _format_build_run_context(
+            command=command,
+            project=project,
+            plan=plan,
+            connection_config=connection_config,
+            concurrency=concurrency,
+            full_refresh=full_refresh,
+            selector_files=selector_files,
+            use_color=use_color,
+        )
+    )
+    stream.flush()
+
+
+def _format_build_run_context(
+    *,
+    command: str,
+    project: CompiledProject,
+    plan: PlanOutput,
+    connection_config: dict[str, object],
+    concurrency: int,
+    full_refresh: bool,
+    selector_files: tuple[SelectorFileSummary, ...],
+    use_color: bool,
+) -> str:
+    style: CliStyle = CliStyle(use_color=use_color)
+    document: CliDocument = CliDocument(style)
+    selected_count: int = (
+        len(plan.model_entries) + len(plan.seed_entries) + len(plan.function_entries)
+    )
+    total_count: int = len(project.models) + len(project.seeds) + len(project.functions)
+    document.header(text="Execution")
+    document.fields(
+        rows=(
+            ("command", command),
+            ("run_id", project.run_id),
+            ("target", _display_value(project.effective_target_name)),
+            ("database", _display_value(project.effective_target_database)),
+            ("schema", _display_value(project.effective_target_schema)),
+            ("warehouse", _display_value(connection_config.get("warehouse"))),
+            ("concurrency", f"{concurrency} configured limit"),
+            ("full_refresh", str(full_refresh).lower()),
+            ("selected", f"{selected_count:,} of {total_count:,} managed resources"),
+            ("date vars", _date_vars_display(project.effective_vars)),
+        ),
+        label_width=12,
+    )
+    if selector_files:
+        document.blank()
+        document.header(text="Selection files")
+        for selector_file in selector_files:
+            selector_noun: str = "selector" if selector_file.selector_count == 1 else "selectors"
+            document.fields(
+                rows=(
+                    (
+                        "selector_file",
+                        f"{selector_file.path} ({selector_file.selector_count:,} {selector_noun})",
+                    ),
+                ),
+                label_width=12,
+            )
+    document.blank()
+    return document.render()
+
+
+def _display_value(value: object) -> str:
+    display_value: str | None = _safe_display_value(value)
+    return display_value if display_value is not None else "not set"
+
+
+def _safe_display_value(value: object) -> str | None:
+    if isinstance(value, str | int | float) and not isinstance(value, bool):
+        return str(value)
+    return None
+
+
+def _date_vars_display(effective_vars: dict[str, object]) -> str:
+    start_date: str | None = _safe_display_value(effective_vars.get("start_date"))
+    end_date: str | None = _safe_display_value(effective_vars.get("end_date"))
+    if start_date is None and end_date is None:
+        return "not set"
+    if start_date is None:
+        return f"end_date={end_date}"
+    if end_date is None:
+        return f"start_date={start_date}"
+    return f"{start_date} to {end_date}"

--- a/src/sqlbuild/cli/commands/_helpers/build_virtual/virtual_execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_virtual/virtual_execution.py
@@ -79,6 +79,8 @@ def execute_virtual_build(
             json_output=request.json_output,
             execution_command=request.execution_command,
             concurrency=request.concurrency,
+            connection_config=connection_config,
+            selector_files=request.selector_files,
         ),
     )
     cursor_overrides: CursorOverrides = request.cursor_overrides or CursorOverrides()

--- a/src/sqlbuild/cli/commands/_helpers/build_virtual/virtual_execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_virtual/virtual_execution.py
@@ -28,6 +28,8 @@ from sqlbuild.compiler.compile.models import CompiledProject
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.models import PythonPlanEntry
 from sqlbuild.compiler.planner.models import CursorOverrides, PlanOutput
+from sqlbuild.spec.contracts.main.resolve_target_config import resolve_target_config
+from sqlbuild.spec.contracts.main.resolve_target_name import resolve_target_name
 from sqlbuild.virtual.executor.main.build import run_virtual_build as run_virtual_build_pipeline
 from sqlbuild.virtual.executor.models import (
     VirtualBuildExecutionHooks,
@@ -65,6 +67,20 @@ def execute_virtual_build(
         stream=stream,
         use_color=request.use_color,
     )
+    physical_target_name: str | None = resolve_target_name(
+        project_config=discovered_inputs.project_config,
+        local_config=discovered_inputs.local_config,
+        selected_target=request.selected_target,
+    )
+    unsuffixed_virtual_environment_name: str | None = (
+        resolve_target_config(
+            project_config=discovered_inputs.project_config,
+            local_config=discovered_inputs.local_config,
+            target_name=physical_target_name,
+        ).state.unsuffixed_virtual_env
+        if physical_target_name is not None
+        else None
+    )
     plan_hook: VirtualBuildPlanHook = VirtualBuildPlanHook(
         stream=stream,
         project_dir=project_dir,
@@ -81,6 +97,10 @@ def execute_virtual_build(
             concurrency=request.concurrency,
             connection_config=connection_config,
             selector_files=request.selector_files,
+            virtual_environment_name=(
+                request.virtual_environment_name or physical_target_name or "default"
+            ),
+            unsuffixed_virtual_environment_name=unsuffixed_virtual_environment_name,
         ),
     )
     cursor_overrides: CursorOverrides = request.cursor_overrides or CursorOverrides()

--- a/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
@@ -42,6 +42,7 @@ from sqlbuild.cli.commands.models import (
     ScenarioTestCommandRequest,
     ScopeCommandRequest,
     SeedCommandRequest,
+    SelectorInputs,
     TestCommandRequest,
 )
 from sqlbuild.cli.commands.types import CliCommand, CompileLineageMode
@@ -59,7 +60,8 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
     project_dir: Path | None = None if args.project_dir is None else Path(args.project_dir)
     effective_project_dir: Path = project_dir if project_dir is not None else Path.cwd()
     _configure_diagnostics(args=args, effective_project_dir=effective_project_dir)
-    select: tuple[str, ...] = (*tuple(args.select), *read_selector_files(args.select_file))
+    selector_inputs: SelectorInputs = read_selector_files(args.select_file)
+    select: tuple[str, ...] = (*tuple(args.select), *selector_inputs.selectors)
     if args.command == CliCommand.COMPILE:
         return handlers.run_compile(
             CompileCommandRequest(
@@ -177,6 +179,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
                 allow_snapshot_schema_change=args.allow_snapshot_schema_change,
                 concurrency=args.concurrency,
                 select=select,
+                selector_files=selector_inputs.files,
                 exclude=tuple(args.exclude),
                 verbose=args.verbose,
                 debug=args.debug,

--- a/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 
 from sqlbuild.cli.commands._helpers.diff.validation import parse_diff_name_range
-from sqlbuild.cli.commands._helpers.entry.parsing import read_selector_files
+from sqlbuild.cli.commands._helpers.entry.parsing import read_selector_file_inputs
 from sqlbuild.cli.commands.classes.cli_namespace import CliNamespace
 from sqlbuild.cli.commands.constants import (
     DBT_INIT_COMMAND,
@@ -60,7 +60,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
     project_dir: Path | None = None if args.project_dir is None else Path(args.project_dir)
     effective_project_dir: Path = project_dir if project_dir is not None else Path.cwd()
     _configure_diagnostics(args=args, effective_project_dir=effective_project_dir)
-    selector_inputs: SelectorInputs = read_selector_files(args.select_file)
+    selector_inputs: SelectorInputs = read_selector_file_inputs(args.select_file)
     select: tuple[str, ...] = (*tuple(args.select), *selector_inputs.selectors)
     if args.command == CliCommand.COMPILE:
         return handlers.run_compile(

--- a/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
@@ -56,7 +56,13 @@ def resolve_env_default_concurrency(explicit_concurrency: int | None) -> int | N
     return concurrency
 
 
-def read_selector_files(paths: list[str]) -> SelectorInputs:
+def read_selector_files(paths: list[str]) -> tuple[str, ...]:
+    """Read newline-delimited selectors."""
+
+    return read_selector_file_inputs(paths).selectors
+
+
+def read_selector_file_inputs(paths: list[str]) -> SelectorInputs:
     """Read newline-delimited selectors while retaining file provenance."""
 
     selectors: list[str] = []

--- a/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
@@ -18,7 +18,11 @@ from sqlbuild.cli.commands.constants import (
     SCOPE_GLOBAL_SUMMARY,
     SQLBUILD_CONCURRENCY_ENV_VAR,
 )
-from sqlbuild.cli.commands.models import ParsedCliInvocation
+from sqlbuild.cli.commands.models import (
+    ParsedCliInvocation,
+    SelectorFileSummary,
+    SelectorInputs,
+)
 from sqlbuild.cli.commands.types import CliCommand
 from sqlbuild.compiler.scopes.types import DeclarationKind
 from sqlbuild.integrations.dbt.types import DbtInteropCommand
@@ -52,18 +56,22 @@ def resolve_env_default_concurrency(explicit_concurrency: int | None) -> int | N
     return concurrency
 
 
-def read_selector_files(paths: list[str]) -> tuple[str, ...]:
-    """Read newline-delimited selector files."""
+def read_selector_files(paths: list[str]) -> SelectorInputs:
+    """Read newline-delimited selectors while retaining file provenance."""
 
     selectors: list[str] = []
+    files: list[SelectorFileSummary] = []
     for raw_path in paths:
         path: Path = Path(raw_path)
+        file_selector_count: int = 0
         for line in path.read_text(encoding="utf-8").splitlines():
             stripped: str = line.strip()
             if not stripped or stripped.startswith("#"):
                 continue
             selectors.append(stripped)
-    return tuple(selectors)
+            file_selector_count += 1
+        files.append(SelectorFileSummary(path=path, selector_count=file_selector_count))
+    return SelectorInputs(selectors=tuple(selectors), files=tuple(files))
 
 
 def parse_cli_invocation(

--- a/src/sqlbuild/cli/commands/classes/virtual_build_plan_hook.py
+++ b/src/sqlbuild/cli/commands/classes/virtual_build_plan_hook.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TextIO
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.cli.commands._helpers.build_execution.run_context import write_build_run_context
 from sqlbuild.cli.commands._helpers.build_planning.full_refresh import (
     enforce_snapshot_full_refresh_policy,
 )
@@ -15,6 +16,7 @@ from sqlbuild.cli.commands.classes.build_progress_callbacks import BuildProgress
 from sqlbuild.cli.commands.models import VirtualBuildPlanHookConfig
 from sqlbuild.cli.output.main.plan import format_plan
 from sqlbuild.cli.progress.main._write_execution_header import write_execution_header
+from sqlbuild.compiler.compile.models import CompiledProject
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.models import PythonPlanEntry
 from sqlbuild.compiler.planner.models import PlanOutput
@@ -46,6 +48,8 @@ class VirtualBuildPlanHook:
         self._json_output = config.json_output
         self._execution_command = config.execution_command
         self._concurrency = config.concurrency
+        self._connection_config = config.connection_config
+        self._selector_files = config.selector_files
         self.callbacks: BuildProgressCallbacks | None = None
 
     @property
@@ -57,13 +61,12 @@ class VirtualBuildPlanHook:
     def on_plan_ready(
         self,
         *,
-        project: object,
+        project: CompiledProject,
         plan_output: PlanOutput,
         python_plan_entries: tuple[PythonPlanEntry, ...],
     ) -> VirtualBuildExecutionHooks:
         """Render the plan and return node progress hooks for execution."""
 
-        del project
         plan_text: str = format_plan(
             plan=plan_output,
             full_refresh=self._full_refresh,
@@ -92,15 +95,31 @@ class VirtualBuildPlanHook:
             debug=self._debug or self._json_output,
         )
         self.callbacks = callbacks
-        write_execution_header(
-            stream=self._stream,
-            command=f"sqb {self._execution_command}",
-            target=None,
-            concurrency=self._concurrency
+        effective_concurrency: int = (
+            self._concurrency
             if self._concurrency is not None
-            else self._discovered_inputs.project_config.settings.concurrency,
-            use_color=self._use_color,
+            else self._discovered_inputs.project_config.settings.concurrency
         )
+        if self._verbose or self._debug:
+            write_build_run_context(
+                stream=self._stream,
+                command=f"sqb {self._execution_command}",
+                project=project,
+                plan=plan_output,
+                connection_config=self._connection_config,
+                concurrency=effective_concurrency,
+                full_refresh=self._full_refresh,
+                selector_files=self._selector_files,
+                use_color=self._use_color,
+            )
+        else:
+            write_execution_header(
+                stream=self._stream,
+                command=f"sqb {self._execution_command}",
+                target=None,
+                concurrency=effective_concurrency,
+                use_color=self._use_color,
+            )
         return VirtualBuildExecutionHooks(
             on_node_start=lambda name, resource_kind: callbacks.on_node_start(
                 name=name, resource_kind=resource_kind

--- a/src/sqlbuild/cli/commands/classes/virtual_build_plan_hook.py
+++ b/src/sqlbuild/cli/commands/classes/virtual_build_plan_hook.py
@@ -7,13 +7,15 @@ from pathlib import Path
 from typing import TextIO
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
-from sqlbuild.cli.commands._helpers.build_execution.run_context import write_build_run_context
+from sqlbuild.cli.commands._helpers.build_execution.run_context import (
+    write_build_run_context,
+)
 from sqlbuild.cli.commands._helpers.build_planning.full_refresh import (
     enforce_snapshot_full_refresh_policy,
 )
 from sqlbuild.cli.commands._helpers.compile.target_writer import write_compile_target
 from sqlbuild.cli.commands.classes.build_progress_callbacks import BuildProgressCallbacks
-from sqlbuild.cli.commands.models import VirtualBuildPlanHookConfig
+from sqlbuild.cli.commands.models import BuildRunContext, VirtualBuildPlanHookConfig
 from sqlbuild.cli.output.main.plan import format_plan
 from sqlbuild.cli.progress.main._write_execution_header import write_execution_header
 from sqlbuild.compiler.compile.models import CompiledProject
@@ -50,6 +52,8 @@ class VirtualBuildPlanHook:
         self._concurrency = config.concurrency
         self._connection_config = config.connection_config
         self._selector_files = config.selector_files
+        self._virtual_environment_name = config.virtual_environment_name or "default"
+        self._unsuffixed_virtual_environment_name = config.unsuffixed_virtual_environment_name
         self.callbacks: BuildProgressCallbacks | None = None
 
     @property
@@ -96,20 +100,34 @@ class VirtualBuildPlanHook:
         )
         self.callbacks = callbacks
         effective_concurrency: int = (
-            self._concurrency
-            if self._concurrency is not None
-            else self._discovered_inputs.project_config.settings.concurrency
+            self._concurrency if self._concurrency is not None else project.settings.concurrency
         )
         if self._verbose or self._debug:
+            base_schema: str | None = project.effective_target_schema
+            logical_schema: str | None = base_schema
+            if (
+                base_schema is not None
+                and self._unsuffixed_virtual_environment_name != self._virtual_environment_name
+            ):
+                logical_schema = f"{base_schema}__{self._virtual_environment_name}"
+            physical_schema: str | None = (
+                f"{base_schema}__sqb_physical" if base_schema is not None else None
+            )
             write_build_run_context(
                 stream=self._stream,
-                command=f"sqb {self._execution_command}",
-                project=project,
-                plan=plan_output,
-                connection_config=self._connection_config,
-                concurrency=effective_concurrency,
-                full_refresh=self._full_refresh,
-                selector_files=self._selector_files,
+                context=BuildRunContext(
+                    command=f"sqb {self._execution_command}",
+                    project=project,
+                    plan=plan_output,
+                    discovered_inputs=self._discovered_inputs,
+                    python_plan_entries=python_plan_entries,
+                    connection_config=self._connection_config,
+                    concurrency=effective_concurrency,
+                    full_refresh=self._full_refresh,
+                    selector_files=self._selector_files,
+                    virtual_logical_schema=logical_schema,
+                    virtual_physical_schema=physical_schema,
+                ),
                 use_color=self._use_color,
             )
         else:

--- a/src/sqlbuild/cli/commands/constants.py
+++ b/src/sqlbuild/cli/commands/constants.py
@@ -4,6 +4,9 @@ from sqlbuild.cli.commands.types import CompileLineageMode, PlaygroundTemplate
 from sqlbuild.compiler.lineage.types import ColumnLineageMode
 from sqlbuild.compiler.planner.types import SelectorKind
 
+C0_CONTROL_CODE_LIMIT: int = 32
+C1_CONTROL_CODE_START: int = 127
+C1_CONTROL_CODE_LIMIT: int = 160
 COMPILE_LINEAGE_MODE_VALUES: tuple[str, ...] = tuple(mode.value for mode in CompileLineageMode)
 RICH_LINEAGE_STATUS_MODEL_THRESHOLD: int = 100
 EMPTY_DAG_PATH: str = ""

--- a/src/sqlbuild/cli/commands/main/execution/_build.py
+++ b/src/sqlbuild/cli/commands/main/execution/_build.py
@@ -80,6 +80,7 @@ def run_build(request: BuildCommandRequest) -> int:
                     reload_sources=request.reload_sources,
                     include_python=request.include_python,
                     select=request.select,
+                    selector_files=request.selector_files,
                     exclude=request.exclude,
                     fail_fast=request.fail_fast,
                     allow_snapshot_full_refresh=request.allow_snapshot_full_refresh,

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -55,6 +55,7 @@ from sqlbuild.compiler.pipeline.models import (
     ClonePipelineResult,
     CompilePipelineResult,
     ProjectGraph,
+    PythonPlanEntry,
 )
 from sqlbuild.compiler.planner.models import CursorOverrides, PlanOutput
 from sqlbuild.compiler.python_nodes.models import PythonNodeGraph, PythonSqlRunLifecyclePlan
@@ -167,6 +168,23 @@ class SelectorInputs:
 
 
 @dataclass(frozen=True)
+class BuildRunContext:
+    """Resolved inputs needed to render one build execution context."""
+
+    command: str
+    project: CompiledProject
+    plan: PlanOutput
+    discovered_inputs: DiscoveredProjectInputs
+    python_plan_entries: tuple[PythonPlanEntry, ...]
+    connection_config: dict[str, object]
+    concurrency: int
+    full_refresh: bool
+    selector_files: tuple[SelectorFileSummary, ...]
+    virtual_logical_schema: str | None = None
+    virtual_physical_schema: str | None = None
+
+
+@dataclass(frozen=True)
 class BuildCommandRequest:
     """CLI inputs for one build command invocation."""
 
@@ -188,7 +206,6 @@ class BuildCommandRequest:
     allow_snapshot_schema_change: bool = False
     concurrency: int | None = None
     select: tuple[str, ...] = ()
-    selector_files: tuple[SelectorFileSummary, ...] = ()
     exclude: tuple[str, ...] = ()
     verbose: bool = False
     debug: bool = False
@@ -202,6 +219,7 @@ class BuildCommandRequest:
     json_output_path: Path | None = None
     event_output_path: Path | None = None
     no_cache: bool = False
+    selector_files: tuple[SelectorFileSummary, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -304,6 +322,8 @@ class VirtualBuildPlanHookConfig:
     concurrency: int | None
     connection_config: dict[str, object] = field(default_factory=dict)
     selector_files: tuple[SelectorFileSummary, ...] = ()
+    virtual_environment_name: str | None = None
+    unsuffixed_virtual_environment_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -323,7 +343,6 @@ class VirtualBuildCliRequest:
     include_python: bool = True
     seed_only: bool = False
     select: tuple[str, ...] = ()
-    selector_files: tuple[SelectorFileSummary, ...] = ()
     exclude: tuple[str, ...] = ()
     fail_fast: bool = False
     allow_snapshot_full_refresh: bool = False
@@ -341,6 +360,7 @@ class VirtualBuildCliRequest:
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None
     providers: ProviderContainer | None = None
     no_cache: bool = False
+    selector_files: tuple[SelectorFileSummary, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -151,6 +151,22 @@ class AuditExecutionPreparation:
 
 
 @dataclass(frozen=True)
+class SelectorFileSummary:
+    """Non-expanded provenance for one selector file."""
+
+    path: Path
+    selector_count: int
+
+
+@dataclass(frozen=True)
+class SelectorInputs:
+    """Expanded selectors paired with selector-file provenance."""
+
+    selectors: tuple[str, ...]
+    files: tuple[SelectorFileSummary, ...]
+
+
+@dataclass(frozen=True)
 class BuildCommandRequest:
     """CLI inputs for one build command invocation."""
 
@@ -172,6 +188,7 @@ class BuildCommandRequest:
     allow_snapshot_schema_change: bool = False
     concurrency: int | None = None
     select: tuple[str, ...] = ()
+    selector_files: tuple[SelectorFileSummary, ...] = ()
     exclude: tuple[str, ...] = ()
     verbose: bool = False
     debug: bool = False
@@ -285,6 +302,8 @@ class VirtualBuildPlanHookConfig:
     json_output: bool
     execution_command: str
     concurrency: int | None
+    connection_config: dict[str, object] = field(default_factory=dict)
+    selector_files: tuple[SelectorFileSummary, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -304,6 +323,7 @@ class VirtualBuildCliRequest:
     include_python: bool = True
     seed_only: bool = False
     select: tuple[str, ...] = ()
+    selector_files: tuple[SelectorFileSummary, ...] = ()
     exclude: tuple[str, ...] = ()
     fail_fast: bool = False
     allow_snapshot_full_refresh: bool = False

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/_test_types.py
@@ -769,6 +769,15 @@ class SelectorSurfaceBuildE2ETestCase:
 
 
 @dataclass(frozen=True)
+class BuildRunContextOutputE2ETestCase:
+    """Test case for verbose build context output modes."""
+
+    description: str
+    command: tuple[str, ...]
+    expected_context_fragments: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class RuntimeArtifactPreservationBuildE2ETestCase:
     """Test case for runtime artifact preservation behavior."""
 

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_selector_surface.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_selector_surface.py
@@ -94,3 +94,55 @@ def test_given_selector_commands_when_running_cli_then_behavior_matches_expectat
         assert fragment in result.stdout, result.stdout + result.stderr
     for fragment in test_case.expected_stderr_fragments:
         assert fragment in result.stderr, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SelectorSurfaceBuildE2ETestCase(
+            description="verbose selector file reports resolved context without secrets",
+            command=("--no-color", "build", "--verbose"),
+            expected_exit_code=0,
+            expected_stdout_fragments=(
+                "Execution\n  command      sqb build",
+                "run_id       ",
+                "target       not set",
+                "warehouse    not set",
+                "concurrency  1 configured limit",
+                "full_refresh false",
+                "selected     1 of 17 managed resources",
+                "date vars    1970-01-01 to 2030-12-31",
+                "Selection files",
+                "(1 selector)",
+            ),
+            expected_stderr_fragments=(),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_verbose_build_selector_file_when_running_then_reports_safe_resolved_context(
+    test_case: SelectorSurfaceBuildE2ETestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_waffle_shop(tmp_path)
+    selector_file: Path = tmp_path / "dagster-selectors.txt"
+    selector_file.write_text("+stg_customers\n", encoding="utf-8")
+
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=(
+            *test_case.command,
+            "--select-file",
+            str(selector_file),
+            "--vars",
+            '{"start_date":"1970-01-01","end_date":"2030-12-31","api_secret":"never-print-secret"}',
+        ),
+        project_dir=project_dir,
+    )
+
+    assert result.returncode == test_case.expected_exit_code, result.stdout + result.stderr
+    fragment: str
+    for fragment in test_case.expected_stdout_fragments:
+        assert fragment in result.stdout
+    assert f"selector_file {selector_file} (1 selector)" in result.stdout
+    assert "never-print-secret" not in result.stdout
+    assert "never-print-secret" not in result.stderr

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_selector_surface.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_selector_surface.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
 import pytest
 
 from tests.e2e.src.sqlbuild.cli.commands.main.build._test_types import (
+    BuildRunContextOutputE2ETestCase,
     SelectorSurfaceBuildE2ETestCase,
 )
 from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
@@ -110,7 +112,7 @@ def test_given_selector_commands_when_running_cli_then_behavior_matches_expectat
                 "warehouse    not set",
                 "concurrency  1 configured limit",
                 "full_refresh false",
-                "selected     1 of 17 managed resources",
+                "selected     2 of 19 build resources",
                 "date vars    1970-01-01 to 2030-12-31",
                 "Selection files",
                 "(1 selector)",
@@ -146,3 +148,95 @@ def test_given_verbose_build_selector_file_when_running_then_reports_safe_resolv
     assert f"selector_file {selector_file} (1 selector)" in result.stdout
     assert "never-print-secret" not in result.stdout
     assert "never-print-secret" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SelectorSurfaceBuildE2ETestCase(
+            description="direct verbose no-work build reports context once",
+            command=(
+                "--no-color",
+                "build",
+                "--verbose",
+                "--select",
+                "stg_customers",
+                "--exclude",
+                "stg_customers",
+                "--no-python",
+            ),
+            expected_exit_code=0,
+            expected_stdout_fragments=(
+                "run_id       ",
+                "selected     0 of 19 build resources",
+            ),
+            expected_stderr_fragments=(),
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_direct_no_work_build_when_verbose_then_reports_context_once(
+    test_case: SelectorSurfaceBuildE2ETestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_waffle_shop(tmp_path)
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=test_case.command,
+        project_dir=project_dir,
+    )
+
+    assert result.returncode == test_case.expected_exit_code, result.stdout + result.stderr
+    assert result.stdout.count("Execution\n") == 1
+    for fragment in test_case.expected_stdout_fragments:
+        assert fragment in result.stdout
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        BuildRunContextOutputE2ETestCase(
+            description="json verbose build keeps context off stdout",
+            command=(
+                "--no-color",
+                "build",
+                "--verbose",
+                "--json",
+                "--select",
+                "stg_customers",
+                "--no-python",
+            ),
+            expected_context_fragments=("build resources",),
+        ),
+        BuildRunContextOutputE2ETestCase(
+            description="json debug build keeps context off stdout",
+            command=(
+                "--no-color",
+                "--debug",
+                "build",
+                "--json",
+                "--select",
+                "stg_customers",
+                "--no-python",
+            ),
+            expected_context_fragments=("build resources",),
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_json_build_output_mode_when_running_then_context_preserves_stdout_contract(
+    test_case: BuildRunContextOutputE2ETestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_waffle_shop(tmp_path)
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=test_case.command,
+        project_dir=project_dir,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stderr.count("Execution\n") == 1
+    for fragment in test_case.expected_context_fragments:
+        assert fragment in result.stderr
+    payload: object = json.loads(result.stdout)
+    assert isinstance(payload, dict)
+    assert "Execution\n" not in result.stdout

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_selector_surface.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_selector_surface.py
@@ -103,14 +103,14 @@ def test_given_selector_commands_when_running_cli_then_behavior_matches_expectat
     [
         SelectorSurfaceBuildE2ETestCase(
             description="verbose selector file reports resolved context without secrets",
-            command=("--no-color", "build", "--verbose"),
+            command=("--no-color", "build", "--verbose", "--concurrency", "3"),
             expected_exit_code=0,
             expected_stdout_fragments=(
                 "Execution\n  command      sqb build",
                 "run_id       ",
                 "target       not set",
                 "warehouse    not set",
-                "concurrency  1 configured limit",
+                "concurrency  3 configured limit",
                 "full_refresh false",
                 "selected     2 of 19 build resources",
                 "date vars    1970-01-01 to 2030-12-31",

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_build_state.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_build_state.py
@@ -31,7 +31,13 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
             description="wide virtual DAG builds with concurrent physical schema setup",
             concurrency=8,
             expected_model_count=8,
-            expected_build_fragments=("Execution  sqb build  (concurrency: 8)",),
+            expected_build_fragments=(
+                "Execution\n  command      sqb build",
+                "target       dev",
+                "schema       dev",
+                "concurrency  8 configured limit",
+                "selected     8 of 8 managed resources",
+            ),
         )
     ],
     ids=lambda case: case.description,
@@ -54,7 +60,13 @@ def test_given_wide_virtual_dag_when_building_concurrently_then_physical_schema_
     assert init_result.returncode == 0, init_result.stderr
 
     build_result: subprocess.CompletedProcess[str] = run_sqb(
-        command=("--no-color", "build", "--concurrency", str(test_case.concurrency)),
+        command=(
+            "--no-color",
+            "build",
+            "--verbose",
+            "--concurrency",
+            str(test_case.concurrency),
+        ),
         project_dir=project_dir,
     )
 

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_build_state.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_build_state.py
@@ -34,9 +34,10 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
             expected_build_fragments=(
                 "Execution\n  command      sqb build",
                 "target       dev",
-                "schema       dev",
+                "logical schema dev__dev",
+                "physical schema dev__sqb_physical",
                 "concurrency  8 configured limit",
-                "selected     8 of 8 managed resources",
+                "selected     8 of 8 build resources",
             ),
         )
     ],
@@ -58,15 +59,13 @@ def test_given_wide_virtual_dag_when_building_concurrently_then_physical_schema_
         project_dir=project_dir,
     )
     assert init_result.returncode == 0, init_result.stderr
+    (project_dir / "sqlbuild_local.toml").write_text(
+        f"[settings]\nconcurrency = {test_case.concurrency}\n",
+        encoding="utf-8",
+    )
 
     build_result: subprocess.CompletedProcess[str] = run_sqb(
-        command=(
-            "--no-color",
-            "build",
-            "--verbose",
-            "--concurrency",
-            str(test_case.concurrency),
-        ),
+        command=("--no-color", "build", "--verbose"),
         project_dir=project_dir,
     )
 

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/build_execution/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/build_execution/_test_types.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlbuild.cli.commands.models import SelectorFileSummary
+
+
+@dataclass(frozen=True)
+class BuildRunContextTestCase:
+    description: str
+    connection_config: dict[str, object]
+    effective_vars: dict[str, object]
+    selector_files: tuple[SelectorFileSummary, ...]
+    full_refresh: bool
+    expected_fragments: tuple[str, ...]
+    expected_absent_fragments: tuple[str, ...]

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/build_execution/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/build_execution/_test_types.py
@@ -14,3 +14,7 @@ class BuildRunContextTestCase:
     full_refresh: bool
     expected_fragments: tuple[str, ...]
     expected_absent_fragments: tuple[str, ...]
+    selected_source_count: int = 0
+    selected_python_count: int = 0
+    total_source_count: int = 0
+    total_task_count: int = 0

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/build_execution/test_run_context.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/build_execution/test_run_context.py
@@ -4,14 +4,25 @@ from __future__ import annotations
 
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
 
-from sqlbuild.cli.commands._helpers.build_execution.run_context import write_build_run_context
-from sqlbuild.cli.commands.models import SelectorFileSummary
-from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject
-from sqlbuild.compiler.planner.models import ModelPlanEntry, PlanOutput, SeedPlanEntry
+from sqlbuild.cli.commands._helpers.build_execution.run_context import (
+    write_build_run_context,
+)
+from sqlbuild.cli.commands.models import BuildRunContext, SelectorFileSummary
+from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject, CompiledSource
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs, DiscoveredTaskFunction
+from sqlbuild.compiler.pipeline.models import PythonPlanEntry
+from sqlbuild.compiler.planner.models import (
+    ModelPlanEntry,
+    PlanOutput,
+    SeedPlanEntry,
+    SourceLoadPlanEntry,
+)
+from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig
 from tests.unit.src.sqlbuild.cli.commands._helpers.build_execution._test_types import (
     BuildRunContextTestCase,
 )
@@ -49,7 +60,7 @@ from tests.unit.src.sqlbuild.cli.commands._helpers.build_execution._test_types i
                 "warehouse    PROD_WH__LARGE",
                 "concurrency  5 configured limit",
                 "full_refresh true",
-                "selected     1 of 2 managed resources",
+                "selected     1 of 2 build resources",
                 "date vars    1970-01-01 to 2030-12-31",
                 "Selection files",
                 "selector_file /tmp/sqlbuild-dagster-select.txt (386 selectors)",
@@ -63,16 +74,30 @@ from tests.unit.src.sqlbuild.cli.commands._helpers.build_execution._test_types i
         ),
         BuildRunContextTestCase(
             description="missing optional placement and unsafe date values",
-            connection_config={"warehouse": {"secret": "nested"}},
-            effective_vars={"start_date": {"secret": "nested"}},
-            selector_files=(),
+            connection_config={"warehouse": "safe\nforged"},
+            effective_vars={"start_date": "never-print-date-secret", "end_date": "2030-12-31"},
+            selector_files=(SelectorFileSummary(path=Path("unsafe\npath"), selector_count=1),),
             full_refresh=False,
             expected_fragments=(
-                "warehouse    not set",
+                "warehouse    safe\\x0aforged",
                 "full_refresh false",
-                "date vars    not set",
+                "date vars    end_date=2030-12-31",
+                "unsafe\\x0apath",
             ),
-            expected_absent_fragments=("nested", "Selection files"),
+            expected_absent_fragments=("never-print-date-secret", "safe\nforged", "unsafe\npath"),
+        ),
+        BuildRunContextTestCase(
+            description="python and source resources use the full build graph count",
+            connection_config={},
+            effective_vars={},
+            selector_files=(),
+            full_refresh=False,
+            expected_fragments=("selected     3 of 4 build resources",),
+            expected_absent_fragments=(),
+            selected_source_count=1,
+            selected_python_count=1,
+            total_source_count=1,
+            total_task_count=1,
         ),
     ],
     ids=lambda case: case.description,
@@ -88,22 +113,47 @@ def test_given_resolved_build_context_when_writing_then_renders_safe_verbose_sum
         effective_target_database="RACING",
         effective_target_schema="DEV_DAGSTER_DEV",
         models=cast(tuple[CompiledModel, ...], (object(), object())),
+        sources=cast(
+            tuple[CompiledSource, ...],
+            tuple(
+                SimpleNamespace(source_entry=SimpleNamespace(loader="load_orders"))
+                for _ in range(test_case.total_source_count)
+            ),
+        ),
     )
     plan: PlanOutput = PlanOutput(
         model_entries=cast(tuple[ModelPlanEntry, ...], (object(),)),
         seed_entries=cast(tuple[SeedPlanEntry, ...], ()),
+        source_load_entries=cast(
+            tuple[SourceLoadPlanEntry, ...],
+            tuple(object() for _ in range(test_case.selected_source_count)),
+        ),
     )
     stream: StringIO = StringIO()
 
     write_build_run_context(
         stream=stream,
-        command="sqb build",
-        project=project,
-        plan=plan,
-        connection_config=test_case.connection_config,
-        concurrency=5,
-        full_refresh=test_case.full_refresh,
-        selector_files=test_case.selector_files,
+        context=BuildRunContext(
+            command="sqb build",
+            project=project,
+            plan=plan,
+            discovered_inputs=DiscoveredProjectInputs(
+                project_config=ProjectConfig(name="test", adapter="duckdb"),
+                local_config=LocalConfig(),
+                task_functions=cast(
+                    tuple[DiscoveredTaskFunction, ...],
+                    tuple(object() for _ in range(test_case.total_task_count)),
+                ),
+            ),
+            python_plan_entries=cast(
+                tuple[PythonPlanEntry, ...],
+                tuple(object() for _ in range(test_case.selected_python_count)),
+            ),
+            connection_config=test_case.connection_config,
+            concurrency=5,
+            full_refresh=test_case.full_refresh,
+            selector_files=test_case.selector_files,
+        ),
         use_color=False,
     )
 

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/build_execution/test_run_context.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/build_execution/test_run_context.py
@@ -1,0 +1,116 @@
+"""Tests for resolved verbose build-start context output."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from sqlbuild.cli.commands._helpers.build_execution.run_context import write_build_run_context
+from sqlbuild.cli.commands.models import SelectorFileSummary
+from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject
+from sqlbuild.compiler.planner.models import ModelPlanEntry, PlanOutput, SeedPlanEntry
+from tests.unit.src.sqlbuild.cli.commands._helpers.build_execution._test_types import (
+    BuildRunContextTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        BuildRunContextTestCase(
+            description="resolved placement dates and selector summary",
+            connection_config={
+                "warehouse": "PROD_WH__LARGE",
+                "password": "never-print-password",
+                "token": "never-print-token",
+                "authenticator": "never-print-authenticator",
+            },
+            effective_vars={
+                "start_date": "1970-01-01",
+                "end_date": "2030-12-31",
+                "api_secret": "never-print-var",
+            },
+            selector_files=(
+                SelectorFileSummary(
+                    path=Path("/tmp/sqlbuild-dagster-select.txt"), selector_count=386
+                ),
+            ),
+            full_refresh=True,
+            expected_fragments=(
+                "Execution",
+                "command      sqb build",
+                "run_id       20260830T175430Z_fb5fb40a8b81",
+                "target       test",
+                "database     RACING",
+                "schema       DEV_DAGSTER_DEV",
+                "warehouse    PROD_WH__LARGE",
+                "concurrency  5 configured limit",
+                "full_refresh true",
+                "selected     1 of 2 managed resources",
+                "date vars    1970-01-01 to 2030-12-31",
+                "Selection files",
+                "selector_file /tmp/sqlbuild-dagster-select.txt (386 selectors)",
+            ),
+            expected_absent_fragments=(
+                "never-print-password",
+                "never-print-token",
+                "never-print-authenticator",
+                "never-print-var",
+            ),
+        ),
+        BuildRunContextTestCase(
+            description="missing optional placement and unsafe date values",
+            connection_config={"warehouse": {"secret": "nested"}},
+            effective_vars={"start_date": {"secret": "nested"}},
+            selector_files=(),
+            full_refresh=False,
+            expected_fragments=(
+                "warehouse    not set",
+                "full_refresh false",
+                "date vars    not set",
+            ),
+            expected_absent_fragments=("nested", "Selection files"),
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_resolved_build_context_when_writing_then_renders_safe_verbose_summary(
+    test_case: BuildRunContextTestCase,
+) -> None:
+    project: CompiledProject = CompiledProject(
+        run_id="20260830T175430Z_fb5fb40a8b81",
+        effective_target_name="test",
+        effective_connection={},
+        effective_vars=test_case.effective_vars,
+        effective_target_database="RACING",
+        effective_target_schema="DEV_DAGSTER_DEV",
+        models=cast(tuple[CompiledModel, ...], (object(), object())),
+    )
+    plan: PlanOutput = PlanOutput(
+        model_entries=cast(tuple[ModelPlanEntry, ...], (object(),)),
+        seed_entries=cast(tuple[SeedPlanEntry, ...], ()),
+    )
+    stream: StringIO = StringIO()
+
+    write_build_run_context(
+        stream=stream,
+        command="sqb build",
+        project=project,
+        plan=plan,
+        connection_config=test_case.connection_config,
+        concurrency=5,
+        full_refresh=test_case.full_refresh,
+        selector_files=test_case.selector_files,
+        use_color=False,
+    )
+
+    output: str = stream.getvalue()
+    expected_fragment: str
+    for expected_fragment in test_case.expected_fragments:
+        assert expected_fragment in output
+    absent_fragment: str
+    for absent_fragment in test_case.expected_absent_fragments:
+        assert absent_fragment not in output

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/_test_types.py
@@ -62,6 +62,7 @@ class MainTestCase:
     expected_column_lineage_mode: ColumnLineageMode = ColumnLineageMode.RICH
     expected_scenario_selectors: tuple[str, ...] = ()
     expected_select: tuple[str, ...] = ()
+    expected_selector_count: int = 0
     expected_exclude: tuple[str, ...] = ()
     expected_dbt_args: tuple[str, ...] = ()
     expected_skills_global: bool = False

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -2379,7 +2379,7 @@ def test_given_plan_load_flag_when_running_then_dispatches_expected_argument(
     ],
     ids=lambda case: case.description,
 )
-def test_given_select_file_when_running_then_dispatches_file_selectors(
+def test_given_plan_select_file_when_running_then_dispatches_file_selectors(
     test_case: MainTestCase,
     tmp_path: Path,
 ) -> None:
@@ -2397,6 +2397,51 @@ def test_given_select_file_when_running_then_dispatches_file_selectors(
 
     assert exit_code == test_case.expected_exit_code
     assert received_selects == [test_case.expected_select]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MainTestCase(
+            description="passes selectors and file provenance to build handler",
+            argv=["build", "--select", "orders", "--select-file", "selectors.txt"],
+            expected_exit_code=4,
+            expected_select=("orders", "customers", "payments"),
+            expected_selector_count=2,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_build_select_file_when_running_then_dispatches_selectors_and_provenance(
+    test_case: MainTestCase,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "selectors.txt").write_text("customers\n\n# ignored\npayments\n", encoding="utf-8")
+    received_values: list[tuple[tuple[str, ...], Path, int]] = []
+
+    def run_build(request: BuildCommandRequest) -> int:
+        received_values.append(
+            (
+                request.select,
+                request.selector_files[0].path,
+                request.selector_files[0].selector_count,
+            )
+        )
+        return test_case.expected_exit_code
+
+    exit_code: int = _main_with_dependencies(
+        argv=[*test_case.argv[:4], str(tmp_path / test_case.argv[4])],
+        handlers=build_handlers(run_build=run_build),
+    )
+
+    assert exit_code == test_case.expected_exit_code
+    assert received_values == [
+        (
+            test_case.expected_select,
+            tmp_path / "selectors.txt",
+            test_case.expected_selector_count,
+        )
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import pytest
 from _pytest.capture import CaptureResult
 
+from sqlbuild.cli.commands._helpers.entry.parsing import read_selector_files
 from sqlbuild.cli.commands.exceptions import CliUserError
 from sqlbuild.cli.commands.main.entrypoint.entry import _main_with_dependencies, main
 from sqlbuild.cli.commands.models import (
@@ -2397,6 +2398,7 @@ def test_given_plan_select_file_when_running_then_dispatches_file_selectors(
 
     assert exit_code == test_case.expected_exit_code
     assert received_selects == [test_case.expected_select]
+    assert read_selector_files([str(tmp_path / "selectors.txt")]) == ("customers", "payments")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Large Dagster subsets and target overrides were difficult to diagnose from compute logs because SQLBuild did not report its resolved execution placement or selector-file provenance.

## Changes

- Report resolved run ID, target placement, warehouse, configured concurrency, full-refresh request, resource counts, and safe date bounds in verbose build output.
- Preserve selector-file provenance without expanding hundreds of selectors into command logs.
- Report actual logical and physical schemas for virtual builds.
- Emit the same context for direct no-work builds and preserve JSON output streams.
- Sanitize dynamic values and retain positional request compatibility.

## Verification

- Focused unit tests: 100 passed.
- Focused direct and virtual E2E tests: 12 passed.
- `make check-ci`: passed.
- Fensu: 0 faults.

Tracks CHI-140.
