### PR TITLE
feat: manage Snowflake table type declaratively with copy-swap conversion

### DIFF
--- a/src/sqlbuild/adapter/contract/classes/base_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/base_adapter.py
@@ -727,6 +727,7 @@ class BaseAdapter(RetentionAdapterMixin, StrictAdapter):
     def render_create_initial_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         snapshot_strategy: str | None,
@@ -899,6 +900,7 @@ class BaseAdapter(RetentionAdapterMixin, StrictAdapter):
     def render_create_initial_historical_timestamp_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -924,6 +926,7 @@ class BaseAdapter(RetentionAdapterMixin, StrictAdapter):
     def render_create_initial_historical_timestamp_changes_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -1058,6 +1061,7 @@ class BaseAdapter(RetentionAdapterMixin, StrictAdapter):
     def render_create_initial_historical_check_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],

--- a/src/sqlbuild/adapter/contract/classes/duckdb_backed_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/duckdb_backed_adapter.py
@@ -379,6 +379,7 @@ class DuckDbBackedAdapter(BaseAdapter):
     def render_create_initial_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         snapshot_strategy: str | None,
@@ -475,6 +476,7 @@ class DuckDbBackedAdapter(BaseAdapter):
     def render_create_initial_historical_timestamp_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -502,6 +504,7 @@ class DuckDbBackedAdapter(BaseAdapter):
     def render_create_initial_historical_timestamp_changes_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -712,6 +715,7 @@ class DuckDbBackedAdapter(BaseAdapter):
     def render_create_initial_historical_check_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],

--- a/src/sqlbuild/adapter/contract/classes/strict_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/strict_adapter.py
@@ -436,6 +436,7 @@ class StrictAdapter(
     def render_create_initial_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         snapshot_strategy: str | None,
@@ -470,6 +471,7 @@ class StrictAdapter(
     def render_create_initial_historical_timestamp_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -487,6 +489,7 @@ class StrictAdapter(
     def render_create_initial_historical_timestamp_changes_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -548,6 +551,7 @@ class StrictAdapter(
     def render_create_initial_historical_check_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],

--- a/src/sqlbuild/adapters/bigquery/classes/bigquery_adapter.py
+++ b/src/sqlbuild/adapters/bigquery/classes/bigquery_adapter.py
@@ -927,6 +927,7 @@ class BigQueryAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         snapshot_strategy: str | None,
@@ -1023,6 +1024,7 @@ class BigQueryAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_timestamp_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -1048,6 +1050,7 @@ class BigQueryAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_timestamp_changes_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -1248,6 +1251,7 @@ class BigQueryAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_check_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],

--- a/src/sqlbuild/adapters/databricks/classes/databricks_adapter.py
+++ b/src/sqlbuild/adapters/databricks/classes/databricks_adapter.py
@@ -806,6 +806,7 @@ class DatabricksAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         snapshot_strategy: str | None,
@@ -902,6 +903,7 @@ class DatabricksAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_timestamp_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -927,6 +929,7 @@ class DatabricksAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_timestamp_changes_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -1135,6 +1138,7 @@ class DatabricksAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_check_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],

--- a/src/sqlbuild/adapters/postgres/classes/postgres_adapter.py
+++ b/src/sqlbuild/adapters/postgres/classes/postgres_adapter.py
@@ -1076,6 +1076,7 @@ class PostgresAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         snapshot_strategy: str | None,
@@ -1245,6 +1246,7 @@ class PostgresAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_timestamp_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -1270,6 +1272,7 @@ class PostgresAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_timestamp_changes_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -1291,6 +1294,7 @@ class PostgresAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_check_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],

--- a/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
+++ b/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
@@ -86,6 +86,7 @@ from sqlbuild.cost.types import CostCapability, CostStatus
 from sqlbuild.diagnostics.main.log_sql import log_sql
 from sqlbuild.spec.contracts.constants import DEFAULT_SEED_CSV_SETTINGS
 from sqlbuild.spec.contracts.models import SeedCsvSettings
+from sqlbuild.spec.contracts.types import TableType
 from sqlbuild.sql_values.models import SqlValue
 
 _EXACT_COLUMN_INSPECTION_LIMIT: int = 32
@@ -626,7 +627,15 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
             self.execute(connection=connection, sql=stmt)
 
     def render_create_table_as(self, *, destination: str, sql: str) -> tuple[str, ...]:
-        return (f"CREATE OR REPLACE TRANSIENT TABLE {destination} AS {sql}",)
+        return self._render_create_table_as_type(
+            destination=destination, sql=sql, table_type="transient"
+        )
+
+    def _render_create_table_as_type(
+        self, *, destination: str, sql: str, table_type: str
+    ) -> tuple[str, ...]:
+        table_kind: str = "TABLE" if table_type == TableType.PERMANENT else "TRANSIENT TABLE"
+        return (f"CREATE OR REPLACE {table_kind} {destination} AS {sql}",)
 
     def render_create_view_as(self, *, destination: str, sql: str) -> tuple[str, ...]:
         return (f"CREATE OR REPLACE VIEW {destination} AS {sql}",)
@@ -764,7 +773,10 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
         config: dict[str, Any] | None = None,
         statement_recorder: StatementRecorder,
     ) -> None:
-        statements: tuple[str, ...] = self.render_create_table_as(destination=destination, sql=sql)
+        table_type: str = str((config or {}).get("table_type", "transient"))
+        statements: tuple[str, ...] = self._render_create_table_as_type(
+            destination=destination, sql=sql, table_type=table_type
+        )
         statement_recorder.record_many(statements)
         stmt: str
         for stmt in statements:

--- a/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
+++ b/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
@@ -1131,6 +1131,7 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         snapshot_strategy: str | None,
@@ -1149,8 +1150,9 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
             source_alias=None,
             current_timestamp=current_timestamp,
         )
-        return self.render_create_table_as(
+        return self._render_create_table_as_type(
             destination=destination,
+            table_type=table_type,
             sql=(
                 f"SELECT *, {valid_from_expr} AS {valid_from_column}, "
                 f"CAST(NULL AS TIMESTAMP) AS {valid_to_column} FROM {origin}"
@@ -1227,6 +1229,7 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_timestamp_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -1247,11 +1250,14 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
             output_columns=output_columns,
             invalidate_hard_deletes=invalidate_hard_deletes,
         )
-        return self.render_create_table_as(destination=destination, sql=historical_sql)
+        return self._render_create_table_as_type(
+            destination=destination, sql=historical_sql, table_type=table_type
+        )
 
     def render_create_initial_historical_timestamp_changes_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -1268,7 +1274,9 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
             valid_to_column=valid_to_column,
             output_columns=output_columns,
         )
-        return self.render_create_table_as(destination=destination, sql=historical_sql)
+        return self._render_create_table_as_type(
+            destination=destination, sql=historical_sql, table_type=table_type
+        )
 
     def render_apply_historical_timestamp_snapshot_changes(
         self,
@@ -1452,6 +1460,7 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_check_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -1472,7 +1481,9 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
             output_columns=output_columns,
             invalidate_hard_deletes=invalidate_hard_deletes,
         )
-        return self.render_create_table_as(destination=destination, sql=historical_sql)
+        return self._render_create_table_as_type(
+            destination=destination, sql=historical_sql, table_type=table_type
+        )
 
     def render_apply_historical_check_snapshot_changes(
         self,

--- a/src/sqlbuild/adapters/sqlserver/classes/sqlserver_adapter.py
+++ b/src/sqlbuild/adapters/sqlserver/classes/sqlserver_adapter.py
@@ -2034,6 +2034,7 @@ class SqlServerAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_check_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -2094,6 +2095,7 @@ class SqlServerAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_timestamp_changes_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -2116,6 +2118,7 @@ class SqlServerAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_historical_timestamp_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -2148,6 +2151,7 @@ class SqlServerAdapter(MicrobatchMixin, BaseAdapter):
     def render_create_initial_snapshot_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         snapshot_strategy: str | None,

--- a/src/sqlbuild/cli/commands/_helpers/build_planning/table_type.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_planning/table_type.py
@@ -1,0 +1,61 @@
+"""Table-type downgrade safety enforcement for build commands."""
+
+from __future__ import annotations
+
+from typing import TextIO
+
+from sqlbuild.cli.commands.exceptions import CliUserError
+from sqlbuild.compiler.planner.models import PlanOutput, TableTypePlanEntry
+from sqlbuild.spec.contracts.types import TableTypeDowngradePolicy
+
+
+def enforce_table_type_downgrade_policy(
+    *,
+    plan: PlanOutput,
+    allow_table_type_downgrade: bool,
+    input_stream: TextIO,
+    output_stream: TextIO,
+) -> None:
+    """Fail or confirm before executing permanent-to-transient conversions."""
+
+    entries: tuple[TableTypePlanEntry, ...] = tuple(
+        entry for entry in plan.table_type_entries if entry.downgrade
+    )
+    denied: tuple[TableTypePlanEntry, ...] = tuple(
+        entry for entry in entries if entry.downgrade_policy == TableTypeDowngradePolicy.DENY
+    )
+    if denied:
+        raise CliUserError(
+            f"table-type downgrade is denied for {_names(denied)} by table_type_downgrade policy"
+        )
+    confirmation: tuple[TableTypePlanEntry, ...] = tuple(
+        entry
+        for entry in entries
+        if entry.downgrade_policy == TableTypeDowngradePolicy.REQUIRE_CONFIRMATION
+    )
+    if not confirmation or allow_table_type_downgrade:
+        return
+    if not input_stream.isatty():
+        raise CliUserError(
+            "table-type downgrade requires confirmation",
+            help="Pass --allow-table-type-downgrade to confirm in non-interactive runs.",
+        )
+    expected: str = _confirmation_text(confirmation)
+    output_stream.write(
+        f"Downgrading {_names(confirmation)} to transient may discard up to 90 days of "
+        "time-travel history.\n\n"
+    )
+    output_stream.write(f"Type `{expected}` to continue: ")
+    output_stream.flush()
+    if input_stream.readline().strip() != expected:
+        raise CliUserError("table-type downgrade cancelled")
+
+
+def _confirmation_text(entries: tuple[TableTypePlanEntry, ...]) -> str:
+    if len(entries) == 1:
+        return f"downgrade table type for {entries[0].model_name}"
+    return f"downgrade table type for {len(entries)} models"
+
+
+def _names(entries: tuple[TableTypePlanEntry, ...]) -> str:
+    return ", ".join(f"'{entry.model_name}'" for entry in entries)

--- a/src/sqlbuild/cli/commands/_helpers/build_virtual/virtual_execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_virtual/virtual_execution.py
@@ -89,6 +89,7 @@ def execute_virtual_build(
         config=VirtualBuildPlanHookConfig(
             full_refresh=request.full_refresh,
             allow_snapshot_full_refresh=request.allow_snapshot_full_refresh,
+            allow_table_type_downgrade=request.allow_table_type_downgrade,
             use_color=request.use_color,
             verbose=request.verbose,
             debug=request.debug,

--- a/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
@@ -176,6 +176,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
                 reload_sources=args.reload,
                 include_python=args.include_python,
                 allow_snapshot_full_refresh=args.allow_snapshot_full_refresh,
+                allow_table_type_downgrade=args.allow_table_type_downgrade,
                 allow_snapshot_schema_change=args.allow_snapshot_schema_change,
                 concurrency=args.concurrency,
                 select=select,

--- a/src/sqlbuild/cli/commands/_helpers/entry/parser_arguments.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parser_arguments.py
@@ -48,6 +48,7 @@ def add_execution_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--fail-fast", action="store_true", default=False)
     parser.add_argument("--full-refresh", action="store_true", default=False)
     parser.add_argument("--allow-snapshot-full-refresh", action="store_true", default=False)
+    parser.add_argument("--allow-table-type-downgrade", action="store_true", default=False)
     parser.add_argument("--allow-snapshot-schema-change", action="store_true", default=False)
     parser.add_argument("--concurrency", type=int, default=None)
     parser.add_argument("--verbose", "-v", action="store_true", default=False)

--- a/src/sqlbuild/cli/commands/classes/cli_namespace.py
+++ b/src/sqlbuild/cli/commands/classes/cli_namespace.py
@@ -57,6 +57,7 @@ _DEFAULT_VALUES: dict[str, object] = {
     "run_tests": True,
     "run_audits": True,
     "allow_snapshot_full_refresh": False,
+    "allow_table_type_downgrade": False,
     "allow_snapshot_schema_change": False,
     "allow_partial_promotion": False,
     "allow_partial_rollback": False,
@@ -200,6 +201,7 @@ class CliNamespace:
     run_tests: bool
     run_audits: bool
     allow_snapshot_full_refresh: bool
+    allow_table_type_downgrade: bool
     allow_snapshot_schema_change: bool
     allow_partial_promotion: bool
     allow_partial_rollback: bool

--- a/src/sqlbuild/cli/commands/classes/virtual_build_plan_hook.py
+++ b/src/sqlbuild/cli/commands/classes/virtual_build_plan_hook.py
@@ -13,6 +13,9 @@ from sqlbuild.cli.commands._helpers.build_execution.run_context import (
 from sqlbuild.cli.commands._helpers.build_planning.full_refresh import (
     enforce_snapshot_full_refresh_policy,
 )
+from sqlbuild.cli.commands._helpers.build_planning.table_type import (
+    enforce_table_type_downgrade_policy,
+)
 from sqlbuild.cli.commands._helpers.compile.target_writer import write_compile_target
 from sqlbuild.cli.commands.classes.build_progress_callbacks import BuildProgressCallbacks
 from sqlbuild.cli.commands.models import BuildRunContext, VirtualBuildPlanHookConfig
@@ -44,6 +47,7 @@ class VirtualBuildPlanHook:
         self._adapter = adapter
         self._full_refresh = config.full_refresh
         self._allow_snapshot_full_refresh = config.allow_snapshot_full_refresh
+        self._allow_table_type_downgrade = config.allow_table_type_downgrade
         self._use_color = config.use_color
         self._verbose = config.verbose
         self._debug = config.debug
@@ -85,6 +89,12 @@ class VirtualBuildPlanHook:
             plan=plan_output,
             snapshots_config=self._discovered_inputs.project_config.snapshots,
             allow_snapshot_full_refresh=self._allow_snapshot_full_refresh,
+            input_stream=sys.stdin,
+            output_stream=sys.stdout,
+        )
+        enforce_table_type_downgrade_policy(
+            plan=plan_output,
+            allow_table_type_downgrade=self._allow_table_type_downgrade,
             input_stream=sys.stdin,
             output_stream=sys.stdout,
         )

--- a/src/sqlbuild/cli/commands/main/execution/_build.py
+++ b/src/sqlbuild/cli/commands/main/execution/_build.py
@@ -30,6 +30,9 @@ from sqlbuild.cli.commands._helpers.build_planning.full_refresh import (
 )
 from sqlbuild.cli.commands._helpers.build_planning.invocation import resolve_build_invocation
 from sqlbuild.cli.commands._helpers.build_planning.planning import compile_build_plan
+from sqlbuild.cli.commands._helpers.build_planning.table_type import (
+    enforce_table_type_downgrade_policy,
+)
 from sqlbuild.cli.commands._helpers.cost.collection import (
     finalize_build_cost,
 )
@@ -104,6 +107,7 @@ def _run_build(*, request: BuildCommandRequest) -> int:
                     exclude=request.exclude,
                     fail_fast=request.fail_fast,
                     allow_snapshot_full_refresh=request.allow_snapshot_full_refresh,
+                    allow_table_type_downgrade=request.allow_table_type_downgrade,
                     allow_snapshot_schema_change=request.allow_snapshot_schema_change,
                     concurrency=request.concurrency,
                     verbose=request.verbose,
@@ -137,6 +141,12 @@ def _run_build(*, request: BuildCommandRequest) -> int:
             plan=pipeline_result.plan_output,
             snapshots_config=invocation.discovered_inputs.project_config.snapshots,
             allow_snapshot_full_refresh=request.allow_snapshot_full_refresh,
+            input_stream=sys.stdin,
+            output_stream=sys.stdout,
+        )
+        enforce_table_type_downgrade_policy(
+            plan=pipeline_result.plan_output,
+            allow_table_type_downgrade=request.allow_table_type_downgrade,
             input_stream=sys.stdin,
             output_stream=sys.stdout,
         )

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -203,6 +203,7 @@ class BuildCommandRequest:
     reload_sources: bool = False
     include_python: bool = True
     allow_snapshot_full_refresh: bool = False
+    allow_table_type_downgrade: bool = False
     allow_snapshot_schema_change: bool = False
     concurrency: int | None = None
     select: tuple[str, ...] = ()
@@ -327,6 +328,7 @@ class VirtualBuildPlanHookConfig:
 
     full_refresh: bool
     allow_snapshot_full_refresh: bool
+    allow_table_type_downgrade: bool
     use_color: bool
     verbose: bool
     debug: bool
@@ -359,6 +361,7 @@ class VirtualBuildCliRequest:
     exclude: tuple[str, ...] = ()
     fail_fast: bool = False
     allow_snapshot_full_refresh: bool = False
+    allow_table_type_downgrade: bool = False
     allow_snapshot_schema_change: bool = False
     concurrency: int | None = None
     verbose: bool = False

--- a/src/sqlbuild/cli/output/_helpers/plan_json.py
+++ b/src/sqlbuild/cli/output/_helpers/plan_json.py
@@ -56,6 +56,19 @@ def format_plan_json(
         }
         for entry in plan.retention_entries
     ]
+    table_type_conversions: list[dict[str, object]] = [
+        {
+            "kind": "table_type_conversion",
+            "model": entry.model_name,
+            "desired_type": entry.desired_type,
+            "actual_type": entry.actual_type,
+            "source": entry.source,
+            "downgrade": entry.downgrade,
+            "downgrade_policy": entry.downgrade_policy,
+            "irreversible_warning": entry.irreversible_warning,
+        }
+        for entry in plan.table_type_entries
+    ]
     python_nodes: list[dict[str, object]] = [
         _serialize_python_plan_entry(entry) for entry in python_plan_entries
     ]
@@ -78,6 +91,7 @@ def format_plan_json(
         "providers": providers,
         "warnings": warnings,
         "retention": retention,
+        "table_type_conversions": table_type_conversions,
     }
     if plan.metadata:
         result["metadata"] = plan.metadata

--- a/src/sqlbuild/cli/output/_helpers/plan_text.py
+++ b/src/sqlbuild/cli/output/_helpers/plan_text.py
@@ -84,9 +84,18 @@ _SCHEMA_CHANGE_SYMBOLS: dict[SchemaChangeKind, str] = {
 
 
 def _format_retention(*, lines: list[str], plan: PlanOutput) -> list[str]:
-    if not plan.retention_entries:
-        return lines
-    lines.append("Retention")
+    if plan.table_type_entries:
+        lines.append("Table type conversions")
+        for table_type_entry in plan.table_type_entries:
+            actual_type: str = table_type_entry.actual_type or "unknown"
+            lines.append(
+                f"  {table_type_entry.model_name} desired={table_type_entry.desired_type} "
+                f"actual={actual_type} source={table_type_entry.source}"
+            )
+            if table_type_entry.irreversible_warning is not None:
+                lines.append(f"    WARNING: {table_type_entry.irreversible_warning}")
+    if plan.retention_entries:
+        lines.append("Retention")
     for entry in plan.retention_entries:
         scope: str = ".".join(
             part

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
@@ -33,9 +33,9 @@ from sqlbuild.compiler.compile._helpers.config.model_validation import (
     validate_non_incremental_config,
     validate_placeholder_config,
     validate_snapshot_config,
-    validate_time_travel_retention,
+    validate_storage_policies,
 )
-from sqlbuild.compiler.compile._helpers.config.retention import resolve_time_travel_retention
+from sqlbuild.compiler.compile._helpers.config.table_type import resolve_storage_policies
 from sqlbuild.compiler.compile._helpers.refs.cache import cached_sql_reference_extractor
 from sqlbuild.compiler.compile._helpers.render.arguments import render_parameterized_sql
 from sqlbuild.compiler.compile._helpers.render.cursor_intrinsics import (
@@ -122,7 +122,6 @@ from sqlbuild.spec.contracts.models import (
     LocalConfig,
     MaterializationDefaultsConfig,
     ProjectConfig,
-    ResolvedTimeTravelRetention,
     SchemaAuditInstance,
     SchemaColumn,
     SchemaModelEntry,
@@ -372,9 +371,7 @@ def _build_model_inputs(
             model_name=model_file.file_path.stem,
             custom_materialization_names=custom_materialization_names,
         )
-        validate_time_travel_retention(
-            config=effective_config, model_name=model_file.file_path.stem
-        )
+        validate_storage_policies(config=effective_config, model_name=model_file.file_path.stem)
         validate_placeholder_config(
             config=effective_config,
             model_name=model_file.file_path.stem,
@@ -414,6 +411,7 @@ def _build_model_inputs(
             logical_schema=effective_config.logical_schema,
             logical_database=effective_config.logical_database,
             time_travel_retention=effective_config.time_travel_retention,
+            table_type=effective_config.table_type,
         )
         hook_name: str
         for hook_name in ("pre_hooks", "post_hooks"):
@@ -771,14 +769,13 @@ def build_model_config(
         run_id=run_id,
     )
     target_resolved_values.update(raw_hook_values)
-    retention: ResolvedTimeTravelRetention = resolve_time_travel_retention(
-        materialized=target_resolved_values.get("materialized"),
-        model_value=model_header_values.get("time_travel_retention"),
-        materialization_defaults=materialization_defaults or MaterializationDefaultsConfig(),
+    target_resolved_values, retention, table_type = resolve_storage_policies(
+        resolved_values=target_resolved_values,
+        model_header_values=model_header_values,
+        materialization_defaults=materialization_defaults,
         target_config=target_config,
         model_name=model_name,
     )
-    target_resolved_values.pop("time_travel_retention", None)
     if (
         MODEL_FULL_REFRESH_CONFIG_KEY not in model_header_values
         and target_resolved_values.get("materialized") != MaterializationType.INCREMENTAL
@@ -791,6 +788,7 @@ def build_model_config(
         logical_schema=logical_schema,
         logical_database=logical_database,
         time_travel_retention=retention,
+        table_type=table_type,
     )
 
 
@@ -1431,6 +1429,7 @@ def strip_model_header_metadata_from_config(config: CompileModelConfig) -> Compi
         logical_schema=config.logical_schema,
         logical_database=config.logical_database,
         time_travel_retention=config.time_travel_retention,
+        table_type=config.table_type,
     )
 
 
@@ -1595,6 +1594,7 @@ def _merge_schema_tags(
         logical_schema=config.logical_schema,
         logical_database=config.logical_database,
         time_travel_retention=config.time_travel_retention,
+        table_type=config.table_type,
     )
 
 

--- a/src/sqlbuild/compiler/compile/_helpers/config/model_validation.py
+++ b/src/sqlbuild/compiler/compile/_helpers/config/model_validation.py
@@ -608,6 +608,32 @@ def validate_time_travel_retention(*, config: CompileModelConfig, model_name: st
         )
 
 
+def validate_table_type(*, config: CompileModelConfig, model_name: str) -> None:
+    """Reject declared table type on materializations without managed tables."""
+
+    if not config.table_type.declared:
+        return
+    materialized: str | None = _str(config=config, key="materialized")
+    if materialized == MaterializationType.VIEW:
+        raise CompileInputError(f"model '{model_name}': table_type is not valid for views")
+    if materialized not in {
+        MaterializationType.TABLE,
+        MaterializationType.INCREMENTAL,
+        MaterializationType.SNAPSHOT,
+    }:
+        raise CompileInputError(
+            f"model '{model_name}': table_type is not supported for materialization "
+            f"'{materialized}'"
+        )
+
+
+def validate_storage_policies(*, config: CompileModelConfig, model_name: str) -> None:
+    """Validate retention and table-type materialization applicability."""
+
+    validate_time_travel_retention(config=config, model_name=model_name)
+    validate_table_type(config=config, model_name=model_name)
+
+
 def validate_placeholder_config(
     *,
     config: CompileModelConfig,

--- a/src/sqlbuild/compiler/compile/_helpers/config/table_type.py
+++ b/src/sqlbuild/compiler/compile/_helpers/config/table_type.py
@@ -1,0 +1,96 @@
+"""Snowflake table-type policy resolution."""
+
+from __future__ import annotations
+
+from sqlbuild.compiler.compile._helpers.config.retention import resolve_time_travel_retention
+from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.compiler.compile.models import ResolvedTableType
+from sqlbuild.compiler.planner.types import MaterializationType
+from sqlbuild.spec.contracts.models import (
+    MaterializationDefaultsConfig,
+    ResolvedTimeTravelRetention,
+    TargetConfig,
+)
+from sqlbuild.spec.contracts.types import TableType, TableTypeSource, TableTypeValue
+
+_SUPPORTED_MATERIALIZATIONS: frozenset[str] = frozenset(
+    {MaterializationType.TABLE, MaterializationType.INCREMENTAL, MaterializationType.SNAPSHOT}
+)
+_STORAGE_POLICY_KEYS: frozenset[str] = frozenset({"time_travel_retention", "table_type"})
+
+
+def resolve_storage_policies(
+    *,
+    resolved_values: dict[str, object],
+    model_header_values: dict[str, object],
+    materialization_defaults: MaterializationDefaultsConfig | None,
+    target_config: TargetConfig | None,
+    model_name: str,
+) -> tuple[dict[str, object], ResolvedTimeTravelRetention, ResolvedTableType]:
+    """Resolve storage policies and remove authored values from ordinary model config."""
+
+    defaults: MaterializationDefaultsConfig = (
+        materialization_defaults or MaterializationDefaultsConfig()
+    )
+    retention: ResolvedTimeTravelRetention = resolve_time_travel_retention(
+        materialized=resolved_values.get("materialized"),
+        model_value=model_header_values.get("time_travel_retention"),
+        materialization_defaults=defaults,
+        target_config=target_config,
+        model_name=model_name,
+    )
+    table_type: ResolvedTableType = resolve_table_type(
+        materialized=resolved_values.get("materialized"),
+        model_value=model_header_values.get("table_type"),
+        materialization_defaults=defaults,
+        target_config=target_config,
+        model_name=model_name,
+    )
+    cleaned_values: dict[str, object] = {
+        key: value for key, value in resolved_values.items() if key not in _STORAGE_POLICY_KEYS
+    }
+    return cleaned_values, retention, table_type
+
+
+def resolve_table_type(
+    *,
+    materialized: object | None,
+    model_value: object | None,
+    materialization_defaults: MaterializationDefaultsConfig,
+    target_config: TargetConfig | None,
+    model_name: str,
+) -> ResolvedTableType:
+    """Resolve target, materialization, and model table-type precedence."""
+
+    value: TableType = TableType.TRANSIENT
+    source: TableTypeSource = TableTypeSource.DEFAULT
+    declared: bool = False
+    materialization: str | None = materialized if isinstance(materialized, str) else None
+    supported: bool = materialization in _SUPPORTED_MATERIALIZATIONS
+    if supported and target_config is not None and target_config.default_table_type is not None:
+        value = target_config.default_table_type
+        source = TableTypeSource.TARGET
+        declared = True
+    if supported and materialization is not None:
+        materialization_value: TableType | None = getattr(
+            materialization_defaults, materialization
+        ).table_type
+        if materialization_value is not None:
+            value = materialization_value
+            source = TableTypeSource.MATERIALIZATION
+            declared = True
+    if model_value is not None:
+        if not isinstance(model_value, str):
+            raise CompileInputError(
+                f"model '{model_name}': table_type must be permanent, transient, or inherit"
+            )
+        if model_value != TableTypeValue.INHERIT:
+            try:
+                value = TableType(model_value)
+            except ValueError as exc:
+                raise CompileInputError(
+                    f"model '{model_name}': table_type must be permanent, transient, or inherit"
+                ) from exc
+            source = TableTypeSource.MODEL
+            declared = True
+    return ResolvedTableType(value=value, source=source, declared=declared)

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -57,6 +57,7 @@ from sqlbuild.compiler.scopes.models import (
 from sqlbuild.spec.contracts.models import (
     LocalConfig,
     ProjectConfig,
+    ResolvedTableType,
     ResolvedTimeTravelRetention,
     ScenarioConfig,
     SchemaModelEntry,
@@ -149,6 +150,7 @@ class CompileModelConfig:
     time_travel_retention: ResolvedTimeTravelRetention = field(
         default_factory=ResolvedTimeTravelRetention
     )
+    table_type: ResolvedTableType = field(default_factory=ResolvedTableType)
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
@@ -55,7 +55,12 @@ from sqlbuild.spec.contracts.models import (
     StateConfig,
     TargetConfig,
 )
-from sqlbuild.spec.contracts.types import TimeTravelRetentionValue
+from sqlbuild.spec.contracts.types import (
+    TableType,
+    TableTypeDowngradePolicy,
+    TableTypeValue,
+    TimeTravelRetentionValue,
+)
 from sqlbuild.sql_values.types import CollectionRendering
 
 _SNAPSHOT_FULL_REFRESH_POLICIES: frozenset[str] = frozenset(
@@ -580,7 +585,7 @@ def _load_materialization_defaults(
         )
         _validate_allowed_keys(
             mapping=materialization_mapping,
-            allowed_keys=frozenset({"time_travel_retention"}),
+            allowed_keys=frozenset({"time_travel_retention", "table_type"}),
             label=f"materialization_defaults.{materialization}",
             file_path=file_path,
         )
@@ -591,7 +596,14 @@ def _load_materialization_defaults(
                 label=f"materialization_defaults.{materialization}.time_travel_retention",
                 file_path=file_path,
                 allow_inherit=True,
-            )
+            ),
+            table_type=_optional_table_type(
+                mapping=materialization_mapping,
+                key="table_type",
+                label=f"materialization_defaults.{materialization}.table_type",
+                file_path=file_path,
+                allow_inherit=True,
+            ),
         )
     return MaterializationDefaultsConfig(**loaded)
 
@@ -620,6 +632,40 @@ def _optional_retention_policy(
             f"{file_path} {label} must be a whole-day string like '7d'{allowed_keywords}"
         )
     return AuthoredTimeTravelRetention(desired_days=int(match.group(1)))
+
+
+def _optional_table_type(
+    *,
+    mapping: dict[str, object],
+    key: str,
+    label: str,
+    file_path: Path,
+    allow_inherit: bool = False,
+) -> TableType | None:
+    value: object | None = mapping.get(key)
+    if value is None or allow_inherit and value == TableTypeValue.INHERIT:
+        return None
+    try:
+        return TableType(value)
+    except (TypeError, ValueError) as exc:
+        suffix: str = ", or 'inherit'" if allow_inherit else ""
+        raise ProjectConfigError(
+            f"{file_path} {label} must be 'permanent' or 'transient'{suffix}"
+        ) from exc
+
+
+def _optional_table_type_downgrade_policy(
+    *, mapping: dict[str, object], key: str, label: str, file_path: Path
+) -> TableTypeDowngradePolicy | None:
+    value: object | None = mapping.get(key)
+    if value is None:
+        return None
+    try:
+        return TableTypeDowngradePolicy(value)
+    except (TypeError, ValueError) as exc:
+        raise ProjectConfigError(
+            f"{file_path} {label} must be 'deny', 'require_confirmation', or 'allow'"
+        ) from exc
 
 
 def _load_targets(*, payload: object, file_path: Path) -> dict[str, TargetConfig]:
@@ -678,6 +724,21 @@ def _load_targets(*, payload: object, file_path: Path) -> dict[str, TargetConfig
                 mapping=target_mapping,
                 key="owns_time_travel_retention_namespace",
                 default=False,
+            ),
+            default_table_type=_optional_table_type(
+                mapping=target_mapping,
+                key="default_table_type",
+                label=f"targets.{target_name}.default_table_type",
+                file_path=file_path,
+            ),
+            table_type_downgrade=(
+                _optional_table_type_downgrade_policy(
+                    mapping=target_mapping,
+                    key="table_type_downgrade",
+                    label=f"targets.{target_name}.table_type_downgrade",
+                    file_path=file_path,
+                )
+                or TableTypeDowngradePolicy.REQUIRE_CONFIRMATION
             ),
             clone=ClonePolicy(
                 allow_as_clone_origin=_optional_bool(
@@ -765,6 +826,18 @@ def _load_local_targets(*, payload: object, file_path: Path) -> dict[str, LocalT
                 mapping=target_mapping,
                 key="owns_time_travel_retention_namespace",
             ),
+            default_table_type=_optional_table_type(
+                mapping=target_mapping,
+                key="default_table_type",
+                label=f"targets.{target_name}.default_table_type",
+                file_path=file_path,
+            ),
+            table_type_downgrade=_optional_table_type_downgrade_policy(
+                mapping=target_mapping,
+                key="table_type_downgrade",
+                label=f"targets.{target_name}.table_type_downgrade",
+                file_path=file_path,
+            ),
             clone=LocalClonePolicy(
                 allow_as_clone_origin=_optional_nullable_bool(
                     mapping=clone_mapping,
@@ -839,6 +912,8 @@ def _validate_target_keys(
                 "compile_cache",
                 "time_travel_retention",
                 "owns_time_travel_retention_namespace",
+                "default_table_type",
+                "table_type_downgrade",
                 "clone",
                 "state",
             }

--- a/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
@@ -86,6 +86,7 @@ from sqlbuild.compiler.planner.types import (
 from sqlbuild.compiler.references.main._render_source_relation import render_source_relation
 from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver, SqlReferenceKind
 from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig, SchemaColumn, SourceEntry
+from sqlbuild.spec.contracts.types import TableType
 
 _MODELS_DIR_PREFIX: str = "models/"
 _IDEMPOTENT_MICROBATCH_STRATEGIES: frozenset[IncrementalStrategy] = frozenset(
@@ -524,17 +525,22 @@ def plan_model_from_change(
         if runtime_owned_cursor_bounds and cursor_column is not None
         else (microbatch_range if microbatch_range else cursor_bounds)
     )
-    logical_ddl: str = _build_logical_ddl_from_adapter(
-        adapter=adapter,
-        action=action,
-        resolved_sql=resolved_sql,
-        destination=model.destination,
-        unique_key=unique_key,
-        merge_exclude_columns=_get_config_string_tuple(model=model, key="merge_exclude_columns"),
-        warehouse_columns=warehouse_columns,
-        cursor_column=cursor_column,
-        cursor_bounds=ddl_cursor_bounds,
-        cursor_type=cursor_type,
+    logical_ddl: str = _render_table_type_ddl(
+        ddl=_build_logical_ddl_from_adapter(
+            adapter=adapter,
+            action=action,
+            resolved_sql=resolved_sql,
+            destination=model.destination,
+            unique_key=unique_key,
+            merge_exclude_columns=_get_config_string_tuple(
+                model=model, key="merge_exclude_columns"
+            ),
+            warehouse_columns=warehouse_columns,
+            cursor_column=cursor_column,
+            cursor_bounds=ddl_cursor_bounds,
+            cursor_type=cursor_type,
+        ),
+        table_type=model.config.table_type.value.value,
     )
 
     entry: ModelPlanEntry = ModelPlanEntry(
@@ -582,6 +588,7 @@ def plan_model_from_change(
         invalidate_hard_deletes=invalidate_hard_deletes,
         snapshot_full_refresh=snapshot_full_refresh,
         snapshot_schema_change=snapshot_schema_change,
+        table_type=model.config.table_type.value.value,
         on_schema_change=on_schema_change,
         type_enforcement=type_enforcement,
         declared_columns=declared_columns,
@@ -942,6 +949,12 @@ def _compute_plan_cursor_bounds(
         is_microbatch=is_microbatch,
         cursor_grain=_get_config_str(model=model, key="cursor_grain"),
     )
+
+
+def _render_table_type_ddl(*, ddl: str, table_type: str) -> str:
+    """Render permanent Snowflake table DDL from the adapter's transient default."""
+
+    return ddl.replace("TRANSIENT TABLE", "TABLE", 1) if table_type == TableType.PERMANENT else ddl
 
 
 def _build_logical_ddl_from_adapter(

--- a/src/sqlbuild/compiler/planner/_helpers/planning/retention.py
+++ b/src/sqlbuild/compiler/planner/_helpers/planning/retention.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 from collections import defaultdict
 
 from sqlbuild.adapter.contract.models import (
+    RelationInfo,
     RenderedRetentionChange,
     RetentionRequest,
     RetentionState,
@@ -18,12 +20,86 @@ from sqlbuild.compiler.planner.models import (
     PlannerScope,
     PlannerWarehouseState,
     RetentionPlanEntry,
+    TableTypePlanEntry,
 )
 from sqlbuild.compiler.planner.types import RetentionDirection, RetentionPlanPhase
 from sqlbuild.spec.contracts.main.resolve_target_config import resolve_target_config
 from sqlbuild.spec.contracts.models import ResolvedTimeTravelRetention, TargetConfig
+from sqlbuild.spec.contracts.types import TableType
 
 _DECREASE_WARNING: str = "Retention decreases are irreversible once warehouse history expires."
+_DOWNGRADE_HISTORY_DAYS: int = 90
+_TABLE_TYPE_COPY_PREFIX: str = "__sqb_type_swap__"
+
+
+def plan_table_types(
+    *, runtime: PlannerRuntime, warehouse: PlannerWarehouseState, scope: PlannerScope
+) -> tuple[TableTypePlanEntry, ...]:
+    """Produce independent entries for selected Snowflake table-type drift."""
+
+    selected_names: frozenset[str] = frozenset(
+        key.name for key in scope.selected_keys if key.resource_type == CompiledResourceType.MODEL
+    )
+    selected_models: tuple[CompiledModel, ...] = tuple(
+        model for model in runtime.project.models if model.name in selected_names
+    )
+    declared_models: tuple[CompiledModel, ...] = tuple(
+        model for model in selected_models if model.config.table_type.declared
+    )
+    if declared_models and runtime.adapter.adapter_name != BuiltinAdapter.SNOWFLAKE:
+        names: str = ", ".join(model.name for model in declared_models)
+        raise PlannerInputError(
+            f"table_type is not supported on this adapter; declared by model(s): {names}"
+        )
+    if runtime.adapter.adapter_name != BuiltinAdapter.SNOWFLAKE:
+        return ()
+    target: TargetConfig = _effective_target(runtime=runtime)
+    entries: list[TableTypePlanEntry] = []
+    for model in selected_models:
+        relation: RelationInfo | None = warehouse.snapshot.existing_relations.get(model.name)
+        if relation is None:
+            continue
+        desired_transient: bool = model.config.table_type.value == TableType.TRANSIENT
+        if relation.is_transient is not None and relation.is_transient == desired_transient:
+            continue
+        downgrade: bool = relation.is_transient is False and desired_transient
+        entries.append(
+            TableTypePlanEntry(
+                model_name=model.name,
+                destination=model.destination,
+                copy_name=table_type_copy_name(
+                    target_name=model.destination.name,
+                    identifier_limit=runtime.adapter.maximum_identifier_length(),
+                ),
+                desired_type=model.config.table_type.value.value,
+                actual_type=(
+                    None
+                    if relation.is_transient is None
+                    else TableType.TRANSIENT.value
+                    if relation.is_transient
+                    else TableType.PERMANENT.value
+                ),
+                source=model.config.table_type.source.value,
+                downgrade=downgrade,
+                downgrade_policy=target.table_type_downgrade.value,
+                irreversible_warning=(
+                    f"Downgrading may discard up to {_DOWNGRADE_HISTORY_DAYS} days of "
+                    "time-travel history."
+                    if downgrade
+                    else None
+                ),
+            )
+        )
+    return tuple(entries)
+
+
+def table_type_copy_name(*, target_name: str, identifier_limit: int) -> str:
+    """Return a deterministic identifier-fitted conversion copy name."""
+
+    digest: str = hashlib.sha256(target_name.encode()).hexdigest()[:12]
+    suffix: str = f"__{digest}"
+    available: int = max(0, identifier_limit - len(_TABLE_TYPE_COPY_PREFIX) - len(suffix))
+    return f"{_TABLE_TYPE_COPY_PREFIX}{target_name[:available]}{suffix}"
 
 
 def plan_retention(
@@ -74,12 +150,16 @@ def _plan_relation_retention(
         desired_days=desired_days,
     )
     if model.name not in warehouse.snapshot.existing_relations:
-        if runtime.adapter.adapter_name == BuiltinAdapter.SNOWFLAKE and desired_days > 1:
+        if (
+            runtime.adapter.adapter_name == BuiltinAdapter.SNOWFLAKE
+            and desired_days > 1
+            and model.config.table_type.value == TableType.TRANSIENT
+        ):
             raise PlannerInputError(
-                f"model '{model.name}': new Snowflake tables are transient and cannot retain "
+                f"model '{model.name}': Snowflake transient tables cannot retain "
                 f"time travel for {desired_days} days; retention above one day requires a "
-                "permanent table; convert it with a one-time manual migration. Declarative "
-                "table-type management is planned"
+                "permanent table; set table_type permanent on the model, its materialization "
+                "default, or the target default_table_type"
             )
         changes: tuple[RenderedRetentionChange, ...] = runtime.adapter.render_retention_changes(
             request=request
@@ -95,14 +175,42 @@ def _plan_relation_retention(
                 statements=_flatten_changes(changes=changes),
             ),
         )
+    relation_is_transient: bool | None = warehouse.snapshot.existing_relations[
+        model.name
+    ].is_transient
     state: RetentionState = runtime.adapter.inspect_retention(
         connection=runtime.connection, request=request
     )
-    if state.is_transient and desired_days > 1:
+    if (
+        state.is_transient
+        and desired_days > 1
+        and model.config.table_type.value == TableType.TRANSIENT
+    ):
         raise PlannerInputError(
             f"model '{model.name}': Snowflake transient tables cannot retain time travel for "
             f"{desired_days} days; retention above one day requires a permanent table; convert "
-            "it with a one-time manual migration. Declarative table-type management is planned"
+            "it by setting table_type permanent on the model, its materialization default, or "
+            "the target default_table_type"
+        )
+    if (
+        runtime.adapter.adapter_name == BuiltinAdapter.SNOWFLAKE
+        and desired_days > 1
+        and relation_is_transient is True
+        and model.config.table_type.value == TableType.PERMANENT
+    ):
+        changes: tuple[RenderedRetentionChange, ...] = runtime.adapter.render_retention_changes(
+            request=request
+        )
+        return (
+            _entry(
+                request=request,
+                model_names=(model.name,),
+                state=state,
+                source=source,
+                direction=RetentionDirection.APPLY_AFTER_CREATE,
+                phase=RetentionPlanPhase.AFTER_CREATE,
+                statements=_flatten_changes(changes=changes),
+            ),
         )
     direction: RetentionDirection = _state_direction(state=state, desired_days=desired_days)
     if direction == RetentionDirection.MATCH:

--- a/src/sqlbuild/compiler/planner/main/execution/execution.py
+++ b/src/sqlbuild/compiler/planner/main/execution/execution.py
@@ -24,7 +24,7 @@ from sqlbuild.compiler.planner._helpers.planning.output_assembly import (
     with_plan_warnings,
 )
 from sqlbuild.compiler.planner._helpers.planning.reconciliation import reconcile_execution_changes
-from sqlbuild.compiler.planner._helpers.planning.retention import plan_retention
+from sqlbuild.compiler.planner._helpers.planning.retention import plan_retention, plan_table_types
 from sqlbuild.compiler.planner._helpers.planning.scope_pruning import prune_planner_execution_scope
 from sqlbuild.compiler.planner._helpers.planning.scopes import resolve_planner_scopes
 from sqlbuild.compiler.planner._helpers.planning.warehouse_state import (
@@ -156,6 +156,9 @@ def build_execution_plan(
     )
     plan_output = replace(
         plan_output,
+        table_type_entries=plan_table_types(
+            runtime=runtime, warehouse=warehouse, scope=scopes.selected_scope
+        ),
         retention_entries=plan_retention(
             runtime=runtime, warehouse=warehouse, scope=scopes.selected_scope
         ),

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -612,6 +612,21 @@ class RetentionPlanEntry:
 
 
 @dataclass(frozen=True)
+class TableTypePlanEntry:
+    """Snowflake table-type work independent of model identity actions."""
+
+    model_name: str
+    destination: CompiledRelationLocation
+    copy_name: str
+    desired_type: str
+    actual_type: str | None
+    source: str
+    downgrade: bool
+    downgrade_policy: str
+    irreversible_warning: str | None = None
+
+
+@dataclass(frozen=True)
 class PlanOutputExtras:
     """Optional supplemental seed fingerprints for plan output assembly."""
 
@@ -662,6 +677,7 @@ class ModelPlanEntry:
     invalidate_hard_deletes: bool = False
     snapshot_full_refresh: str | None = None
     snapshot_schema_change: str | None = None
+    table_type: str = "transient"
     on_schema_change: OnSchemaChange | None = None
     type_enforcement: bool = False
     declared_columns: tuple[ColumnInfo, ...] = field(default_factory=tuple)
@@ -957,6 +973,7 @@ class PlanOutput:
     selected_keys: frozenset[CompiledObjectKey] = field(default_factory=frozenset)
     warnings: tuple[PlanWarning, ...] = field(default_factory=tuple)
     retention_entries: tuple[RetentionPlanEntry, ...] = field(default_factory=tuple)
+    table_type_entries: tuple[TableTypePlanEntry, ...] = field(default_factory=tuple)
     upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]] = field(
         default_factory=dict
     )

--- a/src/sqlbuild/executor/build/_helpers/retention.py
+++ b/src/sqlbuild/executor/build/_helpers/retention.py
@@ -5,10 +5,98 @@ from __future__ import annotations
 from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
-from sqlbuild.adapter.contract.models import RenderedRetentionChange, RetentionState
+from sqlbuild.adapter.contract.models import RelationInfo, RenderedRetentionChange, RetentionState
 from sqlbuild.adapter.contract.types import RetentionChangePhase, RetentionScope
-from sqlbuild.compiler.planner.models import PlanOutput, RetentionPlanEntry
+from sqlbuild.adapter.relations.main.resolve_qualified_name_parts import (
+    resolve_qualified_name_parts,
+)
+from sqlbuild.compiler.planner.exceptions import PlannerInputError
+from sqlbuild.compiler.planner.models import PlanOutput, RetentionPlanEntry, TableTypePlanEntry
 from sqlbuild.compiler.planner.types import RetentionPlanPhase
+from sqlbuild.spec.contracts.types import TableType
+
+
+def apply_table_type_conversions(
+    *, plan: PlanOutput, adapter: BaseAdapter, connection: Any
+) -> None:
+    """Recover by inspection: clean desired targets or recreate and swap undesired targets."""
+
+    _apply_table_type_entries(
+        entries=plan.table_type_entries, adapter=adapter, connection=connection
+    )
+
+
+def _apply_table_type_entries(
+    *, entries: tuple[TableTypePlanEntry, ...], adapter: BaseAdapter, connection: Any
+) -> None:
+    if not entries:
+        return
+    _apply_table_type_entry(entry=entries[0], adapter=adapter, connection=connection)
+    _apply_table_type_entries(entries=entries[1:], adapter=adapter, connection=connection)
+
+
+def _apply_table_type_entry(
+    *, entry: TableTypePlanEntry, adapter: BaseAdapter, connection: Any
+) -> None:
+    destination: str = resolve_qualified_name_parts(
+        adapter=adapter,
+        database=entry.destination.database,
+        schema=entry.destination.schema,
+        name=entry.destination.name,
+    )
+    copy: str = resolve_qualified_name_parts(
+        adapter=adapter,
+        database=entry.destination.database,
+        schema=entry.destination.schema,
+        name=entry.copy_name,
+    )
+    relations: dict[str, RelationInfo] = _inspect_table_type_entry(
+        entry=entry, adapter=adapter, connection=connection
+    )
+    target: RelationInfo | None = relations.get(entry.destination.name.lower())
+    if target is None:
+        raise PlannerInputError(
+            f"model '{entry.model_name}': table-type conversion target no longer exists"
+        )
+    desired_transient: bool = entry.desired_type == TableType.TRANSIENT
+    if target.is_transient is None:
+        raise PlannerInputError(
+            f"model '{entry.model_name}': live table type metadata is unknown; refusing conversion"
+        )
+    if target.is_transient == desired_transient:
+        if entry.copy_name.lower() in relations:
+            adapter.execute(connection=connection, sql=f"DROP TABLE IF EXISTS {copy}")
+        return
+    table_kind: str = "TRANSIENT TABLE" if desired_transient else "TABLE"
+    adapter.execute(
+        connection=connection,
+        sql=f"CREATE OR REPLACE {table_kind} {copy} AS SELECT * FROM {destination}",
+    )
+    copy_info: RelationInfo | None = _inspect_table_type_entry(
+        entry=entry, adapter=adapter, connection=connection
+    ).get(entry.copy_name.lower())
+    if copy_info is None or copy_info.is_transient is None:
+        raise PlannerInputError(
+            f"model '{entry.model_name}': conversion copy type metadata is unknown"
+        )
+    if copy_info.is_transient != desired_transient:
+        raise PlannerInputError(
+            f"model '{entry.model_name}': conversion copy was not created with the desired type"
+        )
+    adapter.execute(connection=connection, sql=f"ALTER TABLE {destination} SWAP WITH {copy}")
+    adapter.execute(connection=connection, sql=f"DROP TABLE IF EXISTS {copy}")
+
+
+def _inspect_table_type_entry(
+    *, entry: TableTypePlanEntry, adapter: BaseAdapter, connection: Any
+) -> dict[str, RelationInfo]:
+    relations: tuple[RelationInfo, ...] = adapter.list_relations(
+        connection=connection,
+        database=entry.destination.database,
+        schemas=(entry.destination.schema,) if entry.destination.schema is not None else None,
+        names=(entry.destination.name, entry.copy_name),
+    )
+    return {relation.name.lower(): relation for relation in relations}
 
 
 def apply_retention_phase(

--- a/src/sqlbuild/executor/build/_helpers/retention.py
+++ b/src/sqlbuild/executor/build/_helpers/retention.py
@@ -10,9 +10,9 @@ from sqlbuild.adapter.contract.types import RetentionChangePhase, RetentionScope
 from sqlbuild.adapter.relations.main.resolve_qualified_name_parts import (
     resolve_qualified_name_parts,
 )
-from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.models import PlanOutput, RetentionPlanEntry, TableTypePlanEntry
 from sqlbuild.compiler.planner.types import RetentionPlanPhase
+from sqlbuild.errors.contracts.exceptions import ExecutorInputError
 from sqlbuild.spec.contracts.types import TableType
 
 
@@ -55,12 +55,12 @@ def _apply_table_type_entry(
     )
     target: RelationInfo | None = relations.get(entry.destination.name.lower())
     if target is None:
-        raise PlannerInputError(
+        raise ExecutorInputError(
             f"model '{entry.model_name}': table-type conversion target no longer exists"
         )
     desired_transient: bool = entry.desired_type == TableType.TRANSIENT
     if target.is_transient is None:
-        raise PlannerInputError(
+        raise ExecutorInputError(
             f"model '{entry.model_name}': live table type metadata is unknown; refusing conversion"
         )
     if target.is_transient == desired_transient:
@@ -76,11 +76,11 @@ def _apply_table_type_entry(
         entry=entry, adapter=adapter, connection=connection
     ).get(entry.copy_name.lower())
     if copy_info is None or copy_info.is_transient is None:
-        raise PlannerInputError(
+        raise ExecutorInputError(
             f"model '{entry.model_name}': conversion copy type metadata is unknown"
         )
     if copy_info.is_transient != desired_transient:
-        raise PlannerInputError(
+        raise ExecutorInputError(
             f"model '{entry.model_name}': conversion copy was not created with the desired type"
         )
     adapter.execute(connection=connection, sql=f"ALTER TABLE {destination} SWAP WITH {copy}")

--- a/src/sqlbuild/executor/build/main/_execute.py
+++ b/src/sqlbuild/executor/build/main/_execute.py
@@ -11,6 +11,7 @@ from sqlbuild.executor.auditing.models import AuditExecutionResult
 from sqlbuild.executor.build._helpers.output import aggregate_build_result
 from sqlbuild.executor.build._helpers.retention import (
     apply_retention_phase,
+    apply_table_type_conversions,
     reconcile_retention_after_build,
 )
 from sqlbuild.executor.build.classes.build_scheduler import BuildScheduler
@@ -64,6 +65,7 @@ def execute_build_plan(
         schema_prepared=schema_prepared,
     )
 
+    _ = apply_table_type_conversions(plan=plan, adapter=adapter, connection=scheduler_connection)
     _ = apply_retention_phase(
         plan=plan,
         adapter=adapter,

--- a/src/sqlbuild/executor/run/_helpers/execution/staging.py
+++ b/src/sqlbuild/executor/run/_helpers/execution/staging.py
@@ -31,6 +31,7 @@ def create_staging_relation(
         connection=connection,
         destination=staging_qualified,
         sql=resolved_sql,
+        config={"table_type": context.entry.table_type},
         statement_recorder=statement_recorder,
     )
     return None

--- a/src/sqlbuild/executor/run/_helpers/materializations/incremental.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/incremental.py
@@ -49,6 +49,7 @@ from sqlbuild.executor.run.models import (
 )
 from sqlbuild.executor.run.types import ExecutionPhase
 from sqlbuild.executor.scheduling.types import ExecutionStatus
+from sqlbuild.spec.contracts.types import TableType
 
 _DEFAULT_ON_SCHEMA_CHANGE: OnSchemaChange = OnSchemaChange.APPEND_NEW_COLUMNS
 
@@ -184,6 +185,7 @@ def execute_incremental_entry(
                     staging_schema=target_schema,
                     staging_table=delta_table,
                     declared_columns=declared_columns,
+                    table_type=TableType.TRANSIENT,
                     statement_recorder=statement_recorder,
                 )
         except Exception as exc:

--- a/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
@@ -114,6 +114,7 @@ from sqlbuild.microbatches.types import (
     ReplayRequirementState,
     UnaccountedPartitionPolicy,
 )
+from sqlbuild.spec.contracts.types import TableType
 
 _DEFAULT_ON_SCHEMA_CHANGE: OnSchemaChange = OnSchemaChange.APPEND_NEW_COLUMNS
 _DEBUG_LOGGER: logging.Logger = logging.getLogger("sqlbuild.execution")
@@ -2000,6 +2001,7 @@ def _enforce_microbatch_types(
                 staging_schema=targets.target_schema,
                 staging_table=targets.delta_table,
                 declared_columns=declared_columns,
+                table_type=TableType.TRANSIENT,
                 statement_recorder=state.statement_recorder,
             )
     except Exception as exc:

--- a/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
@@ -2088,6 +2088,7 @@ def _apply_microbatch_dml(
                     connection=context.connection,
                     destination=targets.target_qualified,
                     sql=f"SELECT * FROM {targets.delta_qualified}",
+                    config={"table_type": context.entry.table_type},
                     statement_recorder=state.statement_recorder,
                 )
             else:

--- a/src/sqlbuild/executor/run/_helpers/materializations/snapshot.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/snapshot.py
@@ -56,6 +56,7 @@ from sqlbuild.executor.run.models import (
 from sqlbuild.executor.run.types import ExecutionPhase
 from sqlbuild.executor.scheduling.types import ExecutionStatus
 from sqlbuild.spec.contracts.models import SnapshotsConfig
+from sqlbuild.spec.contracts.types import TableType
 
 _DEFAULT_VALID_FROM_COLUMN: str = "valid_from"
 _DEFAULT_VALID_TO_COLUMN: str = "valid_to"
@@ -510,6 +511,10 @@ def _create_initial_snapshot_target(
             valid_from_column=valid_from_column,
             valid_to_column=valid_to_column,
             initial_valid_from=entry.initial_valid_from,
+        )
+    if entry.table_type == TableType.PERMANENT:
+        statements = tuple(
+            statement.replace("TRANSIENT TABLE", "TABLE", 1) for statement in statements
         )
     statement_recorder.record_many(statements)
     statement: str

--- a/src/sqlbuild/executor/run/_helpers/materializations/snapshot.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/snapshot.py
@@ -56,7 +56,6 @@ from sqlbuild.executor.run.models import (
 from sqlbuild.executor.run.types import ExecutionPhase
 from sqlbuild.executor.scheduling.types import ExecutionStatus
 from sqlbuild.spec.contracts.models import SnapshotsConfig
-from sqlbuild.spec.contracts.types import TableType
 
 _DEFAULT_VALID_FROM_COLUMN: str = "valid_from"
 _DEFAULT_VALID_TO_COLUMN: str = "valid_to"
@@ -467,6 +466,7 @@ def _create_initial_snapshot_target(
         if entry.historical_input == HistoricalInput.CHANGES:
             statements: tuple[str, ...] = (
                 adapter.render_create_initial_historical_timestamp_changes_destination(
+                    table_type=entry.table_type,
                     destination=target_qualified,
                     origin=delta_qualified,
                     unique_key=entry.unique_key,
@@ -478,6 +478,7 @@ def _create_initial_snapshot_target(
             )
         else:
             statements = adapter.render_create_initial_historical_timestamp_snapshot_destination(
+                table_type=entry.table_type,
                 destination=target_qualified,
                 origin=delta_qualified,
                 unique_key=entry.unique_key,
@@ -491,6 +492,7 @@ def _create_initial_snapshot_target(
     elif entry.snapshot_strategy == SnapshotStrategy.CHECK and entry.observed_at_column is not None:
         output_columns: tuple[str, ...] = tuple(column.name for column in delta_columns)
         statements = adapter.render_create_initial_historical_check_snapshot_destination(
+            table_type=entry.table_type,
             destination=target_qualified,
             origin=delta_qualified,
             unique_key=entry.unique_key,
@@ -503,6 +505,7 @@ def _create_initial_snapshot_target(
         )
     else:
         statements = adapter.render_create_initial_snapshot_destination(
+            table_type=entry.table_type,
             destination=target_qualified,
             origin=delta_qualified,
             snapshot_strategy=entry.snapshot_strategy,
@@ -511,10 +514,6 @@ def _create_initial_snapshot_target(
             valid_from_column=valid_from_column,
             valid_to_column=valid_to_column,
             initial_valid_from=entry.initial_valid_from,
-        )
-    if entry.table_type == TableType.PERMANENT:
-        statements = tuple(
-            statement.replace("TRANSIENT TABLE", "TABLE", 1) for statement in statements
         )
     statement_recorder.record_many(statements)
     statement: str

--- a/src/sqlbuild/executor/run/_helpers/validation/type_enforcement.py
+++ b/src/sqlbuild/executor/run/_helpers/validation/type_enforcement.py
@@ -18,7 +18,7 @@ def enforce_types_staged(
     staging_schema: str | None,
     staging_table: str,
     declared_columns: tuple[ColumnInfo, ...],
-    table_type: str = "transient",
+    table_type: str,
     statement_recorder: StatementRecorder,
 ) -> None:
     """Inspect staging columns and rebuild with casts for declared types."""

--- a/src/sqlbuild/executor/run/_helpers/validation/type_enforcement.py
+++ b/src/sqlbuild/executor/run/_helpers/validation/type_enforcement.py
@@ -18,6 +18,7 @@ def enforce_types_staged(
     staging_schema: str | None,
     staging_table: str,
     declared_columns: tuple[ColumnInfo, ...],
+    table_type: str = "transient",
     statement_recorder: StatementRecorder,
 ) -> None:
     """Inspect staging columns and rebuild with casts for declared types."""
@@ -63,6 +64,7 @@ def enforce_types_staged(
         connection=connection,
         destination=enforced_qualified,
         sql=f"SELECT {projection_sql} FROM {staging_qualified}",
+        config={"table_type": table_type},
         statement_recorder=statement_recorder,
     )
     adapter.drop(

--- a/src/sqlbuild/executor/run/main/_execute.py
+++ b/src/sqlbuild/executor/run/main/_execute.py
@@ -266,6 +266,7 @@ def _staged_lifecycle(
                     staging_schema=targets.target_schema,
                     staging_table=targets.staging_table,
                     declared_columns=declared_columns,
+                    table_type=entry.table_type,
                     statement_recorder=statement_recorder,
                 )
         except Exception as exc:
@@ -435,6 +436,7 @@ def _immediate_lifecycle(
                 connection=connection,
                 destination=target_qualified,
                 sql=state.resolved_sql,
+                config={"table_type": entry.table_type},
                 statement_recorder=statement_recorder,
             )
     except Exception as exc:

--- a/src/sqlbuild/spec/contracts/_helpers/targets.py
+++ b/src/sqlbuild/spec/contracts/_helpers/targets.py
@@ -95,6 +95,16 @@ def resolve_target_config(
             if local_target.owns_time_travel_retention_namespace is not None
             else project_target.owns_time_travel_retention_namespace
         ),
+        default_table_type=(
+            local_target.default_table_type
+            if local_target.default_table_type is not None
+            else project_target.default_table_type
+        ),
+        table_type_downgrade=(
+            local_target.table_type_downgrade
+            if local_target.table_type_downgrade is not None
+            else project_target.table_type_downgrade
+        ),
         clone=_merge_clone_policy(
             project_clone=project_target.clone,
             local_clone=local_target.clone,

--- a/src/sqlbuild/spec/contracts/models.py
+++ b/src/sqlbuild/spec/contracts/models.py
@@ -11,6 +11,9 @@ from sqlbuild.spec.contracts.types import (
     SourceFreshnessStrategy,
     SourceFreshnessValueKind,
     SourceWriteStrategy,
+    TableType,
+    TableTypeDowngradePolicy,
+    TableTypeSource,
     TimeTravelRetentionSource,
 )
 from sqlbuild.sql_values.types import CollectionRendering
@@ -45,6 +48,7 @@ class MaterializationRetentionDefaults:
     """Retention defaults for one built-in materialization."""
 
     time_travel_retention: AuthoredTimeTravelRetention | None = None
+    table_type: TableType | None = None
 
 
 @dataclass(frozen=True)
@@ -69,6 +73,15 @@ class ResolvedTimeTravelRetention:
     desired_days: int | None = None
     unmanaged: bool = True
     source: TimeTravelRetentionSource | None = None
+
+
+@dataclass(frozen=True)
+class ResolvedTableType:
+    """Effective Snowflake table type attached to a compiled model."""
+
+    value: TableType = TableType.TRANSIENT
+    source: TableTypeSource = TableTypeSource.DEFAULT
+    declared: bool = False
 
 
 @dataclass(frozen=True)
@@ -111,6 +124,8 @@ class TargetConfig:
     compile_cache: bool | None = None
     time_travel_retention: AuthoredTimeTravelRetention | None = None
     owns_time_travel_retention_namespace: bool = False
+    default_table_type: TableType | None = None
+    table_type_downgrade: TableTypeDowngradePolicy = TableTypeDowngradePolicy.REQUIRE_CONFIRMATION
 
 
 @dataclass(frozen=True)
@@ -131,6 +146,8 @@ class LocalTargetConfig:
     compile_cache: bool | None = None
     time_travel_retention: AuthoredTimeTravelRetention | None = None
     owns_time_travel_retention_namespace: bool | None = None
+    default_table_type: TableType | None = None
+    table_type_downgrade: TableTypeDowngradePolicy | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/spec/contracts/types.py
+++ b/src/sqlbuild/spec/contracts/types.py
@@ -39,3 +39,33 @@ class TimeTravelRetentionValue(StrEnum):
 
     INHERIT = "inherit"
     DISABLED = "disabled"
+
+
+class TableType(StrEnum):
+    """Snowflake managed table type."""
+
+    PERMANENT = "permanent"
+    TRANSIENT = "transient"
+
+
+class TableTypeSource(StrEnum):
+    """Authored layer that supplied the effective table type."""
+
+    DEFAULT = "default"
+    TARGET = "target"
+    MATERIALIZATION = "materialization"
+    MODEL = "model"
+
+
+class TableTypeValue(StrEnum):
+    """Named non-type table-type value."""
+
+    INHERIT = "inherit"
+
+
+class TableTypeDowngradePolicy(StrEnum):
+    """Permanent-to-transient conversion policy."""
+
+    DENY = "deny"
+    REQUIRE_CONFIRMATION = "require_confirmation"
+    ALLOW = "allow"

--- a/tests/integration/src/sqlbuild/adapters/duckdb/test_snapshot_adapter_methods.py
+++ b/tests/integration/src/sqlbuild/adapters/duckdb/test_snapshot_adapter_methods.py
@@ -64,6 +64,7 @@ def test_given_snapshot_adapter_methods_when_executing_rendered_sql_then_updates
     )
     statement: str
     for statement in adapter.render_create_initial_snapshot_destination(
+        table_type="transient",
         destination="main.initial_custom_target",
         origin="main.initial_custom_source",
         snapshot_strategy="timestamp",
@@ -192,6 +193,7 @@ def test_given_snapshot_adapter_methods_when_executing_rendered_sql_then_updates
         "TIMESTAMP '2024-01-04' AS observed_at"
     )
     for statement in adapter.render_create_initial_historical_timestamp_snapshot_destination(
+        table_type="transient",
         destination="main.hist_ts_target",
         origin="main.hist_ts_source",
         unique_key=("customer_id",),
@@ -246,6 +248,7 @@ def test_given_snapshot_adapter_methods_when_executing_rendered_sql_then_updates
         "UNION ALL SELECT 2 AS customer_id, 'basic' AS plan, TIMESTAMP '2024-01-02' AS observed_at"
     )
     for statement in adapter.render_create_initial_historical_check_snapshot_destination(
+        table_type="transient",
         destination="main.hist_check_target",
         origin="main.hist_check_source",
         unique_key=("customer_id",),

--- a/tests/integration/src/sqlbuild/adapters/snapshot_sql_rendering/test_rendering.py
+++ b/tests/integration/src/sqlbuild/adapters/snapshot_sql_rendering/test_rendering.py
@@ -172,6 +172,7 @@ def test_given_builtin_adapter_when_rendering_snapshot_sql_then_covers_snapshot_
 ) -> None:
     create_initial_sql: str = "\n".join(
         test_case.adapter.render_create_initial_snapshot_destination(
+            table_type="transient",
             destination="target_table",
             origin="source_table",
             snapshot_strategy="timestamp",
@@ -198,6 +199,7 @@ def test_given_builtin_adapter_when_rendering_snapshot_sql_then_covers_snapshot_
     )
     historical_check_initial_sql: str = "\n".join(
         test_case.adapter.render_create_initial_historical_check_snapshot_destination(
+            table_type="transient",
             destination="target_table",
             origin="source_table",
             unique_key=("customer_id",),
@@ -211,6 +213,7 @@ def test_given_builtin_adapter_when_rendering_snapshot_sql_then_covers_snapshot_
     )
     historical_timestamp_initial_sql: str = "\n".join(
         test_case.adapter.render_create_initial_historical_timestamp_snapshot_destination(
+            table_type="transient",
             destination="target_table",
             origin="source_table",
             unique_key=("customer_id",),

--- a/tests/unit/src/sqlbuild/adapters/snowflake/_test_types.py
+++ b/tests/unit/src/sqlbuild/adapters/snowflake/_test_types.py
@@ -17,6 +17,13 @@ class SnowflakeRetentionTestCase:
 
 
 @dataclass(frozen=True)
+class SnowflakeTableTypeDdlTestCase:
+    description: str
+    table_type: str
+    expected_prefix: str
+
+
+@dataclass(frozen=True)
 class SnowflakeCostCollectionTestCase:
     description: str
     connect_error: bool

--- a/tests/unit/src/sqlbuild/adapters/snowflake/test_client.py
+++ b/tests/unit/src/sqlbuild/adapters/snowflake/test_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 
@@ -44,6 +45,7 @@ from tests.unit.src.sqlbuild.adapters.snowflake._test_types import (
     SnowflakeTableFreshnessBatchTestCase,
     SnowflakeTableFreshnessMetadataErrorTestCase,
     SnowflakeTableFreshnessMetadataTestCase,
+    SnowflakeTableTypeDdlTestCase,
 )
 from tests.unit.src.sqlbuild.adapters.snowflake.helpers import (
     FakeSnowflakeDescribeConnection,
@@ -60,6 +62,77 @@ from tests.unit.src.sqlbuild.adapters.snowflake.helpers import (
     expected_qualified_columns,
     install_fake_snowflake_connector,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SnowflakeTableTypeDdlTestCase(
+            description="permanent CTAS omits transient keyword",
+            table_type="permanent",
+            expected_prefix="CREATE OR REPLACE TABLE analytics.orders AS",
+        ),
+        SnowflakeTableTypeDdlTestCase(
+            description="transient CTAS includes transient keyword",
+            table_type="transient",
+            expected_prefix="CREATE OR REPLACE TRANSIENT TABLE analytics.orders AS",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_table_type_config_when_creating_table_as_then_renders_expected_kind(
+    test_case: SnowflakeTableTypeDdlTestCase,
+) -> None:
+    adapter: SnowflakeAdapter = SnowflakeAdapter()
+    recorder: StatementRecorder = StatementRecorder()
+
+    with patch.object(adapter, "execute") as execute:
+        adapter.create_table_as(
+            connection=object(),
+            destination="analytics.orders",
+            sql="SELECT 1 AS id",
+            config={"table_type": test_case.table_type},
+            statement_recorder=recorder,
+        )
+
+    sql: str = str(execute.call_args.kwargs["sql"])
+    assert sql.startswith(test_case.expected_prefix)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SnowflakeTableTypeDdlTestCase(
+            description="permanent initial snapshot omits transient keyword",
+            table_type="permanent",
+            expected_prefix="CREATE OR REPLACE TABLE analytics.orders AS",
+        ),
+        SnowflakeTableTypeDdlTestCase(
+            description="transient initial snapshot includes transient keyword",
+            table_type="transient",
+            expected_prefix="CREATE OR REPLACE TRANSIENT TABLE analytics.orders AS",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_table_type_when_rendering_initial_snapshot_then_uses_expected_kind(
+    test_case: SnowflakeTableTypeDdlTestCase,
+) -> None:
+    adapter: SnowflakeAdapter = SnowflakeAdapter()
+
+    statements: tuple[str, ...] = adapter.render_create_initial_snapshot_destination(
+        table_type=test_case.table_type,
+        destination="analytics.orders",
+        origin="analytics.orders__delta",
+        snapshot_strategy="timestamp",
+        updated_at_column="updated_at",
+        observed_at_column=None,
+        valid_from_column="valid_from",
+        valid_to_column="valid_to",
+        initial_valid_from=None,
+    )
+
+    assert statements[0].startswith(test_case.expected_prefix)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/build_planning/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/build_planning/_test_types.py
@@ -15,3 +15,15 @@ class SnapshotFullRefreshPolicyTestCase:
     expected_output: str = ""
     input_text: str = ""
     input_is_tty: bool = False
+
+
+@dataclass(frozen=True)
+class TableTypeDowngradePolicyTestCase:
+    description: str
+    plan_output: PlanOutput
+    allow_table_type_downgrade: bool
+    expected_error_fragment: str | None = None
+    expected_help_fragment: str = ""
+    expected_output: str = ""
+    input_text: str = ""
+    input_is_tty: bool = False

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/build_planning/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/build_planning/helpers.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationLocation
 from sqlbuild.compiler.compile.types import CompiledResourceType
-from sqlbuild.compiler.planner.models import ModelPlanEntry
+from sqlbuild.compiler.planner.models import ModelPlanEntry, TableTypePlanEntry
 from sqlbuild.compiler.planner.types import MaterializationType, PlanAction, PlanReason
 
 
@@ -32,4 +32,29 @@ def build_snapshot_full_refresh_entry(
         logical_ddl=f"CREATE TABLE main.{name} AS SELECT 1 AS id",
         observed_at_column=observed_at_column,
         snapshot_full_refresh=snapshot_full_refresh,
+    )
+
+
+def build_table_type_entry(
+    *,
+    name: str = "orders",
+    downgrade: bool = True,
+    policy: str = "require_confirmation",
+    desired_type: str = "transient",
+    actual_type: str = "permanent",
+) -> TableTypePlanEntry:
+    return TableTypePlanEntry(
+        model_name=name,
+        destination=CompiledRelationLocation(
+            database=None,
+            schema="main",
+            name=name,
+            qualified_name=f"main.{name}",
+        ),
+        copy_name=f"__sqb_type_swap__{name}",
+        desired_type=desired_type,
+        actual_type=actual_type,
+        source="model",
+        downgrade=downgrade,
+        downgrade_policy=policy,
     )

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/build_planning/test_table_type.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/build_planning/test_table_type.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+from sqlbuild.cli.commands._helpers.build_planning.table_type import (
+    enforce_table_type_downgrade_policy,
+)
+from sqlbuild.cli.commands.exceptions import CliUserError
+from sqlbuild.compiler.planner.models import PlanOutput
+from tests.unit.src.sqlbuild.cli.commands._helpers.build_planning._test_types import (
+    TableTypeDowngradePolicyTestCase,
+)
+from tests.unit.src.sqlbuild.cli.commands._helpers.build_planning.helpers import (
+    build_table_type_entry,
+)
+
+
+class _InputStream(StringIO):
+    def __init__(self, initial_value: str, *, is_tty: bool) -> None:
+        super().__init__(initial_value)
+        self._is_tty = is_tty
+
+    def isatty(self) -> bool:
+        return self._is_tty
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypeDowngradePolicyTestCase(
+            description="deny lists affected models",
+            plan_output=PlanOutput(
+                table_type_entries=(
+                    build_table_type_entry(name="orders", policy="deny"),
+                    build_table_type_entry(name="customers", policy="deny"),
+                )
+            ),
+            allow_table_type_downgrade=False,
+            expected_error_fragment="'orders', 'customers'",
+        ),
+        TableTypeDowngradePolicyTestCase(
+            description="non-interactive confirmation requires CLI flag",
+            plan_output=PlanOutput(table_type_entries=(build_table_type_entry(),)),
+            allow_table_type_downgrade=False,
+            expected_error_fragment="requires confirmation",
+            expected_help_fragment="--allow-table-type-downgrade",
+        ),
+        TableTypeDowngradePolicyTestCase(
+            description="incorrect interactive phrase cancels",
+            plan_output=PlanOutput(table_type_entries=(build_table_type_entry(),)),
+            allow_table_type_downgrade=False,
+            expected_error_fragment="cancelled",
+            input_text="downgrade everything\n",
+            input_is_tty=True,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_unsafe_table_type_downgrade_when_enforcing_then_raises_user_error(
+    test_case: TableTypeDowngradePolicyTestCase,
+) -> None:
+    with pytest.raises(CliUserError) as exc_info:
+        enforce_table_type_downgrade_policy(
+            plan=test_case.plan_output,
+            allow_table_type_downgrade=test_case.allow_table_type_downgrade,
+            input_stream=_InputStream(test_case.input_text, is_tty=test_case.input_is_tty),
+            output_stream=StringIO(),
+        )
+
+    error: CliUserError = exc_info.value
+    assert test_case.expected_error_fragment is not None
+    assert test_case.expected_error_fragment in error.message
+    assert test_case.expected_help_fragment in (error.help or "")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypeDowngradePolicyTestCase(
+            description="CLI flag confirms required downgrade",
+            plan_output=PlanOutput(table_type_entries=(build_table_type_entry(),)),
+            allow_table_type_downgrade=True,
+        ),
+        TableTypeDowngradePolicyTestCase(
+            description="allow policy proceeds silently",
+            plan_output=PlanOutput(table_type_entries=(build_table_type_entry(policy="allow"),)),
+            allow_table_type_downgrade=False,
+        ),
+        TableTypeDowngradePolicyTestCase(
+            description="upgrade is never gated",
+            plan_output=PlanOutput(
+                table_type_entries=(
+                    build_table_type_entry(
+                        downgrade=False,
+                        desired_type="permanent",
+                        actual_type="transient",
+                    ),
+                )
+            ),
+            allow_table_type_downgrade=False,
+        ),
+        TableTypeDowngradePolicyTestCase(
+            description="exact interactive phrase confirms downgrade",
+            plan_output=PlanOutput(table_type_entries=(build_table_type_entry(),)),
+            allow_table_type_downgrade=False,
+            expected_output=(
+                "Downgrading 'orders' to transient may discard up to 90 days of "
+                "time-travel history.\n\n"
+                "Type `downgrade table type for orders` to continue: "
+            ),
+            input_text="downgrade table type for orders\n",
+            input_is_tty=True,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_safe_or_confirmed_table_type_change_when_enforcing_then_allows_execution(
+    test_case: TableTypeDowngradePolicyTestCase,
+) -> None:
+    output: StringIO = StringIO()
+
+    enforce_table_type_downgrade_policy(
+        plan=test_case.plan_output,
+        allow_table_type_downgrade=test_case.allow_table_type_downgrade,
+        input_stream=_InputStream(test_case.input_text, is_tty=test_case.input_is_tty),
+        output_stream=output,
+    )
+
+    assert output.getvalue() == test_case.expected_output
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/config/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/config/_test_types.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+
+from sqlbuild.spec.contracts.models import MaterializationDefaultsConfig, TargetConfig
+from sqlbuild.spec.contracts.types import TableType, TableTypeSource
+
+
+@dataclass(frozen=True)
+class TableTypeResolutionTestCase:
+    description: str
+    model_value: object | None
+    materialization_defaults: MaterializationDefaultsConfig
+    target_config: TargetConfig | None
+    expected_value: TableType
+    expected_source: TableTypeSource
+    expected_declared: bool
+
+
+@dataclass(frozen=True)
+class TableTypeResolutionErrorTestCase:
+    description: str
+    model_value: object
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
+class TableTypeValidationErrorTestCase:
+    description: str
+    materialized: str
+    expected_error_fragment: str
+    expected_declared: bool = True

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/config/test_table_type.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/config/test_table_type.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import pytest
+
+from sqlbuild.compiler.compile._helpers.config.model_validation import validate_table_type
+from sqlbuild.compiler.compile._helpers.config.table_type import resolve_table_type
+from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.compiler.compile.models import CompileModelConfig
+from sqlbuild.spec.contracts.models import (
+    MaterializationDefaultsConfig,
+    MaterializationRetentionDefaults,
+    ResolvedTableType,
+    TargetConfig,
+)
+from sqlbuild.spec.contracts.types import TableType, TableTypeSource
+from tests.unit.src.sqlbuild.compiler.compile._helpers.config._test_types import (
+    TableTypeResolutionErrorTestCase,
+    TableTypeResolutionTestCase,
+    TableTypeValidationErrorTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypeResolutionTestCase(
+            description="model overrides materialization and target",
+            model_value="transient",
+            materialization_defaults=MaterializationDefaultsConfig(
+                table=MaterializationRetentionDefaults(table_type=TableType.PERMANENT)
+            ),
+            target_config=TargetConfig(default_table_type=TableType.PERMANENT),
+            expected_value=TableType.TRANSIENT,
+            expected_source=TableTypeSource.MODEL,
+            expected_declared=True,
+        ),
+        TableTypeResolutionTestCase(
+            description="materialization overrides target",
+            model_value=None,
+            materialization_defaults=MaterializationDefaultsConfig(
+                table=MaterializationRetentionDefaults(table_type=TableType.TRANSIENT)
+            ),
+            target_config=TargetConfig(default_table_type=TableType.PERMANENT),
+            expected_value=TableType.TRANSIENT,
+            expected_source=TableTypeSource.MATERIALIZATION,
+            expected_declared=True,
+        ),
+        TableTypeResolutionTestCase(
+            description="inherit preserves materialization value",
+            model_value="inherit",
+            materialization_defaults=MaterializationDefaultsConfig(
+                table=MaterializationRetentionDefaults(table_type=TableType.PERMANENT)
+            ),
+            target_config=TargetConfig(default_table_type=TableType.TRANSIENT),
+            expected_value=TableType.PERMANENT,
+            expected_source=TableTypeSource.MATERIALIZATION,
+            expected_declared=True,
+        ),
+        TableTypeResolutionTestCase(
+            description="target supplies value without overrides",
+            model_value=None,
+            materialization_defaults=MaterializationDefaultsConfig(),
+            target_config=TargetConfig(default_table_type=TableType.PERMANENT),
+            expected_value=TableType.PERMANENT,
+            expected_source=TableTypeSource.TARGET,
+            expected_declared=True,
+        ),
+        TableTypeResolutionTestCase(
+            description="undeclared value defaults transient",
+            model_value=None,
+            materialization_defaults=MaterializationDefaultsConfig(),
+            target_config=None,
+            expected_value=TableType.TRANSIENT,
+            expected_source=TableTypeSource.DEFAULT,
+            expected_declared=False,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_layered_table_type_when_resolving_then_effective_value_tracks_source(
+    test_case: TableTypeResolutionTestCase,
+) -> None:
+    result: ResolvedTableType = resolve_table_type(
+        materialized="table",
+        model_value=test_case.model_value,
+        materialization_defaults=test_case.materialization_defaults,
+        target_config=test_case.target_config,
+        model_name="orders",
+    )
+
+    assert result.value is test_case.expected_value
+    assert result.source is test_case.expected_source
+    assert result.declared is test_case.expected_declared
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypeResolutionErrorTestCase(
+            description="invalid string is rejected",
+            model_value="temporary",
+            expected_error_fragment="permanent, transient, or inherit",
+        ),
+        TableTypeResolutionErrorTestCase(
+            description="non-string is rejected",
+            model_value=1,
+            expected_error_fragment="permanent, transient, or inherit",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_invalid_model_table_type_when_resolving_then_raises_compile_error(
+    test_case: TableTypeResolutionErrorTestCase,
+) -> None:
+    with pytest.raises(CompileInputError, match=test_case.expected_error_fragment):
+        resolve_table_type(
+            materialized="table",
+            model_value=test_case.model_value,
+            materialization_defaults=MaterializationDefaultsConfig(),
+            target_config=None,
+            model_name="orders",
+        )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypeValidationErrorTestCase(
+            description="view declaration is rejected",
+            materialized="view",
+            expected_error_fragment="not valid for views",
+        ),
+        TableTypeValidationErrorTestCase(
+            description="custom declaration is rejected",
+            materialized="partition_tracked",
+            expected_error_fragment="not supported for materialization",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_non_table_materialization_when_validating_table_type_then_rejects_declaration(
+    test_case: TableTypeValidationErrorTestCase,
+) -> None:
+    config: CompileModelConfig = CompileModelConfig(
+        values={"materialized": test_case.materialized},
+        table_type=ResolvedTableType(
+            value=TableType.PERMANENT,
+            source=TableTypeSource.MODEL,
+            declared=test_case.expected_declared,
+        ),
+    )
+
+    with pytest.raises(CompileInputError, match=test_case.expected_error_fragment):
+        validate_table_type(config=config, model_name="orders")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/_test_types.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from sqlbuild.adapter.contract.models import RetentionState
 from sqlbuild.compiler.planner.types import RetentionDirection, RetentionPlanPhase
+from sqlbuild.spec.contracts.types import TableType, TableTypeDowngradePolicy
 
 
 @dataclass(frozen=True)
@@ -20,3 +21,15 @@ class RetentionPlanningErrorTestCase:
     description: str
     desired_days: int
     expected_error_fragment: str
+
+
+@dataclass(frozen=True)
+class TableTypePlanningTestCase:
+    description: str
+    desired_type: TableType
+    live_is_transient: bool | None
+    relation_exists: bool
+    downgrade_policy: TableTypeDowngradePolicy
+    expected_entry_count: int
+    expected_actual_type: str | None
+    expected_downgrade: bool

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/helpers.py
@@ -19,8 +19,17 @@ from sqlbuild.compiler.planner.models import (
     PlannerWarehouseState,
     WarehouseSnapshot,
 )
-from sqlbuild.spec.contracts.models import ResolvedTimeTravelRetention
-from sqlbuild.spec.contracts.types import TimeTravelRetentionSource
+from sqlbuild.spec.contracts.models import (
+    LocalConfig,
+    ProjectConfig,
+    ResolvedTableType,
+    ResolvedTimeTravelRetention,
+    TargetConfig,
+)
+from sqlbuild.spec.contracts.types import (
+    TableTypeDowngradePolicy,
+    TimeTravelRetentionSource,
+)
 
 
 def build_retention_planner_inputs(
@@ -29,6 +38,8 @@ def build_retention_planner_inputs(
     desired_days: int,
     existing_relations: dict[str, RelationInfo],
     config_values: dict[str, object],
+    table_type: ResolvedTableType | None = None,
+    table_type_downgrade: TableTypeDowngradePolicy = TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
 ) -> tuple[PlannerRuntime, PlannerWarehouseState, PlannerScope]:
     key: CompiledObjectKey = CompiledObjectKey(
         resource_type=CompiledResourceType.MODEL,
@@ -47,6 +58,7 @@ def build_retention_planner_inputs(
                 unmanaged=False,
                 source=TimeTravelRetentionSource.MODEL,
             ),
+            table_type=table_type or ResolvedTableType(),
         ),
         destination=CompiledRelationLocation(
             database="warehouse",
@@ -84,7 +96,17 @@ def build_retention_planner_inputs(
         ),
     )
     return (
-        PlannerRuntime(project=project, adapter=adapter, connection=object()),
+        PlannerRuntime(
+            project=project,
+            adapter=adapter,
+            connection=object(),
+            project_config=ProjectConfig(
+                name="test",
+                adapter=str(adapter.adapter_name),
+                targets={"test": TargetConfig(table_type_downgrade=table_type_downgrade)},
+            ),
+            local_config=LocalConfig(),
+        ),
         warehouse,
         scope,
     )

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/test_retention.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/test_retention.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import UTC, datetime
 from unittest.mock import Mock
 
 import pytest
@@ -15,19 +16,29 @@ from sqlbuild.adapter.contract.types import (
     RetentionChangePhase,
     RetentionScope,
 )
-from sqlbuild.compiler.planner._helpers.planning.retention import plan_retention
+from sqlbuild.compiler.fingerprints.models import Fingerprint
+from sqlbuild.compiler.planner._helpers.planning.retention import plan_retention, plan_table_types
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.models import (
     PlannerRuntime,
     PlannerScope,
     PlannerWarehouseState,
     RetentionPlanEntry,
+    TableTypePlanEntry,
+    WarehouseFingerprints,
 )
 from sqlbuild.compiler.planner.types import RetentionDirection, RetentionPlanPhase
-from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig, TargetConfig
+from sqlbuild.spec.contracts.models import (
+    LocalConfig,
+    ProjectConfig,
+    ResolvedTableType,
+    TargetConfig,
+)
+from sqlbuild.spec.contracts.types import TableType, TableTypeDowngradePolicy, TableTypeSource
 from tests.unit.src.sqlbuild.compiler.planner._helpers.planning._test_types import (
     RetentionPlanningErrorTestCase,
     RetentionPlanningTestCase,
+    TableTypePlanningTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.planner._helpers.planning.helpers import (
     build_retention_planner_inputs,
@@ -41,6 +52,269 @@ _EXISTING_ORDERS: dict[str, RelationInfo] = {
         relation_type="table",
     )
 }
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypePlanningTestCase(
+            description="transient live table plans permanent upgrade",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=True,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=1,
+            expected_actual_type="transient",
+            expected_downgrade=False,
+        ),
+        TableTypePlanningTestCase(
+            description="permanent live table plans transient downgrade with target policy",
+            desired_type=TableType.TRANSIENT,
+            live_is_transient=False,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.DENY,
+            expected_entry_count=1,
+            expected_actual_type="permanent",
+            expected_downgrade=True,
+        ),
+        TableTypePlanningTestCase(
+            description="unknown live metadata plans fail-closed execution entry",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=None,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.ALLOW,
+            expected_entry_count=1,
+            expected_actual_type=None,
+            expected_downgrade=False,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_table_type_drift_when_planning_then_independent_entry_tracks_actual_and_policy(
+    test_case: TableTypePlanningTestCase,
+) -> None:
+    adapter: Mock = Mock(adapter_name=BuiltinAdapter.SNOWFLAKE.value)
+    adapter.maximum_identifier_length.return_value = 255
+    relation: RelationInfo = RelationInfo(
+        database="warehouse",
+        schema="analytics",
+        name="orders",
+        relation_type="BASE TABLE",
+        is_transient=test_case.live_is_transient,
+    )
+    runtime, warehouse, scope = build_retention_planner_inputs(
+        adapter=adapter,
+        desired_days=1,
+        existing_relations={"orders": relation},
+        config_values={"materialized": "table"},
+        table_type=ResolvedTableType(
+            value=test_case.desired_type,
+            source=TableTypeSource.MODEL,
+            declared=True,
+        ),
+        table_type_downgrade=test_case.downgrade_policy,
+    )
+
+    entries: tuple[TableTypePlanEntry, ...] = plan_table_types(
+        runtime=runtime, warehouse=warehouse, scope=scope
+    )
+
+    assert len(entries) == test_case.expected_entry_count
+    assert entries[0].actual_type == test_case.expected_actual_type
+    assert entries[0].downgrade is test_case.expected_downgrade
+    assert entries[0].downgrade_policy == test_case.downgrade_policy.value
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypePlanningTestCase(
+            description="matched permanent table has no conversion",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=False,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=0,
+            expected_actual_type=None,
+            expected_downgrade=False,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_matched_or_missing_table_when_planning_type_then_no_entry_is_created(
+    test_case: TableTypePlanningTestCase,
+) -> None:
+    adapter: Mock = Mock(adapter_name=BuiltinAdapter.SNOWFLAKE.value)
+    adapter.maximum_identifier_length.return_value = 255
+    runtime, warehouse, scope = build_retention_planner_inputs(
+        adapter=adapter,
+        desired_days=1,
+        existing_relations={
+            "orders": RelationInfo(
+                database="warehouse",
+                schema="analytics",
+                name="orders",
+                relation_type="BASE TABLE",
+                is_transient=test_case.live_is_transient,
+            )
+        },
+        config_values={"materialized": "table"},
+        table_type=ResolvedTableType(
+            value=test_case.desired_type,
+            source=TableTypeSource.MODEL,
+            declared=True,
+        ),
+    )
+    entries: tuple[TableTypePlanEntry, ...] = plan_table_types(
+        runtime=runtime, warehouse=warehouse, scope=scope
+    )
+
+    assert len(entries) == test_case.expected_entry_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypePlanningTestCase(
+            description="missing relation has no conversion",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=None,
+            relation_exists=False,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=0,
+            expected_actual_type=None,
+            expected_downgrade=False,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_missing_table_when_planning_type_then_no_entry_is_created(
+    test_case: TableTypePlanningTestCase,
+) -> None:
+    adapter: Mock = Mock(adapter_name=BuiltinAdapter.SNOWFLAKE.value)
+    adapter.maximum_identifier_length.return_value = 255
+    runtime, warehouse, scope = build_retention_planner_inputs(
+        adapter=adapter,
+        desired_days=1,
+        existing_relations={},
+        config_values={"materialized": "table"},
+        table_type=ResolvedTableType(
+            value=test_case.desired_type,
+            source=TableTypeSource.MODEL,
+            declared=True,
+        ),
+    )
+
+    entries: tuple[TableTypePlanEntry, ...] = plan_table_types(
+        runtime=runtime, warehouse=warehouse, scope=scope
+    )
+
+    assert len(entries) == test_case.expected_entry_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        RetentionPlanningErrorTestCase(
+            description="declared table type on DuckDB fails closed",
+            desired_days=1,
+            expected_error_fragment="not supported on this adapter",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_declared_table_type_on_non_snowflake_when_planning_then_raises(
+    test_case: RetentionPlanningErrorTestCase,
+) -> None:
+    adapter: Mock = Mock(adapter_name=BuiltinAdapter.DUCKDB.value)
+    runtime, warehouse, scope = build_retention_planner_inputs(
+        adapter=adapter,
+        desired_days=test_case.desired_days,
+        existing_relations={},
+        config_values={"materialized": "table"},
+        table_type=ResolvedTableType(
+            value=TableType.PERMANENT,
+            source=TableTypeSource.MODEL,
+            declared=True,
+        ),
+    )
+
+    with pytest.raises(PlannerInputError, match=test_case.expected_error_fragment):
+        plan_table_types(runtime=runtime, warehouse=warehouse, scope=scope)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypePlanningTestCase(
+            description="selected current model still receives conversion entry",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=True,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=1,
+            expected_actual_type="transient",
+            expected_downgrade=False,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_changes_only_current_model_when_planning_type_then_selection_still_produces_entry(
+    test_case: TableTypePlanningTestCase,
+) -> None:
+    adapter: Mock = Mock(adapter_name=BuiltinAdapter.SNOWFLAKE.value)
+    adapter.maximum_identifier_length.return_value = 255
+    runtime: PlannerRuntime
+    warehouse: PlannerWarehouseState
+    scope: PlannerScope
+    runtime, warehouse, scope = build_retention_planner_inputs(
+        adapter=adapter,
+        desired_days=1,
+        existing_relations={
+            "orders": RelationInfo(
+                database="warehouse",
+                schema="analytics",
+                name="orders",
+                relation_type="BASE TABLE",
+                is_transient=test_case.live_is_transient,
+            )
+        },
+        config_values={"materialized": "table"},
+        table_type=ResolvedTableType(
+            value=test_case.desired_type,
+            source=TableTypeSource.MODEL,
+            declared=True,
+        ),
+    )
+    warehouse = replace(
+        warehouse,
+        snapshot=replace(
+            warehouse.snapshot,
+            fingerprints=WarehouseFingerprints(
+                models={
+                    "orders": Fingerprint(
+                        node_type="model",
+                        node_name="orders",
+                        target_database="warehouse",
+                        target_schema="analytics",
+                        target_name="orders",
+                        run_id="prior-run",
+                        definition_hash="current",
+                        schema_fingerprint="current",
+                        definition="SELECT 1 AS order_id",
+                        ts=datetime(2026, 1, 1, tzinfo=UTC),
+                        version_hash="current",
+                    )
+                }
+            ),
+        ),
+    )
+
+    entries: tuple[TableTypePlanEntry, ...] = plan_table_types(
+        runtime=runtime, warehouse=warehouse, scope=scope
+    )
+
+    assert len(entries) == test_case.expected_entry_count
 
 
 @pytest.mark.parametrize(
@@ -177,6 +451,132 @@ def test_given_existing_transient_snowflake_relation_above_limit_when_planning_t
 
     with pytest.raises(PlannerInputError, match=test_case.expected_error_fragment):
         plan_retention(runtime=runtime, warehouse=warehouse, scope=scope)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        RetentionPlanningTestCase(
+            description="transient table becoming permanent defers retention until conversion",
+            desired_days=30,
+            observed_state=RetentionState(
+                request_id="orders",
+                scope=RetentionScope.RELATION,
+                configured_days=1,
+                effective_days=1,
+                is_transient=True,
+            ),
+            expected_direction=RetentionDirection.APPLY_AFTER_CREATE,
+            expected_phase=RetentionPlanPhase.AFTER_CREATE,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_transient_live_table_and_permanent_effective_type_when_planning_then_converts_first(
+    test_case: RetentionPlanningTestCase,
+) -> None:
+    adapter: Mock = Mock(adapter_name=BuiltinAdapter.SNOWFLAKE.value)
+    adapter.maximum_identifier_length.return_value = 255
+    adapter.inspect_retention.return_value = test_case.observed_state
+    adapter.render_retention_changes.return_value = (
+        RenderedRetentionChange(
+            phase=RetentionChangePhase.ALTER,
+            statements=("ALTER RETENTION",),
+        ),
+    )
+    runtime, warehouse, scope = build_retention_planner_inputs(
+        adapter=adapter,
+        desired_days=test_case.desired_days,
+        existing_relations={
+            "orders": RelationInfo(
+                database="warehouse",
+                schema="analytics",
+                name="orders",
+                relation_type="BASE TABLE",
+                is_transient=True,
+            )
+        },
+        config_values={"materialized": "table"},
+        table_type=ResolvedTableType(
+            value=TableType.PERMANENT,
+            source=TableTypeSource.MODEL,
+            declared=True,
+        ),
+    )
+
+    conversions: tuple[TableTypePlanEntry, ...] = plan_table_types(
+        runtime=runtime, warehouse=warehouse, scope=scope
+    )
+    retention: tuple[RetentionPlanEntry, ...] = plan_retention(
+        runtime=runtime, warehouse=warehouse, scope=scope
+    )
+
+    assert len(conversions) == 1
+    assert retention[0].direction == test_case.expected_direction
+    assert retention[0].phase == test_case.expected_phase
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        RetentionPlanningTestCase(
+            description="already permanent table plans ordinary retention increase",
+            desired_days=30,
+            observed_state=RetentionState(
+                request_id="orders",
+                scope=RetentionScope.RELATION,
+                configured_days=1,
+                effective_days=1,
+                is_transient=False,
+            ),
+            expected_direction=RetentionDirection.INCREASE,
+            expected_phase=RetentionPlanPhase.PRE,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_permanent_live_table_with_retention_drift_when_planning_then_only_alters_retention(
+    test_case: RetentionPlanningTestCase,
+) -> None:
+    adapter: Mock = Mock(adapter_name=BuiltinAdapter.SNOWFLAKE.value)
+    adapter.maximum_identifier_length.return_value = 255
+    adapter.inspect_retention.return_value = test_case.observed_state
+    adapter.render_retention_changes.return_value = (
+        RenderedRetentionChange(
+            phase=RetentionChangePhase.PREPARE,
+            statements=("ALTER RETENTION",),
+        ),
+    )
+    runtime, warehouse, scope = build_retention_planner_inputs(
+        adapter=adapter,
+        desired_days=test_case.desired_days,
+        existing_relations={
+            "orders": RelationInfo(
+                database="warehouse",
+                schema="analytics",
+                name="orders",
+                relation_type="BASE TABLE",
+                is_transient=False,
+            )
+        },
+        config_values={"materialized": "table"},
+        table_type=ResolvedTableType(
+            value=TableType.PERMANENT,
+            source=TableTypeSource.MODEL,
+            declared=True,
+        ),
+    )
+
+    conversions: tuple[TableTypePlanEntry, ...] = plan_table_types(
+        runtime=runtime, warehouse=warehouse, scope=scope
+    )
+    retention: tuple[RetentionPlanEntry, ...] = plan_retention(
+        runtime=runtime, warehouse=warehouse, scope=scope
+    )
+
+    assert len(conversions) == 0
+    assert retention[0].direction == test_case.expected_direction
+    assert retention[0].phase == test_case.expected_phase
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/test_retention.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/test_retention.py
@@ -126,7 +126,7 @@ def test_given_retention_policy_when_planning_then_orders_metadata_safely(
         RetentionPlanningErrorTestCase(
             description="missing Snowflake relation above transient limit",
             desired_days=30,
-            expected_error_fragment="new Snowflake tables are transient",
+            expected_error_fragment="set table_type permanent",
         )
     ],
     ids=lambda case: case.description,

--- a/tests/unit/src/sqlbuild/executor/build/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/build/_helpers/_test_types.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+from sqlbuild.adapter.contract.models import RelationInfo
 from sqlbuild.adapter.contract.types import RetentionChangePhase
 from sqlbuild.compiler.discovery.models import DiscoveredLoaderFunction
 from sqlbuild.compiler.planner.types import RetentionPlanPhase
@@ -51,6 +52,13 @@ class BuildModelRetentionReconciliationTestCase:
     desired_days: int
     effective_days: int
     change_phase: RetentionChangePhase
+    expected_statements: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TableTypeConversionTestCase:
+    description: str
+    relation_snapshots: tuple[tuple[RelationInfo, ...], ...]
     expected_statements: tuple[str, ...]
 
 

--- a/tests/unit/src/sqlbuild/executor/build/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/build/_helpers/_test_types.py
@@ -63,6 +63,14 @@ class TableTypeConversionTestCase:
 
 
 @dataclass(frozen=True)
+class TableTypeConversionErrorTestCase:
+    description: str
+    relation_snapshots: tuple[tuple[RelationInfo, ...], ...]
+    expected_error_fragment: str
+    expected_statements: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class BuildSchedulerModelHookTestCase:
     description: str
     hook_raises: bool

--- a/tests/unit/src/sqlbuild/executor/build/_helpers/test_retention.py
+++ b/tests/unit/src/sqlbuild/executor/build/_helpers/test_retention.py
@@ -5,23 +5,50 @@ from unittest.mock import Mock, call
 import pytest
 
 from sqlbuild.adapter.contract.models import (
+    RelationInfo,
     RenderedRetentionChange,
     RetentionRequest,
     RetentionState,
 )
 from sqlbuild.adapter.contract.types import RetentionChangePhase, RetentionScope
-from sqlbuild.compiler.planner.models import PlanOutput, RetentionPlanEntry
+from sqlbuild.compiler.compile.models import CompiledRelationLocation
+from sqlbuild.compiler.planner.exceptions import PlannerInputError
+from sqlbuild.compiler.planner.models import PlanOutput, RetentionPlanEntry, TableTypePlanEntry
 from sqlbuild.compiler.planner.types import (
     RetentionDirection,
     RetentionPlanPhase,
 )
 from sqlbuild.executor.build._helpers.retention import (
     apply_retention_phase,
+    apply_table_type_conversions,
     reconcile_model_retention,
 )
 from tests.unit.src.sqlbuild.executor.build._helpers._test_types import (
     BuildModelRetentionReconciliationTestCase,
     BuildRetentionPhaseTestCase,
+    TableTypeConversionTestCase,
+)
+
+_TARGET: RelationInfo = RelationInfo(
+    database="warehouse",
+    schema="analytics",
+    name="orders",
+    relation_type="BASE TABLE",
+    is_transient=False,
+)
+_TRANSIENT_TARGET: RelationInfo = RelationInfo(
+    database="warehouse",
+    schema="analytics",
+    name="orders",
+    relation_type="BASE TABLE",
+    is_transient=True,
+)
+_COPY: RelationInfo = RelationInfo(
+    database="warehouse",
+    schema="analytics",
+    name="__sqb_type_swap__orders",
+    relation_type="BASE TABLE",
+    is_transient=False,
 )
 
 
@@ -160,3 +187,122 @@ def test_given_successful_model_when_reconciling_retention_then_defers_decreases
     assert adapter.execute.call_args_list == [
         call(connection=connection, sql=statement) for statement in test_case.expected_statements
     ]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypeConversionTestCase(
+            description="undesired target with stale copy recreates before swap",
+            relation_snapshots=(
+                (_TRANSIENT_TARGET, _COPY),
+                (_COPY,),
+            ),
+            expected_statements=(
+                "CREATE OR REPLACE TABLE warehouse.analytics.__sqb_type_swap__orders AS SELECT * "
+                "FROM warehouse.analytics.orders",
+                "ALTER TABLE warehouse.analytics.orders SWAP WITH "
+                "warehouse.analytics.__sqb_type_swap__orders",
+                "DROP TABLE IF EXISTS warehouse.analytics.__sqb_type_swap__orders",
+            ),
+        ),
+        TableTypeConversionTestCase(
+            description="desired target with leftover copy only cleans copy",
+            relation_snapshots=((_TARGET, _COPY),),
+            expected_statements=(
+                "DROP TABLE IF EXISTS warehouse.analytics.__sqb_type_swap__orders",
+            ),
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_recoverable_table_type_state_when_converting_then_uses_inspection_only_recovery(
+    test_case: TableTypeConversionTestCase,
+) -> None:
+    adapter: Mock = Mock()
+    adapter.render_qualified_name.side_effect = lambda *, database, schema, name: ".".join(
+        (database, schema, name)
+    )
+    adapter.list_relations.side_effect = test_case.relation_snapshots
+    connection: object = object()
+    entry: TableTypePlanEntry = TableTypePlanEntry(
+        model_name="orders",
+        destination=CompiledRelationLocation(
+            database="warehouse",
+            schema="analytics",
+            name="orders",
+            qualified_name="warehouse.analytics.orders",
+        ),
+        copy_name="__sqb_type_swap__orders",
+        desired_type="permanent",
+        actual_type="transient",
+        source="model",
+        downgrade=False,
+        downgrade_policy="require_confirmation",
+    )
+
+    apply_table_type_conversions(
+        plan=PlanOutput(table_type_entries=(entry,)), adapter=adapter, connection=connection
+    )
+
+    assert tuple(item.kwargs["sql"] for item in adapter.execute.call_args_list) == (
+        test_case.expected_statements
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypeConversionTestCase(
+            description="unknown live metadata fails before SQL",
+            relation_snapshots=(
+                (
+                    RelationInfo(
+                        database="warehouse",
+                        schema="analytics",
+                        name="orders",
+                        relation_type="BASE TABLE",
+                    ),
+                ),
+            ),
+            expected_statements=(),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_unknown_live_table_type_when_converting_then_fails_closed(
+    test_case: TableTypeConversionTestCase,
+) -> None:
+    adapter: Mock = Mock()
+    adapter.render_qualified_name.side_effect = lambda *, database, schema, name: ".".join(
+        (database, schema, name)
+    )
+    adapter.list_relations.side_effect = test_case.relation_snapshots
+    entry: TableTypePlanEntry = TableTypePlanEntry(
+        model_name="orders",
+        destination=CompiledRelationLocation(
+            database="warehouse",
+            schema="analytics",
+            name="orders",
+            qualified_name="warehouse.analytics.orders",
+        ),
+        copy_name="__sqb_type_swap__orders",
+        desired_type="permanent",
+        actual_type=None,
+        source="model",
+        downgrade=False,
+        downgrade_policy="require_confirmation",
+    )
+
+    with pytest.raises(PlannerInputError, match="metadata is unknown"):
+        apply_table_type_conversions(
+            plan=PlanOutput(table_type_entries=(entry,)), adapter=adapter, connection=object()
+        )
+
+    assert tuple(item.kwargs["sql"] for item in adapter.execute.call_args_list) == (
+        test_case.expected_statements
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/unit/src/sqlbuild/executor/build/_helpers/test_retention.py
+++ b/tests/unit/src/sqlbuild/executor/build/_helpers/test_retention.py
@@ -12,12 +12,12 @@ from sqlbuild.adapter.contract.models import (
 )
 from sqlbuild.adapter.contract.types import RetentionChangePhase, RetentionScope
 from sqlbuild.compiler.compile.models import CompiledRelationLocation
-from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.models import PlanOutput, RetentionPlanEntry, TableTypePlanEntry
 from sqlbuild.compiler.planner.types import (
     RetentionDirection,
     RetentionPlanPhase,
 )
+from sqlbuild.errors.contracts.exceptions import ExecutorInputError
 from sqlbuild.executor.build._helpers.retention import (
     apply_retention_phase,
     apply_table_type_conversions,
@@ -26,6 +26,7 @@ from sqlbuild.executor.build._helpers.retention import (
 from tests.unit.src.sqlbuild.executor.build._helpers._test_types import (
     BuildModelRetentionReconciliationTestCase,
     BuildRetentionPhaseTestCase,
+    TableTypeConversionErrorTestCase,
     TableTypeConversionTestCase,
 )
 
@@ -294,7 +295,73 @@ def test_given_unknown_live_table_type_when_converting_then_fails_closed(
         downgrade_policy="require_confirmation",
     )
 
-    with pytest.raises(PlannerInputError, match="metadata is unknown"):
+    with pytest.raises(ExecutorInputError, match="metadata is unknown"):
+        apply_table_type_conversions(
+            plan=PlanOutput(table_type_entries=(entry,)), adapter=adapter, connection=object()
+        )
+
+    assert tuple(item.kwargs["sql"] for item in adapter.execute.call_args_list) == (
+        test_case.expected_statements
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypeConversionErrorTestCase(
+            description="missing target fails before SQL",
+            relation_snapshots=((),),
+            expected_error_fragment="target no longer exists",
+            expected_statements=(),
+        ),
+        TableTypeConversionErrorTestCase(
+            description="wrong copy type fails before swap",
+            relation_snapshots=(
+                (_TRANSIENT_TARGET,),
+                (
+                    RelationInfo(
+                        database="warehouse",
+                        schema="analytics",
+                        name="__sqb_type_swap__orders",
+                        relation_type="BASE TABLE",
+                        is_transient=True,
+                    ),
+                ),
+            ),
+            expected_error_fragment="not created with the desired type",
+            expected_statements=(
+                "CREATE OR REPLACE TABLE warehouse.analytics.__sqb_type_swap__orders AS SELECT * "
+                "FROM warehouse.analytics.orders",
+            ),
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_unrecoverable_table_type_state_when_converting_then_fails_before_swap(
+    test_case: TableTypeConversionErrorTestCase,
+) -> None:
+    adapter: Mock = Mock()
+    adapter.render_qualified_name.side_effect = lambda *, database, schema, name: ".".join(
+        (database, schema, name)
+    )
+    adapter.list_relations.side_effect = test_case.relation_snapshots
+    entry: TableTypePlanEntry = TableTypePlanEntry(
+        model_name="orders",
+        destination=CompiledRelationLocation(
+            database="warehouse",
+            schema="analytics",
+            name="orders",
+            qualified_name="warehouse.analytics.orders",
+        ),
+        copy_name="__sqb_type_swap__orders",
+        desired_type="permanent",
+        actual_type="transient",
+        source="model",
+        downgrade=False,
+        downgrade_policy="require_confirmation",
+    )
+
+    with pytest.raises(ExecutorInputError, match=test_case.expected_error_fragment):
         apply_table_type_conversions(
             plan=PlanOutput(table_type_entries=(entry,)), adapter=adapter, connection=object()
         )

--- a/tests/unit/src/sqlbuild/executor/run/_helpers/test_snapshot_adapter_boundary.py
+++ b/tests/unit/src/sqlbuild/executor/run/_helpers/test_snapshot_adapter_boundary.py
@@ -118,6 +118,7 @@ class _SnapshotRenderingAdapter(DuckDbAdapter):
     def render_create_initial_historical_timestamp_changes_destination(
         self,
         *,
+        table_type: str,
         destination: str,
         origin: str,
         unique_key: tuple[str, ...],
@@ -127,6 +128,7 @@ class _SnapshotRenderingAdapter(DuckDbAdapter):
         output_columns: tuple[str, ...],
     ) -> tuple[str, ...]:
         del (
+            table_type,
             origin,
             unique_key,
             updated_at_column,


### PR DESCRIPTION
## Why

Snowflake retention above one day requires permanent tables, but SQLBuild hardcoded transient creation and had no safe conversion; a full refresh could silently revert a permanent table and destroy its time-travel history. This makes table type declarative, self-converging, and downgrade-safe.

## Changes

- Layered `table_type` config (target `default_table_type` < materialization defaults < model) with source tracking, mirroring retention resolution. Undeclared stays transient. Snowflake-only; other adapters fail closed; views/custom reject at compile.
- Every promoted creation site renders the effective type (staged/immediate tables, incremental and microbatch first-run and full-refresh creates, typed snapshot renderer contracts, type-enforcement rebuilds). Ephemeral deltas stay transient.
- Automatic copy-swap conversion on live-type drift: verified typed copy, atomic `SWAP WITH`, inspection-only recovery, no stored state, unknown metadata fails closed.
- Drift planned from the warehouse snapshot as independent entries, fingerprint-free, so changes-only-skipped models still converge; `table_type` stays out of version identity.
- Downgrades gated by `table_type_downgrade` (default require_confirmation) with typed confirmation or `--allow-table-type-downgrade`, mirroring the snapshot full-refresh gate.
- Retention planner: >1d on transient with effective permanent plans conversion plus retention; effective transient keeps a hard error. Conversion runs before retention and the scheduler.

## Verification

- 4948 unit/integration passed; E2E slices plan 54 / janitor 16 / build 585
- New matrix: config precedence, per-site DDL, drift planning incl. changes-only independence, copy-swap recovery both sides, all gate paths, retention regressions
- Ruff, ty, Fensu 0 faults all clean

Refs CHI-156.
