### PR TITLE
fix: add scopes enforce_placement flag for staged policy adoption

### DIFF
--- a/src/sqlbuild/compiler/compile/main/_scope_index_with_compile_usages.py
+++ b/src/sqlbuild/compiler/compile/main/_scope_index_with_compile_usages.py
@@ -64,4 +64,7 @@ def scope_index_with_compile_usages(*, inputs: CompileProjectInputs) -> ScopeInd
             promotion_impact=True,
         ),
     )
-    return get_placement_validated_scope_index(index=index)
+    return get_placement_validated_scope_index(
+        index=index,
+        enforce_placement=inputs.project_config.scopes.enforce_placement,
+    )

--- a/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
@@ -50,6 +50,7 @@ from sqlbuild.spec.contracts.models import (
     ProjectConfig,
     ScenarioConfig,
     ScenarioSnapshotLimitsConfig,
+    ScopesConfig,
     SettingsConfig,
     SnapshotsConfig,
     StateConfig,
@@ -90,6 +91,7 @@ def load_project_config(*, project_dir: Path) -> ProjectConfig:
         payload=payload.get("connections"), file_path=file_path
     )
     settings: SettingsConfig = _load_settings(payload=payload.get("settings"), file_path=file_path)
+    scopes: ScopesConfig = _load_scopes(payload=payload.get("scopes"), file_path=file_path)
     cost: CostConfig = _load_cost(payload=payload.get("cost"), file_path=file_path)
     constants: ConstantsConfig = _load_constants(
         payload=payload.get("constants"), file_path=file_path
@@ -128,6 +130,7 @@ def load_project_config(*, project_dir: Path) -> ProjectConfig:
         connection=connection,
         connections=connections,
         settings=settings,
+        scopes=scopes,
         cost=cost,
         constants=constants,
         defaults=defaults,
@@ -347,6 +350,21 @@ def _load_settings(*, payload: object, file_path: Path) -> SettingsConfig:
         table_promotion_mode=table_promotion_mode,
         default_audit_severity=default_audit_severity,
         default_audit_run_scope=default_audit_run_scope,
+    )
+
+
+def _load_scopes(*, payload: object, file_path: Path) -> ScopesConfig:
+    mapping: dict[str, object] = _coerce_mapping(
+        payload=payload, label="scopes", file_path=file_path
+    )
+    _validate_allowed_keys(
+        mapping=mapping,
+        allowed_keys=frozenset({"enforce_placement"}),
+        label="scopes",
+        file_path=file_path,
+    )
+    return ScopesConfig(
+        enforce_placement=_optional_bool(mapping=mapping, key="enforce_placement", default=True)
     )
 
 

--- a/src/sqlbuild/compiler/scopes/_helpers/placement.py
+++ b/src/sqlbuild/compiler/scopes/_helpers/placement.py
@@ -17,7 +17,7 @@ from sqlbuild.compiler.scopes.models import (
     ScopeIndex,
     UsageRecord,
 )
-from sqlbuild.compiler.scopes.types import ScopeDiagnosticCode, ScopeKind
+from sqlbuild.compiler.scopes.types import DiagnosticSeverity, ScopeDiagnosticCode, ScopeKind
 
 type _Anchor = tuple[OwnershipRoot, str]
 type _UsagesByDeclaration = dict[DeclarationIdentity, tuple[UsageRecord, ...]]
@@ -34,7 +34,9 @@ _PLACEMENT_CODES: frozenset[ScopeDiagnosticCode] = frozenset(
 )
 
 
-def build_placement_validated_index(*, index: ScopeIndex) -> ScopeIndex:
+def build_placement_validated_index(
+    *, index: ScopeIndex, enforce_placement: bool = True
+) -> ScopeIndex:
     """Return the index with deterministic unused and exact-placement diagnostics."""
 
     if not index.completeness.runtime_usage:
@@ -68,6 +70,7 @@ def build_placement_validated_index(*, index: ScopeIndex) -> ScopeIndex:
                 _diagnostic(
                     declaration=declaration,
                     code=ScopeDiagnosticCode.UNUSED_DECLARATION,
+                    enforce_placement=enforce_placement,
                     message=f"Unused {declaration.scope.value} declaration "
                     f"'{format_identity(identity=declaration.identity)}' at {declaration.path}; "
                     "remove it or add a genuine runtime use",
@@ -94,6 +97,7 @@ def build_placement_validated_index(*, index: ScopeIndex) -> ScopeIndex:
                 _diagnostic(
                     declaration=declaration,
                     code=ScopeDiagnosticCode.REQUIRES_GLOBAL_PLACEMENT,
+                    enforce_placement=enforce_placement,
                     message=_message(
                         declaration=declaration,
                         required_scope=ScopeKind.GLOBAL,
@@ -116,6 +120,7 @@ def build_placement_validated_index(*, index: ScopeIndex) -> ScopeIndex:
             _diagnostic(
                 declaration=declaration,
                 code=code,
+                enforce_placement=enforce_placement,
                 message=_message(
                     declaration=declaration,
                     required_scope=required_scope,
@@ -276,7 +281,11 @@ def _scope_label(scope: ScopeKind) -> str:
 
 
 def _diagnostic(
-    *, declaration: DeclarationRecord, code: ScopeDiagnosticCode, message: str
+    *,
+    declaration: DeclarationRecord,
+    code: ScopeDiagnosticCode,
+    message: str,
+    enforce_placement: bool,
 ) -> ScopeDiagnostic:
     return ScopeDiagnostic(
         code=code,
@@ -285,6 +294,7 @@ def _diagnostic(
         line=declaration.line,
         column=declaration.column,
         declaration=declaration.identity,
+        severity=(DiagnosticSeverity.ERROR if enforce_placement else DiagnosticSeverity.WARNING),
     )
 
 

--- a/src/sqlbuild/compiler/scopes/constants.py
+++ b/src/sqlbuild/compiler/scopes/constants.py
@@ -27,6 +27,7 @@ SCOPE_PROJECT_CONFIG_KEYS: frozenset[str] = frozenset(
         "default_target",
         "defaults",
         "path_defaults",
+        "scopes",
         "settings",
         "targets",
         "vars",

--- a/src/sqlbuild/compiler/scopes/main/_get_placement_validated_scope_index.py
+++ b/src/sqlbuild/compiler/scopes/main/_get_placement_validated_scope_index.py
@@ -6,7 +6,9 @@ from sqlbuild.compiler.scopes._helpers.placement import build_placement_validate
 from sqlbuild.compiler.scopes.models import ScopeIndex
 
 
-def get_placement_validated_scope_index(*, index: ScopeIndex) -> ScopeIndex:
+def get_placement_validated_scope_index(
+    *, index: ScopeIndex, enforce_placement: bool = True
+) -> ScopeIndex:
     """Return complete deterministic usage and placement diagnostics."""
 
-    return build_placement_validated_index(index=index)
+    return build_placement_validated_index(index=index, enforce_placement=enforce_placement)

--- a/src/sqlbuild/spec/contracts/models.py
+++ b/src/sqlbuild/spec/contracts/models.py
@@ -169,6 +169,13 @@ class SettingsConfig:
 
 
 @dataclass(frozen=True)
+class ScopesConfig:
+    """Declaration scope policy configuration."""
+
+    enforce_placement: bool = True
+
+
+@dataclass(frozen=True)
 class CostConfig:
     """Snowflake compute estimate configuration."""
 
@@ -285,6 +292,7 @@ class ProjectConfig:
     connection: dict[str, object] = field(default_factory=dict)
     connections: dict[str, dict[str, object]] = field(default_factory=dict)
     settings: SettingsConfig = field(default_factory=SettingsConfig)
+    scopes: ScopesConfig = field(default_factory=ScopesConfig)
     cost: CostConfig = field(default_factory=CostConfig)
     constants: ConstantsConfig = field(default_factory=ConstantsConfig)
     defaults: DefaultsConfig = field(default_factory=DefaultsConfig)

--- a/tests/unit/src/sqlbuild/cli/commands/main/dag/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/dag/helpers.py
@@ -54,6 +54,25 @@ def prepare_static_dag_project(root: Path) -> Path:
     return project_dir
 
 
+def prepare_advisory_placement_dag_project(root: Path) -> Path:
+    """Create a dag project with an advisory over-broad global declaration."""
+
+    project_dir: Path = prepare_static_dag_project(root)
+    config_path: Path = project_dir / "sqlbuild_project.toml"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8") + "\n[scopes]\nenforce_placement = false\n",
+        encoding="utf-8",
+    )
+    constants_dir: Path = project_dir / "constants"
+    constants_dir.mkdir()
+    (constants_dir / "value.sql").write_text("CONSTANT (name value, value 1);\n", encoding="utf-8")
+    (project_dir / "models" / "orders.sql").write_text(
+        'MODEL (materialized table);\n\nSELECT @const("value") AS order_id\n',
+        encoding="utf-8",
+    )
+    return project_dir
+
+
 def prepare_python_dag_project(root: Path) -> Path:
     """Create a local project with Python tasks, assets, and checks."""
 

--- a/tests/unit/src/sqlbuild/cli/commands/main/dag/test_dag_command.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/dag/test_dag_command.py
@@ -13,9 +13,50 @@ from tests.unit.src.sqlbuild.cli.commands.main.dag._test_types import (
 )
 from tests.unit.src.sqlbuild.cli.commands.main.dag.helpers import (
     NoConnectDuckDbAdapter,
+    prepare_advisory_placement_dag_project,
     prepare_python_dag_project,
     prepare_static_dag_project,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagCommandTestCase(
+            description="emits dag when over-broad global placement is advisory",
+            expected_exit_code=0,
+            expected_project_name="dag_project",
+            expected_node_id="model:orders",
+            expected_asset_key=("analytics", "orders"),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_advisory_over_broad_global_when_running_dag_then_outputs_static_graph(
+    test_case: DagCommandTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_dir: Path = prepare_advisory_placement_dag_project(tmp_path)
+    monkeypatch.setattr(
+        dag_command,
+        "resolve_adapter",
+        lambda *args, **kwargs: NoConnectDuckDbAdapter(),
+    )
+
+    exit_code: int = run_dag(
+        project_dir=project_dir,
+        no_sql_validation=True,
+        json_output=True,
+    )
+    payload: dict[str, object] = json.loads(capsys.readouterr().out)
+    nodes: list[dict[str, object]] = payload["nodes"]
+
+    assert exit_code == test_case.expected_exit_code
+    assert payload["project_name"] == test_case.expected_project_name
+    assert nodes[0]["id"] == test_case.expected_node_id
+    assert tuple(nodes[0]["asset_key"]) == test_case.expected_asset_key
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
@@ -244,6 +244,8 @@ class ScopePlacementCompileTestCase:
     files: dict[str, str]
     expected_fragment: str | None = None
     expected_complete: bool = True
+    expected_model_names: tuple[str, ...] = ()
+    expected_diagnostics: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_declaration_scopes.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_declaration_scopes.py
@@ -27,7 +27,11 @@ from sqlbuild.compiler.scopes.models import (
     ResourceIdentity,
     UsageRecord,
 )
-from sqlbuild.compiler.scopes.types import DeclarationKind, ResourceKind, UsageKind
+from sqlbuild.compiler.scopes.types import (
+    DeclarationKind,
+    ResourceKind,
+    UsageKind,
+)
 from sqlbuild.spec.contracts.models import SourceEntry
 from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
     ExpectedModelDeclarationGrantTestCase,
@@ -565,6 +569,45 @@ def test_given_invalid_declaration_placement_when_assembling_then_project_is_rej
 
     with pytest.raises(CompileInputError, match=cast(str, test_case.expected_fragment)):
         _ = assemble_project(inputs=inputs, skip_column_inference=True)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        ScopePlacementCompileTestCase(
+            description="over broad global is advisory when placement enforcement is disabled",
+            files={
+                "constants/value.sql": "CONSTANT (name value, value 1);",
+                "models/orders.sql": 'MODEL ();\nSELECT @const("value") AS value',
+            },
+            expected_model_names=("orders",),
+            expected_diagnostics=(("S024", "warning"),),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_disabled_placement_enforcement_when_assembling_then_project_and_warning_are_produced(
+    test_case: ScopePlacementCompileTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    project_file: str = _PROJECT_FILE + "\n[scopes]\nenforce_placement = false\n"
+    write_repo_files(
+        tmp_path,
+        {"sqlbuild_project.toml": project_file} | test_case.files,
+    )
+    inputs: CompileProjectInputs = compile_project_inputs(project_dir=tmp_path)
+
+    compiled: CompiledProject = assemble_project(inputs=inputs, skip_column_inference=True)
+
+    assert tuple(model.name for model in compiled.models) == test_case.expected_model_names
+    assert (
+        tuple(
+            (diagnostic.code.value, diagnostic.severity.value)
+            for diagnostic in compiled.scope_index.diagnostics
+        )
+        == test_case.expected_diagnostics
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
@@ -136,6 +136,7 @@ class LoadProjectConfigTestCase:
     expected_auto_load_sources: bool = True
     expected_virtual_environments: bool = False
     expected_changes_only: bool = False
+    expected_enforce_placement: bool = True
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
@@ -336,6 +336,9 @@ concurrency = 8
 auto_load_sources = false
 changes_only = true
 
+[scopes]
+enforce_placement = false
+
 [defaults]
 materialized = "table"
 seed_database = "seed_db"
@@ -423,6 +426,7 @@ enabled = true
             expected_max_concurrency=8,
             expected_auto_load_sources=False,
             expected_changes_only=True,
+            expected_enforce_placement=False,
             expected_materialized="table",
             expected_row_diff_exclude_columns=("loaded_at",),
             expected_row_diff_tolerances={
@@ -504,6 +508,7 @@ def test_given_project_config_file_when_loading_project_config_then_it_returns_e
     assert config.settings.concurrency == test_case.expected_max_concurrency
     assert config.settings.auto_load_sources is test_case.expected_auto_load_sources
     assert config.settings.changes_only is test_case.expected_changes_only
+    assert config.scopes.enforce_placement is test_case.expected_enforce_placement
     assert config.defaults.materialized == test_case.expected_materialized
     assert config.defaults.row_diff_exclude_columns == test_case.expected_row_diff_exclude_columns
     assert config.defaults.row_diff_tolerances == test_case.expected_row_diff_tolerances
@@ -804,6 +809,17 @@ def test_given_local_config_state_when_loading_local_config_then_it_returns_expe
 @pytest.mark.parametrize(
     "test_case",
     [
+        LoadProjectConfigErrorTestCase(
+            description="raises when scope placement enforcement is not a boolean",
+            project_file_contents="""
+name = "demo"
+adapter = "duckdb"
+
+[scopes]
+enforce_placement = "no"
+""".strip(),
+            expected_error_fragment="Expected 'enforce_placement' to be a boolean when provided",
+        ),
         LoadProjectConfigErrorTestCase(
             description="raises when virtual environments setting is not a boolean",
             project_file_contents="""

--- a/tests/unit/src/sqlbuild/compiler/scopes/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/_test_types.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from sqlbuild.compiler.scopes.models import DeclarationIdentity, ResourceIdentity
 from sqlbuild.compiler.scopes.types import (
+    DiagnosticSeverity,
     InaccessibleReason,
     ResourceKind,
     ScopeDiagnosticCode,
@@ -126,6 +127,15 @@ class PlacementValidationCase:
     consumer_paths: tuple[str, ...]
     expected_codes: tuple[ScopeDiagnosticCode, ...]
     expected_direct_codes: tuple[ScopeDiagnosticCode, ...] = ()
+
+
+@dataclass(frozen=True)
+class PlacementEnforcementCase:
+    """One placement diagnostic enforcement policy case."""
+
+    description: str
+    enforce_placement: bool
+    expected_severity: DiagnosticSeverity
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/scopes/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/helpers.py
@@ -12,6 +12,9 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlModelFile,
     EnumDeclaration,
 )
+from sqlbuild.compiler.scopes.main._get_placement_validated_scope_index import (
+    get_placement_validated_scope_index,
+)
 from sqlbuild.compiler.scopes.main.build_scope_lookup import build_scope_lookup
 from sqlbuild.compiler.scopes.models import (
     ConstantMetadata,
@@ -39,6 +42,30 @@ from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig
 
 SCOPE_CACHE_PROJECT: str = 'name = "demo"\nadapter = "duckdb"\n'
 SCOPE_CACHE_MODEL: str = "MODEL();\nSELECT 1 AS id\n"
+
+
+def unused_declaration_index(*, enforce_placement: bool) -> ScopeIndex:
+    """Build an index containing one unused global declaration diagnostic."""
+
+    declaration_identity: DeclarationIdentity = DeclarationIdentity(
+        DeclarationKind.CONSTANT, "limit"
+    )
+    return get_placement_validated_scope_index(
+        index=ScopeIndex(
+            declarations=(
+                DeclarationRecord(
+                    identity=declaration_identity,
+                    path="constants/limit.sql",
+                    line=1,
+                    column=1,
+                    scope=ScopeKind.GLOBAL,
+                    ownership_root=OwnershipRoot("constants"),
+                ),
+            ),
+            completeness=ScopeCompleteness(runtime_usage=True, placement=False),
+        ),
+        enforce_placement=enforce_placement,
+    )
 
 
 def write_scope_cache_project(

--- a/tests/unit/src/sqlbuild/compiler/scopes/test_offline_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/test_offline_cache.py
@@ -13,7 +13,7 @@ from sqlbuild.compiler.scopes._helpers.cache import scope_index_fingerprint
 from sqlbuild.compiler.scopes.constants import SCOPE_CACHE_DIRECTORY, SCOPE_CACHE_FILENAME
 from sqlbuild.compiler.scopes.main.load_or_build_scope_index import load_or_build_scope_index
 from sqlbuild.compiler.scopes.models import ScopeIndex
-from sqlbuild.compiler.scopes.types import ResourceKind, ScopeDiagnosticCode
+from sqlbuild.compiler.scopes.types import DiagnosticSeverity, ResourceKind, ScopeDiagnosticCode
 from tests.unit.src.sqlbuild.compiler.scopes._test_types import (
     CacheFaultCase,
     FingerprintMutationCase,
@@ -120,6 +120,13 @@ def test_given_no_cache_when_loading_twice_then_cache_is_bypassed(
             "sqlbuild_project.toml",
             _PROJECT + '\n[constants]\ncollection_rendering = "value_list"\n',
             _PROJECT + '\n[constants]\ncollection_rendering = "array"\n',
+            True,
+        ),
+        FingerprintMutationCase(
+            "scope placement enforcement",
+            "sqlbuild_project.toml",
+            _PROJECT + "\n[scopes]\nenforce_placement = true\n",
+            _PROJECT + "\n[scopes]\nenforce_placement = false\n",
             True,
         ),
         FingerprintMutationCase(
@@ -492,6 +499,41 @@ def test_given_placement_invalid_project_when_loading_then_complete_diagnostics_
     )
 
     assert result is test_case.expected_result
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (OfflineScopeCase("placement policy flip rebuilds cached diagnostic severity"),),
+    ids=lambda case: case.description,
+)
+def test_given_cached_placement_error_when_disabling_enforcement_then_cache_returns_warning(
+    test_case: OfflineScopeCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    project_path: Path = tmp_path / "sqlbuild_project.toml"
+    write_repo_files(
+        tmp_path,
+        {
+            "sqlbuild_project.toml": _PROJECT + "\n[scopes]\nenforce_placement = true\n",
+            "constants/value.sql": "CONSTANT (name value, value 1);",
+            "models/orders.sql": 'MODEL ();\nSELECT @const("value") AS value',
+        },
+    )
+    enforced: ScopeIndex = load_or_build_scope_index(project_dir=tmp_path)
+
+    project_path.write_text(_PROJECT + "\n[scopes]\nenforce_placement = false\n", encoding="utf-8")
+    advisory: ScopeIndex = load_or_build_scope_index(project_dir=tmp_path)
+    severities: tuple[DiagnosticSeverity, DiagnosticSeverity] = (
+        enforced.diagnostics[0].severity,
+        advisory.diagnostics[0].severity,
+    )
+
+    assert severities == (
+        DiagnosticSeverity.ERROR,
+        DiagnosticSeverity.WARNING,
+    )
+    assert test_case.expected_result
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/scopes/test_placement.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/test_placement.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import pytest
 
+from sqlbuild.compiler.scopes.exceptions import ScopeValidationError
 from sqlbuild.compiler.scopes.main._get_placement_validated_scope_index import (
     get_placement_validated_scope_index,
 )
+from sqlbuild.compiler.scopes.main._validate_scope_index import validate_scope_index
 from sqlbuild.compiler.scopes.models import (
     DeclarationIdentity,
     DeclarationRecord,
@@ -14,11 +16,13 @@ from sqlbuild.compiler.scopes.models import (
     ResourceIdentity,
     ResourceRecord,
     ScopeCompleteness,
+    ScopeDiagnostic,
     ScopeIndex,
     UsageRecord,
 )
 from sqlbuild.compiler.scopes.types import (
     DeclarationKind,
+    DiagnosticSeverity,
     ResourceKind,
     ScopeDiagnosticCode,
     ScopeKind,
@@ -26,8 +30,78 @@ from sqlbuild.compiler.scopes.types import (
 from tests.unit.src.sqlbuild.compiler.scopes._test_types import (
     DeclarationChainPlacementCase,
     DiamondLadderPlacementCase,
+    PlacementEnforcementCase,
     PlacementValidationCase,
 )
+from tests.unit.src.sqlbuild.compiler.scopes.helpers import unused_declaration_index
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        PlacementEnforcementCase("placement enforcement enabled", True, DiagnosticSeverity.ERROR),
+        PlacementEnforcementCase(
+            "placement enforcement disabled", False, DiagnosticSeverity.WARNING
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_placement_policy_when_validating_then_diagnostic_severity_matches_policy(
+    test_case: PlacementEnforcementCase,
+) -> None:
+    result: ScopeIndex = unused_declaration_index(enforce_placement=test_case.enforce_placement)
+
+    assert result.diagnostics[0].code is ScopeDiagnosticCode.UNUSED_DECLARATION
+    assert result.diagnostics[0].severity is test_case.expected_severity
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (PlacementEnforcementCase("advisory placement", False, DiagnosticSeverity.WARNING),),
+    ids=lambda case: case.description,
+)
+def test_given_warning_placement_diagnostic_when_validating_then_validation_succeeds(
+    test_case: PlacementEnforcementCase,
+) -> None:
+    index: ScopeIndex = unused_declaration_index(enforce_placement=test_case.enforce_placement)
+
+    validate_scope_index(index=index)
+    assert index.diagnostics[0].severity is test_case.expected_severity
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (PlacementEnforcementCase("enforced placement", True, DiagnosticSeverity.ERROR),),
+    ids=lambda case: case.description,
+)
+def test_given_error_placement_diagnostic_when_validating_then_validation_raises(
+    test_case: PlacementEnforcementCase,
+) -> None:
+    index: ScopeIndex = unused_declaration_index(enforce_placement=test_case.enforce_placement)
+
+    with pytest.raises(ScopeValidationError) as error:
+        validate_scope_index(index=index)
+    assert error.value.diagnostics[0].severity is test_case.expected_severity
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (PlacementEnforcementCase("non-placement error", False, DiagnosticSeverity.ERROR),),
+    ids=lambda case: case.description,
+)
+def test_given_non_placement_error_when_placement_enforcement_disabled_then_validation_raises(
+    test_case: PlacementEnforcementCase,
+) -> None:
+    index: ScopeIndex = unused_declaration_index(enforce_placement=test_case.enforce_placement)
+    non_placement_error: ScopeDiagnostic = ScopeDiagnostic(
+        ScopeDiagnosticCode.DUPLICATE_DECLARATION, "duplicate"
+    )
+
+    with pytest.raises(ScopeValidationError) as error:
+        validate_scope_index(
+            index=ScopeIndex(diagnostics=(*index.diagnostics, non_placement_error))
+        )
+    assert error.value.diagnostics[0].severity is test_case.expected_severity
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

The declaration placement policy (#428) ships at error severity with no opt-out, and `sqb dag` fails closed on placement findings (P001). The first real adopting project (dagster-mustard, 89 findings on macros authored before the policy existed) cannot upgrade past 0.66.6 without either bulk-relocating declarations mid-flight or a temporary escape hatch. Decision: keep the policy and its default, add an explicit project-level flag for staged adoption.

## Changes

- New `[scopes] enforce_placement = true|false` in `sqlbuild_project.toml`, default `true` (behavior unchanged unless opted out).
- When `false`, placement-family diagnostics (UNUSED_DECLARATION, LOCAL_NEEDED_BY_DESCENDANT, OVER_BROAD_INHERITED, REQUIRES_GLOBAL_PLACEMENT, OVER_BROAD_GLOBAL) are constructed at WARNING severity: still computed, still reported everywhere, no longer blocking `validate_scope_index`, so compile strict paths and `sqb dag` succeed.
- Non-placement scope diagnostics (parse, duplicates, visibility, relationships) keep error severity regardless of the flag.
- `scopes` participates in the scope cache fingerprint, so flipping the flag invalidates persisted indexes rather than serving stale severities.
- Non-boolean values rejected with the standard config error.

## Verification

- 4957 unit/integration passed (12 pre-existing dagster-extra collection errors only); scope e2e slice passed
- New coverage: parse default/false/invalid, warning vs error severity per policy, validation pass-through with flag off, non-placement errors still blocking, warm-cache invalidation on flag flip, end-to-end compile + dag with an advisory over-broad global
- Ruff, ty (8 pre-existing optional-dep diagnostics), Fensu 0 faults, git diff --check clean

Refs CHI-160.
