### PR TITLE
test: cover table type conversion and bulk event publication paths

### DIFF
--- a/tests/integration/src/sqlbuild/adapters/snowflake/_test_types.py
+++ b/tests/integration/src/sqlbuild/adapters/snowflake/_test_types.py
@@ -10,6 +10,7 @@ from sqlbuild.adapter.contract.models import (
 )
 from sqlbuild.compiler.lineage.types import InferredNullability
 from sqlbuild.cost.types import CostStatus
+from sqlbuild.spec.contracts.types import TableType
 
 
 @dataclass(frozen=True)
@@ -95,6 +96,17 @@ class SnowflakeTableFreshnessMetadataTestCase:
     expected_value_kind: str
     expected_supports_metadata: bool
     expected_data_version_type: type[datetime]
+
+
+@dataclass(frozen=True)
+class SnowflakeTableTypeConversionTestCase:
+    description: str
+    initial_type: TableType
+    initial_table_kind: str
+    desired_type: TableType
+    downgrade: bool
+    expected_is_transient: bool
+    expected_conversion_statement_count: int
 
 
 @dataclass(frozen=True)

--- a/tests/integration/src/sqlbuild/adapters/snowflake/conftest.py
+++ b/tests/integration/src/sqlbuild/adapters/snowflake/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 from sqlbuild.adapters.snowflake.classes.snowflake_adapter import SnowflakeAdapter
 from tests.integration.src.sqlbuild.adapters.snowflake.helpers import (
+    RecordingSnowflakeAdapter,
     build_snowflake_connection_config,
     build_unique_schema_name,
 )
@@ -52,3 +53,27 @@ def connection(
     finally:
         adapter.execute(connection=conn, sql=f"DROP SCHEMA IF EXISTS {schema_target} CASCADE")
         adapter.close(conn)
+
+
+@pytest.fixture
+def recording_adapter() -> RecordingSnowflakeAdapter:
+    return RecordingSnowflakeAdapter()
+
+
+@pytest.fixture
+def recording_connection(
+    recording_adapter: RecordingSnowflakeAdapter,
+    snowflake_database: str,
+    snowflake_schema: str,
+) -> Iterator[Any]:
+    config: dict[str, object] = build_snowflake_connection_config(schema=snowflake_schema)
+    schema_target: str = f"{snowflake_database}.{snowflake_schema}"
+    conn: Any = recording_adapter.connect(config)
+    recording_adapter.execute(connection=conn, sql=f"CREATE SCHEMA IF NOT EXISTS {schema_target}")
+    try:
+        yield conn
+    finally:
+        recording_adapter.execute(
+            connection=conn, sql=f"DROP SCHEMA IF EXISTS {schema_target} CASCADE"
+        )
+        recording_adapter.close(conn)

--- a/tests/integration/src/sqlbuild/adapters/snowflake/helpers.py
+++ b/tests/integration/src/sqlbuild/adapters/snowflake/helpers.py
@@ -147,3 +147,14 @@ def build_statement_recorder() -> StatementRecorder:
     """Build a statement recorder for adapter mutation operations."""
 
     return StatementRecorder()
+
+
+class RecordingSnowflakeAdapter(SnowflakeAdapter):
+    """Snowflake adapter recording statements executed through the adapter seam."""
+
+    def __init__(self) -> None:
+        self.statement_recorder = StatementRecorder()
+
+    def execute(self, *, connection: Any, sql: str) -> Any:
+        self.statement_recorder.record(sql)
+        return super().execute(connection=connection, sql=sql)

--- a/tests/integration/src/sqlbuild/adapters/snowflake/test_table_type_conversion.py
+++ b/tests/integration/src/sqlbuild/adapters/snowflake/test_table_type_conversion.py
@@ -1,0 +1,128 @@
+"""Real Snowflake coverage for executor table-type conversion."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sqlbuild.adapter.contract.models import RelationInfo
+from sqlbuild.compiler.compile.models import CompiledRelationLocation
+from sqlbuild.compiler.planner._helpers.planning.retention import table_type_copy_name
+from sqlbuild.compiler.planner.models import PlanOutput, TableTypePlanEntry
+from sqlbuild.executor.build._helpers.retention import apply_table_type_conversions
+from sqlbuild.spec.contracts.types import TableType
+from tests.integration.src.sqlbuild.adapters.snowflake._test_types import (
+    SnowflakeTableTypeConversionTestCase,
+)
+from tests.integration.src.sqlbuild.adapters.snowflake.helpers import (
+    RecordingSnowflakeAdapter,
+    fetch_rows,
+    qualified_name,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SnowflakeTableTypeConversionTestCase(
+            description="permanent table converts to transient without losing rows",
+            initial_type=TableType.PERMANENT,
+            initial_table_kind="TABLE",
+            desired_type=TableType.TRANSIENT,
+            downgrade=True,
+            expected_is_transient=True,
+            expected_conversion_statement_count=3,
+        ),
+        SnowflakeTableTypeConversionTestCase(
+            description="transient table upgrades to permanent without losing rows",
+            initial_type=TableType.TRANSIENT,
+            initial_table_kind="TRANSIENT TABLE",
+            desired_type=TableType.PERMANENT,
+            downgrade=False,
+            expected_is_transient=False,
+            expected_conversion_statement_count=3,
+        ),
+        SnowflakeTableTypeConversionTestCase(
+            description="permanent table already at desired type is a no-op",
+            initial_type=TableType.PERMANENT,
+            initial_table_kind="TABLE",
+            desired_type=TableType.PERMANENT,
+            downgrade=False,
+            expected_is_transient=False,
+            expected_conversion_statement_count=0,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_existing_snowflake_table_when_applying_table_type_then_metadata_and_rows_are_preserved(
+    test_case: SnowflakeTableTypeConversionTestCase,
+    recording_adapter: RecordingSnowflakeAdapter,
+    recording_connection: Any,
+    snowflake_database: str,
+    snowflake_schema: str,
+) -> None:
+    adapter: RecordingSnowflakeAdapter = recording_adapter
+    connection: Any = recording_connection
+    table_name: str = "table_type_orders"
+    table_target: str = qualified_name(
+        database=snowflake_database, schema=snowflake_schema, name=table_name
+    )
+    adapter.execute(
+        connection=connection,
+        sql=(
+            f"CREATE OR REPLACE {test_case.initial_table_kind} {table_target} "
+            "(id NUMBER, status VARCHAR)"
+        ),
+    )
+    adapter.execute(
+        connection=connection,
+        sql=f"INSERT INTO {table_target} VALUES (1, 'ready'), (2, 'complete')",
+    )
+    copy_name: str = table_type_copy_name(
+        target_name=table_name, identifier_limit=adapter.maximum_identifier_length()
+    )
+    entry: TableTypePlanEntry = TableTypePlanEntry(
+        model_name=table_name,
+        destination=CompiledRelationLocation(
+            database=snowflake_database,
+            schema=snowflake_schema,
+            name=table_name,
+            qualified_name=table_target,
+        ),
+        copy_name=copy_name,
+        desired_type=test_case.desired_type.value,
+        actual_type=test_case.initial_type.value,
+        source="model",
+        downgrade=test_case.downgrade,
+        downgrade_policy="allow",
+    )
+    adapter.statement_recorder.events.clear()
+
+    apply_table_type_conversions(
+        plan=PlanOutput(table_type_entries=(entry,)),
+        adapter=adapter,
+        connection=connection,
+    )
+    conversion_statement_count: int = len(adapter.statement_recorder.snapshot())
+    relations: tuple[RelationInfo, ...] = adapter.list_relations(
+        connection=connection,
+        database=snowflake_database,
+        schemas=(snowflake_schema,),
+        names=(table_name, copy_name),
+    )
+    relation_by_name: dict[str, RelationInfo] = {relation.name: relation for relation in relations}
+    rows: tuple[tuple[object, ...], ...] = fetch_rows(
+        adapter=adapter,
+        connection=connection,
+        sql=f"SELECT id, status FROM {table_target} ORDER BY id",
+    )
+
+    assert relation_by_name[table_name].is_transient is test_case.expected_is_transient
+    assert copy_name not in relation_by_name
+    assert rows == ((1, "ready"), (2, "complete"))
+    assert conversion_statement_count == test_case.expected_conversion_statement_count
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/integration/src/sqlbuild/microbatches/classes/__init__.py
+++ b/tests/integration/src/sqlbuild/microbatches/classes/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for microbatch store classes."""

--- a/tests/integration/src/sqlbuild/microbatches/classes/_test_types.py
+++ b/tests/integration/src/sqlbuild/microbatches/classes/_test_types.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DirectStorePublicationTestCase:
+    description: str
+    event_count: int
+    expected_total: int
+    expected_inserted: int
+    expected_already_existing: int
+    expected_statement_count: int
+
+
+@dataclass(frozen=True)
+class DirectStoreSuccessiveWriteTestCase:
+    description: str
+    initial_event_count: int
+    successive_event_count: int
+    expected_initial_statement_count: int
+    expected_successive_statement_count: int
+    expected_initialization_statement_count: int

--- a/tests/integration/src/sqlbuild/microbatches/classes/helpers.py
+++ b/tests/integration/src/sqlbuild/microbatches/classes/helpers.py
@@ -1,0 +1,64 @@
+"""Helpers for direct microbatch store integration tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlbuild.microbatches.main.deterministic_event_id import (
+    deterministic_microbatch_event_id,
+)
+from sqlbuild.microbatches.models import MicrobatchEvent, MicrobatchScope
+from sqlbuild.microbatches.types import (
+    MicrobatchCompletionType,
+    MicrobatchFingerprintStatus,
+    MicrobatchRecordType,
+    MicrobatchRunType,
+)
+
+
+def build_events(*, count: int, start_at: int = 0) -> tuple[MicrobatchEvent, ...]:
+    """Build deterministic direct-mode partition completion events."""
+
+    scope: MicrobatchScope = MicrobatchScope(
+        scope_kind="direct_logical",
+        scope_key="duckdb:main.orders",
+        model_name="orders",
+        target_database=None,
+        target_schema="main",
+        target_name="orders",
+        physical_generation_id="generation-1",
+    )
+    events: list[MicrobatchEvent] = []
+    for index in range(start_at, start_at + count):
+        partition_start: str = str(index)
+        partition_end: str = str(index + 1)
+        event_id: str = deterministic_microbatch_event_id(
+            scope=scope,
+            record_type=MicrobatchRecordType.PARTITION_COMPLETION,
+            partition_start=partition_start,
+            partition_end=partition_end,
+            completion_reason=MicrobatchCompletionType.INITIAL.value,
+        )
+        events.append(
+            MicrobatchEvent(
+                event_id=event_id,
+                record_type=MicrobatchRecordType.PARTITION_COMPLETION,
+                scope=scope,
+                origin_run_id="run-1",
+                execution_run_id="run-1",
+                run_type=MicrobatchRunType.NORMAL,
+                run_start="0",
+                run_end=str(start_at + count),
+                batch_size="1",
+                cursor_column="batch_id",
+                cursor_type="integer",
+                model_version_hash="F2",
+                definition_hash="definition",
+                fingerprint_status=MicrobatchFingerprintStatus.KNOWN,
+                completion_type=MicrobatchCompletionType.INITIAL,
+                partition_start=partition_start,
+                partition_end=partition_end,
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+    return tuple(events)

--- a/tests/integration/src/sqlbuild/microbatches/classes/test_direct_store.py
+++ b/tests/integration/src/sqlbuild/microbatches/classes/test_direct_store.py
@@ -1,0 +1,174 @@
+"""Integration coverage for direct microbatch bulk event publication."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
+from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.microbatches.classes.direct_store import DirectMicrobatchEventStore
+from sqlbuild.microbatches.models import MicrobatchEvent, MicrobatchWriteResult
+from tests.integration.src.sqlbuild.microbatches.classes._test_types import (
+    DirectStorePublicationTestCase,
+    DirectStoreSuccessiveWriteTestCase,
+)
+from tests.integration.src.sqlbuild.microbatches.classes.helpers import build_events
+
+
+class _RecordingDuckDbAdapter(DuckDbAdapter):
+    def __init__(self) -> None:
+        self.statement_recorder = StatementRecorder()
+
+    def execute(self, *, connection: Any, sql: str) -> Any:
+        self.statement_recorder.record(sql)
+        return super().execute(connection=connection, sql=sql)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DirectStorePublicationTestCase(
+            description="one thousand events use four bulk chunks",
+            event_count=1000,
+            expected_total=1000,
+            expected_inserted=1000,
+            expected_already_existing=0,
+            expected_statement_count=14,
+        ),
+        DirectStorePublicationTestCase(
+            description="exact chunk boundary uses one bulk chunk",
+            event_count=250,
+            expected_total=250,
+            expected_inserted=250,
+            expected_already_existing=0,
+            expected_statement_count=8,
+        ),
+        DirectStorePublicationTestCase(
+            description="one event beyond chunk boundary uses two bulk chunks",
+            event_count=251,
+            expected_total=251,
+            expected_inserted=251,
+            expected_already_existing=0,
+            expected_statement_count=10,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_fresh_events_when_bulk_publishing_then_statements_are_bounded_and_counts_are_exact(
+    test_case: DirectStorePublicationTestCase,
+) -> None:
+    adapter: _RecordingDuckDbAdapter = _RecordingDuckDbAdapter()
+    connection: Any = adapter.connect({"database": ":memory:"})
+    store: DirectMicrobatchEventStore = DirectMicrobatchEventStore(
+        adapter=adapter, connection=connection
+    )
+    events: tuple[MicrobatchEvent, ...] = build_events(count=test_case.event_count)
+    try:
+        result: MicrobatchWriteResult = store.write_many(events)
+        statements: tuple[str, ...] = tuple(
+            event.content for event in adapter.statement_recorder.snapshot()
+        )
+
+        assert result.total == test_case.expected_total
+        assert result.inserted == test_case.expected_inserted
+        assert result.already_existing == test_case.expected_already_existing
+        assert len(statements) == test_case.expected_statement_count
+    finally:
+        adapter.close(connection)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DirectStorePublicationTestCase(
+            description="republication performs four lookups and no inserts",
+            event_count=1000,
+            expected_total=1000,
+            expected_inserted=0,
+            expected_already_existing=1000,
+            expected_statement_count=4,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_published_events_when_republishing_then_only_existing_id_lookups_execute(
+    test_case: DirectStorePublicationTestCase,
+) -> None:
+    adapter: _RecordingDuckDbAdapter = _RecordingDuckDbAdapter()
+    connection: Any = adapter.connect({"database": ":memory:"})
+    store: DirectMicrobatchEventStore = DirectMicrobatchEventStore(
+        adapter=adapter, connection=connection
+    )
+    events: tuple[MicrobatchEvent, ...] = build_events(count=test_case.event_count)
+    try:
+        store.write_many(events)
+        adapter.statement_recorder.events.clear()
+
+        result: MicrobatchWriteResult = store.write_many(events)
+        statements: tuple[str, ...] = tuple(
+            event.content for event in adapter.statement_recorder.snapshot()
+        )
+
+        assert result.total == test_case.expected_total
+        assert result.inserted == test_case.expected_inserted
+        assert result.already_existing == test_case.expected_already_existing
+        assert len(statements) == test_case.expected_statement_count
+        assert all(statement.startswith("SELECT event_id") for statement in statements)
+    finally:
+        adapter.close(connection)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DirectStoreSuccessiveWriteTestCase(
+            description="successive writes initialize state once per store",
+            initial_event_count=250,
+            successive_event_count=1,
+            expected_initial_statement_count=8,
+            expected_successive_statement_count=2,
+            expected_initialization_statement_count=6,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_initialized_store_when_publishing_more_events_then_initialization_is_not_repeated(
+    test_case: DirectStoreSuccessiveWriteTestCase,
+) -> None:
+    adapter: _RecordingDuckDbAdapter = _RecordingDuckDbAdapter()
+    connection: Any = adapter.connect({"database": ":memory:"})
+    store: DirectMicrobatchEventStore = DirectMicrobatchEventStore(
+        adapter=adapter, connection=connection
+    )
+    initial_events: tuple[MicrobatchEvent, ...] = build_events(count=test_case.initial_event_count)
+    successive_events: tuple[MicrobatchEvent, ...] = build_events(
+        count=test_case.successive_event_count, start_at=test_case.initial_event_count
+    )
+    try:
+        store.write_many(initial_events)
+        initial_statements: tuple[str, ...] = tuple(
+            event.content for event in adapter.statement_recorder.snapshot()
+        )
+        adapter.statement_recorder.events.clear()
+
+        store.write_many(successive_events)
+        successive_statements: tuple[str, ...] = tuple(
+            event.content for event in adapter.statement_recorder.snapshot()
+        )
+        initialization_statements: tuple[str, ...] = initial_statements[
+            : test_case.expected_initialization_statement_count
+        ]
+
+        assert len(initial_statements) == test_case.expected_initial_statement_count
+        assert len(successive_statements) == test_case.expected_successive_statement_count
+        assert len(initialization_statements) == test_case.expected_initialization_statement_count
+        assert all(statement.startswith("CREATE") for statement in initialization_statements)
+        assert all(not statement.startswith("CREATE") for statement in successive_statements)
+    finally:
+        adapter.close(connection)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])


### PR DESCRIPTION
## Why

Coverage audit of the recent retention/table-type/microbatch work found two gaps where design claims were only verified as rendered-SQL unit assertions:

1. The Snowflake table-type copy-swap conversion had never executed against a real warehouse in any test (the feature is Snowflake-only, so DuckDB e2e cannot exercise it).
2. The concurrent microbatch bulk event publication path (250-event chunks, DDL-once, statement ceiling) had no test counting actual statements through the store.

## Changes

Real-warehouse Snowflake integration (`real_warehouse`-marked, throwaway schema per test):
- Drives `apply_table_type_conversions` with a genuine `TableTypePlanEntry` through a statement-recording adapter.
- Permanent -> transient and transient -> permanent: `is_transient` flips in warehouse metadata, rows survive the copy-swap, the deterministic copy relation is cleaned up, exactly 3 conversion statements execute.
- Already-at-desired-type: exactly 0 statements.

DuckDB direct event store integration:
- First publication ceilings using production deterministic event IDs: 250 events = 8 statements (6 init + 1 lookup + 1 insert), 251 = 10, 1,000 = 14.
- Re-publication of 1,000 events: exactly 4 lookups, zero inserts, result reports total=1000 / inserted=0 / already_existing=1000.
- Initialization statements run once per store instance across successive `write_many` calls.

## Verification

- New Snowflake tests executed against a real warehouse locally: 3 passed.
- Full Snowflake real-warehouse integration suite locally: 20 passed.
- DuckDB direct-store tests: 5 passed; focused microbatch suites: 54 passed.
- Ruff, ty (8 pre-existing optional-dep diagnostics only), Fensu 0 faults, git diff --check clean.
