### PR TITLE
fix: suppress false removals for unresolved stars

### DIFF
--- a/src/sqlbuild/compiler/planner/_helpers/changes/detect.py
+++ b/src/sqlbuild/compiler/planner/_helpers/changes/detect.py
@@ -208,6 +208,7 @@ def detect_model_changes(
             inferred_columns=inferred_columns,
             warehouse_columns=warehouse_columns,
             type_enforcement=type_enforcement,
+            inferred_schema_complete=not model.fast_lineage_has_star,
         )
         if schema_findings:
             raw_policy = get_config_str(model=model, key="replay_on_change")

--- a/src/sqlbuild/compiler/planner/_helpers/changes/schema.py
+++ b/src/sqlbuild/compiler/planner/_helpers/changes/schema.py
@@ -15,6 +15,7 @@ def detect_schema_changes(
     inferred_columns: tuple[InferredColumn, ...] | None,
     warehouse_columns: tuple[ColumnInfo, ...],
     type_enforcement: bool,
+    inferred_schema_complete: bool,
 ) -> tuple[SchemaFinding, ...]:
     """Compare yml and inferred columns against warehouse columns and return findings."""
 
@@ -64,18 +65,21 @@ def detect_schema_changes(
         for col_ne in yml_columns:
             seen_names.add(col_ne.name)
 
-    col_name: str
-    col_type: str
-    for col_name, col_type in warehouse_map.items():
-        if col_name not in seen_names:
-            findings.append(
-                SchemaFinding(
-                    kind=SchemaChangeKind.COLUMN_REMOVED,
-                    column_name=col_name,
-                    source=SchemaColumnSource.YML if yml_columns else SchemaColumnSource.SQLGLOT,
-                    actual_type=col_type,
+    if type_enforcement or inferred_schema_complete:
+        col_name: str
+        col_type: str
+        for col_name, col_type in warehouse_map.items():
+            if col_name not in seen_names:
+                findings.append(
+                    SchemaFinding(
+                        kind=SchemaChangeKind.COLUMN_REMOVED,
+                        column_name=col_name,
+                        source=(
+                            SchemaColumnSource.YML if yml_columns else SchemaColumnSource.SQLGLOT
+                        ),
+                        actual_type=col_type,
+                    )
                 )
-            )
 
     return tuple(findings)
 

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/changes/_test_helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/changes/_test_helpers.py
@@ -48,6 +48,8 @@ def build_model_from_test_case(test_case: DetectModelChangesTestCase) -> Compile
             database=None, schema="staging", name=test_case.model_name, qualified_name=None
         ),
         schema_entry=schema_entry,
+        inferred_columns=test_case.inferred_columns,
+        fast_lineage_has_star=test_case.fast_lineage_has_star,
     )
 
 

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/changes/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/changes/_test_types.py
@@ -22,6 +22,8 @@ class DetectModelChangesTestCase:
     expected_change_kind: ChangeKind
     expected_backfill_action: BackfillAction
     fingerprint_config_values: dict[str, object] | None = None
+    inferred_columns: tuple[InferredColumn, ...] | None = None
+    fast_lineage_has_star: bool = False
 
 
 @dataclass(frozen=True)
@@ -52,6 +54,7 @@ class DetectSchemaChangesTestCase:
     warehouse_columns: tuple[ColumnInfo, ...]
     type_enforcement: bool
     expected_findings: tuple[SchemaFinding, ...]
+    inferred_schema_complete: bool = True
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/changes/test_detect.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/changes/test_detect.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import pytest
 
-from sqlbuild.compiler.compile.models import CompiledModel
+from sqlbuild.compiler.compile.models import CompiledModel, InferredColumn
 from sqlbuild.compiler.discovery.models import SqlHookEntry
 from sqlbuild.compiler.fingerprints.main.compute_query_hash import compute_query_hash
 from sqlbuild.compiler.fingerprints.models import Fingerprint
@@ -161,6 +161,23 @@ _DIFFERENT_HASH: str = "completely_different_hash"
             sql_analysis_enabled=False,
             query_change_tracking=True,
             full_refresh=False,
+            expected_change_kind=ChangeKind.NO_CHANGE,
+            expected_backfill_action=BackfillAction.FORWARD_ONLY,
+        ),
+        DetectModelChangesTestCase(
+            description="does not report passthrough columns removed for unresolved star",
+            model_name="orders",
+            query_sql=_QUERY_SQL,
+            config_values={},
+            schema_columns=(),
+            relation_exists=True,
+            fingerprint_query_hash=_MATCHING_HASH,
+            warehouse_column_names=(("id", "INTEGER"), ("loaded_at", "TIMESTAMP")),
+            sql_analysis_enabled=True,
+            query_change_tracking=True,
+            full_refresh=False,
+            inferred_columns=(InferredColumn(name="loaded_at", type="TIMESTAMP"),),
+            fast_lineage_has_star=True,
             expected_change_kind=ChangeKind.NO_CHANGE,
             expected_backfill_action=BackfillAction.FORWARD_ONLY,
         ),

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/changes/test_schema.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/changes/test_schema.py
@@ -238,6 +238,35 @@ from tests.unit.src.sqlbuild.compiler.planner._helpers.changes._test_types impor
                 ),
             ),
         ),
+        DetectSchemaChangesTestCase(
+            description="unresolved star suppresses removed columns but preserves positive findings",
+            yml_columns=(),
+            inferred_columns=(
+                InferredColumn(name="amount", type="FLOAT"),
+                InferredColumn(name="loaded_at", type="TIMESTAMP"),
+            ),
+            warehouse_columns=(
+                ColumnInfo(name="id", type="INTEGER"),
+                ColumnInfo(name="amount", type="INTEGER"),
+            ),
+            type_enforcement=False,
+            inferred_schema_complete=False,
+            expected_findings=(
+                SchemaFinding(
+                    kind=SchemaChangeKind.COLUMN_TYPE_CHANGED,
+                    column_name="amount",
+                    source=SchemaColumnSource.SQLGLOT,
+                    expected_type="FLOAT",
+                    actual_type="INTEGER",
+                ),
+                SchemaFinding(
+                    kind=SchemaChangeKind.COLUMN_ADDED,
+                    column_name="loaded_at",
+                    source=SchemaColumnSource.SQLGLOT,
+                    expected_type="TIMESTAMP",
+                ),
+            ),
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -249,6 +278,7 @@ def test_given_columns_when_detecting_schema_changes_then_returns_expected_findi
         inferred_columns=test_case.inferred_columns,
         warehouse_columns=test_case.warehouse_columns,
         type_enforcement=test_case.type_enforcement,
+        inferred_schema_complete=test_case.inferred_schema_complete,
     )
 
     assert result == test_case.expected_findings


### PR DESCRIPTION
## Why

Models combining an unresolved `SELECT *` with explicit projections were reporting every passthrough target column as removed because partial compile-time inference was treated as a complete expected schema.

## Changes

- mark unresolved-star inferred schemas as incomplete during planner change detection
- suppress unsupported removed-column findings while retaining explicit additions and type changes
- add comparator and model-level regressions

Linear: CHI-163

## Verification

- `uv run pytest tests/unit -q` (4389 passed)
- `uv run pytest tests/unit/src/sqlbuild/compiler/planner -q` (631 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run fensu check`