### PR TITLE
fix: execute cursor bound inspections per physical relation

### DIFF
--- a/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
+++ b/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
@@ -54,18 +54,17 @@ from sqlbuild.compiler.source_freshness.constants import SOURCE_FRESHNESS_TABLE_
 from sqlbuild.diagnostics.main.log_debug_event import log_debug_event
 from sqlbuild.spec.contracts.models import SourceEntry
 
-_CURSOR_BATCH_SIZE: int = 100
 _DEBUG_LOGGER: logging.Logger = logging.getLogger("sqlbuild.planner")
 
 
 @dataclass(frozen=True)
-class _CursorQuery:
-    """One MIN or MAX query to execute against a relation."""
+class _PhysicalCursorQuery:
+    """One physical relation and cursor column to inspect."""
 
-    tag: str
     relation: str
     cursor_column: str
-    aggregate: str
+    min_tags: tuple[str, ...]
+    max_tags: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -548,18 +547,20 @@ def _gather_cursor_snapshots(
     if not cursor_models:
         return {}
 
-    queries: list[_CursorQuery] = _build_cursor_queries(cursor_models)
+    queries: list[_PhysicalCursorQuery] = _build_cursor_queries(cursor_models)
     cursor_start: float = time.monotonic()
-    results: dict[str, str] = _execute_cursor_queries_batched(
+    results: dict[str, str] = _execute_cursor_queries(
         queries=queries,
         connection=connection,
         execute=execute,
         on_progress=on_progress,
     )
     if on_progress is not None:
-        total: int = len(queries)
+        logical_total: int = sum(len(query.min_tags) + len(query.max_tags) for query in queries)
+        physical_total: int = len(queries)
         on_progress(
-            f"Gathered cursor bounds ({total}/{total}). ({time.monotonic() - cursor_start:.2f}s)"
+            f"Gathered cursor bounds ({len(results)}/{logical_total} logical values; "
+            f"{physical_total} physical relation reads). ({time.monotonic() - cursor_start:.2f}s)"
         )
 
     return _assemble_cursor_snapshots(cursor_models=cursor_models, results=results)
@@ -654,119 +655,129 @@ def _collect_cursor_models(
     return cursor_models
 
 
-def _build_cursor_queries(cursor_models: list[_CursorModelInfo]) -> list[_CursorQuery]:
-    """Build the full list of MIN/MAX queries from cursor model metadata."""
+def _build_cursor_queries(cursor_models: list[_CursorModelInfo]) -> list[_PhysicalCursorQuery]:
+    """Group logical cursor requests by physical relation and column."""
 
-    queries: list[_CursorQuery] = []
+    grouped_tags: dict[tuple[str, str], tuple[list[str], list[str]]] = {}
     info: _CursorModelInfo
     for info in cursor_models:
         if info.target_tag is not None and info.target_relation is not None:
-            queries.append(
-                _CursorQuery(
-                    tag=info.target_tag,
-                    relation=info.target_relation,
-                    cursor_column=info.cursor_column,
-                    aggregate="MAX",
-                )
-            )
+            target_key: tuple[str, str] = (info.target_relation, info.cursor_column)
+            target_tags: tuple[list[str], list[str]] = grouped_tags.setdefault(target_key, ([], []))
+            if info.target_tag not in target_tags[1]:
+                target_tags[1].append(info.target_tag)
         upstream: _UpstreamCursorInfo
         for upstream in info.upstreams:
-            queries.append(
-                _CursorQuery(
-                    tag=upstream.tag_min,
-                    relation=upstream.relation,
-                    cursor_column=upstream.cursor_column,
-                    aggregate="MIN",
-                )
+            upstream_key: tuple[str, str] = (upstream.relation, upstream.cursor_column)
+            upstream_tags: tuple[list[str], list[str]] = grouped_tags.setdefault(
+                upstream_key, ([], [])
             )
-            queries.append(
-                _CursorQuery(
-                    tag=upstream.tag_max,
-                    relation=upstream.relation,
-                    cursor_column=upstream.cursor_column,
-                    aggregate="MAX",
-                )
-            )
+            if upstream.tag_min not in upstream_tags[0]:
+                upstream_tags[0].append(upstream.tag_min)
+            if upstream.tag_max not in upstream_tags[1]:
+                upstream_tags[1].append(upstream.tag_max)
 
-    return queries
+    return [
+        _PhysicalCursorQuery(
+            relation=relation,
+            cursor_column=cursor_column,
+            min_tags=tuple(tags[0]),
+            max_tags=tuple(tags[1]),
+        )
+        for (relation, cursor_column), tags in grouped_tags.items()
+    ]
 
 
-def _execute_cursor_queries_batched(
+def _execute_cursor_queries(
     *,
-    queries: list[_CursorQuery],
+    queries: list[_PhysicalCursorQuery],
     connection: Any,
     execute: AdapterExecute[Any, Any],
     on_progress: Callable[[str], None] | None,
 ) -> dict[str, str]:
-    """Execute cursor queries in UNION ALL batches and return tag -> value results."""
+    """Execute standalone physical cursor queries and fan values out to logical tags."""
 
     results: dict[str, str] = {}
     total: int = len(queries)
-    completed: int = 0
-
-    batch_start: int = 0
-    while batch_start < total:
-        batch_end: int = min(batch_start + _CURSOR_BATCH_SIZE, total)
-        batch: list[_CursorQuery] = queries[batch_start:batch_end]
-
-        batch_results: dict[str, str] = _execute_cursor_batch(
-            batch=batch, connection=connection, execute=execute
+    query_index: int
+    query: _PhysicalCursorQuery
+    for query_index, query in enumerate(queries, start=1):
+        query_results: dict[str, str] = _execute_cursor_query(
+            query=query,
+            query_index=query_index,
+            total=total,
+            connection=connection,
+            execute=execute,
+            on_progress=on_progress,
         )
-        results.update(batch_results)
-
-        completed = batch_end
-        if on_progress is not None:
-            on_progress(f"Gathering cursor bounds ({completed}/{total})...")
-
-        batch_start = batch_end
+        results.update(query_results)
 
     return results
 
 
-def _execute_cursor_batch(
+def _execute_cursor_query(
     *,
-    batch: list[_CursorQuery],
+    query: _PhysicalCursorQuery,
+    query_index: int,
+    total: int,
     connection: Any,
     execute: AdapterExecute[Any, Any],
+    on_progress: Callable[[str], None] | None,
 ) -> dict[str, str]:
-    """Execute one batch of cursor queries as a UNION ALL and return tag -> value."""
+    """Execute one physical cursor query and fan out its returned values."""
 
-    if len(batch) == 1:
-        query: _CursorQuery = batch[0]
-        sql: str = (
-            f"SELECT '{query.tag}' AS _tag, "
-            f"CAST({query.aggregate}({query.cursor_column}) AS VARCHAR) AS _val "
-            f"FROM {query.relation}"
-        )
-    else:
-        parts: list[str] = []
-        q: _CursorQuery
-        for q in batch:
-            parts.append(
-                f"SELECT '{q.tag}' AS _tag, "
-                f"CAST({q.aggregate}({q.cursor_column}) AS VARCHAR) AS _val "
-                f"FROM {q.relation}"
-            )
-        sql = " UNION ALL ".join(parts)
+    bounds: str = ",".join(("min",) if query.min_tags else ())
+    if query.max_tags:
+        bounds = f"{bounds},max" if bounds else "max"
+    identity: str = f"({query_index}/{total}): {query.relation}.{query.cursor_column} [{bounds}]"
+    select_parts: list[str] = []
+    if query.min_tags:
+        select_parts.append(f"CAST(MIN({query.cursor_column}) AS VARCHAR) AS _min")
+    if query.max_tags:
+        select_parts.append(f"CAST(MAX({query.cursor_column}) AS VARCHAR) AS _max")
+    sql: str = f"SELECT {', '.join(select_parts)} FROM {query.relation}"
+    if on_progress is not None:
+        on_progress(f"Inspecting cursor bounds {identity}...")
 
+    query_start: float = time.monotonic()
     try:
         result: Any = execute(connection=connection, sql=sql)
     except Exception as error:
+        elapsed: float = time.monotonic() - query_start
+        if on_progress is not None:
+            on_progress(f"Failed cursor bounds {identity} ({elapsed:.2f}s): {error}")
         log_debug_event(
             logger=_DEBUG_LOGGER,
-            message="cursor bounds batch query failed; treating batch as unavailable",
-            sqlbuild_batch_tags=", ".join(query.tag for query in batch),
+            message="cursor bounds physical query failed; treating relation as unavailable",
+            sqlbuild_relation=query.relation,
+            sqlbuild_cursor_column=query.cursor_column,
+            sqlbuild_bounds=bounds,
+            sqlbuild_elapsed_seconds=f"{elapsed:.2f}",
             sqlbuild_error=str(error),
         )
         return {}
+    elapsed = time.monotonic() - query_start
+    if on_progress is not None:
+        on_progress(f"Inspected cursor bounds {identity} ({elapsed:.2f}s)")
     rows: list[Any] = result.fetchall()
+    if not rows:
+        return {}
     output: dict[str, str] = {}
-    row: Any
-    for row in rows:
-        tag: str = str(row[0])
-        val: str | None = row[1]
-        if val is not None:
-            output[tag] = str(val)
+    row: Any = rows[0]
+    value_index: int = 0
+    if query.min_tags:
+        min_value: Any = row[value_index]
+        if min_value is not None:
+            min_tag: str
+            for min_tag in query.min_tags:
+                output[min_tag] = str(min_value)
+        value_index += 1
+    if query.max_tags:
+        max_value: Any = row[value_index]
+        if max_value is not None:
+            max_tag: str
+            for max_tag in query.max_tags:
+                output[max_tag] = str(max_value)
     return output
 
 

--- a/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
+++ b/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
@@ -742,6 +742,7 @@ def _execute_cursor_query(
     query_start: float = time.monotonic()
     try:
         result: Any = execute(connection=connection, sql=sql)
+        rows: list[Any] = result.fetchall()
     except Exception as error:
         elapsed: float = time.monotonic() - query_start
         if on_progress is not None:
@@ -759,7 +760,6 @@ def _execute_cursor_query(
     elapsed = time.monotonic() - query_start
     if on_progress is not None:
         on_progress(f"Inspected cursor bounds {identity} ({elapsed:.2f}s)")
-    rows: list[Any] = result.fetchall()
     if not rows:
         return {}
     output: dict[str, str] = {}

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/_test_types.py
@@ -45,6 +45,13 @@ class GatherCursorSnapshotTestCase:
 
 
 @dataclass(frozen=True)
+class GatherSharedCursorSnapshotTestCase:
+    description: str
+    expected_cursor_snapshot: ModelCursorSnapshot
+    expected_statements: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class GatherSourceColumnsTestCase:
     description: str
     setup_sql: tuple[str, ...]

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/test_warehouse_snapshot.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/test_warehouse_snapshot.py
@@ -22,6 +22,7 @@ from sqlbuild.compiler.planner.models import ModelCursorSnapshot, WarehouseSnaps
 from tests.integration.src.sqlbuild.compiler.planner._helpers._test_types import (
     GatherCursorSnapshotTestCase,
     GatherEmptySnapshotTestCase,
+    GatherSharedCursorSnapshotTestCase,
     GatherSourceColumnsTestCase,
     GatherWarehouseSnapshotTestCase,
 )
@@ -338,7 +339,7 @@ def test_given_sources_when_gathering_source_columns_then_filters_metadata_names
                     upstream_maxes=("2024-02-01 00:00:00",),
                 ),
             },
-            expected_progress_calls=2,
+            expected_progress_calls=5,
         ),
         GatherCursorSnapshotTestCase(
             description="gathers cursor bounds for first run with no target table",
@@ -356,7 +357,7 @@ def test_given_sources_when_gathering_source_columns_then_filters_metadata_names
                     upstream_maxes=("2024-02-01 00:00:00",),
                 ),
             },
-            expected_progress_calls=2,
+            expected_progress_calls=3,
         ),
         GatherCursorSnapshotTestCase(
             description="skips cursor gathering when full refresh is true",
@@ -386,7 +387,7 @@ def test_given_sources_when_gathering_source_columns_then_filters_metadata_names
                     upstream_maxes=("2024-02-01 00:00:00",),
                 ),
             },
-            expected_progress_calls=2,
+            expected_progress_calls=3,
         ),
         GatherCursorSnapshotTestCase(
             description="skips unselected incremental models",
@@ -470,7 +471,7 @@ def test_given_incremental_models_when_gathering_cursor_snapshots_then_returns_e
                     upstream_maxes=("2024-03-01 00:00:00",),
                 ),
             },
-            expected_progress_calls=2,
+            expected_progress_calls=3,
         ),
         GatherCursorSnapshotTestCase(
             description="non-selected upstream reads cursor from deferred env",
@@ -492,7 +493,7 @@ def test_given_incremental_models_when_gathering_cursor_snapshots_then_returns_e
                     upstream_maxes=("2024-06-01 00:00:00",),
                 ),
             },
-            expected_progress_calls=2,
+            expected_progress_calls=3,
         ),
     ],
     ids=lambda case: case.description,
@@ -535,3 +536,71 @@ def test_given_deferred_locations_when_gathering_cursor_snapshots_then_resolves_
     for model_name, expected_snap in test_case.expected_cursor_snapshots.items():
         assert snapshot.cursor_snapshots[model_name] == expected_snap
     assert len(progress_calls) == test_case.expected_progress_calls
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        GatherSharedCursorSnapshotTestCase(
+            description="two models share one physical source cursor read",
+            expected_cursor_snapshot=ModelCursorSnapshot(
+                target_max=None,
+                upstream_mins=("2024-01-01 00:00:00",),
+                upstream_maxes=("2024-03-01 00:00:00",),
+            ),
+            expected_statements=(
+                "SELECT CAST(MIN(event_time) AS VARCHAR) AS _min, "
+                "CAST(MAX(event_time) AS VARCHAR) AS _max FROM staging.raw_events",
+            ),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_models_sharing_one_source_when_gathering_snapshot_then_executes_one_bounds_statement(
+    test_case: GatherSharedCursorSnapshotTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+) -> None:
+    connection.execute("CREATE TABLE staging.raw_events (event_time TIMESTAMP)")
+    connection.execute("INSERT INTO staging.raw_events VALUES ('2024-01-01'), ('2024-03-01')")
+    statements: list[str] = []
+
+    def _record_execute(*, connection: Any, sql: str) -> Any:
+        statements.append(sql)
+        return connection.execute(sql)
+
+    project: CompiledProject = build_project_with_targets(
+        model_locations={"raw_events": "staging"},
+        incremental_models=(
+            _IncrementalModelSpec(
+                name="daily_events",
+                schema="staging",
+                cursor="event_time",
+                ref_names=("raw_events",),
+            ),
+            _IncrementalModelSpec(
+                name="monthly_events",
+                schema="staging",
+                cursor="event_time",
+                ref_names=("raw_events",),
+            ),
+        ),
+    )
+
+    snapshot: WarehouseSnapshot = gather_warehouse_snapshot(
+        project=project,
+        adapter=adapter,
+        connection=connection,
+        execute=_record_execute,
+    )
+
+    assert snapshot.cursor_snapshots == {
+        "daily_events": test_case.expected_cursor_snapshot,
+        "monthly_events": test_case.expected_cursor_snapshot,
+    }
+    assert tuple(statements) == test_case.expected_statements
+    assert "UNION ALL" not in statements[0]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/integration/src/sqlbuild/compiler/planner/main/test_build_execution_plan.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/test_build_execution_plan.py
@@ -435,8 +435,9 @@ def test_given_missing_source_cursor_input_column_when_building_plan_then_raises
             expected_warning_severity=WarningSeverity.WARNING,
             expected_warning_fragment="appears to be integer",
             expected_progress_fragments=(
-                "Gathering cursor bounds (1/1)",
-                "Gathered cursor bounds (1/1). (",
+                "Inspecting cursor bounds (1/1): staging.events.event_time [max]...",
+                "Inspected cursor bounds (1/1): staging.events.event_time [max] (",
+                "Gathered cursor bounds (1/1 logical values; 1 physical relation reads). (",
             ),
         ),
         BuildExecutionPlanTestCase(

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
@@ -121,6 +121,13 @@ class CursorQueryFailureTestCase:
 
 
 @dataclass(frozen=True)
+class CursorFetchFailureTestCase:
+    description: str
+    expected_results: dict[str, str]
+    expected_progress: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class SeedIdentityTestCase:
     description: str
     seed_contents: str

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
@@ -96,6 +96,31 @@ class MetadataNameFilterTestCase:
 
 
 @dataclass(frozen=True)
+class CursorQueryShapeTestCase:
+    description: str
+    min_tags: tuple[str, ...]
+    max_tags: tuple[str, ...]
+    row: tuple[str | None, ...]
+    expected_sql: str
+    expected_results: dict[str, str]
+    expected_bounds: str
+
+
+@dataclass(frozen=True)
+class CursorQueryGroupingTestCase:
+    description: str
+    expected_physical_queries: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...]], ...]
+
+
+@dataclass(frozen=True)
+class CursorQueryFailureTestCase:
+    description: str
+    expected_results: dict[str, str]
+    expected_failure_progress: str
+    expected_success_progress: str
+
+
+@dataclass(frozen=True)
 class SeedIdentityTestCase:
     description: str
     seed_contents: str

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_warehouse_cursor_queries.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_warehouse_cursor_queries.py
@@ -13,6 +13,7 @@ from sqlbuild.compiler.planner._helpers.warehouse.snapshot import (
     _UpstreamCursorInfo,
 )
 from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
+    CursorFetchFailureTestCase,
     CursorQueryFailureTestCase,
     CursorQueryGroupingTestCase,
     CursorQueryShapeTestCase,
@@ -20,11 +21,30 @@ from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
 
 
 class _RowsResult:
-    def __init__(self, rows: list[tuple[str | None, ...]]) -> None:
+    def __init__(
+        self,
+        *,
+        rows: list[tuple[str | None, ...]],
+        progress: list[str],
+        expected_progress_at_fetch: tuple[str, ...],
+    ) -> None:
         self._rows: list[tuple[str | None, ...]] = rows
+        self._progress: list[str] = progress
+        self._expected_progress_at_fetch: tuple[str, ...] = expected_progress_at_fetch
 
     def fetchall(self) -> list[tuple[str | None, ...]]:
+        assert tuple(self._progress) == self._expected_progress_at_fetch
         return self._rows
+
+
+class _FailingRowsResult:
+    def __init__(self, *, progress: list[str], expected_progress_at_fetch: tuple[str, ...]) -> None:
+        self._progress: list[str] = progress
+        self._expected_progress_at_fetch: tuple[str, ...] = expected_progress_at_fetch
+
+    def fetchall(self) -> list[tuple[str | None, ...]]:
+        assert tuple(self._progress) == self._expected_progress_at_fetch
+        raise RuntimeError("result transfer failed")
 
 
 class _FailFirstExecute:
@@ -38,7 +58,36 @@ class _FailFirstExecute:
             assert self.progress[-1] == "Inspecting cursor bounds (1/2): schema.bad.ts [max]..."
             raise RuntimeError("warehouse unavailable")
         assert self.progress[-1] == "Inspecting cursor bounds (2/2): schema.good.ts [min,max]..."
-        return _RowsResult([("2024-01-01", "2024-02-01")])
+        return _RowsResult(
+            rows=[("2024-01-01", "2024-02-01")],
+            progress=self.progress,
+            expected_progress_at_fetch=tuple(self.progress),
+        )
+
+
+class _FailFirstFetch:
+    def __init__(self, *, progress: list[str]) -> None:
+        self.progress: list[str] = progress
+        self.sql: list[str] = []
+
+    def __call__(self, *, connection: Any, sql: str) -> _RowsResult | _FailingRowsResult:
+        self.sql.append(sql)
+        if "schema.bad" in sql:
+            return _FailingRowsResult(
+                progress=self.progress,
+                expected_progress_at_fetch=(
+                    "Inspecting cursor bounds (1/2): schema.bad.ts [max]...",
+                ),
+            )
+        return _RowsResult(
+            rows=[("2024-01-01", "2024-02-01")],
+            progress=self.progress,
+            expected_progress_at_fetch=(
+                "Inspecting cursor bounds (1/2): schema.bad.ts [max]...",
+                "Failed cursor bounds (1/2): schema.bad.ts [max] (0.25s): result transfer failed",
+                "Inspecting cursor bounds (2/2): schema.good.ts [min,max]...",
+            ),
+        )
 
 
 @pytest.mark.parametrize(
@@ -156,7 +205,14 @@ def test_given_requested_bounds_when_executing_then_uses_one_standalone_query_wi
             f"Inspecting cursor bounds (1/1): raw.events.event_time [{test_case.expected_bounds}]..."
         ]
         statements.append(sql)
-        return _RowsResult([test_case.row])
+        return _RowsResult(
+            rows=[test_case.row],
+            progress=progress,
+            expected_progress_at_fetch=(
+                f"Inspecting cursor bounds (1/1): raw.events.event_time "
+                f"[{test_case.expected_bounds}]...",
+            ),
+        )
 
     monotonic_values: Any = iter((10.0, 10.42))
     monkeypatch.setattr(snapshot_module.time, "monotonic", monotonic_values.__next__)
@@ -233,6 +289,57 @@ def test_given_one_failed_physical_read_when_executing_then_reports_failure_and_
     assert len(execute.sql) == 2
     assert progress[1] == test_case.expected_failure_progress
     assert progress[3] == test_case.expected_success_progress
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        CursorFetchFailureTestCase(
+            description="fetch failure remains unavailable and later relation succeeds",
+            expected_results={"good__min": "2024-01-01", "good__max": "2024-02-01"},
+            expected_progress=(
+                "Inspecting cursor bounds (1/2): schema.bad.ts [max]...",
+                "Failed cursor bounds (1/2): schema.bad.ts [max] (0.25s): result transfer failed",
+                "Inspecting cursor bounds (2/2): schema.good.ts [min,max]...",
+                "Inspected cursor bounds (2/2): schema.good.ts [min,max] (0.50s)",
+            ),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_fetch_failure_when_executing_then_reports_failure_and_continues(
+    test_case: CursorFetchFailureTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    progress: list[str] = []
+    execute: _FailFirstFetch = _FailFirstFetch(progress=progress)
+    monotonic_values: Any = iter((20.0, 20.25, 30.0, 30.50))
+    monkeypatch.setattr(snapshot_module.time, "monotonic", monotonic_values.__next__)
+    queries: list[_PhysicalCursorQuery] = [
+        _PhysicalCursorQuery(
+            relation="schema.bad",
+            cursor_column="ts",
+            min_tags=(),
+            max_tags=("bad__max",),
+        ),
+        _PhysicalCursorQuery(
+            relation="schema.good",
+            cursor_column="ts",
+            min_tags=("good__min",),
+            max_tags=("good__max",),
+        ),
+    ]
+
+    results: dict[str, str] = _execute_cursor_queries(
+        queries=queries,
+        connection=object(),
+        execute=execute,
+        on_progress=progress.append,
+    )
+
+    assert results == test_case.expected_results
+    assert len(execute.sql) == 2
+    assert tuple(progress) == test_case.expected_progress
 
 
 if __name__ == "__main__":

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_warehouse_cursor_queries.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_warehouse_cursor_queries.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sqlbuild.compiler.planner._helpers.warehouse import snapshot as snapshot_module
+from sqlbuild.compiler.planner._helpers.warehouse.snapshot import (
+    _build_cursor_queries,
+    _CursorModelInfo,
+    _execute_cursor_queries,
+    _PhysicalCursorQuery,
+    _UpstreamCursorInfo,
+)
+from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
+    CursorQueryFailureTestCase,
+    CursorQueryGroupingTestCase,
+    CursorQueryShapeTestCase,
+)
+
+
+class _RowsResult:
+    def __init__(self, rows: list[tuple[str | None, ...]]) -> None:
+        self._rows: list[tuple[str | None, ...]] = rows
+
+    def fetchall(self) -> list[tuple[str | None, ...]]:
+        return self._rows
+
+
+class _FailFirstExecute:
+    def __init__(self, *, progress: list[str]) -> None:
+        self.progress: list[str] = progress
+        self.sql: list[str] = []
+
+    def __call__(self, *, connection: Any, sql: str) -> _RowsResult:
+        self.sql.append(sql)
+        if "schema.bad" in sql:
+            assert self.progress[-1] == "Inspecting cursor bounds (1/2): schema.bad.ts [max]..."
+            raise RuntimeError("warehouse unavailable")
+        assert self.progress[-1] == "Inspecting cursor bounds (2/2): schema.good.ts [min,max]..."
+        return _RowsResult([("2024-01-01", "2024-02-01")])
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        CursorQueryGroupingTestCase(
+            description="deduplicates physical reads and fans out logical tags in stable order",
+            expected_physical_queries=(
+                (
+                    "analytics.first_target",
+                    "event_time",
+                    (),
+                    ("first__target__max",),
+                ),
+                (
+                    "raw.events",
+                    "event_time",
+                    ("first__events__min", "second__events__min"),
+                    ("first__events__max", "second__events__max"),
+                ),
+            ),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_duplicate_logical_requests_when_building_queries_then_groups_by_physical_relation(
+    test_case: CursorQueryGroupingTestCase,
+) -> None:
+    shared_first: _UpstreamCursorInfo = _UpstreamCursorInfo(
+        tag_min="first__events__min",
+        tag_max="first__events__max",
+        relation="raw.events",
+        cursor_column="event_time",
+    )
+    first: _CursorModelInfo = _CursorModelInfo(
+        model_name="first",
+        target_tag="first__target__max",
+        target_relation="analytics.first_target",
+        cursor_column="event_time",
+        upstreams=(shared_first, shared_first),
+    )
+    second: _CursorModelInfo = _CursorModelInfo(
+        model_name="second",
+        target_tag=None,
+        target_relation=None,
+        cursor_column="event_time",
+        upstreams=(
+            _UpstreamCursorInfo(
+                tag_min="second__events__min",
+                tag_max="second__events__max",
+                relation="raw.events",
+                cursor_column="event_time",
+            ),
+        ),
+    )
+
+    queries: list[_PhysicalCursorQuery] = _build_cursor_queries([first, first, second])
+
+    actual: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...]], ...] = tuple(
+        (query.relation, query.cursor_column, query.min_tags, query.max_tags) for query in queries
+    )
+    assert actual == test_case.expected_physical_queries
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        CursorQueryShapeTestCase(
+            description="min only",
+            min_tags=("model__source__min",),
+            max_tags=(),
+            row=("2024-01-01",),
+            expected_sql="SELECT CAST(MIN(event_time) AS VARCHAR) AS _min FROM raw.events",
+            expected_results={"model__source__min": "2024-01-01"},
+            expected_bounds="min",
+        ),
+        CursorQueryShapeTestCase(
+            description="max only",
+            min_tags=(),
+            max_tags=("model__target__max",),
+            row=("2024-02-01",),
+            expected_sql="SELECT CAST(MAX(event_time) AS VARCHAR) AS _max FROM raw.events",
+            expected_results={"model__target__max": "2024-02-01"},
+            expected_bounds="max",
+        ),
+        CursorQueryShapeTestCase(
+            description="min and max",
+            min_tags=("first__source__min", "second__source__min"),
+            max_tags=("first__source__max", "second__source__max"),
+            row=("2024-01-01", "2024-02-01"),
+            expected_sql=(
+                "SELECT CAST(MIN(event_time) AS VARCHAR) AS _min, "
+                "CAST(MAX(event_time) AS VARCHAR) AS _max FROM raw.events"
+            ),
+            expected_results={
+                "first__source__min": "2024-01-01",
+                "second__source__min": "2024-01-01",
+                "first__source__max": "2024-02-01",
+                "second__source__max": "2024-02-01",
+            },
+            expected_bounds="min,max",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_requested_bounds_when_executing_then_uses_one_standalone_query_with_observability(
+    test_case: CursorQueryShapeTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    progress: list[str] = []
+    statements: list[str] = []
+
+    def _execute(*, connection: Any, sql: str) -> _RowsResult:
+        assert progress == [
+            f"Inspecting cursor bounds (1/1): raw.events.event_time [{test_case.expected_bounds}]..."
+        ]
+        statements.append(sql)
+        return _RowsResult([test_case.row])
+
+    monotonic_values: Any = iter((10.0, 10.42))
+    monkeypatch.setattr(snapshot_module.time, "monotonic", monotonic_values.__next__)
+    query: _PhysicalCursorQuery = _PhysicalCursorQuery(
+        relation="raw.events",
+        cursor_column="event_time",
+        min_tags=test_case.min_tags,
+        max_tags=test_case.max_tags,
+    )
+
+    results: dict[str, str] = _execute_cursor_queries(
+        queries=[query],
+        connection=object(),
+        execute=_execute,
+        on_progress=progress.append,
+    )
+
+    assert results == test_case.expected_results
+    assert statements == [test_case.expected_sql]
+    assert "UNION ALL" not in statements[0]
+    assert progress[-1] == (
+        f"Inspected cursor bounds (1/1): raw.events.event_time "
+        f"[{test_case.expected_bounds}] (0.42s)"
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        CursorQueryFailureTestCase(
+            description="failed relation remains unavailable and later relation succeeds",
+            expected_results={"good__min": "2024-01-01", "good__max": "2024-02-01"},
+            expected_failure_progress=(
+                "Failed cursor bounds (1/2): schema.bad.ts [max] (0.25s): warehouse unavailable"
+            ),
+            expected_success_progress=(
+                "Inspected cursor bounds (2/2): schema.good.ts [min,max] (0.50s)"
+            ),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_one_failed_physical_read_when_executing_then_reports_failure_and_continues(
+    test_case: CursorQueryFailureTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    progress: list[str] = []
+    execute: _FailFirstExecute = _FailFirstExecute(progress=progress)
+    monotonic_values: Any = iter((20.0, 20.25, 30.0, 30.50))
+    monkeypatch.setattr(snapshot_module.time, "monotonic", monotonic_values.__next__)
+    queries: list[_PhysicalCursorQuery] = [
+        _PhysicalCursorQuery(
+            relation="schema.bad",
+            cursor_column="ts",
+            min_tags=(),
+            max_tags=("bad__max",),
+        ),
+        _PhysicalCursorQuery(
+            relation="schema.good",
+            cursor_column="ts",
+            min_tags=("good__min",),
+            max_tags=("good__max",),
+        ),
+    ]
+
+    results: dict[str, str] = _execute_cursor_queries(
+        queries=queries,
+        connection=object(),
+        execute=execute,
+        on_progress=progress.append,
+    )
+
+    assert results == test_case.expected_results
+    assert len(execute.sql) == 2
+    assert progress[1] == test_case.expected_failure_progress
+    assert progress[3] == test_case.expected_success_progress
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])


### PR DESCRIPTION
## Why

`betfair_prices_job` appeared frozen at `Inspecting warehouse state...`. SQLBuild had combined 66 cursor `MIN`/`MAX` checks across 28 relations into one synchronous `UNION ALL`. Snowflake's normal metadata optimization was defeated: the query ran for 20+ minutes and scanned 2.23 TB before cancellation, while no relation-level progress appeared.

Real-warehouse proof with result cache disabled: standalone `MIN/MAX` against both the 33.8-billion-row Betfair archive and the mapped target completed in 50–51 ms with 0 bytes scanned.

## Changes

- Group logical cursor requests by physical `(relation, cursor_column)` and execute one standalone statement per unique physical read.
- Fetch only requested bounds (`MIN`, `MAX`, or both) and fan results out to all deduplicated logical tags.
- Remove cross-relation batching and `_CURSOR_BATCH_SIZE`; preserve deterministic first-seen order.
- Emit progress **before** each query with index/total, relation, column, and bounds; emit success/failure with elapsed time.
- Include both driver execution and result retrieval in timing. Fetch failures report timed failure, treat only that physical read as unavailable, and continue subsequent reads.
- Final summary reports logical values and physical reads separately.

## Verification

- Full available unit/integration: 4,972 passed, 92 skipped
- Planner: 695 passed; build: 190 passed; focused cursor/integration: 46 passed
- Real Snowflake standalone shape: 50/51 ms, 0 bytes scanned, cache disabled
- Ruff, ty (8 documented optional-dependency diagnostics only), Fensu 0 faults, diff check clean

Refs CHI-164.
