### PR TITLE
fix: exclude views from table type conversion planning

### DIFF
--- a/src/sqlbuild/compiler/compile/_helpers/config/model_validation.py
+++ b/src/sqlbuild/compiler/compile/_helpers/config/model_validation.py
@@ -597,11 +597,7 @@ def validate_time_travel_retention(*, config: CompileModelConfig, model_name: st
             f"model '{model_name}': managed time_travel_retention is not valid for views; "
             "set time_travel_retention disabled"
         )
-    if materialized not in {
-        MaterializationType.TABLE,
-        MaterializationType.INCREMENTAL,
-        MaterializationType.SNAPSHOT,
-    }:
+    if not MaterializationType.is_table_backed(materialized=materialized):
         raise CompileInputError(
             f"model '{model_name}': managed time_travel_retention is not supported for "
             f"materialization '{materialized}'"
@@ -616,11 +612,7 @@ def validate_table_type(*, config: CompileModelConfig, model_name: str) -> None:
     materialized: str | None = _str(config=config, key="materialized")
     if materialized == MaterializationType.VIEW:
         raise CompileInputError(f"model '{model_name}': table_type is not valid for views")
-    if materialized not in {
-        MaterializationType.TABLE,
-        MaterializationType.INCREMENTAL,
-        MaterializationType.SNAPSHOT,
-    }:
+    if not MaterializationType.is_table_backed(materialized=materialized):
         raise CompileInputError(
             f"model '{model_name}': table_type is not supported for materialization "
             f"'{materialized}'"

--- a/src/sqlbuild/compiler/compile/_helpers/config/retention.py
+++ b/src/sqlbuild/compiler/compile/_helpers/config/retention.py
@@ -17,14 +17,6 @@ from sqlbuild.spec.contracts.types import (
     TimeTravelRetentionValue,
 )
 
-_SUPPORTED_MATERIALIZATIONS: frozenset[str] = frozenset(
-    {
-        MaterializationType.TABLE,
-        MaterializationType.INCREMENTAL,
-        MaterializationType.SNAPSHOT,
-    }
-)
-
 
 def resolve_time_travel_retention(
     *,
@@ -42,7 +34,9 @@ def resolve_time_travel_retention(
     source: TimeTravelRetentionSource | None = (
         TimeTravelRetentionSource.TARGET if policy is not None else None
     )
-    if isinstance(materialized, str) and materialized in _SUPPORTED_MATERIALIZATIONS:
+    if isinstance(materialized, str) and MaterializationType.is_table_backed(
+        materialized=materialized
+    ):
         materialization_policy: AuthoredTimeTravelRetention | None = getattr(
             materialization_defaults, materialized
         ).time_travel_retention

--- a/src/sqlbuild/compiler/compile/_helpers/config/table_type.py
+++ b/src/sqlbuild/compiler/compile/_helpers/config/table_type.py
@@ -13,9 +13,6 @@ from sqlbuild.spec.contracts.models import (
 )
 from sqlbuild.spec.contracts.types import TableType, TableTypeSource, TableTypeValue
 
-_SUPPORTED_MATERIALIZATIONS: frozenset[str] = frozenset(
-    {MaterializationType.TABLE, MaterializationType.INCREMENTAL, MaterializationType.SNAPSHOT}
-)
 _STORAGE_POLICY_KEYS: frozenset[str] = frozenset({"time_travel_retention", "table_type"})
 
 
@@ -66,7 +63,7 @@ def resolve_table_type(
     source: TableTypeSource = TableTypeSource.DEFAULT
     declared: bool = False
     materialization: str | None = materialized if isinstance(materialized, str) else None
-    supported: bool = materialization in _SUPPORTED_MATERIALIZATIONS
+    supported: bool = MaterializationType.is_table_backed(materialized=materialization)
     if supported and target_config is not None and target_config.default_table_type is not None:
         value = target_config.default_table_type
         source = TableTypeSource.TARGET

--- a/src/sqlbuild/compiler/planner/_helpers/planning/retention.py
+++ b/src/sqlbuild/compiler/planner/_helpers/planning/retention.py
@@ -22,7 +22,11 @@ from sqlbuild.compiler.planner.models import (
     RetentionPlanEntry,
     TableTypePlanEntry,
 )
-from sqlbuild.compiler.planner.types import RetentionDirection, RetentionPlanPhase
+from sqlbuild.compiler.planner.types import (
+    MaterializationType,
+    RetentionDirection,
+    RetentionPlanPhase,
+)
 from sqlbuild.spec.contracts.main.resolve_target_config import resolve_target_config
 from sqlbuild.spec.contracts.models import ResolvedTimeTravelRetention, TargetConfig
 from sqlbuild.spec.contracts.types import TableType
@@ -56,6 +60,10 @@ def plan_table_types(
     target: TargetConfig = _effective_target(runtime=runtime)
     entries: list[TableTypePlanEntry] = []
     for model in selected_models:
+        if not MaterializationType.is_table_backed(
+            materialized=model.config.values.get("materialized")
+        ):
+            continue
         relation: RelationInfo | None = warehouse.snapshot.existing_relations.get(model.name)
         if relation is None:
             continue

--- a/src/sqlbuild/compiler/planner/types.py
+++ b/src/sqlbuild/compiler/planner/types.py
@@ -215,6 +215,12 @@ class MaterializationType(StrEnum):
     SEED = "seed"
     CUSTOM = "custom"
 
+    @classmethod
+    def is_table_backed(cls, *, materialized: object | None) -> bool:
+        """Return whether a materialization owns a physical managed table."""
+
+        return materialized in {cls.TABLE, cls.INCREMENTAL, cls.SNAPSHOT}
+
 
 class SchemaActionKind(StrEnum):
     ADD_COLUMN = "add_column"

--- a/tests/integration/src/sqlbuild/compiler/planner/main/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/_test_types.py
@@ -67,3 +67,9 @@ class SourceCursorInputPlanErrorTestCase:
     cursor_column: str
     cursor_input_column: str
     expected_error_fragment: str
+
+
+@dataclass(frozen=True)
+class TableTypePlanAssemblyTestCase:
+    description: str
+    expected_entry_names: tuple[str, ...]

--- a/tests/integration/src/sqlbuild/compiler/planner/main/test_build_execution_plan.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/test_build_execution_plan.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import pytest
 
+from sqlbuild.adapter.contract.types import BuiltinAdapter
 from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
 from sqlbuild.cli.output.main.plan import format_plan
+from sqlbuild.compiler.compile.models import CompiledProject
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.models import (
@@ -20,10 +23,18 @@ from sqlbuild.compiler.planner.types import (
     PlanReason,
     WarningSeverity,
 )
+from sqlbuild.spec.contracts.models import (
+    LocalConfig,
+    ProjectConfig,
+    ResolvedTableType,
+    TargetConfig,
+)
+from sqlbuild.spec.contracts.types import TableType, TableTypeSource
 from tests.integration.src.sqlbuild.compiler.planner.main._test_types import (
     BuildExecutionPlanTestCase,
     FormatPlanIntegrationTestCase,
     SourceCursorInputPlanErrorTestCase,
+    TableTypePlanAssemblyTestCase,
 )
 from tests.integration.src.sqlbuild.compiler.planner.main.helpers import (
     build_execution_plan_from_kwargs,
@@ -366,6 +377,77 @@ def test_given_project_when_building_plan_then_produces_expected_output(
     expected_progress_fragment: str
     for expected_progress_fragment in test_case.expected_progress_fragments:
         assert expected_progress_fragment in progress_output
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypePlanAssemblyTestCase(
+            description="selected view and table under permanent target default",
+            expected_entry_names=("orders",),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_view_and_table_with_target_default_when_assembling_plan_then_only_table_has_drift(
+    test_case: TableTypePlanAssemblyTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection.execute("CREATE OR REPLACE VIEW staging.orders_view AS SELECT 1 AS id")
+    connection.execute("CREATE OR REPLACE TABLE staging.orders AS SELECT 1 AS id")
+    project: CompiledProject = build_project_from_test_case(
+        BuildExecutionPlanTestCase(
+            description=test_case.description,
+            setup_sql=(),
+            model_locations={"orders_view": "staging", "orders": "staging"},
+            model_configs={
+                "orders_view": {"materialized": "view"},
+                "orders": {"materialized": "table"},
+            },
+            model_queries={"orders_view": "SELECT 1 AS id", "orders": "SELECT 1 AS id"},
+            full_refresh=False,
+            expected_action={},
+            expected_reason={},
+        )
+    )
+    view_model, table_model = project.models
+    project = replace(
+        project,
+        effective_target_name="test",
+        models=(
+            view_model,
+            replace(
+                table_model,
+                config=replace(
+                    table_model.config,
+                    table_type=ResolvedTableType(
+                        value=TableType.PERMANENT,
+                        source=TableTypeSource.TARGET,
+                        declared=True,
+                    ),
+                ),
+            ),
+        ),
+    )
+    monkeypatch.setattr(adapter, "adapter_name", BuiltinAdapter.SNOWFLAKE.value)
+
+    plan: PlanOutput = build_execution_plan_from_kwargs(
+        project=project,
+        adapter=adapter,
+        connection=connection,
+        project_config=ProjectConfig(
+            name="test",
+            adapter=BuiltinAdapter.SNOWFLAKE.value,
+            targets={"test": TargetConfig(default_table_type=TableType.PERMANENT)},
+        ),
+        local_config=LocalConfig(),
+    )
+
+    assert tuple(entry.model_name for entry in plan.table_type_entries) == (
+        test_case.expected_entry_names
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/config/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/config/_test_types.py
@@ -7,6 +7,7 @@ from sqlbuild.spec.contracts.types import TableType, TableTypeSource
 @dataclass(frozen=True)
 class TableTypeResolutionTestCase:
     description: str
+    materialized: str
     model_value: object | None
     materialization_defaults: MaterializationDefaultsConfig
     target_config: TargetConfig | None

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/config/test_table_type.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/config/test_table_type.py
@@ -25,6 +25,7 @@ from tests.unit.src.sqlbuild.compiler.compile._helpers.config._test_types import
     [
         TableTypeResolutionTestCase(
             description="model overrides materialization and target",
+            materialized="table",
             model_value="transient",
             materialization_defaults=MaterializationDefaultsConfig(
                 table=MaterializationRetentionDefaults(table_type=TableType.PERMANENT)
@@ -36,6 +37,7 @@ from tests.unit.src.sqlbuild.compiler.compile._helpers.config._test_types import
         ),
         TableTypeResolutionTestCase(
             description="materialization overrides target",
+            materialized="table",
             model_value=None,
             materialization_defaults=MaterializationDefaultsConfig(
                 table=MaterializationRetentionDefaults(table_type=TableType.TRANSIENT)
@@ -47,6 +49,7 @@ from tests.unit.src.sqlbuild.compiler.compile._helpers.config._test_types import
         ),
         TableTypeResolutionTestCase(
             description="inherit preserves materialization value",
+            materialized="table",
             model_value="inherit",
             materialization_defaults=MaterializationDefaultsConfig(
                 table=MaterializationRetentionDefaults(table_type=TableType.PERMANENT)
@@ -58,6 +61,7 @@ from tests.unit.src.sqlbuild.compiler.compile._helpers.config._test_types import
         ),
         TableTypeResolutionTestCase(
             description="target supplies value without overrides",
+            materialized="table",
             model_value=None,
             materialization_defaults=MaterializationDefaultsConfig(),
             target_config=TargetConfig(default_table_type=TableType.PERMANENT),
@@ -67,9 +71,20 @@ from tests.unit.src.sqlbuild.compiler.compile._helpers.config._test_types import
         ),
         TableTypeResolutionTestCase(
             description="undeclared value defaults transient",
+            materialized="table",
             model_value=None,
             materialization_defaults=MaterializationDefaultsConfig(),
             target_config=None,
+            expected_value=TableType.TRANSIENT,
+            expected_source=TableTypeSource.DEFAULT,
+            expected_declared=False,
+        ),
+        TableTypeResolutionTestCase(
+            description="target default does not apply to view",
+            materialized="view",
+            model_value=None,
+            materialization_defaults=MaterializationDefaultsConfig(),
+            target_config=TargetConfig(default_table_type=TableType.PERMANENT),
             expected_value=TableType.TRANSIENT,
             expected_source=TableTypeSource.DEFAULT,
             expected_declared=False,
@@ -81,7 +96,7 @@ def test_given_layered_table_type_when_resolving_then_effective_value_tracks_sou
     test_case: TableTypeResolutionTestCase,
 ) -> None:
     result: ResolvedTableType = resolve_table_type(
-        materialized="table",
+        materialized=test_case.materialized,
         model_value=test_case.model_value,
         materialization_defaults=test_case.materialization_defaults,
         target_config=test_case.target_config,
@@ -133,6 +148,16 @@ def test_given_invalid_model_table_type_when_resolving_then_raises_compile_error
         TableTypeValidationErrorTestCase(
             description="custom declaration is rejected",
             materialized="partition_tracked",
+            expected_error_fragment="not supported for materialization",
+        ),
+        TableTypeValidationErrorTestCase(
+            description="ephemeral declaration is rejected",
+            materialized="ephemeral",
+            expected_error_fragment="not supported for materialization",
+        ),
+        TableTypeValidationErrorTestCase(
+            description="seed declaration is rejected",
+            materialized="seed",
             expected_error_fragment="not supported for materialization",
         ),
     ],

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/_test_types.py
@@ -33,3 +33,6 @@ class TableTypePlanningTestCase:
     expected_entry_count: int
     expected_actual_type: str | None
     expected_downgrade: bool
+    materialized: str = "table"
+    additional_config: tuple[tuple[str, object], ...] = ()
+    relation_type: str = "BASE TABLE"

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/test_retention.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/planning/test_retention.py
@@ -27,7 +27,11 @@ from sqlbuild.compiler.planner.models import (
     TableTypePlanEntry,
     WarehouseFingerprints,
 )
-from sqlbuild.compiler.planner.types import RetentionDirection, RetentionPlanPhase
+from sqlbuild.compiler.planner.types import (
+    MaterializationType,
+    RetentionDirection,
+    RetentionPlanPhase,
+)
 from sqlbuild.spec.contracts.models import (
     LocalConfig,
     ProjectConfig,
@@ -201,6 +205,137 @@ def test_given_missing_table_when_planning_type_then_no_entry_is_created(
         table_type=ResolvedTableType(
             value=test_case.desired_type,
             source=TableTypeSource.MODEL,
+            declared=True,
+        ),
+    )
+
+    entries: tuple[TableTypePlanEntry, ...] = plan_table_types(
+        runtime=runtime, warehouse=warehouse, scope=scope
+    )
+
+    assert len(entries) == test_case.expected_entry_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TableTypePlanningTestCase(
+            description="table relation plans table type drift",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=None,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=1,
+            expected_actual_type=None,
+            expected_downgrade=False,
+            materialized=MaterializationType.TABLE,
+        ),
+        TableTypePlanningTestCase(
+            description="incremental relation plans table type drift",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=None,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=1,
+            expected_actual_type=None,
+            expected_downgrade=False,
+            materialized=MaterializationType.INCREMENTAL,
+        ),
+        TableTypePlanningTestCase(
+            description="microbatch incremental relation plans table type drift",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=None,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=1,
+            expected_actual_type=None,
+            expected_downgrade=False,
+            materialized=MaterializationType.INCREMENTAL,
+            additional_config=(("incremental_mode", "microbatch"),),
+        ),
+        TableTypePlanningTestCase(
+            description="snapshot relation plans table type drift",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=None,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=1,
+            expected_actual_type=None,
+            expected_downgrade=False,
+            materialized=MaterializationType.SNAPSHOT,
+        ),
+        TableTypePlanningTestCase(
+            description="warehouse view with unknown table metadata has no drift",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=None,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=0,
+            expected_actual_type=None,
+            expected_downgrade=False,
+            materialized=MaterializationType.VIEW,
+            relation_type="VIEW",
+        ),
+        TableTypePlanningTestCase(
+            description="ephemeral model has no table type drift",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=None,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=0,
+            expected_actual_type=None,
+            expected_downgrade=False,
+            materialized="ephemeral",
+        ),
+        TableTypePlanningTestCase(
+            description="seed materialization has no table type drift",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=None,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=0,
+            expected_actual_type=None,
+            expected_downgrade=False,
+            materialized=MaterializationType.SEED,
+        ),
+        TableTypePlanningTestCase(
+            description="custom materialization has no table type drift",
+            desired_type=TableType.PERMANENT,
+            live_is_transient=None,
+            relation_exists=True,
+            downgrade_policy=TableTypeDowngradePolicy.REQUIRE_CONFIRMATION,
+            expected_entry_count=0,
+            expected_actual_type=None,
+            expected_downgrade=False,
+            materialized=MaterializationType.CUSTOM,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_materialization_family_when_planning_table_types_then_only_tables_have_drift(
+    test_case: TableTypePlanningTestCase,
+) -> None:
+    adapter: Mock = Mock(adapter_name=BuiltinAdapter.SNOWFLAKE.value)
+    adapter.maximum_identifier_length.return_value = 255
+    relation: RelationInfo = RelationInfo(
+        database="warehouse",
+        schema="analytics",
+        name="orders",
+        relation_type=test_case.relation_type,
+        is_transient=test_case.live_is_transient,
+    )
+    config_values: dict[str, object] = {
+        "materialized": test_case.materialized,
+        **dict(test_case.additional_config),
+    }
+    runtime, warehouse, scope = build_retention_planner_inputs(
+        adapter=adapter,
+        desired_days=1,
+        existing_relations={"orders": relation},
+        config_values=config_values,
+        table_type=ResolvedTableType(
+            value=test_case.desired_type,
+            source=TableTypeSource.TARGET,
             declared=True,
         ),
     )


### PR DESCRIPTION
## Why

`betfair_prices_job` failed after 427.84s of planning with `live table type metadata is unknown; refusing conversion` for `market__mart_v_price_collections__betfair`. The model is a view. Snowflake correctly reports no permanent/transient metadata for views, but table-type planning treated every selected model as table-backed and created an impossible conversion entry from `is_transient = NULL`.

## Changes

- Add canonical `MaterializationType.is_table_backed()` classification for `table`, `incremental` (including microbatch), and `snapshot`.
- Use it consistently in table-type config resolution, time-travel retention resolution/validation, and warehouse table-type planning.
- Exclude views, ephemeral models, seeds, custom materializations, and all other non-table-backed models from table-type drift planning. Target/materialization defaults no longer create view conversion entries.
- Preserve fail-fast validation for explicit `table_type` or managed retention declarations on unsupported materializations.

## Verification

- Planner unit/integration: 704 passed
- Build + Snowflake retention: 10 passed
- Coverage: table/incremental/microbatch/snapshot, view/ephemeral/seed/custom, explicit invalid declarations, warehouse view with unknown table metadata, and real plan assembly under a permanent Snowflake target default
- Ruff, ty (8 documented optional-dependency diagnostics only), Fensu 0 faults, diff check clean

Refs CHI-187.
