### PR TITLE
fix: scope cursor validation to selected models

### DIFF
--- a/src/sqlbuild/compiler/planner/_helpers/planning/warehouse_state.py
+++ b/src/sqlbuild/compiler/planner/_helpers/planning/warehouse_state.py
@@ -10,6 +10,7 @@ from sqlbuild.compiler.planner._helpers.planning.full_refresh import (
 )
 from sqlbuild.compiler.planner._helpers.warehouse.snapshot import gather_warehouse_snapshot
 from sqlbuild.compiler.planner.models import (
+    CursorSnapshotScope,
     DeferralInputs,
     PlannerOverrides,
     PlannerRelationsContext,
@@ -44,7 +45,10 @@ def gather_planner_warehouse_state(
         ),
         on_progress=runtime.on_progress,
         deferred_locations=deferral.deferred_locations,
-        runtime_producer_keys=scopes.selected_scope.selected_keys,
+        cursor_scope=CursorSnapshotScope(
+            model_keys=scopes.selected_scope.selected_keys,
+            runtime_producer_keys=scopes.selected_scope.selected_keys,
+        ),
     )
     inspection_relations: PlannerRelationsContext = build_planner_relations_context(
         project=runtime.project,

--- a/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
+++ b/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
@@ -42,6 +42,7 @@ from sqlbuild.compiler.planner._helpers.planning.full_refresh import (
 from sqlbuild.compiler.planner.constants import METADATA_NAME_FILTER_LIMIT
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.models import (
+    CursorSnapshotScope,
     MissingUpstream,
     ModelCursorSnapshot,
     PlannerScope,
@@ -142,7 +143,7 @@ def gather_warehouse_snapshot(
     full_refresh_model_names: frozenset[str] | None = None,
     on_progress: Callable[[str], None] | None = None,
     deferred_locations: dict[str, CompiledRelationLocation] | None = None,
-    runtime_producer_keys: frozenset[CompiledObjectKey] | None = None,
+    cursor_scope: CursorSnapshotScope | None = None,
 ) -> WarehouseSnapshot:
     """Gather relations, columns, and fingerprints for all target schemas."""
 
@@ -200,11 +201,13 @@ def gather_warehouse_snapshot(
         connection=connection,
         execute=execute,
         existing_relations=relations,
-        selected_keys=selected_keys,
+        selected_keys=cursor_scope.model_keys if cursor_scope is not None else selected_keys,
         full_refresh_model_names=effective_full_refresh_names,
         on_progress=on_progress,
         deferred_locations=deferred_locations,
-        runtime_producer_keys=runtime_producer_keys,
+        runtime_producer_keys=(
+            cursor_scope.runtime_producer_keys if cursor_scope is not None else None
+        ),
     )
 
     return WarehouseSnapshot(

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -334,6 +334,14 @@ class WarehouseFingerprints:
 
 
 @dataclass(frozen=True)
+class CursorSnapshotScope:
+    """Execution selection used for cursor validation and runtime producer resolution."""
+
+    model_keys: frozenset[CompiledObjectKey]
+    runtime_producer_keys: frozenset[CompiledObjectKey]
+
+
+@dataclass(frozen=True)
 class WarehouseSnapshot:
     """Frozen point-in-time picture of warehouse state for planning."""
 

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/_test_types.py
@@ -52,6 +52,20 @@ class GatherSharedCursorSnapshotTestCase:
 
 
 @dataclass(frozen=True)
+class GatherSelectedCursorScopeTestCase:
+    description: str
+    expected_cursor_snapshot: ModelCursorSnapshot
+    expected_statements: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class GatherInvalidCursorScopeTestCase:
+    description: str
+    expected_error_code: str
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
 class GatherSourceColumnsTestCase:
     description: str
     setup_sql: tuple[str, ...]

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/helpers.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -25,7 +25,12 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSourceFile,
 )
 from sqlbuild.compiler.references.types import SqlReferenceKind
-from sqlbuild.spec.contracts.models import SchemaSeedEntry, SourceEntry
+from sqlbuild.spec.contracts.models import (
+    SchemaColumn,
+    SchemaModelEntry,
+    SchemaSeedEntry,
+    SourceEntry,
+)
 
 
 class RecordingDuckDbAdapter(DuckDbAdapter):
@@ -193,6 +198,26 @@ def build_project_with_targets(
         sources=tuple(sources),
         seeds=tuple(seeds),
     )
+
+
+def with_leading_enforced_model_contracts(
+    project: CompiledProject, *, columns_by_model: dict[str, tuple[str, ...]]
+) -> CompiledProject:
+    """Attach enforced contracts to leading models in a compiled test project."""
+
+    models: list[CompiledModel] = list(project.models)
+    for index, (model_name, column_names) in enumerate(columns_by_model.items()):
+        model: CompiledModel = models[index]
+        assert model.name == model_name
+        models[index] = replace(
+            model,
+            config=replace(model.config, values=model.config.values | {"contract": "enforced"}),
+            schema_entry=SchemaModelEntry(
+                name=model.name,
+                columns=tuple(SchemaColumn(name=name) for name in column_names),
+            ),
+        )
+    return replace(project, models=tuple(models))
 
 
 def build_deferred_locations_from_map(

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/test_warehouse_snapshot.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/test_warehouse_snapshot.py
@@ -18,10 +18,17 @@ from sqlbuild.compiler.fingerprints.models import Fingerprint
 from sqlbuild.compiler.planner._helpers.output.plan_entry import gather_source_columns
 from sqlbuild.compiler.planner._helpers.warehouse.snapshot import gather_warehouse_snapshot
 from sqlbuild.compiler.planner.constants import METADATA_NAME_FILTER_LIMIT
-from sqlbuild.compiler.planner.models import ModelCursorSnapshot, WarehouseSnapshot
+from sqlbuild.compiler.planner.exceptions import PlannerInputError
+from sqlbuild.compiler.planner.models import (
+    CursorSnapshotScope,
+    ModelCursorSnapshot,
+    WarehouseSnapshot,
+)
 from tests.integration.src.sqlbuild.compiler.planner._helpers._test_types import (
     GatherCursorSnapshotTestCase,
     GatherEmptySnapshotTestCase,
+    GatherInvalidCursorScopeTestCase,
+    GatherSelectedCursorScopeTestCase,
     GatherSharedCursorSnapshotTestCase,
     GatherSourceColumnsTestCase,
     GatherWarehouseSnapshotTestCase,
@@ -31,6 +38,7 @@ from tests.integration.src.sqlbuild.compiler.planner._helpers.helpers import (
     _IncrementalModelSpec,
     build_deferred_locations_from_map,
     build_project_with_targets,
+    with_leading_enforced_model_contracts,
 )
 
 _INCREMENTAL_MODEL: _IncrementalModelSpec = _IncrementalModelSpec(
@@ -600,6 +608,148 @@ def test_given_models_sharing_one_source_when_gathering_snapshot_then_executes_o
     }
     assert tuple(statements) == test_case.expected_statements
     assert "UNION ALL" not in statements[0]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        GatherSelectedCursorScopeTestCase(
+            description="selected cursor ignores unrelated invalid model",
+            expected_cursor_snapshot=ModelCursorSnapshot(
+                target_max=None,
+                upstream_mins=("2024-01-01 00:00:00",),
+                upstream_maxes=("2024-03-01 00:00:00",),
+            ),
+            expected_statements=(
+                "SELECT CAST(MIN(event_time) AS VARCHAR) AS _min, "
+                "CAST(MAX(event_time) AS VARCHAR) AS _max FROM staging.valid_upstream",
+            ),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_broad_metadata_scope_when_gathering_selected_cursor_then_ignores_unrelated_invalid_model(
+    test_case: GatherSelectedCursorScopeTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+) -> None:
+    connection.execute("CREATE TABLE staging.valid_upstream (event_time TIMESTAMP)")
+    connection.execute(
+        "INSERT INTO staging.valid_upstream VALUES ('2024-01-01'), ('2024-03-01')"
+    )
+    connection.execute("CREATE TABLE staging.invalid_upstream (id INTEGER)")
+    statements: list[str] = []
+
+    def _record_execute(*, connection: Any, sql: str) -> Any:
+        statements.append(sql)
+        return connection.execute(sql)
+
+    project: CompiledProject = build_project_with_targets(
+        model_locations={"valid_upstream": "staging", "invalid_upstream": "staging"},
+        incremental_models=(
+            _IncrementalModelSpec(
+                name="selected_cursor",
+                schema="staging",
+                cursor="event_time",
+                ref_names=("valid_upstream",),
+            ),
+            _IncrementalModelSpec(
+                name="unrelated_cursor",
+                schema="staging",
+                cursor="event_time",
+                ref_names=("invalid_upstream",),
+                extra_config={
+                    "cursor_filter_inputs": {"invalid_upstream": "id"},
+                    "cursor_watermark_inputs": {"invalid_upstream": "meeting_date"},
+                },
+            ),
+        ),
+    )
+    project = with_leading_enforced_model_contracts(
+        project,
+        columns_by_model={
+            "valid_upstream": ("event_time",),
+            "invalid_upstream": ("id",),
+        },
+    )
+    selected_cursor_key: CompiledObjectKey = CompiledObjectKey(
+        resource_type=CompiledResourceType.MODEL,
+        name="selected_cursor",
+    )
+    metadata_keys: frozenset[CompiledObjectKey] = frozenset(model.key for model in project.models)
+
+    snapshot: WarehouseSnapshot = gather_warehouse_snapshot(
+        project=project,
+        adapter=adapter,
+        connection=connection,
+        execute=_record_execute,
+        selected_keys=metadata_keys,
+        cursor_scope=CursorSnapshotScope(
+            model_keys=frozenset({selected_cursor_key}),
+            runtime_producer_keys=frozenset({selected_cursor_key}),
+        ),
+    )
+
+    assert snapshot.cursor_snapshots == {"selected_cursor": test_case.expected_cursor_snapshot}
+    assert tuple(statements) == test_case.expected_statements
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        GatherInvalidCursorScopeTestCase(
+            description="selected invalid cursor fails precise contract validation",
+            expected_error_code="S302",
+            expected_error_fragment="Declared contract columns: id",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_selected_invalid_cursor_model_when_gathering_snapshot_then_raises_s302(
+    test_case: GatherInvalidCursorScopeTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+    execute: Any,
+) -> None:
+    connection.execute("CREATE TABLE staging.invalid_upstream (id INTEGER)")
+    project: CompiledProject = build_project_with_targets(
+        model_locations={"invalid_upstream": "staging"},
+        incremental_models=(
+            _IncrementalModelSpec(
+                name="invalid_cursor",
+                schema="staging",
+                cursor="id",
+                ref_names=("invalid_upstream",),
+                extra_config={
+                    "cursor_filter_inputs": {"invalid_upstream": "id"},
+                    "cursor_watermark_inputs": {"invalid_upstream": "meeting_date"},
+                },
+            ),
+        ),
+    )
+    project = with_leading_enforced_model_contracts(
+        project,
+        columns_by_model={"invalid_upstream": ("id",)},
+    )
+    invalid_cursor_key: CompiledObjectKey = CompiledObjectKey(
+        resource_type=CompiledResourceType.MODEL,
+        name="invalid_cursor",
+    )
+
+    with pytest.raises(PlannerInputError, match=test_case.expected_error_fragment) as exc_info:
+        gather_warehouse_snapshot(
+            project=project,
+            adapter=adapter,
+            connection=connection,
+            execute=execute,
+            selected_keys=frozenset(model.key for model in project.models),
+            cursor_scope=CursorSnapshotScope(
+                model_keys=frozenset({invalid_cursor_key}),
+                runtime_producer_keys=frozenset({invalid_cursor_key}),
+            ),
+        )
+
+    assert exc_info.value.code == test_case.expected_error_code
 
 
 if __name__ == "__main__":

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/test_warehouse_snapshot.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/test_warehouse_snapshot.py
@@ -634,9 +634,7 @@ def test_given_broad_metadata_scope_when_gathering_selected_cursor_then_ignores_
     connection: Any,
 ) -> None:
     connection.execute("CREATE TABLE staging.valid_upstream (event_time TIMESTAMP)")
-    connection.execute(
-        "INSERT INTO staging.valid_upstream VALUES ('2024-01-01'), ('2024-03-01')"
-    )
+    connection.execute("INSERT INTO staging.valid_upstream VALUES ('2024-01-01'), ('2024-03-01')")
     connection.execute("CREATE TABLE staging.invalid_upstream (id INTEGER)")
     statements: list[str] = []
 


### PR DESCRIPTION
## Why

SQLBuild 0.72.0 reused the planner's broad stale-warning scope for cursor watermark validation. A Dagster build selecting only Betfair assets therefore failed during warehouse inspection on an unselected Amtote model whose enforced upstream contract omitted its configured cursor column.

The stale-warning scope must remain broad for upstream fingerprints and metadata, but strict cursor validation belongs only to models selected for execution.

## Changes

- Add an explicit cursor snapshot scope separating cursor models from runtime-produced relations.
- Keep stale-warning scope for relation, column, fingerprint, and staleness inspection.
- Validate and collect cursor snapshots only for selected execution models.
- Continue traversing selected models to query unselected and deferred watermark upstreams.
- Preserve direct `gather_warehouse_snapshot` fallback semantics for full-project, selected, and empty scopes.

## Verification

- Regression proves a selected valid cursor model is not blocked by an unrelated invalid cursor model.
- Selecting the invalid model still raises precise S302.
- Selected models still read unselected/deferred physical watermark inputs.
- Mixed-grain planner-owned replay E2E remains green.
- Planner suites: 738 passed
- Full available unit: 4,450 passed
- Full available integration: 695 passed, 92 skipped
- Ruff, ty, Fensu 0 faults, diff check clean

Refs CHI-189.
