### PR TITLE
fix: bound implausible future cursor watermarks

### DIFF
--- a/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
+++ b/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import cast
 
+from sqlbuild.cli.output._helpers.future_cursor_safety import serialize_future_cursor_safety
 from sqlbuild.compiler.auditing.types import AuditOutcome
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import (
@@ -498,6 +499,7 @@ def _format_model_assets(
                 "error_help": result.error_help,
                 "error_message": result.error_message,
                 "warnings": result.warning_messages,
+                "future_cursor_safety": serialize_future_cursor_safety(result.future_cursor_safety),
                 "microbatch": _format_microbatch_result(result),
             }
         )

--- a/src/sqlbuild/cli/output/_helpers/future_cursor_safety.py
+++ b/src/sqlbuild/cli/output/_helpers/future_cursor_safety.py
@@ -1,0 +1,50 @@
+"""Structured future-cursor safety output."""
+
+from __future__ import annotations
+
+from sqlbuild.compiler.planner.models import FutureCursorSafetyEvidence
+
+
+def serialize_future_cursor_safety(
+    evidence: FutureCursorSafetyEvidence | None,
+) -> dict[str, object] | None:
+    """Serialize cap policy, bounds, and physical input evidence."""
+
+    if evidence is None:
+        return None
+    return {
+        "action": evidence.action.value,
+        "max_distance": evidence.max_distance,
+        "invocation_time": evidence.invocation_time,
+        "discovered_bounds": {
+            "start": evidence.discovered_start,
+            "end": evidence.discovered_end,
+        },
+        "applied_bounds": {
+            "start": evidence.applied_start,
+            "end": evidence.applied_end,
+        },
+        "maximum_allowed_bounds": {
+            "start": evidence.maximum_allowed_start,
+            "end": evidence.maximum_allowed_end,
+        },
+        "future_start_detected": evidence.future_start_detected,
+        "future_end_detected": evidence.future_end_detected,
+        "determining_input": (
+            {
+                "relation": evidence.determining_relation,
+                "cursor_column": evidence.determining_cursor_column,
+            }
+            if evidence.determining_relation is not None
+            else None
+        ),
+        "inputs": [
+            {
+                "relation": item.relation,
+                "cursor_column": item.cursor_column,
+                "minimum": item.minimum,
+                "maximum": item.maximum,
+            }
+            for item in evidence.inputs
+        ],
+    }

--- a/src/sqlbuild/cli/output/_helpers/plan_json.py
+++ b/src/sqlbuild/cli/output/_helpers/plan_json.py
@@ -7,11 +7,13 @@ import json
 from typing import cast
 
 from sqlbuild.cli.output._helpers.cursor_plan import build_cursor_plan_details
+from sqlbuild.cli.output._helpers.future_cursor_safety import serialize_future_cursor_safety
 from sqlbuild.cli.output.models import CursorPlanDetails
 from sqlbuild.compiler.pipeline.models import PythonPlanEntry
 from sqlbuild.compiler.planner.models import (
     CascadeResult,
     FunctionPlanEntry,
+    FutureCursorSafetyEvidence,
     ModelPlanEntry,
     PlanOutput,
     PlanProviderUsage,
@@ -136,6 +138,16 @@ def _serialize_model_entry(entry: ModelPlanEntry) -> dict[str, object]:
             "start": entry.cursor_bounds.start,
             "end": entry.cursor_bounds.end,
         }
+    future_safety: FutureCursorSafetyEvidence | None = (
+        entry.microbatch_range.future_safety
+        if entry.microbatch_range is not None and entry.microbatch_range.future_safety is not None
+        else (entry.cursor_bounds.future_safety if entry.cursor_bounds is not None else None)
+    )
+    serialized_future_safety: dict[str, object] | None = serialize_future_cursor_safety(
+        future_safety
+    )
+    if serialized_future_safety is not None:
+        model["future_cursor_safety"] = serialized_future_safety
     cursor_details: CursorPlanDetails | None = build_cursor_plan_details(entry=entry)
     if cursor_details is not None:
         model["cursor"] = _serialize_cursor_details(details=cursor_details)

--- a/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
@@ -37,8 +37,10 @@ from sqlbuild.spec.contracts.models import (
     ClonePolicy,
     ConstantsConfig,
     CostConfig,
+    CursorsConfig,
     DbtConfig,
     DefaultsConfig,
+    FutureCursorsConfig,
     JanitorConfig,
     LocalClonePolicy,
     LocalConfig,
@@ -57,6 +59,7 @@ from sqlbuild.spec.contracts.models import (
     TargetConfig,
 )
 from sqlbuild.spec.contracts.types import (
+    FutureCursorAction,
     TableType,
     TableTypeDowngradePolicy,
     TableTypeValue,
@@ -75,6 +78,9 @@ _DEFAULT_HISTORICAL_SNAPSHOT_FULL_REFRESH: str = "require_confirmation"
 _DEFAULT_SNAPSHOT_SCHEMA_CHANGE: str = "append_new_columns"
 _DEFAULT_WILDCARD_CHECK_SNAPSHOT_SCHEMA_CHANGE: str = "require_confirmation"
 _BATCH_CONCURRENCY_CONFIG_KEY: str = "batch_concurrency"
+_CURSOR_DURATION_PATTERN: re.Pattern[str] = re.compile(
+    r"^(?=.*[1-9])(?:(\d+)y)?(?:(\d+)mo)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$"
+)
 
 
 def load_project_config(*, project_dir: Path) -> ProjectConfig:
@@ -96,6 +102,7 @@ def load_project_config(*, project_dir: Path) -> ProjectConfig:
     constants: ConstantsConfig = _load_constants(
         payload=payload.get("constants"), file_path=file_path
     )
+    cursors: CursorsConfig = _load_cursors(payload=payload.get("cursors"), file_path=file_path)
     defaults: DefaultsConfig = _load_defaults(payload=payload.get("defaults"), file_path=file_path)
     materialization_defaults: MaterializationDefaultsConfig = _load_materialization_defaults(
         payload=payload.get("materialization_defaults"), file_path=file_path
@@ -133,6 +140,7 @@ def load_project_config(*, project_dir: Path) -> ProjectConfig:
         scopes=scopes,
         cost=cost,
         constants=constants,
+        cursors=cursors,
         defaults=defaults,
         materialization_defaults=materialization_defaults,
         path_defaults=path_defaults,
@@ -351,6 +359,38 @@ def _load_settings(*, payload: object, file_path: Path) -> SettingsConfig:
         default_audit_severity=default_audit_severity,
         default_audit_run_scope=default_audit_run_scope,
     )
+
+
+def _load_cursors(*, payload: object, file_path: Path) -> CursorsConfig:
+    mapping: dict[str, object] = _coerce_mapping(
+        payload=payload, label="cursors", file_path=file_path
+    )
+    _validate_allowed_keys(
+        mapping=mapping,
+        allowed_keys=frozenset({"future"}),
+        label="cursors",
+        file_path=file_path,
+    )
+    future: dict[str, object] = _coerce_mapping(
+        payload=mapping.get("future"), label="cursors.future", file_path=file_path
+    )
+    _validate_allowed_keys(
+        mapping=future,
+        allowed_keys=frozenset({"max_distance", "action"}),
+        label="cursors.future",
+        file_path=file_path,
+    )
+    max_distance: str | None = _optional_str(payload=future, key="max_distance")
+    if max_distance is not None and _CURSOR_DURATION_PATTERN.fullmatch(max_distance) is None:
+        raise ProjectConfigError(
+            "cursors.future.max_distance must be a positive duration like 7d, 12h, or 1mo"
+        )
+    raw_action: str | None = _optional_str(payload=future, key="action")
+    try:
+        action: FutureCursorAction = FutureCursorAction(raw_action or FutureCursorAction.ERROR)
+    except ValueError:
+        raise ProjectConfigError("cursors.future.action must be one of: cap, error") from None
+    return CursorsConfig(future=FutureCursorsConfig(max_distance=max_distance, action=action))
 
 
 def _load_scopes(*, payload: object, file_path: Path) -> ScopesConfig:

--- a/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
@@ -55,10 +55,13 @@ from sqlbuild.compiler.planner.constants import (
 )
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.main.changes._model_changes import detect_model_changes
+from sqlbuild.compiler.planner.main.execution.future_cursor_safety import apply_future_cursor_safety
+from sqlbuild.compiler.planner.main.execution.future_cursor_warning import future_cursor_cap_warning
 from sqlbuild.compiler.planner.models import (
     BackfillResult,
     ChangeDetectionResult,
     CursorBounds,
+    CursorInputEvidence,
     CursorInputRelation,
     CursorOverridePair,
     CursorOverrides,
@@ -92,7 +95,13 @@ from sqlbuild.compiler.planner.types import (
 )
 from sqlbuild.compiler.references.main._render_source_relation import render_source_relation
 from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver, SqlReferenceKind
-from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig, SchemaColumn, SourceEntry
+from sqlbuild.spec.contracts.models import (
+    FutureCursorsConfig,
+    LocalConfig,
+    ProjectConfig,
+    SchemaColumn,
+    SourceEntry,
+)
 from sqlbuild.spec.contracts.types import TableType
 
 _MODELS_DIR_PREFIX: str = "models/"
@@ -290,6 +299,8 @@ def build_plan_entries(
                 source_warehouse_columns=relations.source_warehouse_columns,
                 star_exclude_keyword=relations.star_exclude_keyword,
                 runtime_cursor_producer_names=runtime_cursor_producer_names,
+                future_cursor_config=inputs.future_cursor_config,
+                invocation_time=inputs.invocation_time,
             ),
             sql_analysis_enabled=project.settings.sql_analysis,
             full_refresh=effective_full_refresh,
@@ -391,7 +402,6 @@ def plan_model_from_change(
     if backfill_override is not None:
         change_result = replace(change_result, backfill=backfill_override)
 
-    models_by_name: dict[str, CompiledModel] = context.models_by_name
     start_cursor_override: str | None = cursor_overrides.start_cursor_override
     end_cursor_override: str | None = cursor_overrides.end_cursor_override
     backfill: BackfillResult = (
@@ -404,7 +414,7 @@ def plan_model_from_change(
     validate_source_cursor_input_columns(
         model=model,
         cursor_column=cursor_column,
-        models_by_name=models_by_name,
+        models_by_name=context.models_by_name,
         source_map=context.source_map,
         source_warehouse_columns=context.source_warehouse_columns,
     )
@@ -464,7 +474,7 @@ def plan_model_from_change(
             model=model,
             adapter=adapter,
             model_locations=context.model_locations,
-            models_by_name=models_by_name,
+            models_by_name=context.models_by_name,
             seed_locations=context.seed_locations,
             source_map=context.source_map,
             cursor_column=cursor_column,
@@ -481,6 +491,8 @@ def plan_model_from_change(
         start_cursor_override=start_cursor_override,
         end_cursor_override=end_cursor_override,
         runtime_owned_cursor_bounds=runtime_owned_cursor_bounds,
+        future_cursor_config=context.future_cursor_config,
+        invocation_time=context.invocation_time,
     )
 
     cursor_type_warning: PlanWarning | None = check_cursor_type_consistency(
@@ -516,6 +528,14 @@ def plan_model_from_change(
         end_cursor_override=end_cursor_override,
         runtime_owned_cursor_bounds=runtime_owned_cursor_bounds,
         cursor_input_relations=cursor_input_relations,
+        future_cursor_config=context.future_cursor_config,
+        invocation_time=context.invocation_time,
+    )
+
+    warnings = _append_future_cap_warning(
+        warnings=warnings,
+        model_name=model.name,
+        bounds=microbatch_range or cursor_bounds,
     )
 
     fingerprint: Fingerprint | None = snapshot.fingerprints.models.get(model.name)
@@ -591,6 +611,8 @@ def plan_model_from_change(
         microbatch_range=microbatch_range,
         start_cursor_override=start_cursor_override,
         end_cursor_override=end_cursor_override,
+        future_cursor_config=context.future_cursor_config,
+        invocation_time=context.invocation_time,
         unique_key=unique_key,
         merge_exclude_columns=_get_config_string_tuple(model=model, key="merge_exclude_columns"),
         snapshot_strategy=snapshot_strategy,
@@ -860,6 +882,8 @@ def _compute_microbatch_range(
     end_cursor_override: str | None,
     runtime_owned_cursor_bounds: bool,
     cursor_input_relations: tuple[CursorInputRelation, ...],
+    future_cursor_config: FutureCursorsConfig | None = None,
+    invocation_time: datetime | None = None,
 ) -> CursorBounds | None:
     """Compute the real overall cursor range for microbatch batch splitting."""
 
@@ -906,7 +930,7 @@ def _compute_microbatch_range(
     if backfill.action == BackfillAction.BOUNDED:
         backfill_duration = backfill.duration
 
-    return compute_cursor_bounds(
+    bounds: CursorBounds | None = compute_cursor_bounds(
         cursor_snapshot=cursor_snapshot,
         cursor_type=cursor_type,
         cursor_start=cursor_start,
@@ -916,6 +940,16 @@ def _compute_microbatch_range(
         end_cursor_override=end_cursor_override,
         cursor_grain=effective_grain,
         is_microbatch=False,
+    )
+    return _apply_future_safety(
+        bounds=bounds,
+        cursor_type=cursor_type,
+        cursor_grain=effective_grain,
+        start_cursor_override=start_cursor_override,
+        end_cursor_override=end_cursor_override,
+        future_cursor_config=future_cursor_config,
+        invocation_time=invocation_time,
+        input_evidence=cursor_snapshot.input_evidence,
     )
 
 
@@ -943,6 +977,8 @@ def _compute_plan_cursor_bounds(
     start_cursor_override: str | None,
     end_cursor_override: str | None,
     runtime_owned_cursor_bounds: bool,
+    future_cursor_config: FutureCursorsConfig | None = None,
+    invocation_time: datetime | None = None,
 ) -> CursorBounds | None:
     """Compute cursor bounds for inclusion on the plan entry."""
 
@@ -976,16 +1012,73 @@ def _compute_plan_cursor_bounds(
     if backfill.action == BackfillAction.BOUNDED:
         backfill_duration = backfill.duration
 
-    return compute_cursor_bounds(
+    cursor_type: str | None = _get_config_str(model=model, key="cursor_type")
+    cursor_grain: str | None = _get_config_str(model=model, key="cursor_grain")
+    bounds: CursorBounds | None = compute_cursor_bounds(
         cursor_snapshot=cursor_snapshot,
-        cursor_type=_get_config_str(model=model, key="cursor_type"),
+        cursor_type=cursor_type,
         cursor_start=cursor_start,
         lookback=lookback,
         backfill_duration=backfill_duration,
         start_cursor_override=start_cursor_override,
         end_cursor_override=end_cursor_override,
         is_microbatch=is_microbatch,
-        cursor_grain=_get_config_str(model=model, key="cursor_grain"),
+        cursor_grain=cursor_grain,
+    )
+    return _apply_future_safety(
+        bounds=bounds,
+        cursor_type=cursor_type,
+        cursor_grain=cursor_grain,
+        start_cursor_override=start_cursor_override,
+        end_cursor_override=end_cursor_override,
+        future_cursor_config=future_cursor_config,
+        invocation_time=invocation_time,
+        input_evidence=cursor_snapshot.input_evidence,
+    )
+
+
+def _apply_future_safety(
+    *,
+    bounds: CursorBounds | None,
+    cursor_type: str | None,
+    cursor_grain: str | None,
+    start_cursor_override: str | None,
+    end_cursor_override: str | None,
+    future_cursor_config: FutureCursorsConfig | None,
+    invocation_time: datetime | None,
+    input_evidence: tuple[CursorInputEvidence, ...],
+) -> CursorBounds | None:
+    if bounds is None:
+        return None
+    if bounds.end == MICROBATCH_END_SENTINEL:
+        return bounds
+    return apply_future_cursor_safety(
+        bounds=bounds,
+        cursor_type=cursor_type,
+        cursor_grain=cursor_grain,
+        config=future_cursor_config,
+        invocation_time=invocation_time,
+        has_complete_override=(
+            start_cursor_override is not None and end_cursor_override is not None
+        ),
+        input_evidence=input_evidence,
+    )
+
+
+def _append_future_cap_warning(
+    *, warnings: tuple[PlanWarning, ...], model_name: str, bounds: CursorBounds | None
+) -> tuple[PlanWarning, ...]:
+    message: str | None = future_cursor_cap_warning(bounds)
+    if message is None:
+        return warnings
+    return (
+        *warnings,
+        PlanWarning(
+            model_name=model_name,
+            severity=WarningSeverity.WARNING,
+            code="FUTURE_CURSOR_CAPPED",
+            message=message,
+        ),
     )
 
 

--- a/src/sqlbuild/compiler/planner/_helpers/planning/entries.py
+++ b/src/sqlbuild/compiler/planner/_helpers/planning/entries.py
@@ -64,6 +64,12 @@ def build_planner_entry_results(
                 else frozenset()
             ),
             external_blocked_model_names=frozenset(overrides.external_blocked_model_names),
+            future_cursor_config=(
+                runtime.project_config.cursors.future
+                if runtime.project_config is not None
+                else None
+            ),
+            invocation_time=runtime.invocation_time,
         ),
     )
     return PlannerEntryResults(

--- a/src/sqlbuild/compiler/planner/_helpers/resolve/cursor.py
+++ b/src/sqlbuild/compiler/planner/_helpers/resolve/cursor.py
@@ -121,6 +121,7 @@ def normalize_cursor_snapshot_grain(
             _floor_timestamp_string(value=value, grain=effective_grain)
             for value in cursor_snapshot.upstream_maxes
         ),
+        input_evidence=cursor_snapshot.input_evidence,
         expected_watermark_count=cursor_snapshot.expected_watermark_count,
         unavailable_watermark_tags=cursor_snapshot.unavailable_watermark_tags,
     )

--- a/src/sqlbuild/compiler/planner/_helpers/resolve/future_cursor_safety.py
+++ b/src/sqlbuild/compiler/planner/_helpers/resolve/future_cursor_safety.py
@@ -1,0 +1,190 @@
+"""Future cursor safety calculation."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, date, datetime, time, timedelta
+
+from sqlbuild.compiler.planner.exceptions import FutureCursorSafetyError
+from sqlbuild.compiler.planner.models import (
+    CursorBounds,
+    CursorInputEvidence,
+    Duration,
+    FutureCursorSafetyEvidence,
+)
+from sqlbuild.compiler.planner.types import CursorGrain, CursorType
+from sqlbuild.spec.contracts.models import FutureCursorsConfig
+from sqlbuild.spec.contracts.types import FutureCursorAction
+
+
+def resolve_future_cursor_safety(
+    *,
+    bounds: CursorBounds,
+    cursor_type: str | None,
+    cursor_grain: str | None,
+    config: FutureCursorsConfig | None,
+    invocation_time: datetime | None,
+    has_complete_override: bool,
+    input_evidence: tuple[CursorInputEvidence, ...] = (),
+) -> CursorBounds:
+    """Apply future cursor policy to effective timestamp bounds."""
+
+    if (
+        config is None
+        or config.max_distance is None
+        or cursor_type != CursorType.TIMESTAMP
+        or invocation_time is None
+        or has_complete_override
+    ):
+        return bounds
+    duration: Duration | None = Duration.parse(config.max_distance)
+    if duration is None:
+        raise FutureCursorSafetyError(
+            f"invalid cursors.future.max_distance '{config.max_distance}'"
+        )
+    allowed_start, allowed_end = _allowed_bounds(
+        discovered_end=bounds.end,
+        cursor_grain=cursor_grain,
+        invocation_time=invocation_time,
+        duration=duration,
+    )
+    future_start_detected: bool = _comparison_key(bounds.start) > _comparison_key(allowed_start)
+    future_end_detected: bool = _comparison_key(bounds.end) > _comparison_key(allowed_end)
+    if not future_start_detected and not future_end_detected:
+        return bounds
+    determining: CursorInputEvidence | None = _determining_input(input_evidence)
+    if config.action == FutureCursorAction.ERROR:
+        raise FutureCursorSafetyError(
+            _error_message(
+                bounds=bounds,
+                allowed_start=allowed_start,
+                allowed_end=allowed_end,
+                max_distance=config.max_distance,
+            )
+        )
+    applied_end: str = allowed_end if future_end_detected else bounds.end
+    return replace(
+        bounds,
+        end=applied_end,
+        future_safety=FutureCursorSafetyEvidence(
+            action=config.action,
+            max_distance=config.max_distance,
+            invocation_time=invocation_time.astimezone(UTC).isoformat(),
+            discovered_start=bounds.start,
+            discovered_end=bounds.end,
+            applied_start=bounds.start,
+            applied_end=applied_end,
+            maximum_allowed_start=allowed_start,
+            maximum_allowed_end=allowed_end,
+            future_start_detected=future_start_detected,
+            future_end_detected=future_end_detected,
+            determining_relation=determining.relation if determining is not None else None,
+            determining_cursor_column=(
+                determining.cursor_column if determining is not None else None
+            ),
+            inputs=input_evidence,
+        ),
+    )
+
+
+def _allowed_bounds(
+    *,
+    discovered_end: str,
+    cursor_grain: str | None,
+    invocation_time: datetime,
+    duration: Duration,
+) -> tuple[str, str]:
+    clock: datetime = invocation_time.astimezone(UTC).replace(tzinfo=None)
+    maximum: datetime = duration.add_to(clock)
+    plain_date: date | None = _plain_date(discovered_end)
+    if plain_date is not None:
+        allowed_date: date = _floor_date(value=maximum.date(), cursor_grain=cursor_grain)
+        return allowed_date.isoformat(), _advance_date(
+            value=allowed_date, cursor_grain=cursor_grain
+        ).isoformat()
+    allowed_timestamp: datetime = _floor_timestamp(value=maximum, cursor_grain=cursor_grain)
+    if datetime.fromisoformat(discovered_end).tzinfo is not None:
+        allowed_timestamp = allowed_timestamp.replace(tzinfo=UTC)
+    return (
+        allowed_timestamp.isoformat(),
+        _advance_timestamp(value=allowed_timestamp, cursor_grain=cursor_grain).isoformat(),
+    )
+
+
+def _floor_date(*, value: date, cursor_grain: str | None) -> date:
+    if cursor_grain == CursorGrain.MONTH:
+        return value.replace(day=1)
+    if cursor_grain == CursorGrain.YEAR:
+        return value.replace(month=1, day=1)
+    return value
+
+
+def _advance_date(*, value: date, cursor_grain: str | None) -> date:
+    moment: datetime = datetime.combine(value, time.min)
+    if cursor_grain == CursorGrain.MONTH:
+        return Duration(months=1).add_to(moment).date()
+    if cursor_grain == CursorGrain.YEAR:
+        return Duration(years=1).add_to(moment).date()
+    return value + timedelta(days=1)
+
+
+def _floor_timestamp(*, value: datetime, cursor_grain: str | None) -> datetime:
+    if cursor_grain == CursorGrain.YEAR:
+        return value.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+    if cursor_grain == CursorGrain.MONTH:
+        return value.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if cursor_grain == CursorGrain.DAY:
+        return value.replace(hour=0, minute=0, second=0, microsecond=0)
+    if cursor_grain == CursorGrain.HOUR:
+        return value.replace(minute=0, second=0, microsecond=0)
+    if cursor_grain == CursorGrain.MINUTE:
+        return value.replace(second=0, microsecond=0)
+    return value.replace(microsecond=0)
+
+
+def _advance_timestamp(*, value: datetime, cursor_grain: str | None) -> datetime:
+    if cursor_grain == CursorGrain.YEAR:
+        return Duration(years=1).add_to(value)
+    if cursor_grain == CursorGrain.MONTH:
+        return Duration(months=1).add_to(value)
+    if cursor_grain == CursorGrain.DAY:
+        return value + timedelta(days=1)
+    if cursor_grain == CursorGrain.HOUR:
+        return value + timedelta(hours=1)
+    if cursor_grain == CursorGrain.MINUTE:
+        return value + timedelta(minutes=1)
+    return value + timedelta(seconds=1)
+
+
+def _comparison_key(value: str) -> datetime:
+    plain_date: date | None = _plain_date(value)
+    if plain_date is not None:
+        return datetime.combine(plain_date, time.min)
+    parsed: datetime = datetime.fromisoformat(value)
+    return parsed.astimezone(UTC).replace(tzinfo=None) if parsed.tzinfo is not None else parsed
+
+
+def _plain_date(value: str) -> date | None:
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _determining_input(
+    evidence: tuple[CursorInputEvidence, ...],
+) -> CursorInputEvidence | None:
+    if not evidence:
+        return None
+    return min(evidence, key=lambda item: _comparison_key(item.maximum))
+
+
+def _error_message(
+    *, bounds: CursorBounds, allowed_start: str, allowed_end: str, max_distance: str
+) -> str:
+    return (
+        "future cursor safety limit exceeded: effective bounds "
+        f"['{bounds.start}', '{bounds.end}') exceed maximum allowed bounds "
+        f"['{allowed_start}', '{allowed_end}') "
+        f"(cursors.future.max_distance={max_distance})"
+    )

--- a/src/sqlbuild/compiler/planner/_helpers/resolve/resolve.py
+++ b/src/sqlbuild/compiler/planner/_helpers/resolve/resolve.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.models import ColumnInfo
 from sqlbuild.compiler.compile.main._cursor_roles import resolve_cursor_input_roles
@@ -32,6 +34,7 @@ from sqlbuild.compiler.planner._helpers.resolve.sources import (
 )
 from sqlbuild.compiler.planner.constants import MICROBATCH_END_SENTINEL, MICROBATCH_START_SENTINEL
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
+from sqlbuild.compiler.planner.main.execution.future_cursor_safety import apply_future_cursor_safety
 from sqlbuild.compiler.planner.models import (
     BackfillResult,
     CursorBounds,
@@ -45,7 +48,7 @@ from sqlbuild.compiler.references.main.assert_no_unresolved_sql_markers import (
     assert_no_unresolved_sql_markers,
 )
 from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver
-from sqlbuild.spec.contracts.models import SourceEntry
+from sqlbuild.spec.contracts.models import FutureCursorsConfig, SourceEntry
 
 
 def resolve_model_sql(
@@ -80,6 +83,8 @@ def resolve_model_sql(
         end_cursor_override=cursor_overrides.end_cursor_override,
         runtime_cursor_producer_names=context.runtime_cursor_producer_names,
         suppress_runtime_cursor_bounds=suppress_runtime_cursor_bounds,
+        future_cursor_config=context.future_cursor_config,
+        invocation_time=context.invocation_time,
     )
 
     cursor_roles: CursorInputRoles = resolve_cursor_input_roles(model=model)
@@ -211,6 +216,8 @@ def _compute_model_cursor_bounds(
     end_cursor_override: str | None,
     runtime_cursor_producer_names: frozenset[str],
     suppress_runtime_cursor_bounds: bool,
+    future_cursor_config: FutureCursorsConfig | None,
+    invocation_time: datetime | None,
 ) -> CursorBounds | None:
     """Compute cursor bounds for a model if it is incremental with a cursor."""
 
@@ -267,7 +274,7 @@ def _compute_model_cursor_bounds(
     if backfill.action == BackfillAction.BOUNDED:
         backfill_duration = backfill.duration
 
-    return compute_cursor_bounds(
+    bounds: CursorBounds | None = compute_cursor_bounds(
         cursor_snapshot=cursor_snapshot,
         cursor_type=get_config_str(model=model, key="cursor_type"),
         cursor_start=cursor_start,
@@ -277,4 +284,17 @@ def _compute_model_cursor_bounds(
         end_cursor_override=end_cursor_override,
         is_microbatch=is_microbatch,
         cursor_grain=get_config_str(model=model, key="cursor_grain"),
+    )
+    if bounds is None:
+        return None
+    return apply_future_cursor_safety(
+        bounds=bounds,
+        cursor_type=get_config_str(model=model, key="cursor_type"),
+        cursor_grain=get_config_str(model=model, key="cursor_grain"),
+        config=future_cursor_config,
+        invocation_time=invocation_time,
+        has_complete_override=(
+            start_cursor_override is not None and end_cursor_override is not None
+        ),
+        input_evidence=cursor_snapshot.input_evidence,
     )

--- a/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
+++ b/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
@@ -42,6 +42,7 @@ from sqlbuild.compiler.planner._helpers.planning.full_refresh import (
 from sqlbuild.compiler.planner.constants import METADATA_NAME_FILTER_LIMIT
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.models import (
+    CursorInputEvidence,
     CursorSnapshotScope,
     MissingUpstream,
     ModelCursorSnapshot,
@@ -830,6 +831,7 @@ def _assemble_cursor_snapshots(
 
         upstream_mins: list[str] = []
         upstream_maxes: list[str] = []
+        input_evidence: list[CursorInputEvidence] = []
         unavailable_watermark_tags: list[str] = []
         upstream: _UpstreamCursorInfo
         for upstream in info.upstreams:
@@ -841,6 +843,14 @@ def _assemble_cursor_snapshots(
                 unavailable_watermark_tags.append(upstream.tag_min)
             if max_val is not None:
                 upstream_maxes.append(max_val)
+                input_evidence.append(
+                    CursorInputEvidence(
+                        relation=upstream.relation,
+                        cursor_column=upstream.cursor_column,
+                        minimum=min_val,
+                        maximum=max_val,
+                    )
+                )
             else:
                 unavailable_watermark_tags.append(upstream.tag_max)
 
@@ -848,6 +858,7 @@ def _assemble_cursor_snapshots(
             target_max=target_max,
             upstream_mins=tuple(upstream_mins),
             upstream_maxes=tuple(upstream_maxes),
+            input_evidence=tuple(input_evidence),
             expected_watermark_count=len(info.upstreams),
             unavailable_watermark_tags=tuple(unavailable_watermark_tags),
         )

--- a/src/sqlbuild/compiler/planner/exceptions.py
+++ b/src/sqlbuild/compiler/planner/exceptions.py
@@ -13,3 +13,7 @@ class PlannerInputError(ValueError):
         self.message = message
         self.code = code if code is not None else self.code
         self.help = help
+
+
+class FutureCursorSafetyError(PlannerInputError):
+    """Raised when an effective cursor exceeds the configured future limit."""

--- a/src/sqlbuild/compiler/planner/main/execution/future_cursor_safety.py
+++ b/src/sqlbuild/compiler/planner/main/execution/future_cursor_safety.py
@@ -1,0 +1,37 @@
+"""Public future cursor safety entry point."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlbuild.compiler.planner._helpers.resolve.future_cursor_safety import (
+    resolve_future_cursor_safety,
+)
+from sqlbuild.compiler.planner.models import (
+    CursorBounds,
+    CursorInputEvidence,
+)
+from sqlbuild.spec.contracts.models import FutureCursorsConfig
+
+
+def apply_future_cursor_safety(
+    *,
+    bounds: CursorBounds,
+    cursor_type: str | None,
+    cursor_grain: str | None,
+    config: FutureCursorsConfig | None,
+    invocation_time: datetime | None,
+    has_complete_override: bool,
+    input_evidence: tuple[CursorInputEvidence, ...] = (),
+) -> CursorBounds:
+    """Apply configured future safety to effective cursor bounds."""
+
+    return resolve_future_cursor_safety(
+        bounds=bounds,
+        cursor_type=cursor_type,
+        cursor_grain=cursor_grain,
+        config=config,
+        invocation_time=invocation_time,
+        has_complete_override=has_complete_override,
+        input_evidence=input_evidence,
+    )

--- a/src/sqlbuild/compiler/planner/main/execution/future_cursor_warning.py
+++ b/src/sqlbuild/compiler/planner/main/execution/future_cursor_warning.py
@@ -1,0 +1,18 @@
+"""Public future cursor warning rendering entry point."""
+
+from __future__ import annotations
+
+from sqlbuild.compiler.planner.models import CursorBounds, FutureCursorSafetyEvidence
+
+
+def future_cursor_cap_warning(bounds: CursorBounds | None) -> str | None:
+    """Render a prominent warning for applied future cursor policy."""
+
+    if bounds is None or bounds.future_safety is None:
+        return None
+    evidence: FutureCursorSafetyEvidence = bounds.future_safety
+    return (
+        "FUTURE CURSOR CAPPED: discovered bounds "
+        f"['{evidence.discovered_start}', '{evidence.discovered_end}'), applied bounds "
+        f"['{evidence.applied_start}', '{evidence.applied_end}')."
+    )

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -7,7 +7,7 @@ import re
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, ClassVar
@@ -54,8 +54,14 @@ from sqlbuild.compiler.source_freshness.models import (
     DirectSourceFreshnessPlanningResult,
 )
 from sqlbuild.runtime.contracts.types import ExecutionResourceKind
-from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig, SeedCsvSettings, SourceEntry
-from sqlbuild.spec.contracts.types import SourceWriteStrategy
+from sqlbuild.spec.contracts.models import (
+    FutureCursorsConfig,
+    LocalConfig,
+    ProjectConfig,
+    SeedCsvSettings,
+    SourceEntry,
+)
+from sqlbuild.spec.contracts.types import FutureCursorAction, SourceWriteStrategy
 from sqlbuild.sql_values.models import SqlValue
 
 
@@ -189,6 +195,7 @@ class ModelCursorSnapshot:
     target_max: str | None
     upstream_mins: tuple[str, ...]
     upstream_maxes: tuple[str, ...]
+    input_evidence: tuple[CursorInputEvidence, ...] = field(default=(), compare=False)
     expected_watermark_count: int = field(default=0, compare=False)
     unavailable_watermark_tags: tuple[str, ...] = ()
 
@@ -205,6 +212,37 @@ class CursorBounds:
 
     start: str
     end: str
+    future_safety: FutureCursorSafetyEvidence | None = None
+
+
+@dataclass(frozen=True)
+class CursorInputEvidence:
+    """Observed bounds for one physical cursor input."""
+
+    relation: str
+    cursor_column: str
+    minimum: str | None
+    maximum: str
+
+
+@dataclass(frozen=True)
+class FutureCursorSafetyEvidence:
+    """Structured evidence for one applied future-cursor cap."""
+
+    action: FutureCursorAction
+    max_distance: str
+    invocation_time: str
+    discovered_start: str
+    discovered_end: str
+    applied_start: str
+    applied_end: str
+    maximum_allowed_start: str
+    maximum_allowed_end: str
+    future_start_detected: bool
+    future_end_detected: bool
+    determining_relation: str | None
+    determining_cursor_column: str | None
+    inputs: tuple[CursorInputEvidence, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -508,6 +546,8 @@ class ModelPlanContext:
     source_warehouse_columns: dict[str, tuple[ColumnInfo, ...]]
     star_exclude_keyword: str
     runtime_cursor_producer_names: frozenset[str] = frozenset()
+    future_cursor_config: FutureCursorsConfig | None = None
+    invocation_time: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -544,6 +584,8 @@ class PlanEntryBuildInputs:
     external_blocked_model_names: frozenset[str] = frozenset()
     start_cursor_override: str | None = None
     end_cursor_override: str | None = None
+    future_cursor_config: FutureCursorsConfig | None = None
+    invocation_time: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -688,6 +730,8 @@ class ModelPlanEntry:
     microbatch_range: CursorBounds | None = None
     start_cursor_override: str | None = None
     end_cursor_override: str | None = None
+    future_cursor_config: FutureCursorsConfig | None = None
+    invocation_time: datetime | None = None
     unique_key: tuple[str, ...] = field(default_factory=tuple)
     merge_exclude_columns: tuple[str, ...] = field(default_factory=tuple)
     snapshot_strategy: str | None = None
@@ -1063,6 +1107,7 @@ class PlannerRuntime:
     project_config: ProjectConfig | None = None
     local_config: LocalConfig | None = None
     on_progress: Callable[[str], None] | None = None
+    invocation_time: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/executor/run/_helpers/execution/results.py
+++ b/src/sqlbuild/executor/run/_helpers/execution/results.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
-from sqlbuild.compiler.planner.models import ModelPlanEntry
+from sqlbuild.compiler.planner.models import (
+    CursorBounds,
+    FutureCursorSafetyEvidence,
+    ModelPlanEntry,
+)
 from sqlbuild.errors.contracts.main.error_code import error_code
 from sqlbuild.errors.contracts.main.error_help import error_help
 from sqlbuild.errors.contracts.main.error_message import error_message
@@ -62,6 +66,7 @@ def build_failed_result(
         error_code=rendered_code,
         error_help=rendered_help,
         error_message=rendered_error,
+        future_cursor_safety=_future_cursor_safety(entry),
     )
 
 
@@ -90,7 +95,13 @@ def build_skipped_result(
         hook_results=tuple(hook_results),
         skip_mode=skipped_hook.skip_mode if skipped_hook is not None else None,
         skip_reason=skipped_hook.skip_reason if skipped_hook is not None else None,
+        future_cursor_safety=_future_cursor_safety(entry),
     )
+
+
+def _future_cursor_safety(entry: ModelPlanEntry) -> FutureCursorSafetyEvidence | None:
+    bounds: CursorBounds | None = entry.microbatch_range or entry.cursor_bounds
+    return bounds.future_safety if bounds is not None else None
 
 
 def _last_skipped_hook(

--- a/src/sqlbuild/executor/run/_helpers/materializations/incremental.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/incremental.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
@@ -14,6 +14,7 @@ from sqlbuild.adapter.relations.main.resolve_qualified_name_parts import (
 from sqlbuild.adapter.relations.main.resolve_relation_location_qualified_name import (
     resolve_relation_location_qualified_name,
 )
+from sqlbuild.compiler.planner.main.execution.future_cursor_warning import future_cursor_cap_warning
 from sqlbuild.compiler.planner.models import CursorBounds, ModelPlanEntry
 from sqlbuild.compiler.planner.types import IncrementalStrategy, OnSchemaChange
 from sqlbuild.diagnostics.main.diagnostics_context import diagnostics_context
@@ -86,17 +87,32 @@ def execute_incremental_entry(
         schema=target_schema,
         name=delta_table,
     )
-    seed_table: str = f"{target_table}__reuse_seed"
-    seed_qualified: str = resolve_qualified_name_parts(
-        adapter=adapter,
-        database=target_database,
-        schema=target_schema,
-        name=seed_table,
-    )
     warnings: list[str] = []
     audit_results: list[AuditExecutionResult] = []
     hook_results: list[HookExecutionResult] = []
     statement_recorder: StatementRecorder = StatementRecorder()
+
+    try:
+        preparation: _DeltaPreparation = _resolve_incremental_cursor_bounds(
+            context=context,
+            target_database=target_database,
+            target_schema=target_schema,
+            target_table=target_table,
+            target_qualified=target_qualified,
+        )
+    except Exception as exc:
+        return build_failed_result(
+            entry=entry,
+            phase=ExecutionPhase.STAGING,
+            error=str(exc),
+            warnings=warnings,
+            audit_results=audit_results,
+            statement_recorder=statement_recorder,
+            hook_results=hook_results,
+        )
+    context = _context_with_runtime_cursor(context=context, preparation=preparation)
+    entry = context.entry
+    warnings.extend(_future_cursor_warnings(entry.cursor_bounds))
 
     pre_hook_exit: ModelExecutionResult | None = run_pre_hook_phase(
         context=context,
@@ -109,14 +125,12 @@ def execute_incremental_entry(
         return pre_hook_exit
 
     try:
-        preparation: _DeltaPreparation = _prepare_delta_relation(
+        _prepare_delta_relation(
             context=context,
             target_database=target_database,
             target_schema=target_schema,
-            target_table=target_table,
-            target_qualified=target_qualified,
-            seed_qualified=seed_qualified,
             delta_qualified=delta_qualified,
+            preparation=preparation,
             statement_recorder=statement_recorder,
         )
     except Exception as exc:
@@ -342,6 +356,13 @@ def execute_incremental_entry(
         model_name=entry.name,
         status=ExecutionStatus.SUCCESS,
         promoted_relation=target_qualified,
+        cursor_range_start=cursor_start,
+        cursor_range_end=cursor_end,
+        cursor_type=entry.cursor_type,
+        cursor_grain=entry.cursor_grain,
+        future_cursor_safety=(
+            effective_bounds.future_safety if effective_bounds is not None else None
+        ),
         audit_results=tuple(audit_results),
         warning_messages=tuple(warnings),
         lifecycle_events=statement_recorder.snapshot(),
@@ -354,47 +375,20 @@ def _prepare_delta_relation(
     context: ModelMaterializationContext,
     target_database: str | None,
     target_schema: str | None,
-    target_table: str,
-    target_qualified: str,
-    seed_qualified: str,
     delta_qualified: str,
+    preparation: _DeltaPreparation,
     statement_recorder: StatementRecorder,
-) -> _DeltaPreparation:
-    """Seed reuse, resolve runtime cursors, and create the delta relation."""
+) -> None:
+    """Create the delta relation after cursor safety has resolved."""
 
-    entry: ModelPlanEntry = context.entry
     adapter: BaseAdapter = context.adapter
     connection: Any = context.connection
-    runtime_cursor_bounds: CursorBounds | None = None
-    resolved_sql: str = entry.resolved_sql
     if not context.schema_prepared:
         adapter.ensure_schema(
             connection=connection,
             database=target_database,
             schema=target_schema,
             statement_recorder=statement_recorder,
-        )
-    if has_runtime_owned_cursor_watermarks(
-        entry.cursor_input_relations
-    ) and not has_authoritative_cursor_override(entry=entry):
-        if entry.cursor_column is None:
-            raise ExecutorInputError("runtime-owned cursor resolution requires cursor_column")
-        runtime_cursor_bounds = resolve_runtime_cursor_bounds(
-            adapter=adapter,
-            connection=connection,
-            target_relation=target_qualified,
-            target_database=target_database,
-            target_schema=target_schema,
-            target_name=target_table,
-            spec=build_runtime_cursor_spec(entry=entry),
-            watermark_resolver=context.watermark_resolver,
-        )
-        if runtime_cursor_bounds is None:
-            raise ExecutorInputError(
-                f"runtime cursor bounds could not be resolved for '{entry.name}'"
-            )
-        resolved_sql = substitute_cursor_sentinels(
-            sql=entry.resolved_sql, bounds=runtime_cursor_bounds
         )
     with diagnostics_context(sqlbuild_phase="materialize", sqlbuild_action_name="create_delta"):
         adapter.drop(
@@ -406,13 +400,62 @@ def _prepare_delta_relation(
         adapter.create_table_as(
             connection=connection,
             destination=delta_qualified,
-            sql=resolved_sql,
+            sql=preparation.resolved_sql,
             statement_recorder=statement_recorder,
         )
+
+
+def _resolve_incremental_cursor_bounds(
+    *,
+    context: ModelMaterializationContext,
+    target_database: str | None,
+    target_schema: str | None,
+    target_table: str,
+    target_qualified: str,
+) -> _DeltaPreparation:
+    """Resolve runtime cursor policy before pre-hook execution."""
+
+    entry: ModelPlanEntry = context.entry
+    if not has_runtime_owned_cursor_watermarks(
+        entry.cursor_input_relations
+    ) or has_authoritative_cursor_override(entry=entry):
+        return _DeltaPreparation(resolved_sql=entry.resolved_sql, runtime_cursor_bounds=None)
+    if entry.cursor_column is None:
+        raise ExecutorInputError("runtime-owned cursor resolution requires cursor_column")
+    runtime_cursor_bounds: CursorBounds | None = resolve_runtime_cursor_bounds(
+        adapter=context.adapter,
+        connection=context.connection,
+        target_relation=target_qualified,
+        target_database=target_database,
+        target_schema=target_schema,
+        target_name=target_table,
+        spec=build_runtime_cursor_spec(entry=entry),
+        watermark_resolver=context.watermark_resolver,
+    )
+    if runtime_cursor_bounds is None:
+        raise ExecutorInputError(f"runtime cursor bounds could not be resolved for '{entry.name}'")
     return _DeltaPreparation(
-        resolved_sql=resolved_sql,
+        resolved_sql=substitute_cursor_sentinels(
+            sql=entry.resolved_sql, bounds=runtime_cursor_bounds
+        ),
         runtime_cursor_bounds=runtime_cursor_bounds,
     )
+
+
+def _context_with_runtime_cursor(
+    *, context: ModelMaterializationContext, preparation: _DeltaPreparation
+) -> ModelMaterializationContext:
+    if preparation.runtime_cursor_bounds is None:
+        return context
+    return replace(
+        context,
+        entry=replace(context.entry, cursor_bounds=preparation.runtime_cursor_bounds),
+    )
+
+
+def _future_cursor_warnings(bounds: CursorBounds | None) -> list[str]:
+    warning: str | None = future_cursor_cap_warning(bounds)
+    return [warning] if warning is not None else []
 
 
 def _apply_schema_change(

--- a/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
@@ -25,6 +25,7 @@ from sqlbuild.compiler.planner.main.execution.cursor_bound_display import cursor
 from sqlbuild.compiler.planner.main.execution.effective_microbatch_batch_size import (
     resolve_effective_microbatch_batch_size,
 )
+from sqlbuild.compiler.planner.main.execution.future_cursor_warning import future_cursor_cap_warning
 from sqlbuild.compiler.planner.main.execution.inclusive_cursor_end import inclusive_cursor_end
 from sqlbuild.compiler.planner.models import (
     CursorBounds,
@@ -144,6 +145,7 @@ class _MicrobatchPlan:
     effective_batch_size: str | None = None
     resolved_range: CursorBounds | None = None
     early_exit: ModelExecutionResult | None = None
+    runtime_discovery: bool = False
 
 
 @dataclass(frozen=True)
@@ -230,15 +232,6 @@ def execute_microbatch_entry(  # noqa: PLR0915
         hook_results=[],
         statement_recorder=StatementRecorder(),
     )
-    pre_hook_exit: ModelExecutionResult | None = run_pre_hook_phase(
-        context=context,
-        warnings=state.warnings,
-        audit_results=state.audit_results,
-        hook_results=state.hook_results,
-        statement_recorder=state.statement_recorder,
-    )
-    if pre_hook_exit is not None:
-        return pre_hook_exit
     batch_plan: _MicrobatchPlan = _plan_microbatch_windows(
         context=context,
         is_full_refresh=is_full_refresh,
@@ -250,6 +243,19 @@ def execute_microbatch_entry(  # noqa: PLR0915
     )
     if batch_plan.early_exit is not None:
         return batch_plan.early_exit
+    context = _context_with_microbatch_range(context=context, batch_plan=batch_plan)
+    cap_warning: str | None = future_cursor_cap_warning(batch_plan.resolved_range)
+    if cap_warning is not None:
+        state.warnings.append(cap_warning)
+    pre_hook_exit: ModelExecutionResult | None = run_pre_hook_phase(
+        context=context,
+        warnings=state.warnings,
+        audit_results=state.audit_results,
+        hook_results=state.hook_results,
+        statement_recorder=state.statement_recorder,
+    )
+    if pre_hook_exit is not None:
+        return pre_hook_exit
     history_read: (
         tuple[
             MicrobatchEventStore,
@@ -334,7 +340,7 @@ def execute_microbatch_entry(  # noqa: PLR0915
         state = replace(state, warnings=[*state.warnings, "no batches to process"])
     if (
         on_progress is not None
-        and context.entry.microbatch_range is None
+        and batch_plan.runtime_discovery
         and batch_plan.resolved_range is not None
         and batch_plan.effective_batch_size is not None
     ):
@@ -451,6 +457,7 @@ def execute_microbatch_entry(  # noqa: PLR0915
         cursor_range_end=None if resolved_range is None else resolved_range.end,
         cursor_type=context.entry.cursor_type,
         cursor_grain=context.entry.cursor_grain,
+        future_cursor_safety=(resolved_range.future_safety if resolved_range is not None else None),
         audit_results=tuple(state.audit_results),
         warning_messages=tuple(state.warnings),
         lifecycle_events=state.statement_recorder.snapshot(),
@@ -2523,6 +2530,17 @@ def _promote_microbatch_full_refresh(
     return None
 
 
+def _context_with_microbatch_range(
+    *, context: ModelMaterializationContext, batch_plan: _MicrobatchPlan
+) -> ModelMaterializationContext:
+    if batch_plan.resolved_range is None:
+        return context
+    return replace(
+        context,
+        entry=replace(context.entry, microbatch_range=batch_plan.resolved_range),
+    )
+
+
 def _plan_microbatch_windows(
     *,
     context: ModelMaterializationContext,
@@ -2629,6 +2647,7 @@ def _plan_microbatch_windows(
         batches=batches,
         effective_batch_size=effective_batch_size,
         resolved_range=microbatch_range,
+        runtime_discovery=runtime_discovery,
     )
 
 

--- a/src/sqlbuild/executor/run/_helpers/materializations/table_cursor.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/table_cursor.py
@@ -1,0 +1,78 @@
+"""Table cursor resolution before lifecycle side effects."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from sqlbuild.compiler.planner.main.execution.future_cursor_warning import (
+    future_cursor_cap_warning,
+)
+from sqlbuild.compiler.planner.models import CursorBounds, ModelPlanEntry
+from sqlbuild.errors.contracts.exceptions import ExecutorInputError
+from sqlbuild.executor.run._helpers.validation.cursor_bounds import (
+    build_runtime_cursor_spec,
+    has_authoritative_cursor_override,
+    has_runtime_owned_cursor_watermarks,
+    resolve_runtime_cursor_bounds,
+    substitute_cursor_sentinels,
+)
+from sqlbuild.executor.run.models import (
+    ModelExecutionResult,
+    ModelMaterializationContext,
+    TableCursorResolution,
+    TableTargets,
+)
+
+
+def resolve_table_cursor(
+    *,
+    context: ModelMaterializationContext,
+    targets: TableTargets,
+    is_full_refresh: bool,
+) -> TableCursorResolution:
+    """Resolve table cursor policy before pre-hook execution."""
+
+    entry: ModelPlanEntry = context.entry
+    planned_bounds: CursorBounds | None = entry.microbatch_range or entry.cursor_bounds
+    runtime_owned: bool = (
+        not is_full_refresh
+        and not has_authoritative_cursor_override(entry=entry)
+        and has_runtime_owned_cursor_watermarks(entry.cursor_input_relations)
+    )
+    if not runtime_owned:
+        return TableCursorResolution(
+            resolved_sql=entry.resolved_sql,
+            bounds=planned_bounds,
+            warning=future_cursor_cap_warning(planned_bounds),
+        )
+    if entry.cursor_column is None:
+        raise ExecutorInputError("runtime-owned cursor resolution requires cursor_column")
+    bounds: CursorBounds | None = resolve_runtime_cursor_bounds(
+        adapter=context.adapter,
+        connection=context.connection,
+        target_relation=targets.target_qualified,
+        target_database=targets.target_database,
+        target_schema=targets.target_schema,
+        target_name=targets.target_table,
+        spec=build_runtime_cursor_spec(entry=entry),
+        watermark_resolver=context.watermark_resolver,
+    )
+    if bounds is None:
+        raise ExecutorInputError(f"runtime cursor bounds could not be resolved for '{entry.name}'")
+    return TableCursorResolution(
+        resolved_sql=substitute_cursor_sentinels(sql=entry.resolved_sql, bounds=bounds),
+        bounds=bounds,
+        warning=future_cursor_cap_warning(bounds),
+    )
+
+
+def result_with_cursor_safety(
+    *, result: ModelExecutionResult, entry: ModelPlanEntry
+) -> ModelExecutionResult:
+    """Attach effective cursor safety evidence to a table result."""
+
+    bounds: CursorBounds | None = entry.microbatch_range or entry.cursor_bounds
+    return replace(
+        result,
+        future_cursor_safety=bounds.future_safety if bounds is not None else None,
+    )

--- a/src/sqlbuild/executor/run/_helpers/validation/cursor_bounds.py
+++ b/src/sqlbuild/executor/run/_helpers/validation/cursor_bounds.py
@@ -16,7 +16,13 @@ from sqlbuild.compiler.planner.main.execution.bounded_cursor_override import (
     resolve_bounded_cursor_override,
 )
 from sqlbuild.compiler.planner.main.execution.cursor_replay_policy import apply_cursor_replay_policy
-from sqlbuild.compiler.planner.models import CursorBounds, CursorInputRelation, ModelPlanEntry
+from sqlbuild.compiler.planner.main.execution.future_cursor_safety import apply_future_cursor_safety
+from sqlbuild.compiler.planner.models import (
+    CursorBounds,
+    CursorInputEvidence,
+    CursorInputRelation,
+    ModelPlanEntry,
+)
 from sqlbuild.compiler.planner.types import BackfillAction, CursorGrain, CursorType
 from sqlbuild.errors.contracts.exceptions import ExecutorInputError
 from sqlbuild.executor.run.models import RuntimeCursorSpec
@@ -66,6 +72,8 @@ def build_runtime_cursor_spec(
             entry.backfill.duration if entry.backfill.action == BackfillAction.BOUNDED else None
         ),
         read_destination_cursor=read_destination_cursor,
+        future_cursor_config=entry.future_cursor_config,
+        invocation_time=entry.invocation_time,
     )
 
 
@@ -118,6 +126,7 @@ def resolve_runtime_cursor_bounds(
     read_minimum: bool = target_max_raw is None
     upstream_mins: list[object] = []
     upstream_maxes: list[object] = []
+    input_evidence: list[CursorInputEvidence] = []
     input_index: int
     physical_input: tuple[str, str]
     for input_index, physical_input in enumerate(physical_inputs, start=1):
@@ -137,6 +146,20 @@ def resolve_runtime_cursor_bounds(
         if minimum is not None:
             upstream_mins.append(minimum)
         upstream_maxes.append(maximum)
+        normalized_maximum: str | None = _normalize_bound(value=maximum, is_end=False)
+        if normalized_maximum is not None:
+            input_evidence.append(
+                CursorInputEvidence(
+                    relation=physical_input[0],
+                    cursor_column=physical_input[1],
+                    minimum=(
+                        _normalize_bound(value=minimum, is_end=False)
+                        if minimum is not None
+                        else None
+                    ),
+                    maximum=normalized_maximum,
+                )
+            )
     if not upstream_maxes:
         return None
     effective_grain: str | None = resolve_effective_timestamp_grain(
@@ -201,7 +224,17 @@ def resolve_runtime_cursor_bounds(
         backfill_duration=spec.backfill_duration,
         has_start_override=spec.start_cursor_override is not None,
     )
-    return CursorBounds(start=start, end=end)
+    return apply_future_cursor_safety(
+        bounds=CursorBounds(start=start, end=end),
+        cursor_type=cursor_type,
+        cursor_grain=effective_grain,
+        config=spec.future_cursor_config,
+        invocation_time=spec.invocation_time,
+        has_complete_override=(
+            spec.start_cursor_override is not None and spec.end_cursor_override is not None
+        ),
+        input_evidence=tuple(input_evidence),
+    )
 
 
 def _query_watermark_raw(

--- a/src/sqlbuild/executor/run/main/_execute.py
+++ b/src/sqlbuild/executor/run/main/_execute.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
@@ -9,13 +10,15 @@ from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecord
 from sqlbuild.adapter.contract.models import ColumnInfo
 from sqlbuild.adapter.contract.types import TablePromotionMode
 from sqlbuild.compiler.fingerprints.models import Fingerprint
-from sqlbuild.compiler.planner.models import CursorBounds, ModelPlanEntry
+from sqlbuild.compiler.planner.models import ModelPlanEntry
 from sqlbuild.diagnostics.main.diagnostics_context import diagnostics_context
 from sqlbuild.errors.contracts.exceptions import ExecutorInputError
 from sqlbuild.executor.auditing.models import AuditExecutionResult
 from sqlbuild.executor.run._helpers.execution.final_audits import run_final_model_audits
-from sqlbuild.executor.run._helpers.execution.hook_phases import run_post_hook_phase
-from sqlbuild.executor.run._helpers.execution.hooks import execute_hooks, render_hooks
+from sqlbuild.executor.run._helpers.execution.hook_phases import (
+    run_post_hook_phase,
+    run_pre_hook_phase,
+)
 from sqlbuild.executor.run._helpers.execution.promotion import promote_relation_to_destination
 from sqlbuild.executor.run._helpers.execution.results import (
     build_failed_result,
@@ -35,30 +38,27 @@ from sqlbuild.executor.run._helpers.materializations.microbatch import (
 from sqlbuild.executor.run._helpers.materializations.snapshot import (
     execute_snapshot_entry as execute_snapshot_entry,
 )
+from sqlbuild.executor.run._helpers.materializations.table_cursor import (
+    resolve_table_cursor,
+    result_with_cursor_safety,
+)
 from sqlbuild.executor.run._helpers.materializations.view import (
     execute_view_entry as execute_view_entry,
 )
 from sqlbuild.executor.run._helpers.reuse.fingerprinting import try_write_fingerprint
 from sqlbuild.executor.run._helpers.validation.contracts import validate_runtime_contract
-from sqlbuild.executor.run._helpers.validation.cursor_bounds import (
-    build_runtime_cursor_spec,
-    has_authoritative_cursor_override,
-    has_runtime_owned_cursor_watermarks,
-    resolve_runtime_cursor_bounds,
-    substitute_cursor_sentinels,
-)
 from sqlbuild.executor.run._helpers.validation.type_enforcement import enforce_types_staged
 from sqlbuild.executor.run.models import (
     FinalAuditRun,
     HookExecutionResult,
-    HookRunContext,
     ModelExecutionResult,
     ModelMaterializationContext,
     PostHookPhaseOutcome,
+    TableCursorResolution,
     TableLifecycleState,
     TableTargets,
 )
-from sqlbuild.executor.run.types import ExecutionPhase, HookPhase
+from sqlbuild.executor.run.types import ExecutionPhase
 from sqlbuild.executor.scheduling.types import ExecutionStatus
 
 
@@ -79,55 +79,27 @@ def execute_table_entry(
     audit_results: list[AuditExecutionResult] = []
     hook_results: list[HookExecutionResult] = []
     statement_recorder: StatementRecorder = StatementRecorder()
-    runtime_owned_cursor_bounds: bool = (
-        not is_full_refresh
-        and not has_authoritative_cursor_override(entry=entry)
-        and has_runtime_owned_cursor_watermarks(entry.cursor_input_relations)
-    )
-    resolved_sql: str = entry.resolved_sql
-
-    if runtime_owned_cursor_bounds:
-        if entry.cursor_column is None:
-            return build_failed_result(
-                entry=entry,
-                phase=ExecutionPhase.STAGING,
-                error="runtime-owned cursor resolution requires cursor_column",
-                warnings=warnings,
-                audit_results=audit_results,
-                statement_recorder=statement_recorder,
-                hook_results=hook_results,
-            )
-        try:
-            runtime_bounds: CursorBounds | None = resolve_runtime_cursor_bounds(
-                adapter=adapter,
-                connection=connection,
-                target_relation=targets.target_qualified,
-                target_database=targets.target_database,
-                target_schema=targets.target_schema,
-                target_name=targets.target_table,
-                spec=build_runtime_cursor_spec(entry=entry),
-                watermark_resolver=context.watermark_resolver,
-            )
-        except Exception as exc:
-            return build_failed_result(
-                entry=entry,
-                phase=ExecutionPhase.STAGING,
-                error=f"failed to resolve runtime cursor bounds: {exc}",
-                warnings=warnings,
-                audit_results=audit_results,
-                statement_recorder=statement_recorder,
-                hook_results=hook_results,
-            )
-        if runtime_bounds is None:
-            return build_failed_result(
-                entry=entry,
-                phase=ExecutionPhase.STAGING,
-                error=f"runtime cursor bounds could not be resolved for '{entry.name}'",
-                warnings=warnings,
-                audit_results=audit_results,
-                statement_recorder=statement_recorder,
-            )
-        resolved_sql = substitute_cursor_sentinels(sql=entry.resolved_sql, bounds=runtime_bounds)
+    try:
+        cursor_resolution: TableCursorResolution = resolve_table_cursor(
+            context=context,
+            targets=targets,
+            is_full_refresh=is_full_refresh,
+        )
+    except Exception as exc:
+        return build_failed_result(
+            entry=entry,
+            phase=ExecutionPhase.STAGING,
+            error=f"failed to resolve runtime cursor bounds: {exc}",
+            warnings=warnings,
+            audit_results=audit_results,
+            statement_recorder=statement_recorder,
+            hook_results=hook_results,
+        )
+    if cursor_resolution.bounds is not None:
+        entry = replace(entry, cursor_bounds=cursor_resolution.bounds)
+        context = replace(context, entry=entry)
+    if cursor_resolution.warning is not None:
+        warnings.append(cursor_resolution.warning)
 
     try:
         if not context.schema_prepared:
@@ -136,36 +108,6 @@ def execute_table_entry(
                 database=targets.target_database,
                 schema=targets.target_schema,
                 statement_recorder=statement_recorder,
-            )
-        statement_recorder.record_many(
-            render_hooks(hooks=entry.pre_hooks, phase=HookPhase.PRE_HOOKS)
-        )
-        with diagnostics_context(sqlbuild_phase="pre_hook", sqlbuild_action_name="run"):
-            pre_hook_skipped: bool = execute_hooks(
-                connection=connection,
-                adapter=adapter,
-                hooks=entry.pre_hooks,
-                phase=HookPhase.PRE_HOOKS,
-                hook_functions=context.hook_functions,
-                hook_results=hook_results,
-                hook_run=HookRunContext(
-                    model_name=entry.name,
-                    destination=entry.destination,
-                    run_id=context.run_id,
-                    target=context.effective_target_name,
-                    effective_vars=context.effective_vars,
-                    statement_recorder=statement_recorder,
-                    providers=context.providers,
-                    python_identity_recorder=context.python_identity_recorder,
-                ),
-            )
-        if pre_hook_skipped:
-            return build_skipped_result(
-                entry=entry,
-                warnings=warnings,
-                audit_results=audit_results,
-                statement_recorder=statement_recorder,
-                hook_results=hook_results,
             )
     except Exception as exc:
         return build_failed_result(
@@ -177,22 +119,32 @@ def execute_table_entry(
             statement_recorder=statement_recorder,
             hook_results=hook_results,
         )
+    pre_hook_exit: ModelExecutionResult | None = run_pre_hook_phase(
+        context=context,
+        warnings=warnings,
+        audit_results=audit_results,
+        hook_results=hook_results,
+        statement_recorder=statement_recorder,
+    )
+    if pre_hook_exit is not None:
+        return pre_hook_exit
 
     state: TableLifecycleState = TableLifecycleState(
         warnings=warnings,
         audit_results=audit_results,
         statement_recorder=statement_recorder,
         hook_results=hook_results,
-        resolved_sql=resolved_sql,
+        resolved_sql=cursor_resolution.resolved_sql,
     )
 
     if promotion_mode == TablePromotionMode.STAGED:
-        return _staged_lifecycle(
+        result: ModelExecutionResult = _staged_lifecycle(
             context=context,
             targets=targets,
             state=state,
             declared_columns=declared_columns,
         )
+        return result_with_cursor_safety(result=result, entry=entry)
 
     if entry.contract_enforced:
         return build_failed_result(
@@ -209,12 +161,13 @@ def execute_table_entry(
             hook_results=hook_results,
         )
 
-    return _immediate_lifecycle(
+    result = _immediate_lifecycle(
         context=context,
         targets=targets,
         state=state,
         declared_columns=declared_columns,
     )
+    return result_with_cursor_safety(result=result, entry=entry)
 
 
 def _staged_lifecycle(

--- a/src/sqlbuild/executor/run/models.py
+++ b/src/sqlbuild/executor/run/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
@@ -11,7 +12,13 @@ from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecord
 from sqlbuild.adapter.contract.models import LifeCycleEvent, QueryResult
 from sqlbuild.compiler.compile.models import CompiledRelationLocation
 from sqlbuild.compiler.discovery.models import DiscoveredHookFunction
-from sqlbuild.compiler.planner.models import AuditPlanEntry, CursorInputRelation, ModelPlanEntry
+from sqlbuild.compiler.planner.models import (
+    AuditPlanEntry,
+    CursorBounds,
+    CursorInputRelation,
+    FutureCursorSafetyEvidence,
+    ModelPlanEntry,
+)
 from sqlbuild.compiler.python_nodes.types import SkipMode
 from sqlbuild.executor.auditing.models import AuditExecutionResult
 from sqlbuild.executor.custom.models import MaterializationResult
@@ -27,7 +34,7 @@ from sqlbuild.executor.scheduling.types import ExecutionStatus
 from sqlbuild.microbatches.models import MicrobatchScope
 from sqlbuild.microbatches.types import MicrobatchEventStore
 from sqlbuild.provider.main.runtime import ProviderContainer, _empty_provider_container
-from sqlbuild.spec.contracts.models import SourceEntry
+from sqlbuild.spec.contracts.models import FutureCursorsConfig, SourceEntry
 
 
 @dataclass(frozen=True)
@@ -118,6 +125,7 @@ class ModelExecutionResult:
     cursor_range_end: str | None = None
     cursor_type: str | None = None
     cursor_grain: str | None = None
+    future_cursor_safety: FutureCursorSafetyEvidence | None = None
     audit_results: tuple[AuditExecutionResult, ...] = field(default_factory=tuple)
     warning_messages: tuple[str, ...] = field(default_factory=tuple)
     lifecycle_events: tuple[LifeCycleEvent, ...] = field(default_factory=tuple)
@@ -222,6 +230,8 @@ class RuntimeCursorSpec:
     lookback: str | None = None
     backfill_duration: str | None = None
     read_destination_cursor: bool = True
+    future_cursor_config: FutureCursorsConfig | None = None
+    invocation_time: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -332,6 +342,16 @@ class MicrobatchPhaseOutcome:
     failure: ModelExecutionResult | None = None
     completed_batches: int = 0
     rows_affected: int | None = None
+
+
+@dataclass(frozen=True)
+class TableCursorResolution:
+    """Runtime cursor outcome resolved before table pre-hooks."""
+
+    resolved_sql: str
+    bounds: CursorBounds | None
+    warning: str | None = None
+    error: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
+++ b/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
@@ -24,6 +24,7 @@ from sqlbuild.integrations.dagster.constants import (
     CHECK_EVENT,
     CLONE_ASSET_EVENT,
     COMPLETED_EXECUTION_STATUSES,
+    FAILED_EXECUTION_STATUS,
     VERBOSE_FLAGS,
 )
 
@@ -239,6 +240,7 @@ class SqlBuildCliInvocation:
         dg: Any = load_dagster()
         emitted_asset_keys: set[tuple[str, ...]] = set()
         emitted_check_keys: set[tuple[tuple[str, ...], str]] = set()
+        logged_failed_assets: set[tuple[str, str]] = set()
         event_path: Path | None = self.event_jsonl_path
         dag: Mapping[str, Any] | None = self.dag
         if event_path is None or dag is None:
@@ -269,6 +271,7 @@ class SqlBuildCliInvocation:
                             dg=dg,
                             dag=dag,
                             event_stream=event_stream,
+                            logged_failed_assets=logged_failed_assets,
                         ):
                             if isinstance(result, dg.AssetCheckResult):
                                 check_key: tuple[tuple[str, ...], str] = (
@@ -327,6 +330,7 @@ class SqlBuildCliInvocation:
         dg: Any,
         dag: Mapping[str, Any],
         event_stream: IO[str],
+        logged_failed_assets: set[tuple[str, str]],
     ) -> Iterator[Any]:
         pending: str = ""
         while True:
@@ -336,18 +340,33 @@ class SqlBuildCliInvocation:
                 lines: list[str] = pending.split("\n")
                 pending = lines.pop()
                 for line in lines:
-                    yield from self._results_from_live_event_line(dg=dg, dag=dag, line=line)
+                    yield from self._results_from_live_event_line(
+                        dg=dg,
+                        dag=dag,
+                        line=line,
+                        logged_failed_assets=logged_failed_assets,
+                    )
                 continue
             if self.process.poll() is not None:
                 final_chunk: str = event_stream.read()
                 pending += final_chunk
                 for line in pending.splitlines():
-                    yield from self._results_from_live_event_line(dg=dg, dag=dag, line=line)
+                    yield from self._results_from_live_event_line(
+                        dg=dg,
+                        dag=dag,
+                        line=line,
+                        logged_failed_assets=logged_failed_assets,
+                    )
                 return
             time.sleep(0.01)
 
     def _results_from_live_event_line(
-        self, *, dg: Any, dag: Mapping[str, Any], line: str
+        self,
+        *,
+        dg: Any,
+        dag: Mapping[str, Any],
+        line: str,
+        logged_failed_assets: set[tuple[str, str]],
     ) -> Iterator[Any]:
         if line:
             event: Any
@@ -364,6 +383,11 @@ class SqlBuildCliInvocation:
             check: object = event.get("check")
             if not isinstance(asset, Mapping) and not isinstance(check, Mapping):
                 return
+            if isinstance(asset, Mapping):
+                _ = self._log_live_asset_failure(
+                    asset=asset,
+                    logged_failed_assets=logged_failed_assets,
+                )
             payload: Mapping[str, Any] = {
                 "version": event.get("version"),
                 "command": event.get("command"),
@@ -378,3 +402,47 @@ class SqlBuildCliInvocation:
                 command=self.command,
                 context=self.context,
             )
+
+    def _log_live_asset_failure(
+        self,
+        *,
+        asset: Mapping[str, Any],
+        logged_failed_assets: set[tuple[str, str]],
+    ) -> set[tuple[str, str]]:
+        if str(asset.get("status")) != FAILED_EXECUTION_STATUS:
+            return logged_failed_assets
+        asset_kind: str = str(asset.get("kind"))
+        asset_name: str = str(asset.get("name"))
+        asset_identity: tuple[str, str] = (asset_kind, asset_name)
+        if asset_identity in logged_failed_assets:
+            return logged_failed_assets
+        logged_failed_assets.add(asset_identity)
+        logger: Any = getattr(self.context, "log", None) if self.context is not None else None
+        if logger is None:
+            return logged_failed_assets
+        asset_label: str = f"{asset_kind}:{asset_name}"
+        phase: str = str(asset.get("failed_phase") or "unknown")
+        code: str = str(asset.get("error_code") or "unknown")
+        message: str = str(asset.get("error_message") or "Unknown SQLBuild asset failure")
+        metadata: dict[str, Any] = {
+            "sqlbuild_asset": asset_label,
+            "sqlbuild_asset_kind": asset_kind,
+            "sqlbuild_asset_name": asset_name,
+            "sqlbuild_phase": phase,
+            "sqlbuild_error_code": code,
+            "sqlbuild_error_message": message,
+            "sqlbuild_command": " ".join(self.command),
+        }
+        for key in ("target", "staging_relation", "duration_ms", "error_help"):
+            value: object = asset.get(key)
+            if value is not None:
+                metadata[f"sqlbuild_{key}"] = value
+        logger.error(
+            "SQLBuild asset failed: asset=%s phase=%s code=%s message=%s",
+            asset_label,
+            phase,
+            code,
+            message,
+            extra=metadata,
+        )
+        return logged_failed_assets

--- a/src/sqlbuild/integrations/dagster/constants.py
+++ b/src/sqlbuild/integrations/dagster/constants.py
@@ -47,6 +47,7 @@ MATERIALIZABLE_NODE_KINDS: frozenset[str] = frozenset(
 )
 COMPLETED_EXECUTION_STATUSES: frozenset[str] = frozenset({"success", "skipped"})
 SUCCESS_EXECUTION_STATUS: str = "success"
+FAILED_EXECUTION_STATUS: str = "failed"
 CHECK_NAME_SEPARATOR_CHARACTER: str = "_"
 CHECK_METADATA_EXCLUDED_KEYS: frozenset[str] = frozenset(
     {"passed", "steps", "expected_results", "assertion_results"}

--- a/src/sqlbuild/spec/contracts/models.py
+++ b/src/sqlbuild/spec/contracts/models.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from sqlbuild.cost.constants import DEFAULT_USD_PER_CREDIT
 from sqlbuild.spec.contracts.types import (
+    FutureCursorAction,
     SourceFreshnessStrategy,
     SourceFreshnessValueKind,
     SourceWriteStrategy,
@@ -191,6 +192,21 @@ class ConstantsConfig:
 
 
 @dataclass(frozen=True)
+class FutureCursorsConfig:
+    """Safety policy for automatically discovered future cursor watermarks."""
+
+    max_distance: str | None = None
+    action: FutureCursorAction = FutureCursorAction.ERROR
+
+
+@dataclass(frozen=True)
+class CursorsConfig:
+    """Project-wide cursor safety configuration."""
+
+    future: FutureCursorsConfig = field(default_factory=FutureCursorsConfig)
+
+
+@dataclass(frozen=True)
 class DefaultsConfig:
     """Project-wide resource defaults."""
 
@@ -295,6 +311,7 @@ class ProjectConfig:
     scopes: ScopesConfig = field(default_factory=ScopesConfig)
     cost: CostConfig = field(default_factory=CostConfig)
     constants: ConstantsConfig = field(default_factory=ConstantsConfig)
+    cursors: CursorsConfig = field(default_factory=CursorsConfig)
     defaults: DefaultsConfig = field(default_factory=DefaultsConfig)
     materialization_defaults: MaterializationDefaultsConfig = field(
         default_factory=MaterializationDefaultsConfig

--- a/src/sqlbuild/spec/contracts/types.py
+++ b/src/sqlbuild/spec/contracts/types.py
@@ -14,6 +14,13 @@ class SourceWriteStrategy(StrEnum):
     TABLE = "table"
 
 
+class FutureCursorAction(StrEnum):
+    """Response when an effective cursor lies beyond the future horizon."""
+
+    CAP = "cap"
+    ERROR = "error"
+
+
 class SourceFreshnessStrategy(StrEnum):
     ADAPTER = "adapter"
     COLUMN = "column"

--- a/tests/integration/src/sqlbuild/compiler/planner/main/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/_test_types.py
@@ -70,6 +70,23 @@ class SourceCursorInputPlanErrorTestCase:
 
 
 @dataclass(frozen=True)
+class FutureCursorPlannerTestCase:
+    """Planner call-flow case for future cursor policy."""
+
+    description: str
+    warehouse_type: str
+    minimum: str
+    maximum: str
+    expected_relation: str
+
+
+@dataclass(frozen=True)
+class FutureCursorPlannerErrorTestCase:
+    description: str
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
 class TableTypePlanAssemblyTestCase:
     description: str
     expected_entry_names: tuple[str, ...]

--- a/tests/integration/src/sqlbuild/compiler/planner/main/helpers.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/helpers.py
@@ -253,6 +253,41 @@ def build_project_from_source_cursor_input_test_case(
     )
 
 
+def build_future_cursor_project() -> CompiledProject:
+    """Build one timestamp incremental source project for future safety tests."""
+
+    case: SourceCursorInputPlanErrorTestCase = SourceCursorInputPlanErrorTestCase(
+        description="future cursor",
+        setup_sql=(),
+        model_name="events_incremental",
+        source_name="raw_events",
+        source_schema="raw",
+        source_table="events",
+        cursor_column="occurred_at",
+        cursor_input_column="occurred_at",
+        expected_error_fragment="",
+    )
+    project: CompiledProject = build_project_from_source_cursor_input_test_case(case)
+    model: CompiledModel = project.models[0]
+    return replace(
+        project,
+        models=(
+            replace(
+                model,
+                config=replace(
+                    model.config,
+                    values={
+                        **model.config.values,
+                        "cursor_type": "timestamp",
+                        "cursor_grain": "day",
+                        "incremental_strategy": "delete_insert",
+                    },
+                ),
+            ),
+        ),
+    )
+
+
 def write_previous_function_fingerprints(
     *,
     test_case: BuildExecutionPlanTestCase,

--- a/tests/integration/src/sqlbuild/compiler/planner/main/test_build_execution_plan.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/main/test_build_execution_plan.py
@@ -13,6 +13,7 @@ from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.models import (
     CascadeResult,
+    CursorBounds,
     ModelPlanEntry,
     PlanOutput,
     PlanWarning,
@@ -24,20 +25,25 @@ from sqlbuild.compiler.planner.types import (
     WarningSeverity,
 )
 from sqlbuild.spec.contracts.models import (
+    CursorsConfig,
+    FutureCursorsConfig,
     LocalConfig,
     ProjectConfig,
     ResolvedTableType,
     TargetConfig,
 )
-from sqlbuild.spec.contracts.types import TableType, TableTypeSource
+from sqlbuild.spec.contracts.types import FutureCursorAction, TableType, TableTypeSource
 from tests.integration.src.sqlbuild.compiler.planner.main._test_types import (
     BuildExecutionPlanTestCase,
     FormatPlanIntegrationTestCase,
+    FutureCursorPlannerErrorTestCase,
+    FutureCursorPlannerTestCase,
     SourceCursorInputPlanErrorTestCase,
     TableTypePlanAssemblyTestCase,
 )
 from tests.integration.src.sqlbuild.compiler.planner.main.helpers import (
     build_execution_plan_from_kwargs,
+    build_future_cursor_project,
     build_project_from_format_test_case,
     build_project_from_source_cursor_input_test_case,
     build_project_from_test_case,
@@ -926,3 +932,91 @@ def test_given_real_plan_when_formatting_then_contains_expected_fragments(
         assert fragment in result, f"Expected '{fragment}' in output:\n{result}"
     for fragment in test_case.unexpected_format_fragments:
         assert fragment not in result, f"Did not expect '{fragment}' in output:\n{result}"
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        FutureCursorPlannerTestCase(
+            description="timestamp upstream is capped during real planning",
+            warehouse_type="TIMESTAMP",
+            minimum="2026-01-01 00:00:00",
+            maximum="2500-01-01 00:00:00",
+            expected_relation="raw.events",
+        ),
+        FutureCursorPlannerTestCase(
+            description="date upstream is capped during real planning",
+            warehouse_type="DATE",
+            minimum="2026-01-01",
+            maximum="2500-01-01",
+            expected_relation="raw.events",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_future_upstream_when_building_real_plan_then_cap_has_structured_evidence(
+    test_case: FutureCursorPlannerTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+) -> None:
+    project: CompiledProject = build_future_cursor_project()
+    connection.execute("CREATE SCHEMA IF NOT EXISTS raw")
+    connection.execute("CREATE SCHEMA IF NOT EXISTS staging")
+    connection.execute(f"CREATE TABLE raw.events (occurred_at {test_case.warehouse_type})")
+    connection.execute(
+        "INSERT INTO raw.events VALUES (CAST(? AS "
+        f"{test_case.warehouse_type})), (CAST(? AS {test_case.warehouse_type}))",
+        [test_case.minimum, test_case.maximum],
+    )
+
+    plan: PlanOutput = build_execution_plan_from_kwargs(
+        project=project,
+        adapter=adapter,
+        connection=connection,
+        project_config=ProjectConfig(
+            name="future_cursor",
+            adapter="duckdb",
+            cursors=CursorsConfig(future=FutureCursorsConfig("1d", FutureCursorAction.CAP)),
+        ),
+    )
+
+    bounds: CursorBounds | None = plan.model_entries[0].cursor_bounds
+    assert bounds is not None
+    assert bounds.future_safety is not None
+    assert bounds.future_safety.action == "cap"
+    assert bounds.future_safety.inputs[0].relation == test_case.expected_relation
+    assert bounds.future_safety.inputs[0].cursor_column == "occurred_at"
+    assert bounds.future_safety.determining_relation == "raw.events"
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        FutureCursorPlannerErrorTestCase(
+            "future planner error", "future cursor safety limit exceeded"
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_future_upstream_and_error_policy_when_building_real_plan_then_fails_closed(
+    test_case: FutureCursorPlannerErrorTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+) -> None:
+    project: CompiledProject = build_future_cursor_project()
+    connection.execute("CREATE SCHEMA IF NOT EXISTS raw")
+    connection.execute("CREATE SCHEMA IF NOT EXISTS staging")
+    connection.execute("CREATE TABLE raw.events (occurred_at TIMESTAMP)")
+    connection.execute("INSERT INTO raw.events VALUES (TIMESTAMP '2500-01-01')")
+
+    with pytest.raises(PlannerInputError, match=test_case.expected_error_fragment):
+        build_execution_plan_from_kwargs(
+            project=project,
+            adapter=adapter,
+            connection=connection,
+            project_config=ProjectConfig(
+                name="future_cursor",
+                adapter="duckdb",
+                cursors=CursorsConfig(future=FutureCursorsConfig("1d", FutureCursorAction.ERROR)),
+            ),
+        )

--- a/tests/integration/src/sqlbuild/executor/run/incremental/_test_types.py
+++ b/tests/integration/src/sqlbuild/executor/run/incremental/_test_types.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass, field
+from datetime import datetime
 
 from sqlbuild.compiler.auditing.types import AuditRunScope
 from sqlbuild.compiler.planner.types import OnSchemaChange
 from sqlbuild.executor.run.types import ExecutionPhase
 from sqlbuild.executor.scheduling.types import ExecutionStatus
+from sqlbuild.spec.contracts.models import FutureCursorsConfig
 
 
 @dataclass(frozen=True)
@@ -46,6 +48,9 @@ class IncrementalSuccessTestCase:
     hook_functions: tuple[object, ...] = field(default_factory=tuple)
     start_cursor_override: str | None = None
     end_cursor_override: str | None = None
+    future_cursor_config: FutureCursorsConfig | None = None
+    invocation_time: datetime | None = None
+    expected_has_future_cursor_safety: bool = False
 
 
 @dataclass(frozen=True)
@@ -87,6 +92,9 @@ class IncrementalFailureTestCase:
     hook_functions: tuple[object, ...] = field(default_factory=tuple)
     start_cursor_override: str | None = None
     end_cursor_override: str | None = None
+    future_cursor_config: FutureCursorsConfig | None = None
+    invocation_time: datetime | None = None
+    expected_has_future_cursor_safety: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/integration/src/sqlbuild/executor/run/incremental/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/run/incremental/helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -220,6 +221,7 @@ def verify_success_state(
     assert actual_count == test_case.expected_row_count
     assert len(result.audit_results) == test_case.expected_audit_count
     assert len(result.warning_messages) == test_case.expected_warning_count
+    assert (result.future_cursor_safety is not None) is test_case.expected_has_future_cursor_safety
 
     query: str
     expected_rows: tuple[tuple[object, ...], ...]
@@ -261,6 +263,7 @@ def verify_failure_state(
     assert len(result.audit_results) == test_case.expected_audit_count
     assert result.staging_relation == test_case.expected_staging_relation
     assert result.promoted_relation == test_case.expected_promoted_relation
+    assert (result.future_cursor_safety is not None) is test_case.expected_has_future_cursor_safety
 
     assert (test_case.expected_error_fragment or "") in (result.error_message or "")
     _FAILURE_ROW_COUNT_VERIFIERS.get(
@@ -310,6 +313,11 @@ def _execute_test(
         post_hooks=test_case.post_hook,
         start_cursor_override=test_case.start_cursor_override,
         end_cursor_override=test_case.end_cursor_override,
+    )
+    entry = replace(
+        entry,
+        future_cursor_config=test_case.future_cursor_config,
+        invocation_time=test_case.invocation_time,
     )
 
     declared_columns: tuple[ColumnInfo, ...] = build_declared_columns(test_case.declared_columns)

--- a/tests/integration/src/sqlbuild/executor/run/incremental/test_incremental_execution.py
+++ b/tests/integration/src/sqlbuild/executor/run/incremental/test_incremental_execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -10,9 +11,12 @@ import pytest
 from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
 from sqlbuild.compiler.auditing.types import AuditRunScope
 from sqlbuild.compiler.discovery.models import DiscoveredHookFunction, PythonHookEntry, SqlHookEntry
+from sqlbuild.compiler.planner.constants import MICROBATCH_END_SENTINEL, MICROBATCH_START_SENTINEL
 from sqlbuild.compiler.planner.types import OnSchemaChange
 from sqlbuild.executor.run.models import ModelExecutionResult
 from sqlbuild.executor.run.types import ExecutionPhase
+from sqlbuild.spec.contracts.models import FutureCursorsConfig
+from sqlbuild.spec.contracts.types import FutureCursorAction
 from tests.integration.src.sqlbuild.executor.run.incremental._test_types import (
     IncrementalFailureTestCase,
     IncrementalSuccessTestCase,
@@ -39,6 +43,36 @@ class ZeroCopyDuckDbAdapter(DuckDbAdapter):
 @pytest.mark.parametrize(
     "test_case",
     [
+        IncrementalSuccessTestCase(
+            description="future cap resolves before pre-hook mutates upstream",
+            setup_sql=(
+                "CREATE TABLE main.future_input (id INTEGER, event_time TIMESTAMP)",
+                "INSERT INTO main.future_input VALUES (1, '2500-01-01')",
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP)",
+            ),
+            model_sql=(
+                "SELECT * FROM main.future_input "
+                f"WHERE event_time >= '{MICROBATCH_START_SENTINEL}' "
+                f"AND event_time < '{MICROBATCH_END_SENTINEL}'"
+            ),
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="delete_insert",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            cursor_grain="second",
+            cursor_input_relations=(("main.future_input", "event_time"),),
+            cursor_inputs_model_backed=True,
+            pre_hook=[
+                SqlHookEntry(statement="DELETE FROM main.future_input"),
+                SqlHookEntry(statement="INSERT INTO main.future_input VALUES (2, '2026-01-01')"),
+            ],
+            future_cursor_config=FutureCursorsConfig("2d", FutureCursorAction.CAP),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            expected_row_count=0,
+            expected_warning_count=1,
+            expected_has_future_cursor_safety=True,
+        ),
         IncrementalSuccessTestCase(
             description="model-backed cursor input resolves runtime bounds for normal incremental",
             setup_sql=(
@@ -488,6 +522,61 @@ def test_given_existing_table_when_running_incremental_then_succeeds(
 @pytest.mark.parametrize(
     "test_case",
     [
+        IncrementalFailureTestCase(
+            description="future error blocks pre-hook side effects",
+            setup_sql=(
+                "CREATE TABLE main.future_input (id INTEGER, event_time TIMESTAMP)",
+                "INSERT INTO main.future_input VALUES (1, '2500-01-01')",
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP)",
+                "CREATE TABLE main.hook_log (phase VARCHAR)",
+            ),
+            model_sql=(
+                "SELECT * FROM main.future_input "
+                f"WHERE event_time >= '{MICROBATCH_START_SENTINEL}' "
+                f"AND event_time < '{MICROBATCH_END_SENTINEL}'"
+            ),
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="delete_insert",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            cursor_grain="second",
+            cursor_input_relations=(("main.future_input", "event_time"),),
+            cursor_inputs_model_backed=True,
+            pre_hook=[SqlHookEntry(statement="INSERT INTO main.hook_log VALUES ('pre')")],
+            future_cursor_config=FutureCursorsConfig("2d", FutureCursorAction.ERROR),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            expected_failed_phase=ExecutionPhase.STAGING,
+            expected_error_fragment="future cursor safety limit exceeded",
+            expected_query_results=(("SELECT * FROM main.hook_log", ()),),
+        ),
+        IncrementalFailureTestCase(
+            description="failed pre-hook preserves resolved future cap evidence",
+            setup_sql=(
+                "CREATE TABLE main.future_input (id INTEGER, event_time TIMESTAMP)",
+                "INSERT INTO main.future_input VALUES (1, '2500-01-01')",
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP)",
+            ),
+            model_sql=(
+                "SELECT * FROM main.future_input "
+                f"WHERE event_time >= '{MICROBATCH_START_SENTINEL}' "
+                f"AND event_time < '{MICROBATCH_END_SENTINEL}'"
+            ),
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="delete_insert",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            cursor_grain="second",
+            cursor_input_relations=(("main.future_input", "event_time"),),
+            cursor_inputs_model_backed=True,
+            pre_hook=[SqlHookEntry(statement="SELECT * FROM missing_pre_hook_table")],
+            future_cursor_config=FutureCursorsConfig("2d", FutureCursorAction.CAP),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            expected_failed_phase=ExecutionPhase.PRE_HOOK,
+            expected_error_fragment="missing_pre_hook_table",
+            expected_has_future_cursor_safety=True,
+        ),
         IncrementalFailureTestCase(
             description="sync_all_columns fails on incompatible type change",
             setup_sql=(

--- a/tests/integration/src/sqlbuild/executor/run/microbatch/_test_types.py
+++ b/tests/integration/src/sqlbuild/executor/run/microbatch/_test_types.py
@@ -1,10 +1,12 @@
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime
 
 from sqlbuild.compiler.auditing.types import AuditRunScope
 from sqlbuild.compiler.planner.types import OnSchemaChange
 from sqlbuild.executor.run.types import ExecutionPhase
 from sqlbuild.executor.scheduling.types import ExecutionStatus
+from sqlbuild.spec.contracts.models import FutureCursorsConfig
 
 
 @dataclass(frozen=True)
@@ -63,6 +65,9 @@ class MicrobatchSuccessTestCase:
     expected_batch_count: int | None = None
     start_cursor_override: str | None = None
     end_cursor_override: str | None = None
+    future_cursor_config: FutureCursorsConfig | None = None
+    invocation_time: datetime | None = None
+    expected_has_future_cursor_safety: bool = False
 
 
 @dataclass(frozen=True)
@@ -103,3 +108,6 @@ class MicrobatchFailureTestCase:
     hook_functions: tuple[object, ...] = field(default_factory=tuple)
     start_cursor_override: str | None = None
     end_cursor_override: str | None = None
+    future_cursor_config: FutureCursorsConfig | None = None
+    invocation_time: datetime | None = None
+    expected_has_future_cursor_safety: bool = False

--- a/tests/integration/src/sqlbuild/executor/run/microbatch/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/run/microbatch/helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -199,6 +200,7 @@ def verify_success_state(
     assert actual_count == test_case.expected_row_count
     assert len(result.audit_results) == test_case.expected_audit_count
     assert len(result.warning_messages) == test_case.expected_warning_count
+    assert (result.future_cursor_safety is not None) is test_case.expected_has_future_cursor_safety
     state_table_count: int = connection.execute(
         "SELECT COUNT(*) FROM information_schema.tables "
         "WHERE table_schema = 'main' AND table_name = '_sqlbuild_microbatches'"
@@ -247,6 +249,7 @@ def verify_failure_state(
     """Verify result fields and warehouse state for a failed microbatch execution."""
 
     assert result.failed_phase == test_case.expected_failed_phase
+    assert (result.future_cursor_safety is not None) is test_case.expected_has_future_cursor_safety
     assert len(result.audit_results) == test_case.expected_audit_count
 
     assert (test_case.expected_error_fragment or "") in (result.error_message or "")
@@ -287,6 +290,11 @@ def _execute_test(
         connection.execute(sql)
 
     entry: ModelPlanEntry = build_microbatch_plan_entry(test_case=test_case)
+    entry = replace(
+        entry,
+        future_cursor_config=test_case.future_cursor_config,
+        invocation_time=test_case.invocation_time,
+    )
     model_audits: tuple[AuditPlanEntry, ...] = _build_model_audits(test_case)
     target_qualified: str = _build_target_qualified(
         target_schema=test_case.target_schema, target_name=test_case.target_name

--- a/tests/integration/src/sqlbuild/executor/run/microbatch/test_microbatch_execution.py
+++ b/tests/integration/src/sqlbuild/executor/run/microbatch/test_microbatch_execution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,8 @@ from sqlbuild.compiler.planner.constants import (
 from sqlbuild.compiler.planner.types import OnSchemaChange
 from sqlbuild.executor.run.models import ModelExecutionResult
 from sqlbuild.executor.run.types import ExecutionPhase
+from sqlbuild.spec.contracts.models import FutureCursorsConfig
+from sqlbuild.spec.contracts.types import FutureCursorAction
 from tests.integration.src.sqlbuild.executor.run.microbatch._test_types import (
     MicrobatchFailureTestCase,
     MicrobatchSuccessTestCase,
@@ -476,6 +479,71 @@ def test_given_microbatch_model_when_executing_then_succeeds(
 @pytest.mark.parametrize(
     "test_case",
     [
+        MicrobatchFailureTestCase(
+            description="runtime cap evidence survives pre-hook failure",
+            setup_sql=(
+                "CREATE TABLE main.future_input (id INTEGER, event_time TIMESTAMP)",
+                "INSERT INTO main.future_input VALUES (1, '2500-01-01')",
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP)",
+            ),
+            model_sql=(
+                "SELECT * FROM main.future_input "
+                f"WHERE event_time >= '{MICROBATCH_START_SENTINEL}' "
+                f"AND event_time < '{MICROBATCH_END_SENTINEL}'"
+            ),
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="delete_insert",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            cursor_grain="second",
+            batch_size="1h",
+            microbatch_start="2026-01-01T00:00:00",
+            microbatch_end="2026-01-01T01:00:00",
+            use_plan_microbatch_range=False,
+            cursor_input_relations=(("main.future_input", "event_time"),),
+            cursor_inputs_model_backed=True,
+            pre_hook=[SqlHookEntry(statement="SELECT * FROM missing_pre_hook_table")],
+            future_cursor_config=FutureCursorsConfig("2d", FutureCursorAction.CAP),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            expected_failed_phase=ExecutionPhase.PRE_HOOK,
+            expected_error_fragment="missing_pre_hook_table",
+            expected_row_count=0,
+            expected_has_future_cursor_safety=True,
+        ),
+        MicrobatchFailureTestCase(
+            description="runtime error blocks microbatch pre-hook side effects",
+            setup_sql=(
+                "CREATE TABLE main.future_input (id INTEGER, event_time TIMESTAMP)",
+                "INSERT INTO main.future_input VALUES (1, '2500-01-01')",
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP)",
+                "CREATE TABLE main.hook_log (phase VARCHAR)",
+            ),
+            model_sql=(
+                "SELECT * FROM main.future_input "
+                f"WHERE event_time >= '{MICROBATCH_START_SENTINEL}' "
+                f"AND event_time < '{MICROBATCH_END_SENTINEL}'"
+            ),
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="delete_insert",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            cursor_grain="second",
+            batch_size="1h",
+            microbatch_start="2026-01-01T00:00:00",
+            microbatch_end="2026-01-01T01:00:00",
+            use_plan_microbatch_range=False,
+            cursor_input_relations=(("main.future_input", "event_time"),),
+            cursor_inputs_model_backed=True,
+            pre_hook=[SqlHookEntry(statement="INSERT INTO main.hook_log VALUES ('pre')")],
+            future_cursor_config=FutureCursorsConfig("2d", FutureCursorAction.ERROR),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            expected_failed_phase=ExecutionPhase.STAGING,
+            expected_error_fragment="future cursor safety limit exceeded",
+            expected_row_count=0,
+            expected_query_results=(("SELECT * FROM main.hook_log", ()),),
+        ),
         MicrobatchFailureTestCase(
             description="pre_hook failure blocks all batches",
             setup_sql=(

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
@@ -13,6 +13,12 @@ class MicrobatchExecutionProtocolTestCase:
 
 
 @dataclass(frozen=True)
+class FutureCursorExecutionProtocolTestCase:
+    description: str
+    expected_action: str
+
+
+@dataclass(frozen=True)
 class SqlTestCaseExecutionProtocolTestCase:
     """Expected identity and typed parameter fields for one SQL test case."""
 

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_protocol_v1.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_protocol_v1.py
@@ -13,6 +13,10 @@ from sqlbuild.cli.output._helpers.execution_protocol_v1 import (
     _format_sql_test_checks,
 )
 from sqlbuild.compiler.discovery.models import SqlTestParameterDeclaration
+from sqlbuild.compiler.planner.models import (
+    CursorInputEvidence,
+    FutureCursorSafetyEvidence,
+)
 from sqlbuild.executor.run.models import (
     MicrobatchAccountingInterval,
     ModelExecutionResult,
@@ -20,9 +24,11 @@ from sqlbuild.executor.run.models import (
 from sqlbuild.executor.scheduling.types import ExecutionStatus
 from sqlbuild.executor.testing.models import SqlTestExecutionResult
 from sqlbuild.executor.testing.types import SqlTestOutcome
+from sqlbuild.spec.contracts.types import FutureCursorAction
 from sqlbuild.sql_values.models import SqlLogicalType, SqlValue
 from sqlbuild.sql_values.types import SqlValueKind
 from tests.unit.src.sqlbuild.cli.output._helpers._test_types import (
+    FutureCursorExecutionProtocolTestCase,
     MicrobatchExecutionProtocolTestCase,
     SqlTestCaseExecutionProtocolTestCase,
 )
@@ -101,6 +107,78 @@ def test_given_microbatch_result_when_formatting_json_then_interval_provenance_i
                 "model_version_hash": None,
                 "completion_type": None,
                 "event_id": None,
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [FutureCursorExecutionProtocolTestCase("structured future cursor evidence", "cap")],
+    ids=lambda case: case.description,
+)
+def test_given_future_cursor_cap_when_formatting_execution_json_then_structured_evidence_is_exposed(
+    test_case: FutureCursorExecutionProtocolTestCase,
+) -> None:
+    evidence: FutureCursorSafetyEvidence = FutureCursorSafetyEvidence(
+        action=FutureCursorAction.CAP,
+        max_distance="2d",
+        invocation_time="2026-09-01T12:00:00+00:00",
+        discovered_start="2500-01-01T00:00:00",
+        discovered_end="2500-01-01T00:00:01",
+        applied_start="2500-01-01T00:00:00",
+        applied_end="2026-09-03T12:00:00",
+        maximum_allowed_start="2026-09-03T12:00:00",
+        maximum_allowed_end="2026-09-03T12:00:01",
+        future_start_detected=True,
+        future_end_detected=True,
+        determining_relation="raw.events",
+        determining_cursor_column="occurred_at",
+        inputs=(
+            CursorInputEvidence(
+                relation="raw.events",
+                cursor_column="occurred_at",
+                minimum=None,
+                maximum="2500-01-01T00:00:00",
+            ),
+        ),
+    )
+    result: ModelExecutionResult = ModelExecutionResult(
+        model_name="orders",
+        status=ExecutionStatus.SUCCESS,
+        future_cursor_safety=evidence,
+    )
+
+    asset: dict[str, object] = _format_model_assets(results=(result,), plan=None)[0]
+
+    assert asset["future_cursor_safety"] == {
+        "action": test_case.expected_action,
+        "max_distance": "2d",
+        "invocation_time": "2026-09-01T12:00:00+00:00",
+        "discovered_bounds": {
+            "start": "2500-01-01T00:00:00",
+            "end": "2500-01-01T00:00:01",
+        },
+        "applied_bounds": {
+            "start": "2500-01-01T00:00:00",
+            "end": "2026-09-03T12:00:00",
+        },
+        "maximum_allowed_bounds": {
+            "start": "2026-09-03T12:00:00",
+            "end": "2026-09-03T12:00:01",
+        },
+        "future_start_detected": True,
+        "future_end_detected": True,
+        "determining_input": {
+            "relation": "raw.events",
+            "cursor_column": "occurred_at",
+        },
+        "inputs": [
+            {
+                "relation": "raw.events",
+                "cursor_column": "occurred_at",
+                "minimum": None,
+                "maximum": "2500-01-01T00:00:00",
             }
         ],
     }

--- a/tests/unit/src/sqlbuild/cli/output/main/plan_json/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/plan_json/_test_types.py
@@ -12,3 +12,9 @@ class JsonOutputTestCase:
     python_plan_entries: tuple[PythonPlanEntry, ...] = field(default_factory=tuple)
     expected_fragments: tuple[str, ...] = field(default_factory=tuple)
     unexpected_fragments: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class FutureCursorPlanJsonTestCase:
+    description: str
+    expected_action: str

--- a/tests/unit/src/sqlbuild/cli/output/main/plan_json/test_plan_json.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/plan_json/test_plan_json.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 
@@ -11,7 +12,11 @@ from sqlbuild.compiler.pipeline.models import PythonPlanEntry
 from sqlbuild.compiler.planner.models import (
     CascadeCause,
     CascadeResult,
+    CursorBounds,
+    CursorInputEvidence,
     CursorInputRelation,
+    FutureCursorSafetyEvidence,
+    PlanOutput,
 )
 from sqlbuild.compiler.planner.types import (
     BackfillAction,
@@ -25,6 +30,7 @@ from sqlbuild.compiler.python_nodes.types import (
     PythonNodeKind,
     PythonRunPhase,
 )
+from sqlbuild.spec.contracts.types import FutureCursorAction
 from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
     build_discovered_provider_usage,
     build_model_entry,
@@ -34,7 +40,72 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
     build_source_load_entry,
     build_warning,
 )
-from tests.unit.src.sqlbuild.cli.output.main.plan_json._test_types import JsonOutputTestCase
+from tests.unit.src.sqlbuild.cli.output.main.plan_json._test_types import (
+    FutureCursorPlanJsonTestCase,
+    JsonOutputTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [FutureCursorPlanJsonTestCase("future cursor plan structure", "cap")],
+    ids=lambda case: case.description,
+)
+def test_given_future_cursor_cap_when_formatting_plan_json_then_structured_bounds_are_exposed(
+    test_case: FutureCursorPlanJsonTestCase,
+) -> None:
+    evidence: FutureCursorSafetyEvidence = FutureCursorSafetyEvidence(
+        action=FutureCursorAction.CAP,
+        max_distance="1d",
+        invocation_time="2026-09-01T12:00:00+00:00",
+        discovered_start="2500-01-01",
+        discovered_end="2500-01-02",
+        applied_start="2500-01-01",
+        applied_end="2026-09-03",
+        maximum_allowed_start="2026-09-02",
+        maximum_allowed_end="2026-09-03",
+        future_start_detected=True,
+        future_end_detected=True,
+        determining_relation="raw.events",
+        determining_cursor_column="occurred_at",
+        inputs=(
+            CursorInputEvidence(
+                relation="raw.events",
+                cursor_column="occurred_at",
+                minimum="2026-01-01",
+                maximum="2500-01-01",
+            ),
+        ),
+    )
+    plan: PlanOutput = build_plan_output(
+        model_entries=(
+            build_model_entry(
+                name="events",
+                cursor_bounds=CursorBounds(
+                    start="2500-01-01",
+                    end="2026-09-03",
+                    future_safety=evidence,
+                ),
+            ),
+        )
+    )
+
+    payload: dict[str, object] = json.loads(format_plan_json(plan=plan))
+    model: Any = payload["models"][0]
+
+    assert model["future_cursor_safety"]["action"] == test_case.expected_action
+    assert model["future_cursor_safety"]["discovered_bounds"] == {
+        "start": "2500-01-01",
+        "end": "2500-01-02",
+    }
+    assert model["future_cursor_safety"]["applied_bounds"] == {
+        "start": "2500-01-01",
+        "end": "2026-09-03",
+    }
+    assert model["future_cursor_safety"]["determining_input"] == {
+        "relation": "raw.events",
+        "cursor_column": "occurred_at",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
@@ -6,6 +6,21 @@ from sqlbuild.sql_values.types import CollectionRendering
 
 
 @dataclass(frozen=True)
+class FutureCursorConfigTestCase:
+    description: str
+    future_toml: str
+    expected_max_distance: str
+    expected_action: str
+
+
+@dataclass(frozen=True)
+class FutureCursorConfigErrorTestCase:
+    description: str
+    future_toml: str
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
 class DiscoverMacroFilesTestCase:
     description: str
     files: dict[str, str]

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
@@ -13,6 +13,8 @@ from sqlbuild.compiler.discovery.exceptions import ProjectConfigError
 from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig
 from sqlbuild.sql_values.types import CollectionRendering
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
+    FutureCursorConfigErrorTestCase,
+    FutureCursorConfigTestCase,
     LoadLocalConfigErrorTestCase,
     LoadLocalConfigTestCase,
     LoadNamedConnectionsTestCase,
@@ -54,6 +56,60 @@ def test_given_no_cost_config_when_loading_project_then_default_rate_is_flagged(
 
     assert config.cost.usd_per_credit == test_case.expected_usd_per_credit
     assert config.cost.usd_per_credit_is_default is test_case.expected_is_default
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        FutureCursorConfigTestCase(
+            description="future cap policy is typed",
+            future_toml='max_distance = "7d"\naction = "cap"',
+            expected_max_distance="7d",
+            expected_action="cap",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_future_cursor_config_when_loading_project_then_policy_is_typed(
+    test_case: FutureCursorConfigTestCase, tmp_path: Path
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        f'name = "demo"\nadapter = "duckdb"\n[cursors.future]\n{test_case.future_toml}\n',
+        encoding="utf-8",
+    )
+
+    config: ProjectConfig = load_project_config(project_dir=tmp_path)
+
+    assert config.cursors.future.max_distance == test_case.expected_max_distance
+    assert config.cursors.future.action == test_case.expected_action
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        FutureCursorConfigErrorTestCase(
+            description="invalid duration",
+            future_toml='max_distance = "tomorrow"',
+            expected_error_fragment="max_distance must be a positive duration",
+        ),
+        FutureCursorConfigErrorTestCase(
+            description="invalid action",
+            future_toml='max_distance = "7d"\naction = "warn"',
+            expected_error_fragment="action must be one of: cap, error",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_invalid_future_cursor_config_when_loading_project_then_config_error_is_raised(
+    test_case: FutureCursorConfigErrorTestCase, tmp_path: Path
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        f'name = "demo"\nadapter = "duckdb"\n[cursors.future]\n{test_case.future_toml}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ProjectConfigError, match=test_case.expected_error_fragment):
+        load_project_config(project_dir=tmp_path)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/planner/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/main/_test_types.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass
+from datetime import datetime
 
 from sqlbuild.compiler.planner.models import (
+    CursorBounds,
     SelectionStalenessGraph,
     SelectionStalenessWarning,
 )
+from sqlbuild.spec.contracts.models import FutureCursorsConfig
 
 
 @dataclass(frozen=True)
@@ -130,3 +133,17 @@ class EffectiveMicrobatchBatchSizeTestCase:
     batch_size: str
     effective_grain: str
     expected_batch_size: str
+
+
+@dataclass(frozen=True)
+class FutureCursorSafetyTestCase:
+    description: str
+    bounds: CursorBounds
+    config: FutureCursorsConfig
+    invocation_time: datetime
+    cursor_grain: str
+    has_complete_override: bool
+    expected_start: str
+    expected_end: str
+    expected_has_safety: bool
+    expected_error_fragment: str | None = None

--- a/tests/unit/src/sqlbuild/compiler/planner/main/test_future_cursor_safety.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/main/test_future_cursor_safety.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from sqlbuild.compiler.planner.exceptions import FutureCursorSafetyError
+from sqlbuild.compiler.planner.main.execution.future_cursor_safety import apply_future_cursor_safety
+from sqlbuild.compiler.planner.main.execution.future_cursor_warning import future_cursor_cap_warning
+from sqlbuild.compiler.planner.models import CursorBounds
+from sqlbuild.compiler.planner.types import CursorGrain, CursorType
+from sqlbuild.spec.contracts.models import FutureCursorsConfig
+from sqlbuild.spec.contracts.types import FutureCursorAction
+from tests.unit.src.sqlbuild.compiler.planner.main._test_types import FutureCursorSafetyTestCase
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        FutureCursorSafetyTestCase(
+            description="timestamp cap advances equality horizon by one second",
+            bounds=CursorBounds("2026-09-01T00:00:00", "2030-01-01T00:00:01"),
+            config=FutureCursorsConfig("2d", FutureCursorAction.CAP),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            cursor_grain=CursorGrain.SECOND,
+            has_complete_override=False,
+            expected_start="2026-09-01T00:00:00",
+            expected_end="2026-09-03T12:00:01",
+            expected_has_safety=True,
+        ),
+        FutureCursorSafetyTestCase(
+            description="date cap retains final inclusive day",
+            bounds=CursorBounds("2026-09-01", "2030-01-02"),
+            config=FutureCursorsConfig("2d", FutureCursorAction.CAP),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            cursor_grain=CursorGrain.DAY,
+            has_complete_override=False,
+            expected_start="2026-09-01",
+            expected_end="2026-09-04",
+            expected_has_safety=True,
+        ),
+        FutureCursorSafetyTestCase(
+            description="future start is preserved when end is within horizon",
+            bounds=CursorBounds("2030-01-01", "2026-09-02"),
+            config=FutureCursorsConfig("2d", FutureCursorAction.CAP),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            cursor_grain=CursorGrain.DAY,
+            has_complete_override=False,
+            expected_start="2030-01-01",
+            expected_end="2026-09-02",
+            expected_has_safety=True,
+        ),
+        FutureCursorSafetyTestCase(
+            description="month grain caps at next month boundary",
+            bounds=CursorBounds("2026-01-01T00:00:00", "2030-01-01T00:00:00"),
+            config=FutureCursorsConfig("1mo", FutureCursorAction.CAP),
+            invocation_time=datetime(2026, 1, 15, 12, 0, tzinfo=UTC),
+            cursor_grain=CursorGrain.MONTH,
+            has_complete_override=False,
+            expected_start="2026-01-01T00:00:00",
+            expected_end="2026-03-01T00:00:00",
+            expected_has_safety=True,
+        ),
+        FutureCursorSafetyTestCase(
+            description="year grain caps at next year boundary",
+            bounds=CursorBounds("2026-01-01T00:00:00", "2030-01-01T00:00:00"),
+            config=FutureCursorsConfig("1y", FutureCursorAction.CAP),
+            invocation_time=datetime(2026, 6, 15, 12, 0, tzinfo=UTC),
+            cursor_grain=CursorGrain.YEAR,
+            has_complete_override=False,
+            expected_start="2026-01-01T00:00:00",
+            expected_end="2028-01-01T00:00:00",
+            expected_has_safety=True,
+        ),
+        FutureCursorSafetyTestCase(
+            description="exclusive end equal to horizon is accepted",
+            bounds=CursorBounds("2026-09-01T00:00:00", "2026-09-03T12:00:01"),
+            config=FutureCursorsConfig("2d", FutureCursorAction.ERROR),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            cursor_grain=CursorGrain.SECOND,
+            has_complete_override=False,
+            expected_start="2026-09-01T00:00:00",
+            expected_end="2026-09-03T12:00:01",
+            expected_has_safety=False,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_effective_cursor_when_applying_cap_then_expected_bounds_are_returned(
+    test_case: FutureCursorSafetyTestCase,
+) -> None:
+    result: CursorBounds = apply_future_cursor_safety(
+        bounds=test_case.bounds,
+        cursor_type=CursorType.TIMESTAMP,
+        cursor_grain=test_case.cursor_grain,
+        config=test_case.config,
+        invocation_time=test_case.invocation_time,
+        has_complete_override=test_case.has_complete_override,
+    )
+
+    assert result.start == test_case.expected_start
+    assert result.end == test_case.expected_end
+    assert (result.future_safety is not None) is test_case.expected_has_safety
+    assert (future_cursor_cap_warning(result) is not None) is test_case.expected_has_safety
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        FutureCursorSafetyTestCase(
+            description="future end fails closed",
+            bounds=CursorBounds("2026-09-01", "2030-01-01"),
+            config=FutureCursorsConfig("2d", FutureCursorAction.ERROR),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            cursor_grain=CursorGrain.DAY,
+            has_complete_override=False,
+            expected_start="2026-09-01",
+            expected_end="2030-01-01",
+            expected_has_safety=False,
+            expected_error_fragment="future cursor safety limit exceeded",
+        ),
+        FutureCursorSafetyTestCase(
+            description="future start independently fails closed",
+            bounds=CursorBounds("2030-01-01", "2026-09-02"),
+            config=FutureCursorsConfig("2d", FutureCursorAction.ERROR),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            cursor_grain=CursorGrain.DAY,
+            has_complete_override=False,
+            expected_start="2030-01-01",
+            expected_end="2026-09-02",
+            expected_has_safety=False,
+            expected_error_fragment="future cursor safety limit exceeded",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_future_effective_cursor_when_applying_error_then_fails_closed(
+    test_case: FutureCursorSafetyTestCase,
+) -> None:
+    with pytest.raises(FutureCursorSafetyError, match=test_case.expected_error_fragment):
+        apply_future_cursor_safety(
+            bounds=test_case.bounds,
+            cursor_type=CursorType.TIMESTAMP,
+            cursor_grain=test_case.cursor_grain,
+            config=test_case.config,
+            invocation_time=test_case.invocation_time,
+            has_complete_override=test_case.has_complete_override,
+        )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        FutureCursorSafetyTestCase(
+            description="complete override bypasses safety",
+            bounds=CursorBounds("2029-01-01", "2030-01-01"),
+            config=FutureCursorsConfig("2d", FutureCursorAction.ERROR),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            cursor_grain=CursorGrain.DAY,
+            has_complete_override=True,
+            expected_start="2029-01-01",
+            expected_end="2030-01-01",
+            expected_has_safety=False,
+        ),
+        FutureCursorSafetyTestCase(
+            description="absent max distance disables safety",
+            bounds=CursorBounds("2026-09-01", "2030-01-01"),
+            config=FutureCursorsConfig(action=FutureCursorAction.ERROR),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            cursor_grain=CursorGrain.DAY,
+            has_complete_override=False,
+            expected_start="2026-09-01",
+            expected_end="2030-01-01",
+            expected_has_safety=False,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_bypass_condition_when_applying_safety_then_bounds_are_unchanged(
+    test_case: FutureCursorSafetyTestCase,
+) -> None:
+    result: CursorBounds = apply_future_cursor_safety(
+        bounds=test_case.bounds,
+        cursor_type=CursorType.TIMESTAMP,
+        cursor_grain=test_case.cursor_grain,
+        config=test_case.config,
+        invocation_time=test_case.invocation_time,
+        has_complete_override=test_case.has_complete_override,
+    )
+
+    assert result.start == test_case.expected_start
+    assert result.end == test_case.expected_end
+    assert (result.future_safety is not None) is test_case.expected_has_safety

--- a/tests/unit/src/sqlbuild/executor/run/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/run/_helpers/_test_types.py
@@ -6,6 +6,15 @@ from sqlbuild.executor.run.types import AuditGateReuseReason, AuditGateStatus, E
 
 
 @dataclass(frozen=True)
+class RuntimeFutureCursorTestCase:
+    description: str
+    expected_start: str
+    expected_end: str
+    expected_error_fragment: str | None = None
+    expected_determining_relation: str | None = None
+
+
+@dataclass(frozen=True)
 class CursorSentinelSubstitutionErrorTestCase:
     description: str
     sql: str

--- a/tests/unit/src/sqlbuild/executor/run/_helpers/test_cursor_bounds.py
+++ b/tests/unit/src/sqlbuild/executor/run/_helpers/test_cursor_bounds.py
@@ -8,6 +8,7 @@ import duckdb
 import pytest
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.compiler.planner.exceptions import FutureCursorSafetyError
 from sqlbuild.compiler.planner.models import CursorBounds, CursorInputRelation
 from sqlbuild.compiler.planner.types import CursorGrain, CursorType
 from sqlbuild.errors.contracts.exceptions import ExecutorInputError
@@ -16,6 +17,8 @@ from sqlbuild.executor.run._helpers.validation.cursor_bounds import (
     substitute_cursor_sentinels,
 )
 from sqlbuild.executor.run.models import RuntimeCursorSpec
+from sqlbuild.spec.contracts.models import FutureCursorsConfig
+from sqlbuild.spec.contracts.types import FutureCursorAction
 from tests.unit.src.sqlbuild.executor.run._helpers._test_types import (
     AuthoritativeRuntimeCursorOverrideTestCase,
     CursorSentinelSubstitutionErrorTestCase,
@@ -25,6 +28,7 @@ from tests.unit.src.sqlbuild.executor.run._helpers._test_types import (
     RuntimeCursorPolicyTestCase,
     RuntimeCursorStartTestCase,
     RuntimeExistingTargetOverrideTestCase,
+    RuntimeFutureCursorTestCase,
     RuntimeTargetMaxTestCase,
     RuntimeTargetProbeFailureTestCase,
     RuntimeWatermarkStatementTestCase,
@@ -33,6 +37,138 @@ from tests.unit.src.sqlbuild.executor.run._helpers.helpers import (
     FakeCursorAdapter,
     RecordingCursorAdapter,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [RuntimeFutureCursorTestCase("runtime cap", "2026-09-01T00:00:00", "2026-09-03T12:00:01")],
+    ids=lambda case: case.description,
+)
+def test_given_future_runtime_watermark_when_resolving_then_cap_uses_invocation_clock(
+    test_case: RuntimeFutureCursorTestCase,
+) -> None:
+    connection: duckdb.DuckDBPyConnection = duckdb.connect(":memory:")
+    connection.execute("CREATE TABLE upstream_data (cursor_value TIMESTAMP)")
+    connection.execute(
+        "INSERT INTO upstream_data VALUES (TIMESTAMP '2026-09-01'), (TIMESTAMP '2030-01-01')"
+    )
+
+    bounds: CursorBounds | None = resolve_runtime_cursor_bounds(
+        adapter=cast(BaseAdapter, FakeCursorAdapter()),
+        connection=connection,
+        target_relation="target_data",
+        target_database=None,
+        target_schema=None,
+        target_name="target_data",
+        spec=RuntimeCursorSpec(
+            cursor_column="cursor_value",
+            cursor_type=CursorType.TIMESTAMP,
+            cursor_grain=CursorGrain.SECOND,
+            cursor_start=None,
+            cursor_input_relations=(
+                CursorInputRelation(relation="upstream_data", cursor_column="cursor_value"),
+            ),
+            future_cursor_config=FutureCursorsConfig("2d", FutureCursorAction.CAP),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+        ),
+    )
+
+    assert bounds is not None
+    assert bounds.start == test_case.expected_start
+    assert bounds.end == test_case.expected_end
+    assert bounds.future_safety is not None
+    assert bounds.future_safety.discovered_end == "2030-01-01T00:00:01"
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [RuntimeFutureCursorTestCase("runtime error", "", "", "future cursor safety limit exceeded")],
+    ids=lambda case: case.description,
+)
+def test_given_future_runtime_watermark_and_error_policy_when_resolving_then_fails_closed(
+    test_case: RuntimeFutureCursorTestCase,
+) -> None:
+    connection: duckdb.DuckDBPyConnection = duckdb.connect(":memory:")
+    connection.execute("CREATE TABLE upstream_data (cursor_value TIMESTAMP)")
+    connection.execute("INSERT INTO upstream_data VALUES (TIMESTAMP '2026-09-01')")
+    connection.execute("CREATE TABLE target_data (cursor_value TIMESTAMP)")
+    connection.execute("INSERT INTO target_data VALUES (TIMESTAMP '2500-01-01')")
+
+    with pytest.raises(FutureCursorSafetyError, match=test_case.expected_error_fragment):
+        resolve_runtime_cursor_bounds(
+            adapter=cast(BaseAdapter, FakeCursorAdapter(target_relation_exists=True)),
+            connection=connection,
+            target_relation="target_data",
+            target_database=None,
+            target_schema=None,
+            target_name="target_data",
+            spec=RuntimeCursorSpec(
+                cursor_column="cursor_value",
+                cursor_type=CursorType.TIMESTAMP,
+                cursor_grain=CursorGrain.SECOND,
+                cursor_start=None,
+                cursor_input_relations=(
+                    CursorInputRelation(relation="upstream_data", cursor_column="cursor_value"),
+                ),
+                future_cursor_config=FutureCursorsConfig("2d", FutureCursorAction.ERROR),
+                invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        RuntimeFutureCursorTestCase(
+            "future target evidence",
+            "2500-01-01T00:00:00",
+            "2026-09-01T00:00:01",
+            expected_determining_relation="input_a",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_future_target_and_multiple_inputs_when_capping_then_start_and_input_evidence_are_preserved(
+    test_case: RuntimeFutureCursorTestCase,
+) -> None:
+    connection: duckdb.DuckDBPyConnection = duckdb.connect(":memory:")
+    connection.execute("CREATE TABLE target_data (cursor_value TIMESTAMP)")
+    connection.execute("INSERT INTO target_data VALUES (TIMESTAMP '2500-01-01')")
+    connection.execute("CREATE TABLE input_a (cursor_value TIMESTAMP)")
+    connection.execute("INSERT INTO input_a VALUES (TIMESTAMP '2026-09-01')")
+    connection.execute("CREATE TABLE input_b (cursor_value TIMESTAMP)")
+    connection.execute("INSERT INTO input_b VALUES (TIMESTAMP '2026-09-02')")
+
+    bounds: CursorBounds | None = resolve_runtime_cursor_bounds(
+        adapter=cast(BaseAdapter, FakeCursorAdapter(target_relation_exists=True)),
+        connection=connection,
+        target_relation="target_data",
+        target_database=None,
+        target_schema=None,
+        target_name="target_data",
+        spec=RuntimeCursorSpec(
+            cursor_column="cursor_value",
+            cursor_type=CursorType.TIMESTAMP,
+            cursor_grain=CursorGrain.SECOND,
+            cursor_start=None,
+            cursor_input_relations=(
+                CursorInputRelation(relation="input_b", cursor_column="cursor_value"),
+                CursorInputRelation(relation="input_a", cursor_column="cursor_value"),
+            ),
+            future_cursor_config=FutureCursorsConfig("2d", FutureCursorAction.CAP),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+        ),
+    )
+
+    assert bounds is not None
+    assert bounds.start == test_case.expected_start
+    assert bounds.end == test_case.expected_end
+    assert bounds.future_safety is not None
+    assert bounds.future_safety.determining_relation == test_case.expected_determining_relation
+    assert tuple(item.relation for item in bounds.future_safety.inputs) == (
+        "input_a",
+        "input_b",
+    )
 
 
 @pytest.mark.parametrize(
@@ -718,6 +854,14 @@ def test_given_full_refresh_runtime_discovery_when_resolving_then_ignores_old_ta
             end_cursor_override="20",
             expected_bounds=CursorBounds(start="10", end="21"),
         ),
+        AuthoritativeRuntimeCursorOverrideTestCase(
+            description="future timestamp override bypasses configured safety",
+            cursor_type=CursorType.TIMESTAMP,
+            cursor_grain=CursorGrain.DAY,
+            start_cursor_override="2500-01-01",
+            end_cursor_override="2500-01-04",
+            expected_bounds=CursorBounds(start="2500-01-01", end="2500-01-05"),
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -747,6 +891,8 @@ def test_given_complete_override_when_runtime_resolution_invoked_then_returns_wi
             ),
             start_cursor_override=test_case.start_cursor_override,
             end_cursor_override=test_case.end_cursor_override,
+            future_cursor_config=FutureCursorsConfig("2d", FutureCursorAction.ERROR),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
         ),
     )
 

--- a/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
@@ -102,6 +102,20 @@ class DagsterCliJsonStreamTestCase:
 
 
 @dataclass(frozen=True)
+class DagsterFutureCursorMetadataTestCase:
+    description: str
+    expected_action: str
+
+
+@dataclass(frozen=True)
+class DagsterLiveFailureLoggingTestCase:
+    description: str
+    expected_phase: str
+    expected_error_code: str
+    expected_error_message: str
+
+
+@dataclass(frozen=True)
 class DagsterCliCloneStreamTestCase:
     description: str
     command_stdout: str

--- a/tests/unit/src/sqlbuild/integrations/dagster/helpers.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/helpers.py
@@ -341,6 +341,58 @@ def write_blocking_execution_event_command(
     return ["python", str(script_path)]
 
 
+def write_blocking_failed_execution_event_command(*, root: Path, release_path: Path) -> list[str]:
+    asset: dict[str, object] = {
+        "kind": "model",
+        "name": "customers",
+        "status": "failed",
+        "failed_phase": "staging",
+        "error_code": "R002",
+        "error_message": "invalid identifier CUSTOMER_ID",
+        "error_help": "Check the projected columns.",
+        "staging_relation": "analytics.customers__staging",
+        "duration_ms": 123,
+    }
+    event_payload: str = json.dumps(
+        {"version": 1, "command": "build", "event": "asset", "asset": asset}
+    )
+    execution_payload: str = json.dumps(
+        {
+            "version": 1,
+            "command": "build",
+            "status": "failed",
+            "summary": {"failure_count": 1},
+            "assets": [asset],
+            "checks": [],
+        }
+    )
+    script_path: Path = root / "blocking_failed_build_event.py"
+    script_path.write_text(
+        "\n".join(
+            (
+                "from pathlib import Path",
+                "import os",
+                "import sys",
+                "import time",
+                "event_path = Path(os.environ['SQLBUILD_EXECUTION_EVENT_PATH'])",
+                "with event_path.open('a', encoding='utf-8') as stream:",
+                f"    stream.write({event_payload + chr(10)!r})",
+                f"    stream.write({event_payload + chr(10)!r})",
+                "    stream.flush()",
+                f"release_path = Path({str(release_path)!r})",
+                "while not release_path.exists():",
+                "    time.sleep(0.01)",
+                "json_path = Path(sys.argv[sys.argv.index('--json-output') + 1])",
+                f"json_path.write_text({execution_payload!r}, encoding='utf-8')",
+                "raise SystemExit(1)",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return ["python", str(script_path)]
+
+
 def write_dagster_test_dag(*, root: Path) -> Path:
     root.mkdir(parents=True, exist_ok=True)
     dag_path: Path = root / "sqlbuild_dag.json"

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections import defaultdict
 from collections.abc import Generator, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -22,12 +23,15 @@ from tests.unit.src.sqlbuild.integrations.dagster._test_types import (
     DagsterCliLiveLogTestCase,
     DagsterCliSelectionTestCase,
     DagsterCliStreamTestCase,
+    DagsterFutureCursorMetadataTestCase,
+    DagsterLiveFailureLoggingTestCase,
 )
 from tests.unit.src.sqlbuild.integrations.dagster.helpers import (
     assert_json_output_file_behavior,
     assert_positional_selector_behavior,
     assert_select_file_selector_behavior,
     write_blocking_execution_event_command,
+    write_blocking_failed_execution_event_command,
     write_blocking_fake_sqb_command,
     write_dagster_test_dag,
     write_fake_sqb_command,
@@ -279,6 +283,69 @@ def test_given_execution_json_when_streaming_then_yields_structured_dagster_even
 
 @pytest.mark.parametrize(
     "test_case",
+    [DagsterFutureCursorMetadataTestCase("future cursor metadata", "cap")],
+    ids=lambda case: case.description,
+)
+def test_given_future_cursor_execution_metadata_when_streaming_then_dagster_retains_structure(
+    test_case: DagsterFutureCursorMetadataTestCase, tmp_path: Path
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    safety: dict[str, object] = {
+        "action": "cap",
+        "max_distance": "2d",
+        "discovered_bounds": {"start": "2500-01-01", "end": "2500-01-02"},
+        "applied_bounds": {"start": "2500-01-01", "end": "2026-09-04"},
+        "determining_input": {
+            "relation": "raw.events",
+            "cursor_column": "occurred_at",
+        },
+        "inputs": [
+            {
+                "relation": "raw.events",
+                "cursor_column": "occurred_at",
+                "minimum": None,
+                "maximum": "2500-01-01",
+            }
+        ],
+    }
+    stdout: str = json.dumps(
+        {
+            "version": 1,
+            "command": "build",
+            "status": "success",
+            "summary": {},
+            "assets": [
+                {
+                    "kind": "model",
+                    "name": "orders",
+                    "status": "success",
+                    "future_cursor_safety": safety,
+                }
+            ],
+            "checks": [],
+        }
+    )
+    context: Any = type(
+        "SelectedAssetContext",
+        (),
+        {"selected_asset_keys": {dg.AssetKey(["analytics", "orders"])}},
+    )()
+    resource: SqlBuildCliResource = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_fake_sqb_command(root=tmp_path, stdout=stdout),
+        dag_path=str(write_dagster_test_dag(root=tmp_path)),
+    )
+
+    results: list[Any] = list(resource.cli(args=["build"], context=context).stream())
+
+    materialization: Any = results[0]
+    assert materialization.metadata["future_cursor_safety"] == safety
+    assert materialization.metadata["future_cursor_safety"]["action"] == test_case.expected_action
+
+
+@pytest.mark.parametrize(
+    "test_case",
     [
         DagsterCliCloneStreamTestCase(
             description="clone execution yields materializations for successful items only",
@@ -423,6 +490,69 @@ def test_given_running_clone_when_item_completes_then_materializes_before_proces
         test_case.expected_remaining_asset_keys
     )
     assert invocation.returncode == 0
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagsterLiveFailureLoggingTestCase(
+            "live failed asset logging", "staging", "R002", "invalid identifier CUSTOMER_ID"
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_live_failed_asset_when_event_arrives_then_logs_error_before_process_exit(
+    test_case: DagsterLiveFailureLoggingTestCase, tmp_path: Path
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    release_path: Path = tmp_path / "release"
+    error_received: Event = Event()
+    logger: Mock = Mock()
+    logger.error.side_effect = lambda *_args, **_kwargs: error_received.set()
+    context: Any = type(
+        "FailedAssetContext",
+        (),
+        {"log": logger, "selected_asset_keys": set()},
+    )()
+    invocation: SqlBuildCliInvocation = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_blocking_failed_execution_event_command(
+            root=tmp_path,
+            release_path=release_path,
+        ),
+        dag_path=str(write_dagster_test_dag(root=tmp_path)),
+    ).cli(args=["build"], context=context, raise_on_error=False)
+    expected_command: str = " ".join(invocation.command)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        stream_future: Future[list[Any]] = executor.submit(lambda: list(invocation.stream()))
+        assert error_received.wait(timeout=3)
+        assert not stream_future.done()
+        release_path.touch()
+        stream_future.result(timeout=3)
+
+    logger.error.assert_called_once()
+    log_call: Any = logger.error.call_args
+    assert log_call.args == (
+        "SQLBuild asset failed: asset=%s phase=%s code=%s message=%s",
+        "model:customers",
+        test_case.expected_phase,
+        test_case.expected_error_code,
+        test_case.expected_error_message,
+    )
+    assert log_call.kwargs["extra"] == {
+        "sqlbuild_asset": "model:customers",
+        "sqlbuild_asset_kind": "model",
+        "sqlbuild_asset_name": "customers",
+        "sqlbuild_phase": "staging",
+        "sqlbuild_error_code": "R002",
+        "sqlbuild_error_message": "invalid identifier CUSTOMER_ID",
+        "sqlbuild_command": expected_command,
+        "sqlbuild_staging_relation": "analytics.customers__staging",
+        "sqlbuild_duration_ms": 123,
+        "sqlbuild_error_help": "Check the projected columns.",
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

A malformed 2029 source watermark caused a daily incremental model to plan about 1,058 batches. SQLBuild also delayed the first red Dagster signal for a failed asset until the subprocess drained.

## Changes

- add `[cursors.future]` with `max_distance` and `cap | error`
- bound planner-owned and runtime-owned DATE/TIMESTAMP watermarks using a fixed invocation clock
- preserve future target cursors while safely producing no-op ranges
- expose structured discovered/applied bounds and physical input evidence in plan, execution, and Dagster metadata
- evaluate runtime safety before pre-hooks and retain evidence on later failures
- emit immediate structured Dagster error logs for live failed assets without enabling fail-fast
- keep complete explicit start/end overrides authoritative

## Verification

- full unit and integration suites: 5,190 passed, 76 skipped
- focused final suite: 80 passed
- `ty check src/sqlbuild`: passed
- Ruff: passed
- Fensu: 0 faults
- independent final review: no blocking findings

Linear: CHI-190
