### PR TITLE
feat: add configurable microbatch limits

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/build_planning/planning.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_planning/planning.py
@@ -48,6 +48,7 @@ def compile_build_plan(
                 discovered_inputs=invocation.discovered_inputs,
             ),
             resolve_python_run_selectors=(request.include_python or invocation.should_load_sources),
+            max_microbatches=request.max_microbatches,
         ),
         hooks=ConnectionHooks(
             on_progress=invocation.planning_progress.on_progress,

--- a/src/sqlbuild/cli/commands/_helpers/build_virtual/virtual_execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/build_virtual/virtual_execution.py
@@ -133,6 +133,7 @@ def execute_virtual_build(
                     no_cache=request.no_cache,
                     defer_sources_to=request.defer_sources_to,
                     cursor_overrides=request.cursor_overrides,
+                    max_microbatches=request.max_microbatches,
                     full_refresh=request.full_refresh,
                     virtual_environment_name=request.virtual_environment_name,
                     include_stale_upstreams=request.include_stale_upstreams,

--- a/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
@@ -143,6 +143,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
                 cli_vars=args.vars,
                 include_stale_upstreams=args.include_stale_upstreams,
                 changes_only=args.changes_only,
+                max_microbatches=args.max_microbatches,
             )
         )
     if args.command == CliCommand.DBT:
@@ -193,6 +194,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
                 json_output=args.json,
                 json_output_path=args.json_output,
                 event_output_path=args.event_output,
+                max_microbatches=args.max_microbatches,
             )
         )
     if args.command == CliCommand.FRESHNESS:

--- a/src/sqlbuild/cli/commands/_helpers/entry/parser.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parser.py
@@ -11,6 +11,7 @@ from sqlbuild.cli.commands._helpers.entry.parser_arguments import (
     add_dbt_config_args,
     add_execution_args,
     add_execution_json_output_arg,
+    add_microbatch_limit_override_arg,
     add_scenario_snapshot_safety_args,
     add_select_args,
     add_vars_args,
@@ -147,6 +148,7 @@ def _add_plan_and_build_parsers(
     plan_load_group.add_argument("--load", dest="load_sources", action="store_true", default=None)
     plan_load_group.add_argument("--no-load", dest="load_sources", action="store_false")
     _ = add_cursor_override_args(plan_parser)
+    _ = add_microbatch_limit_override_arg(plan_parser)
     _ = add_select_args(plan_parser)
     _ = add_vars_args(plan_parser)
     _ = add_dbt_config_args(parser=plan_parser)
@@ -181,6 +183,7 @@ def _add_plan_and_build_parsers(
     _ = add_execution_json_output_arg(build_parser)
     build_parser.add_argument("--event-output", type=Path, default=None, help=argparse.SUPPRESS)
     _ = add_cursor_override_args(build_parser)
+    _ = add_microbatch_limit_override_arg(build_parser)
     build_load_group: argparse._MutuallyExclusiveGroup = build_parser.add_mutually_exclusive_group()
     build_load_group.add_argument("--load", dest="load_sources", action="store_true", default=None)
     build_load_group.add_argument("--no-load", dest="load_sources", action="store_false")

--- a/src/sqlbuild/cli/commands/_helpers/entry/parser_arguments.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parser_arguments.py
@@ -42,6 +42,19 @@ def add_cursor_override_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--end-cursor-int", default=None)
 
 
+def add_microbatch_limit_override_arg(parser: argparse.ArgumentParser) -> None:
+    """Add the intentional per-model microbatch limit override."""
+
+    parser.add_argument("--max-microbatches", type=_positive_integer, default=None)
+
+
+def _positive_integer(value: str) -> int:
+    parsed: int = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return parsed
+
+
 def add_execution_args(parser: argparse.ArgumentParser) -> None:
     """Add execution control flags shared by build and run commands."""
 

--- a/src/sqlbuild/cli/commands/_helpers/plan/planning.py
+++ b/src/sqlbuild/cli/commands/_helpers/plan/planning.py
@@ -54,6 +54,7 @@ def compile_plan_pipeline(
                 exclude=request.exclude,
                 cli_vars=request.cli_vars,
                 external_sql_reference_resolver=external_sql_reference_resolver,
+                max_microbatches=request.max_microbatches,
             ),
             hooks=ConnectionHooks(
                 on_progress=invocation.planning_progress.on_progress,
@@ -96,6 +97,7 @@ def compile_plan_pipeline(
             cli_vars=request.cli_vars,
             external_sql_reference_resolver=external_sql_reference_resolver,
             resolve_python_run_selectors=request.include_python,
+            max_microbatches=request.max_microbatches,
         ),
         hooks=ConnectionHooks(
             on_progress=invocation.planning_progress.on_progress,

--- a/src/sqlbuild/cli/commands/classes/cli_namespace.py
+++ b/src/sqlbuild/cli/commands/classes/cli_namespace.py
@@ -41,6 +41,7 @@ _DEFAULT_VALUES: dict[str, object] = {
     "profile_skip_contracts": False,
     "profile_skip_write": False,
     "start_cursor_ts": None,
+    "max_microbatches": None,
     "end_cursor_ts": None,
     "start_cursor_int": None,
     "end_cursor_int": None,
@@ -185,6 +186,7 @@ class CliNamespace:
     profile_skip_contracts: bool
     profile_skip_write: bool
     start_cursor_ts: str | None
+    max_microbatches: int | None
     end_cursor_ts: str | None
     start_cursor_int: str | None
     end_cursor_int: str | None

--- a/src/sqlbuild/cli/commands/main/execution/_build.py
+++ b/src/sqlbuild/cli/commands/main/execution/_build.py
@@ -120,6 +120,7 @@ def _run_build(*, request: BuildCommandRequest) -> int:
                     use_color=invocation.use_color,
                     providers=provider_session.providers,
                     command_started_at=command_started_at,
+                    max_microbatches=request.max_microbatches,
                 ),
             )
         if invocation.effective_defer_clone_from is not None:

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -220,6 +220,7 @@ class BuildCommandRequest:
     json_output_path: Path | None = None
     event_output_path: Path | None = None
     no_cache: bool = False
+    max_microbatches: int | None = None
     selector_files: tuple[SelectorFileSummary, ...] = ()
 
 
@@ -377,6 +378,7 @@ class VirtualBuildCliRequest:
     providers: ProviderContainer | None = None
     no_cache: bool = False
     selector_files: tuple[SelectorFileSummary, ...] = ()
+    max_microbatches: int | None = None
     command_started_at: float | None = None
 
 
@@ -1015,6 +1017,7 @@ class PlanCommandRequest:
     include_stale_upstreams: bool = False
     changes_only: bool = False
     no_cache: bool = False
+    max_microbatches: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
+++ b/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
@@ -510,7 +510,7 @@ def _format_model_assets(
 def _format_microbatch_result(result: ModelExecutionResult) -> dict[str, object] | None:
     if result.microbatch_run_type is None:
         return None
-    return {
+    microbatch: dict[str, object] = {
         "run_type": result.microbatch_run_type,
         "batch_count": result.batch_count,
         "batch_size": result.batch_size,
@@ -541,6 +541,20 @@ def _format_microbatch_result(result: ModelExecutionResult) -> dict[str, object]
             for interval in result.microbatch_accounting_intervals
         ],
     }
+    if result.microbatch_limit is not None:
+        microbatch.update(
+            {
+                "limit": result.microbatch_limit,
+                "count": result.microbatch_limit_count,
+                "action": (
+                    result.microbatch_limit_action.value
+                    if result.microbatch_limit_action is not None
+                    else None
+                ),
+                "warning": result.microbatch_limit_warning,
+            }
+        )
+    return microbatch
 
 
 def _format_seed_assets(

--- a/src/sqlbuild/cli/output/_helpers/plan_json.py
+++ b/src/sqlbuild/cli/output/_helpers/plan_json.py
@@ -123,12 +123,26 @@ def _serialize_model_entry(entry: ModelPlanEntry) -> dict[str, object]:
     if entry.incremental_mode is not None:
         model["incremental_mode"] = entry.incremental_mode
     if entry.incremental_mode == IncrementalMode.MICROBATCH:
-        model["microbatch_state"] = {
+        microbatch_state: dict[str, object] = {
             "completion_tracking": "universal",
             "batch_concurrency": entry.batch_concurrency,
             "unaccounted_partition_policy": entry.unaccounted_partition_policy,
             "reconciliation": "runtime",
         }
+        if entry.microbatch_limit is not None:
+            microbatch_state.update(
+                {
+                    "limit": entry.microbatch_limit,
+                    "count": entry.microbatch_limit_count,
+                    "action": (
+                        entry.microbatch_limit_action.value
+                        if entry.microbatch_limit_action is not None
+                        else None
+                    ),
+                    "warning": entry.microbatch_limit_warning,
+                }
+            )
+        model["microbatch_state"] = microbatch_state
     if entry.cursor_column is not None:
         model["cursor_column"] = entry.cursor_column
     if entry.cursor_type is not None:

--- a/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
@@ -49,6 +49,8 @@ from sqlbuild.spec.contracts.models import (
     LocalTargetConfig,
     MaterializationDefaultsConfig,
     MaterializationRetentionDefaults,
+    MicrobatchesConfig,
+    MicrobatchLimitsConfig,
     ProjectConfig,
     ScenarioConfig,
     ScenarioSnapshotLimitsConfig,
@@ -60,6 +62,7 @@ from sqlbuild.spec.contracts.models import (
 )
 from sqlbuild.spec.contracts.types import (
     FutureCursorAction,
+    MicrobatchLimitAction,
     TableType,
     TableTypeDowngradePolicy,
     TableTypeValue,
@@ -78,6 +81,7 @@ _DEFAULT_HISTORICAL_SNAPSHOT_FULL_REFRESH: str = "require_confirmation"
 _DEFAULT_SNAPSHOT_SCHEMA_CHANGE: str = "append_new_columns"
 _DEFAULT_WILDCARD_CHECK_SNAPSHOT_SCHEMA_CHANGE: str = "require_confirmation"
 _BATCH_CONCURRENCY_CONFIG_KEY: str = "batch_concurrency"
+_MAX_BATCHES_CONFIG_KEY: str = "max_batches"
 _CURSOR_DURATION_PATTERN: re.Pattern[str] = re.compile(
     r"^(?=.*[1-9])(?:(\d+)y)?(?:(\d+)mo)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$"
 )
@@ -103,6 +107,9 @@ def load_project_config(*, project_dir: Path) -> ProjectConfig:
         payload=payload.get("constants"), file_path=file_path
     )
     cursors: CursorsConfig = _load_cursors(payload=payload.get("cursors"), file_path=file_path)
+    microbatches: MicrobatchesConfig = _load_microbatches(
+        payload=payload.get("microbatches"), file_path=file_path
+    )
     defaults: DefaultsConfig = _load_defaults(payload=payload.get("defaults"), file_path=file_path)
     materialization_defaults: MaterializationDefaultsConfig = _load_materialization_defaults(
         payload=payload.get("materialization_defaults"), file_path=file_path
@@ -141,6 +148,7 @@ def load_project_config(*, project_dir: Path) -> ProjectConfig:
         cost=cost,
         constants=constants,
         cursors=cursors,
+        microbatches=microbatches,
         defaults=defaults,
         materialization_defaults=materialization_defaults,
         path_defaults=path_defaults,
@@ -391,6 +399,40 @@ def _load_cursors(*, payload: object, file_path: Path) -> CursorsConfig:
     except ValueError:
         raise ProjectConfigError("cursors.future.action must be one of: cap, error") from None
     return CursorsConfig(future=FutureCursorsConfig(max_distance=max_distance, action=action))
+
+
+def _load_microbatches(*, payload: object, file_path: Path) -> MicrobatchesConfig:
+    mapping: dict[str, object] = _coerce_mapping(
+        payload=payload, label="microbatches", file_path=file_path
+    )
+    _validate_allowed_keys(
+        mapping=mapping,
+        allowed_keys=frozenset({"limits"}),
+        label="microbatches",
+        file_path=file_path,
+    )
+    limits: dict[str, object] = _coerce_mapping(
+        payload=mapping.get("limits"), label="microbatches.limits", file_path=file_path
+    )
+    _validate_allowed_keys(
+        mapping=limits,
+        allowed_keys=frozenset({_MAX_BATCHES_CONFIG_KEY, "action"}),
+        label="microbatches.limits",
+        file_path=file_path,
+    )
+    max_batches: int | None = None
+    if _MAX_BATCHES_CONFIG_KEY in limits:
+        if isinstance(limits[_MAX_BATCHES_CONFIG_KEY], bool):
+            raise ProjectConfigError("microbatches.limits.max_batches must be a positive integer")
+        max_batches = _optional_int(mapping=limits, key=_MAX_BATCHES_CONFIG_KEY, default=0)
+        if max_batches < 1:
+            raise ProjectConfigError("microbatches.limits.max_batches must be a positive integer")
+    raw_action: str = _optional_str(payload=limits, key="action") or MicrobatchLimitAction.ERROR
+    try:
+        action: MicrobatchLimitAction = MicrobatchLimitAction(raw_action)
+    except ValueError:
+        raise ProjectConfigError("microbatches.limits.action must be one of: error, warn") from None
+    return MicrobatchesConfig(limits=MicrobatchLimitsConfig(max_batches=max_batches, action=action))
 
 
 def _load_scopes(*, payload: object, file_path: Path) -> ScopesConfig:

--- a/src/sqlbuild/compiler/pipeline/main/compile.py
+++ b/src/sqlbuild/compiler/pipeline/main/compile.py
@@ -201,6 +201,7 @@ def _build_result(
             cursor_overrides=options.cursor_overrides,
             full_refresh=options.full_refresh,
             reload_sources=options.reload_sources,
+            max_microbatches=options.max_microbatches,
         ),
         deferral=DeferralInputs(
             deferred_locations=deferred_locations,

--- a/src/sqlbuild/compiler/pipeline/models.py
+++ b/src/sqlbuild/compiler/pipeline/models.py
@@ -47,6 +47,7 @@ class CompilePipelineOptions:
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None
     resolve_python_run_selectors: bool = False
     no_cache: bool = False
+    max_microbatches: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/planner/_helpers/output/microbatch_count.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/microbatch_count.py
@@ -1,0 +1,45 @@
+"""Planner-private microbatch count calculation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+
+from sqlbuild.compiler.planner.models import CursorBounds, Duration
+from sqlbuild.compiler.planner.types import CursorType
+
+
+def count_microbatches(
+    *, bounds: CursorBounds, batch_size: str, cursor_type: str, equal_bounds_are_batch: bool = False
+) -> int:
+    """Count batches for one concrete cursor range."""
+
+    if cursor_type == CursorType.INTEGER:
+        try:
+            start: int = int(Decimal(bounds.start))
+            end: int = int(Decimal(bounds.end))
+            size: int = int(Decimal(batch_size))
+        except (InvalidOperation, ValueError, OverflowError):
+            return 0
+        if equal_bounds_are_batch and start == end:
+            return 1
+        if size <= 0 or start >= end:
+            return 0
+        return (end - start + size - 1) // size
+    if cursor_type != CursorType.TIMESTAMP:
+        return 0
+    duration: Duration | None = Duration.parse(batch_size)
+    if duration is None:
+        return 0
+    try:
+        current: datetime = datetime.fromisoformat(bounds.start)
+        end_at: datetime = datetime.fromisoformat(bounds.end)
+    except (TypeError, ValueError):
+        return 0
+    if equal_bounds_are_batch and current == end_at:
+        return 1
+    count: int = 0
+    while current < end_at:
+        current = min(duration.add_to(current), end_at)
+        count += 1
+    return count

--- a/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
@@ -28,6 +28,7 @@ from sqlbuild.compiler.planner._helpers.output.cursor_type_check import (
 from sqlbuild.compiler.planner._helpers.output.inclusive_cursor_end import (
     resolve_bounded_cursor_override,
 )
+from sqlbuild.compiler.planner._helpers.output.microbatch_count import count_microbatches
 from sqlbuild.compiler.planner._helpers.output.strategy import (
     build_model_warnings,
     get_materialization_type,
@@ -57,6 +58,9 @@ from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.main.changes._model_changes import detect_model_changes
 from sqlbuild.compiler.planner.main.execution.future_cursor_safety import apply_future_cursor_safety
 from sqlbuild.compiler.planner.main.execution.future_cursor_warning import future_cursor_cap_warning
+from sqlbuild.compiler.planner.main.execution.microbatch_limit import (
+    microbatch_limit_warning,
+)
 from sqlbuild.compiler.planner.models import (
     BackfillResult,
     ChangeDetectionResult,
@@ -102,7 +106,7 @@ from sqlbuild.spec.contracts.models import (
     SchemaColumn,
     SourceEntry,
 )
-from sqlbuild.spec.contracts.types import TableType
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction, TableType
 
 _MODELS_DIR_PREFIX: str = "models/"
 _IDEMPOTENT_MICROBATCH_STRATEGIES: frozenset[IncrementalStrategy] = frozenset(
@@ -340,6 +344,14 @@ def build_plan_entries(
                     or project.settings.microbatch_unaccounted_partition_policy
                 ),
             )
+            if entry.action != PlanAction.SKIP:
+                entry, limit_warning = _apply_microbatch_limit(
+                    entry=entry,
+                    max_batches=inputs.max_microbatches,
+                    action=inputs.microbatch_limit_action,
+                )
+                if limit_warning is not None:
+                    warnings.append(limit_warning)
         entries.append(entry)
         warnings.extend(entry_warnings)
     configured_concurrent_entries: tuple[ModelPlanEntry, ...] = tuple(
@@ -382,6 +394,52 @@ def build_plan_entries(
             )
         )
     return PlannerModelEntryResults(entries=tuple(entries), warnings=tuple(warnings))
+
+
+def _apply_microbatch_limit(
+    *, entry: ModelPlanEntry, max_batches: int | None, action: MicrobatchLimitAction
+) -> tuple[ModelPlanEntry, PlanWarning | None]:
+    if entry.action == PlanAction.SKIP:
+        return entry, None
+    batch_count: int | None = None
+    if (
+        entry.microbatch_range is not None
+        and entry.batch_size is not None
+        and entry.cursor_type is not None
+    ):
+        batch_count = count_microbatches(
+            bounds=entry.microbatch_range,
+            batch_size=entry.batch_size,
+            cursor_type=entry.cursor_type,
+            equal_bounds_are_batch=entry.action == PlanAction.CREATE_TABLE,
+        )
+    warning: str | None = (
+        None
+        if batch_count is None
+        else microbatch_limit_warning(
+            model_name=entry.name,
+            max_batches=max_batches,
+            batch_count=batch_count,
+            action=action,
+        )
+    )
+    limited_entry: ModelPlanEntry = replace(
+        entry,
+        microbatch_limit=max_batches,
+        microbatch_limit_count=batch_count,
+        microbatch_limit_action=action if max_batches is not None else None,
+        microbatch_limit_warning=warning,
+    )
+    if warning is None:
+        return limited_entry, None
+    if action == MicrobatchLimitAction.ERROR:
+        raise CompileInputError(warning)
+    return limited_entry, PlanWarning(
+        model_name=entry.name,
+        severity=WarningSeverity.WARNING,
+        code="MICROBATCH_LIMIT_EXCEEDED",
+        message=warning,
+    )
 
 
 def plan_model_from_change(

--- a/src/sqlbuild/compiler/planner/_helpers/planning/entries.py
+++ b/src/sqlbuild/compiler/planner/_helpers/planning/entries.py
@@ -70,6 +70,20 @@ def build_planner_entry_results(
                 else None
             ),
             invocation_time=runtime.invocation_time,
+            max_microbatches=(
+                overrides.max_microbatches
+                if overrides.max_microbatches is not None
+                else (
+                    runtime.project_config.microbatches.limits.max_batches
+                    if runtime.project_config is not None
+                    else None
+                )
+            ),
+            microbatch_limit_action=(
+                runtime.project_config.microbatches.limits.action
+                if runtime.project_config is not None
+                else PlanEntryBuildInputs().microbatch_limit_action
+            ),
         ),
     )
     return PlannerEntryResults(

--- a/src/sqlbuild/compiler/planner/main/execution/microbatch_limit.py
+++ b/src/sqlbuild/compiler/planner/main/execution/microbatch_limit.py
@@ -1,0 +1,19 @@
+"""Microbatch planning limit decisions shared by planner and runtime."""
+
+from __future__ import annotations
+
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction
+
+
+def microbatch_limit_warning(
+    *, model_name: str, max_batches: int | None, batch_count: int, action: MicrobatchLimitAction
+) -> str | None:
+    """Return the prominent warning/error message when one model exceeds its limit."""
+
+    if max_batches is None or batch_count <= max_batches:
+        return None
+    return (
+        f"MICROBATCH LIMIT EXCEEDED: model '{model_name}' planned {batch_count} batches, "
+        f"above the per-model limit of {max_batches} (action={action.value}). "
+        "Use --max-microbatches with an intentional invocation-specific value for this backfill."
+    )

--- a/src/sqlbuild/compiler/planner/main/execution/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/main/execution/plan_entry.py
@@ -18,6 +18,7 @@ from sqlbuild.compiler.planner.models import (
     ChangeDetectionResult,
     DeferralInputs,
     ModelChangesPlanInputs,
+    PlanEntryBuildInputs,
     PlannerChangeResults,
     PlannerModelEntryResults,
     PlannerRelationsContext,
@@ -73,6 +74,27 @@ def build_plan_output_from_model_changes_phase(
         resolved_actions=resolved_actions,
         cursor_overrides=resolved.cursor_overrides,
         full_refresh=resolved.full_refresh,
+        build_inputs=PlanEntryBuildInputs(
+            future_cursor_config=(
+                resolved.project_config.cursors.future
+                if resolved.project_config is not None
+                else None
+            ),
+            max_microbatches=(
+                resolved.max_microbatches
+                if resolved.max_microbatches is not None
+                else (
+                    resolved.project_config.microbatches.limits.max_batches
+                    if resolved.project_config is not None
+                    else None
+                )
+            ),
+            microbatch_limit_action=(
+                resolved.project_config.microbatches.limits.action
+                if resolved.project_config is not None
+                else PlanEntryBuildInputs().microbatch_limit_action
+            ),
+        ),
     )
     return build_plan_output(
         project=project,

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -61,7 +61,11 @@ from sqlbuild.spec.contracts.models import (
     SeedCsvSettings,
     SourceEntry,
 )
-from sqlbuild.spec.contracts.types import FutureCursorAction, SourceWriteStrategy
+from sqlbuild.spec.contracts.types import (
+    FutureCursorAction,
+    MicrobatchLimitAction,
+    SourceWriteStrategy,
+)
 from sqlbuild.sql_values.models import SqlValue
 
 
@@ -573,6 +577,7 @@ class ModelChangesPlanInputs:
     seed_version_hashes: dict[str, str] | None = None
     seed_metadata_jsons: dict[str, str] | None = None
     seed_plan_reasons: dict[str, PlanReason] | None = None
+    max_microbatches: int | None = None
 
 
 @dataclass(frozen=True)
@@ -586,6 +591,8 @@ class PlanEntryBuildInputs:
     end_cursor_override: str | None = None
     future_cursor_config: FutureCursorsConfig | None = None
     invocation_time: datetime | None = None
+    max_microbatches: int | None = None
+    microbatch_limit_action: MicrobatchLimitAction = MicrobatchLimitAction.ERROR
 
 
 @dataclass(frozen=True)
@@ -728,6 +735,10 @@ class ModelPlanEntry:
     batch_concurrency: int = 1
     unaccounted_partition_policy: str | None = None
     microbatch_range: CursorBounds | None = None
+    microbatch_limit: int | None = None
+    microbatch_limit_count: int | None = None
+    microbatch_limit_action: MicrobatchLimitAction | None = None
+    microbatch_limit_warning: str | None = None
     start_cursor_override: str | None = None
     end_cursor_override: str | None = None
     future_cursor_config: FutureCursorsConfig | None = None
@@ -1078,6 +1089,7 @@ class PlannerOverrides:
     reload_sources: bool = False
     forced_stale_model_names: tuple[str, ...] = ()
     external_blocked_model_names: tuple[str, ...] = ()
+    max_microbatches: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/executor/run/_helpers/execution/results.py
+++ b/src/sqlbuild/executor/run/_helpers/execution/results.py
@@ -67,6 +67,10 @@ def build_failed_result(
         error_help=rendered_help,
         error_message=rendered_error,
         future_cursor_safety=_future_cursor_safety(entry),
+        microbatch_limit=entry.microbatch_limit,
+        microbatch_limit_count=entry.microbatch_limit_count,
+        microbatch_limit_action=entry.microbatch_limit_action,
+        microbatch_limit_warning=entry.microbatch_limit_warning,
     )
 
 
@@ -96,6 +100,10 @@ def build_skipped_result(
         skip_mode=skipped_hook.skip_mode if skipped_hook is not None else None,
         skip_reason=skipped_hook.skip_reason if skipped_hook is not None else None,
         future_cursor_safety=_future_cursor_safety(entry),
+        microbatch_limit=entry.microbatch_limit,
+        microbatch_limit_count=entry.microbatch_limit_count,
+        microbatch_limit_action=entry.microbatch_limit_action,
+        microbatch_limit_warning=entry.microbatch_limit_warning,
     )
 
 

--- a/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
@@ -27,6 +27,7 @@ from sqlbuild.compiler.planner.main.execution.effective_microbatch_batch_size im
 )
 from sqlbuild.compiler.planner.main.execution.future_cursor_warning import future_cursor_cap_warning
 from sqlbuild.compiler.planner.main.execution.inclusive_cursor_end import inclusive_cursor_end
+from sqlbuild.compiler.planner.main.execution.microbatch_limit import microbatch_limit_warning
 from sqlbuild.compiler.planner.models import (
     CursorBounds,
     Duration,
@@ -126,7 +127,7 @@ from sqlbuild.microbatches.types import (
     ReplayRequirementState,
     UnaccountedPartitionPolicy,
 )
-from sqlbuild.spec.contracts.types import TableType
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction, TableType
 
 _DEFAULT_ON_SCHEMA_CHANGE: OnSchemaChange = OnSchemaChange.APPEND_NEW_COLUMNS
 _DEBUG_LOGGER: logging.Logger = logging.getLogger("sqlbuild.execution")
@@ -243,19 +244,7 @@ def execute_microbatch_entry(  # noqa: PLR0915
     )
     if batch_plan.early_exit is not None:
         return batch_plan.early_exit
-    context = _context_with_microbatch_range(context=context, batch_plan=batch_plan)
-    cap_warning: str | None = future_cursor_cap_warning(batch_plan.resolved_range)
-    if cap_warning is not None:
-        state.warnings.append(cap_warning)
-    pre_hook_exit: ModelExecutionResult | None = run_pre_hook_phase(
-        context=context,
-        warnings=state.warnings,
-        audit_results=state.audit_results,
-        hook_results=state.hook_results,
-        statement_recorder=state.statement_recorder,
-    )
-    if pre_hook_exit is not None:
-        return pre_hook_exit
+    state = _with_future_cursor_warning(state=state, bounds=batch_plan.resolved_range)
     history_read: (
         tuple[
             MicrobatchEventStore,
@@ -299,14 +288,6 @@ def execute_microbatch_entry(  # noqa: PLR0915
     )
     if isinstance(history_context, ModelExecutionResult):
         return history_context
-    if full_refresh_relations is not None:
-        preparation_failure: ModelExecutionResult | None = _prepare_full_refresh_rebuild(
-            context=context,
-            state=state,
-            relations=full_refresh_relations,
-        )
-        if preparation_failure is not None:
-            return preparation_failure
     if history_context.run_type == MicrobatchRunType.REPLAY_ON_CHANGE:
         replay_batches: tuple[BatchWindow, ...] = compute_batch_windows(
             start=history_context.run_start,
@@ -338,6 +319,14 @@ def execute_microbatch_entry(  # noqa: PLR0915
     state = _with_reconciliation_warnings(context=context, state=state, history=history_context)
     if not batch_plan.batches:
         state = replace(state, warnings=[*state.warnings, "no batches to process"])
+    context, state, limit_failure = _enforce_microbatch_limit(
+        context=context, state=state, batch_plan=batch_plan
+    )
+    if limit_failure is not None:
+        return replace(
+            limit_failure,
+            **_microbatch_result_fields(history=history_context, succeeded=False),
+        )
     if (
         on_progress is not None
         and batch_plan.runtime_discovery
@@ -353,6 +342,29 @@ def execute_microbatch_entry(  # noqa: PLR0915
                 cursor_grain=context.entry.cursor_grain,
             )
         )
+    pre_hook_exit: ModelExecutionResult | None = run_pre_hook_phase(
+        context=context,
+        warnings=state.warnings,
+        audit_results=state.audit_results,
+        hook_results=state.hook_results,
+        statement_recorder=state.statement_recorder,
+    )
+    if pre_hook_exit is not None:
+        return replace(
+            pre_hook_exit,
+            **_microbatch_result_fields(history=history_context, succeeded=False),
+        )
+    if full_refresh_relations is not None:
+        preparation_failure: ModelExecutionResult | None = _prepare_full_refresh_rebuild(
+            context=context,
+            state=state,
+            relations=full_refresh_relations,
+        )
+        if preparation_failure is not None:
+            return replace(
+                preparation_failure,
+                **_microbatch_result_fields(history=history_context, succeeded=False),
+            )
     batch_outcome: MicrobatchPhaseOutcome = _execute_microbatch_batches(
         context=context,
         declared_columns=declared_columns,
@@ -411,7 +423,10 @@ def execute_microbatch_entry(  # noqa: PLR0915
             relations=full_refresh_relations,
         )
         if promotion_failure is not None:
-            return promotion_failure
+            return replace(
+                promotion_failure,
+                **_microbatch_result_fields(history=history_context, succeeded=True),
+            )
     post_hook_outcome: PostHookPhaseOutcome = run_post_hook_phase(
         context=context,
         warnings=state.warnings,
@@ -426,13 +441,16 @@ def execute_microbatch_entry(  # noqa: PLR0915
             **_microbatch_result_fields(history=history_context, succeeded=True),
         )
     if post_hook_outcome.skipped:
-        return build_skipped_result(
-            entry=context.entry,
-            warnings=state.warnings,
-            audit_results=state.audit_results,
-            statement_recorder=state.statement_recorder,
-            hook_results=state.hook_results,
-            promoted_relation=targets.target_qualified,
+        return replace(
+            build_skipped_result(
+                entry=context.entry,
+                warnings=state.warnings,
+                audit_results=state.audit_results,
+                statement_recorder=state.statement_recorder,
+                hook_results=state.hook_results,
+                promoted_relation=targets.target_qualified,
+            ),
+            **_microbatch_result_fields(history=history_context, succeeded=True),
         )
     state.warnings.extend(
         try_write_fingerprint(
@@ -462,8 +480,71 @@ def execute_microbatch_entry(  # noqa: PLR0915
         warning_messages=tuple(state.warnings),
         lifecycle_events=state.statement_recorder.snapshot(),
         hook_results=tuple(state.hook_results),
+        microbatch_limit=context.entry.microbatch_limit,
+        microbatch_limit_count=context.entry.microbatch_limit_count,
+        microbatch_limit_action=context.entry.microbatch_limit_action,
+        microbatch_limit_warning=context.entry.microbatch_limit_warning,
         **_microbatch_result_fields(history=history_context, succeeded=True),
     )
+
+
+def _enforce_microbatch_limit(
+    *,
+    context: ModelMaterializationContext,
+    state: MicrobatchLifecycleState,
+    batch_plan: _MicrobatchPlan,
+) -> tuple[ModelMaterializationContext, MicrobatchLifecycleState, ModelExecutionResult | None]:
+    limit_count: int = len(batch_plan.batches)
+    action: MicrobatchLimitAction | None = context.entry.microbatch_limit_action
+    warning: str | None = (
+        None
+        if action is None
+        else microbatch_limit_warning(
+            model_name=context.entry.name,
+            max_batches=context.entry.microbatch_limit,
+            batch_count=limit_count,
+            action=action,
+        )
+    )
+    limited_context: ModelMaterializationContext = replace(
+        context,
+        entry=replace(
+            context.entry,
+            microbatch_limit_count=limit_count,
+            microbatch_limit_warning=warning,
+        ),
+    )
+    limited_context = _context_with_microbatch_range(context=limited_context, batch_plan=batch_plan)
+    if warning is None:
+        return limited_context, state, None
+    if action == MicrobatchLimitAction.WARN:
+        warned_state: MicrobatchLifecycleState = replace(state, warnings=[*state.warnings, warning])
+        return limited_context, warned_state, None
+    failure: ModelExecutionResult = build_failed_result(
+        entry=limited_context.entry,
+        phase=ExecutionPhase.STAGING,
+        error=warning,
+        warnings=state.warnings,
+        audit_results=state.audit_results,
+        statement_recorder=state.statement_recorder,
+    )
+    return (
+        limited_context,
+        state,
+        replace(
+            failure,
+            microbatch_run_type=_microbatch_run_type(context=limited_context).value,
+        ),
+    )
+
+
+def _with_future_cursor_warning(
+    *, state: MicrobatchLifecycleState, bounds: CursorBounds | None
+) -> MicrobatchLifecycleState:
+    warning: str | None = future_cursor_cap_warning(bounds)
+    if warning is None:
+        return state
+    return replace(state, warnings=[*state.warnings, warning])
 
 
 def _run_microbatch_reconciliation(

--- a/src/sqlbuild/executor/run/models.py
+++ b/src/sqlbuild/executor/run/models.py
@@ -35,6 +35,7 @@ from sqlbuild.microbatches.models import MicrobatchScope
 from sqlbuild.microbatches.types import MicrobatchEventStore
 from sqlbuild.provider.main.runtime import ProviderContainer, _empty_provider_container
 from sqlbuild.spec.contracts.models import FutureCursorsConfig, SourceEntry
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction
 
 
 @dataclass(frozen=True)
@@ -153,6 +154,10 @@ class ModelExecutionResult:
     microbatch_accounting_intervals: tuple[MicrobatchAccountingInterval, ...] = field(
         default_factory=tuple
     )
+    microbatch_limit: int | None = None
+    microbatch_limit_count: int | None = None
+    microbatch_limit_action: MicrobatchLimitAction | None = None
+    microbatch_limit_warning: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
+++ b/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
@@ -167,14 +167,20 @@ class SqlBuildCliInvocation:
         if self.execution_payload is not None:
             incomplete_assets: list[str] = []
             failure_details: list[str] = []
+            microbatch_limits: dict[str, object] = {}
             for asset in self.execution_payload.get("assets", ()):
                 status: str = str(asset.get("status"))
                 if status in COMPLETED_EXECUTION_STATUSES:
                     continue
                 incomplete_assets.append(f"{asset.get('kind')}:{asset.get('name')} ({status})")
                 failure_details.append(_format_asset_failure(asset))
+                microbatch: object | None = asset.get("microbatch")
+                if isinstance(microbatch, dict) and microbatch.get("limit") is not None:
+                    microbatch_limits[str(asset.get("name"))] = microbatch
             metadata["execution_status"] = str(self.execution_payload.get("status"))
             metadata["incomplete_assets"] = ", ".join(incomplete_assets)
+            if microbatch_limits:
+                metadata["microbatch_limits"] = microbatch_limits
             if failure_details:
                 description += "\n\nFailures:\n\n" + "\n\n".join(failure_details)
         else:
@@ -212,6 +218,7 @@ class SqlBuildCliInvocation:
             if execution_payload is None:
                 execution_payload = _load_execution_payload(self.stdout)
             if execution_payload is not None:
+                self.execution_payload = execution_payload
                 yield from _build_results_from_execution_payload(
                     dg=dg,
                     dag=self.dag,

--- a/src/sqlbuild/spec/contracts/models.py
+++ b/src/sqlbuild/spec/contracts/models.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from sqlbuild.cost.constants import DEFAULT_USD_PER_CREDIT
 from sqlbuild.spec.contracts.types import (
     FutureCursorAction,
+    MicrobatchLimitAction,
     SourceFreshnessStrategy,
     SourceFreshnessValueKind,
     SourceWriteStrategy,
@@ -207,6 +208,21 @@ class CursorsConfig:
 
 
 @dataclass(frozen=True)
+class MicrobatchLimitsConfig:
+    """Per-model microbatch planning safety limit."""
+
+    max_batches: int | None = None
+    action: MicrobatchLimitAction = MicrobatchLimitAction.ERROR
+
+
+@dataclass(frozen=True)
+class MicrobatchesConfig:
+    """Project-wide microbatch configuration."""
+
+    limits: MicrobatchLimitsConfig = field(default_factory=MicrobatchLimitsConfig)
+
+
+@dataclass(frozen=True)
 class DefaultsConfig:
     """Project-wide resource defaults."""
 
@@ -312,6 +328,7 @@ class ProjectConfig:
     cost: CostConfig = field(default_factory=CostConfig)
     constants: ConstantsConfig = field(default_factory=ConstantsConfig)
     cursors: CursorsConfig = field(default_factory=CursorsConfig)
+    microbatches: MicrobatchesConfig = field(default_factory=MicrobatchesConfig)
     defaults: DefaultsConfig = field(default_factory=DefaultsConfig)
     materialization_defaults: MaterializationDefaultsConfig = field(
         default_factory=MaterializationDefaultsConfig

--- a/src/sqlbuild/spec/contracts/types.py
+++ b/src/sqlbuild/spec/contracts/types.py
@@ -21,6 +21,13 @@ class FutureCursorAction(StrEnum):
     ERROR = "error"
 
 
+class MicrobatchLimitAction(StrEnum):
+    """Response when one model plans more than the configured batch limit."""
+
+    ERROR = "error"
+    WARN = "warn"
+
+
 class SourceFreshnessStrategy(StrEnum):
     ADAPTER = "adapter"
     COLUMN = "column"

--- a/src/sqlbuild/virtual/executor/_helpers/build.py
+++ b/src/sqlbuild/virtual/executor/_helpers/build.py
@@ -927,6 +927,7 @@ def _plan_virtual_build(
                     seed_version_hashes=reads.semantics.expected_seed_version_hashes,
                     seed_metadata_jsons=reads.semantics.seed_identity_metadata_jsons,
                     seed_plan_reasons=reads.semantics.seed_plan_reasons,
+                    max_microbatches=options.planning.max_microbatches,
                 ),
             )
         finally:

--- a/src/sqlbuild/virtual/planner/models.py
+++ b/src/sqlbuild/virtual/planner/models.py
@@ -30,6 +30,7 @@ class VirtualPlanOptions:
     cli_vars: dict[str, object] | None = None
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None
     no_cache: bool = False
+    max_microbatches: int | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/integration/src/sqlbuild/executor/run/microbatch/_test_types.py
+++ b/tests/integration/src/sqlbuild/executor/run/microbatch/_test_types.py
@@ -7,6 +7,7 @@ from sqlbuild.compiler.planner.types import OnSchemaChange
 from sqlbuild.executor.run.types import ExecutionPhase
 from sqlbuild.executor.scheduling.types import ExecutionStatus
 from sqlbuild.spec.contracts.models import FutureCursorsConfig
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction
 
 
 @dataclass(frozen=True)
@@ -68,6 +69,10 @@ class MicrobatchSuccessTestCase:
     future_cursor_config: FutureCursorsConfig | None = None
     invocation_time: datetime | None = None
     expected_has_future_cursor_safety: bool = False
+    microbatch_limit: int | None = None
+    microbatch_limit_action: MicrobatchLimitAction | None = None
+    expected_microbatch_limit_count: int | None = None
+    expected_microbatch_limit_warning: bool = False
 
 
 @dataclass(frozen=True)
@@ -111,3 +116,7 @@ class MicrobatchFailureTestCase:
     future_cursor_config: FutureCursorsConfig | None = None
     invocation_time: datetime | None = None
     expected_has_future_cursor_safety: bool = False
+    microbatch_limit: int | None = None
+    microbatch_limit_action: MicrobatchLimitAction | None = None
+    expected_microbatch_limit_count: int | None = None
+    expected_microbatch_limit_warning: bool = False

--- a/tests/integration/src/sqlbuild/executor/run/microbatch/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/run/microbatch/helpers.py
@@ -37,7 +37,9 @@ from sqlbuild.compiler.planner.types import (
 )
 from sqlbuild.executor.run._helpers.materializations.microbatch import execute_microbatch_entry
 from sqlbuild.executor.run.models import (
+    BatchWindow,
     HookContext,
+    HookSkipResult,
     ModelExecutionResult,
     ModelMaterializationContext,
 )
@@ -60,6 +62,16 @@ def insert_microbatch_hook_log(ctx: HookContext, phase: str) -> None:
 
 def fail_microbatch_hook(ctx: HookContext, message: str) -> None:
     raise RuntimeError(message)
+
+
+def skip_microbatch_hook(ctx: HookContext, reason: str) -> HookSkipResult:
+    return ctx.skip(reason=reason)
+
+
+def reconcile_microbatch_batches(
+    *, history: Any, reconciled_batches: tuple[BatchWindow, ...], **_: Any
+) -> tuple[Any, tuple[BatchWindow, ...]]:
+    return history, reconciled_batches
 
 
 def build_microbatch_plan_entry(
@@ -124,6 +136,8 @@ def build_microbatch_plan_entry(
         on_schema_change=test_case.on_schema_change,
         pre_hooks=test_case.pre_hook,
         post_hooks=test_case.post_hook,
+        microbatch_limit=test_case.microbatch_limit,
+        microbatch_limit_action=test_case.microbatch_limit_action,
     )
 
 
@@ -184,6 +198,21 @@ def run_failure_test(
     return result
 
 
+def run_skipped_test(
+    *,
+    test_case: MicrobatchSuccessTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+) -> ModelExecutionResult:
+    """Execute a microbatch hook-skip test case and return the result."""
+
+    result: ModelExecutionResult = _execute_test(
+        test_case=test_case, adapter=adapter, connection=connection
+    )
+    assert result.status == ExecutionStatus.SKIPPED
+    return result
+
+
 def verify_success_state(
     *,
     result: ModelExecutionResult,
@@ -200,6 +229,10 @@ def verify_success_state(
     assert actual_count == test_case.expected_row_count
     assert len(result.audit_results) == test_case.expected_audit_count
     assert len(result.warning_messages) == test_case.expected_warning_count
+    normalized_batch_count: int | None = {None: result.batch_count}.get(
+        test_case.expected_batch_count, test_case.expected_batch_count
+    )
+    assert result.batch_count == normalized_batch_count
     assert (result.future_cursor_safety is not None) is test_case.expected_has_future_cursor_safety
     state_table_count: int = connection.execute(
         "SELECT COUNT(*) FROM information_schema.tables "

--- a/tests/integration/src/sqlbuild/executor/run/microbatch/test_microbatch_execution.py
+++ b/tests/integration/src/sqlbuild/executor/run/microbatch/test_microbatch_execution.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import dataclasses
 from datetime import UTC, datetime
+from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.cli.output._helpers.execution_protocol_v1 import _format_model_assets
 from sqlbuild.compiler.auditing.types import AuditRunScope
 from sqlbuild.compiler.discovery.models import DiscoveredHookFunction, PythonHookEntry, SqlHookEntry
 from sqlbuild.compiler.planner.constants import (
@@ -17,10 +19,11 @@ from sqlbuild.compiler.planner.constants import (
     MICROBATCH_START_SENTINEL,
 )
 from sqlbuild.compiler.planner.types import OnSchemaChange
-from sqlbuild.executor.run.models import ModelExecutionResult
+from sqlbuild.executor.run._helpers.materializations import microbatch as microbatch_module
+from sqlbuild.executor.run.models import BatchWindow, ModelExecutionResult
 from sqlbuild.executor.run.types import ExecutionPhase
 from sqlbuild.spec.contracts.models import FutureCursorsConfig
-from sqlbuild.spec.contracts.types import FutureCursorAction
+from sqlbuild.spec.contracts.types import FutureCursorAction, MicrobatchLimitAction
 from tests.integration.src.sqlbuild.executor.run.microbatch._test_types import (
     MicrobatchFailureTestCase,
     MicrobatchSuccessTestCase,
@@ -28,8 +31,11 @@ from tests.integration.src.sqlbuild.executor.run.microbatch._test_types import (
 from tests.integration.src.sqlbuild.executor.run.microbatch.helpers import (
     fail_microbatch_hook,
     insert_microbatch_hook_log,
+    reconcile_microbatch_batches,
     run_failure_test,
+    run_skipped_test,
     run_success_test,
+    skip_microbatch_hook,
     verify_failure_state,
     verify_success_state,
 )
@@ -67,6 +73,31 @@ _INT_MODEL_SQL: str = (
 @pytest.mark.parametrize(
     "test_case",
     [
+        MicrobatchSuccessTestCase(
+            description="runtime warn limit executes complete microbatch range",
+            setup_sql=(
+                _TS_SOURCE_SQL,
+                _TS_SOURCE_DATA,
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP, payload VARCHAR)",
+            ),
+            model_sql=_TS_MODEL_SQL,
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="delete_insert",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            batch_size="1h",
+            microbatch_start="2026-01-01T00:00:00",
+            microbatch_end="2026-01-01T03:00:00",
+            expected_row_count=3,
+            expected_batch_count=3,
+            expected_warning_count=1,
+            microbatch_limit=2,
+            microbatch_limit_action=MicrobatchLimitAction.WARN,
+            expected_microbatch_limit_count=3,
+            expected_microbatch_limit_warning=True,
+            expected_query_results=(("SELECT COUNT(*) FROM main.orders", ((3,),)),),
+        ),
         MicrobatchSuccessTestCase(
             description="model-backed cursor input resolves runtime range for microbatch",
             setup_sql=(
@@ -222,6 +253,28 @@ _INT_MODEL_SQL: str = (
                     ((99, "old"),),
                 ),
             ),
+        ),
+        MicrobatchSuccessTestCase(
+            description="equal-bound full refresh executes and reports one limited batch",
+            setup_sql=(
+                _TS_SOURCE_SQL,
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP, payload VARCHAR)",
+            ),
+            model_sql=_TS_MODEL_SQL,
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="append",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            batch_size="1h",
+            microbatch_start="1970-01-01T00:00:00",
+            microbatch_end="1970-01-01T00:00:00",
+            is_full_refresh=True,
+            cursor_input_relations=(("main.raw_events", "event_time"),),
+            expected_row_count=0,
+            expected_batch_count=1,
+            microbatch_limit=1,
+            microbatch_limit_action=MicrobatchLimitAction.ERROR,
         ),
         MicrobatchSuccessTestCase(
             description="full-refresh discovers range from input when output groups away cursor",
@@ -479,6 +532,258 @@ def test_given_microbatch_model_when_executing_then_succeeds(
 @pytest.mark.parametrize(
     "test_case",
     [
+        MicrobatchFailureTestCase(
+            description="warn limit survives failed pre-hook serialization",
+            setup_sql=(
+                _TS_SOURCE_SQL,
+                _TS_SOURCE_DATA,
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP, payload VARCHAR)",
+            ),
+            model_sql=_TS_MODEL_SQL,
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="append",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            batch_size="1h",
+            microbatch_start="2026-01-01T00:00:00",
+            microbatch_end="2026-01-01T03:00:00",
+            pre_hook=[SqlHookEntry(statement="SELECT * FROM missing_warn_hook_table")],
+            expected_failed_phase=ExecutionPhase.PRE_HOOK,
+            expected_error_fragment="missing_warn_hook_table",
+            expected_row_count=0,
+            microbatch_limit=2,
+            microbatch_limit_action=MicrobatchLimitAction.WARN,
+            expected_microbatch_limit_count=3,
+            expected_microbatch_limit_warning=True,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_warn_limit_when_pre_hook_fails_then_execution_metadata_is_preserved(
+    test_case: MicrobatchFailureTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+) -> None:
+    result: ModelExecutionResult = run_failure_test(
+        test_case=test_case, adapter=adapter, connection=connection
+    )
+    asset: dict[str, object] = _format_model_assets(results=(result,), plan=None)[0]
+    microbatch: dict[str, object] = cast(dict[str, object], asset["microbatch"])
+
+    assert result.microbatch_limit_count == test_case.expected_microbatch_limit_count
+    assert (
+        result.microbatch_limit_warning is not None
+    ) is test_case.expected_microbatch_limit_warning
+    assert result.warning_messages == (result.microbatch_limit_warning,)
+    assert microbatch["limit"] == 2
+    assert microbatch["count"] == 3
+    assert microbatch["action"] == "warn"
+    assert microbatch["warning"] == result.microbatch_limit_warning
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MicrobatchSuccessTestCase(
+            description="warn limit survives skipped pre-hook serialization",
+            setup_sql=(
+                _TS_SOURCE_SQL,
+                _TS_SOURCE_DATA,
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP, payload VARCHAR)",
+            ),
+            model_sql=_TS_MODEL_SQL,
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="append",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            batch_size="1h",
+            microbatch_start="2026-01-01T00:00:00",
+            microbatch_end="2026-01-01T03:00:00",
+            expected_row_count=0,
+            pre_hook=[PythonHookEntry(name="skip_hook", kwargs={"reason": "not today"})],
+            hook_functions=(
+                DiscoveredHookFunction(
+                    file_path=Path(__file__),
+                    relative_path=Path("hooks/python/microbatch.py"),
+                    name="skip_hook",
+                    function=skip_microbatch_hook,
+                ),
+            ),
+            microbatch_limit=2,
+            microbatch_limit_action=MicrobatchLimitAction.WARN,
+            expected_microbatch_limit_count=3,
+            expected_microbatch_limit_warning=True,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_warn_limit_when_pre_hook_skips_then_execution_metadata_is_preserved(
+    test_case: MicrobatchSuccessTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+) -> None:
+    result: ModelExecutionResult = run_skipped_test(
+        test_case=test_case, adapter=adapter, connection=connection
+    )
+    asset: dict[str, object] = _format_model_assets(results=(result,), plan=None)[0]
+    microbatch: dict[str, object] = cast(dict[str, object], asset["microbatch"])
+
+    assert result.microbatch_limit_count == test_case.expected_microbatch_limit_count
+    assert (
+        result.microbatch_limit_warning is not None
+    ) is test_case.expected_microbatch_limit_warning
+    assert result.warning_messages == (result.microbatch_limit_warning,)
+    assert microbatch["limit"] == 2
+    assert microbatch["count"] == 3
+    assert microbatch["action"] == "warn"
+    assert microbatch["warning"] == result.microbatch_limit_warning
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MicrobatchFailureTestCase(
+            description="reconciliation expansion is rejected before pre-hook",
+            setup_sql=(
+                _TS_SOURCE_SQL,
+                _TS_SOURCE_DATA,
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP, payload VARCHAR)",
+                "CREATE TABLE main.hook_log (phase VARCHAR)",
+            ),
+            model_sql=_TS_MODEL_SQL,
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="append",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            batch_size="3h",
+            microbatch_start="2026-01-01T00:00:00",
+            microbatch_end="2026-01-01T03:00:00",
+            pre_hook=[SqlHookEntry(statement="INSERT INTO main.hook_log VALUES ('pre')")],
+            expected_failed_phase=ExecutionPhase.STAGING,
+            expected_error_fragment="planned 3 batches",
+            expected_row_count=0,
+            expected_query_results=(("SELECT * FROM main.hook_log", ()),),
+            microbatch_limit=2,
+            microbatch_limit_action=MicrobatchLimitAction.ERROR,
+            expected_microbatch_limit_count=3,
+            expected_microbatch_limit_warning=True,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_reconciliation_expands_work_when_enforcing_limit_then_final_set_is_rejected(
+    test_case: MicrobatchFailureTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reconciled_batches: tuple[BatchWindow, ...] = (
+        BatchWindow(start="2026-01-01T00:00:00", end="2026-01-01T01:00:00", index=0),
+        BatchWindow(start="2026-01-01T01:00:00", end="2026-01-01T02:00:00", index=1),
+        BatchWindow(start="2026-01-01T02:00:00", end="2026-01-01T03:00:00", index=2),
+    )
+    monkeypatch.setattr(
+        microbatch_module,
+        "_run_microbatch_reconciliation",
+        partial(reconcile_microbatch_batches, reconciled_batches=reconciled_batches),
+    )
+
+    result: ModelExecutionResult = run_failure_test(
+        test_case=test_case, adapter=adapter, connection=connection
+    )
+
+    assert result.microbatch_limit_count == test_case.expected_microbatch_limit_count
+    verify_failure_state(result=result, test_case=test_case, connection=connection)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MicrobatchSuccessTestCase(
+            description="reconciliation reduction permits final batch set",
+            setup_sql=(
+                _TS_SOURCE_SQL,
+                _TS_SOURCE_DATA,
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP, payload VARCHAR)",
+                "CREATE TABLE main.hook_log (phase VARCHAR)",
+            ),
+            model_sql=_TS_MODEL_SQL,
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="append",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            batch_size="1h",
+            microbatch_start="2026-01-01T00:00:00",
+            microbatch_end="2026-01-01T03:00:00",
+            pre_hook=[SqlHookEntry(statement="INSERT INTO main.hook_log VALUES ('pre')")],
+            expected_row_count=1,
+            expected_batch_count=1,
+            expected_query_results=(("SELECT phase FROM main.hook_log", (("pre",),)),),
+            microbatch_limit=2,
+            microbatch_limit_action=MicrobatchLimitAction.ERROR,
+            expected_microbatch_limit_count=1,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_reconciliation_reduces_work_when_enforcing_limit_then_final_set_executes(
+    test_case: MicrobatchSuccessTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reconciled_batches: tuple[BatchWindow, ...] = (
+        BatchWindow(start="2026-01-01T00:00:00", end="2026-01-01T01:00:00", index=0),
+    )
+    monkeypatch.setattr(
+        microbatch_module,
+        "_run_microbatch_reconciliation",
+        partial(reconcile_microbatch_batches, reconciled_batches=reconciled_batches),
+    )
+
+    result: ModelExecutionResult = run_success_test(
+        test_case=test_case, adapter=adapter, connection=connection
+    )
+
+    assert result.microbatch_limit_count == test_case.expected_microbatch_limit_count
+    verify_success_state(result=result, test_case=test_case, connection=connection)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MicrobatchFailureTestCase(
+            description="runtime error limit blocks pre-hook and all batches",
+            setup_sql=(
+                _TS_SOURCE_SQL,
+                _TS_SOURCE_DATA,
+                "CREATE TABLE main.orders (id INTEGER, event_time TIMESTAMP, payload VARCHAR)",
+                "CREATE TABLE main.hook_log (phase VARCHAR)",
+            ),
+            model_sql=_TS_MODEL_SQL,
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="delete_insert",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            batch_size="1h",
+            microbatch_start="2026-01-01T00:00:00",
+            microbatch_end="2026-01-01T03:00:00",
+            pre_hook=[SqlHookEntry(statement="INSERT INTO main.hook_log VALUES ('pre')")],
+            expected_failed_phase=ExecutionPhase.STAGING,
+            expected_error_fragment="MICROBATCH LIMIT EXCEEDED",
+            expected_row_count=0,
+            microbatch_limit=2,
+            microbatch_limit_action=MicrobatchLimitAction.ERROR,
+            expected_query_results=(
+                ("SELECT COUNT(*) FROM main.hook_log", ((0,),)),
+                ("SELECT COUNT(*) FROM main.orders", ((0,),)),
+            ),
+        ),
         MicrobatchFailureTestCase(
             description="runtime cap evidence survives pre-hook failure",
             setup_sql=(

--- a/tests/unit/src/sqlbuild/cli/output/main/build_execution_json/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/build_execution_json/_test_types.py
@@ -34,3 +34,9 @@ class ExecutionJsonCostTestCase:
     description: str
     expected_run_id: str
     expected_cost: dict[str, object]
+
+
+@dataclass(frozen=True)
+class ExecutionJsonMicrobatchLimitTestCase:
+    description: str
+    expected_microbatch: dict[str, object]

--- a/tests/unit/src/sqlbuild/cli/output/main/build_execution_json/test_execution_protocol_v1.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/build_execution_json/test_execution_protocol_v1.py
@@ -15,9 +15,11 @@ from sqlbuild.executor.build.types import BuildStatus
 from sqlbuild.executor.python_nodes.models import PythonNodeExecutionResult
 from sqlbuild.executor.run.models import ModelExecutionResult
 from sqlbuild.executor.scheduling.types import ExecutionStatus
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction
 from tests.unit.src.sqlbuild.cli.commands.shared._helpers.helpers import build_audit_result
 from tests.unit.src.sqlbuild.cli.output.main.build_execution_json._test_types import (
     ExecutionJsonCostTestCase,
+    ExecutionJsonMicrobatchLimitTestCase,
     ExecutionJsonRelationReuseTestCase,
     ExecutionJsonSeedReasonTestCase,
     ExecutionJsonTestCase,
@@ -27,6 +29,48 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
     build_plan_output,
     build_seed_entry,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ExecutionJsonMicrobatchLimitTestCase(
+            description="execution json preserves microbatch limit evidence",
+            expected_microbatch={
+                "limit": 2,
+                "count": 3,
+                "action": "warn",
+                "warning": "MICROBATCH LIMIT EXCEEDED",
+            },
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_microbatch_limit_result_when_formatting_execution_json_then_metadata_is_preserved(
+    test_case: ExecutionJsonMicrobatchLimitTestCase,
+) -> None:
+    result: str = format_build_execution_json(
+        result=BuildExecutionResult(
+            status=BuildStatus.SUCCESS,
+            model_results=(
+                ModelExecutionResult(
+                    model_name="events",
+                    status=ExecutionStatus.SUCCESS,
+                    microbatch_run_type="normal",
+                    microbatch_limit=2,
+                    microbatch_limit_count=3,
+                    microbatch_limit_action=MicrobatchLimitAction.WARN,
+                    microbatch_limit_warning="MICROBATCH LIMIT EXCEEDED",
+                ),
+            ),
+        ),
+        plan=build_plan_output(model_entries=(build_model_entry(name="events"),)),
+    )
+    payload: dict[str, object] = json.loads(result)
+    microbatch: dict[str, object] = payload["assets"][0]["microbatch"]  # type: ignore[index,assignment]
+
+    actual: dict[str, object] = {key: microbatch[key] for key in test_case.expected_microbatch}
+    assert actual == test_case.expected_microbatch
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/output/main/plan/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/plan/helpers.py
@@ -34,7 +34,7 @@ from sqlbuild.compiler.planner.types import (
     WarningSeverity,
 )
 from sqlbuild.spec.contracts.models import SeedCsvSettings
-from sqlbuild.spec.contracts.types import SourceWriteStrategy
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction, SourceWriteStrategy
 
 
 def build_model_entry(
@@ -69,6 +69,10 @@ def build_model_entry(
     custom_materialization_name: str | None = None,
     query_changed: bool = False,
     config_changed: bool = False,
+    microbatch_limit: int | None = None,
+    microbatch_limit_count: int | None = None,
+    microbatch_limit_action: MicrobatchLimitAction | None = None,
+    microbatch_limit_warning: str | None = None,
 ) -> ModelPlanEntry:
     """Build a minimal ModelPlanEntry for formatter tests."""
 
@@ -110,6 +114,10 @@ def build_model_entry(
         custom_materialization_name=custom_materialization_name,
         query_changed=query_changed,
         config_changed=config_changed,
+        microbatch_limit=microbatch_limit,
+        microbatch_limit_count=microbatch_limit_count,
+        microbatch_limit_action=microbatch_limit_action,
+        microbatch_limit_warning=microbatch_limit_warning,
     )
 
 

--- a/tests/unit/src/sqlbuild/cli/output/main/plan_json/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/plan_json/_test_types.py
@@ -18,3 +18,12 @@ class JsonOutputTestCase:
 class FutureCursorPlanJsonTestCase:
     description: str
     expected_action: str
+
+
+@dataclass(frozen=True)
+class MicrobatchLimitPlanJsonTestCase:
+    description: str
+    expected_limit: int
+    expected_count: int
+    expected_action: str
+    expected_warning: str

--- a/tests/unit/src/sqlbuild/cli/output/main/plan_json/test_plan_json.py
+++ b/tests/unit/src/sqlbuild/cli/output/main/plan_json/test_plan_json.py
@@ -30,7 +30,7 @@ from sqlbuild.compiler.python_nodes.types import (
     PythonNodeKind,
     PythonRunPhase,
 )
-from sqlbuild.spec.contracts.types import FutureCursorAction
+from sqlbuild.spec.contracts.types import FutureCursorAction, MicrobatchLimitAction
 from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
     build_discovered_provider_usage,
     build_model_entry,
@@ -43,7 +43,53 @@ from tests.unit.src.sqlbuild.cli.output.main.plan.helpers import (
 from tests.unit.src.sqlbuild.cli.output.main.plan_json._test_types import (
     FutureCursorPlanJsonTestCase,
     JsonOutputTestCase,
+    MicrobatchLimitPlanJsonTestCase,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MicrobatchLimitPlanJsonTestCase(
+            description="microbatch limit decision is preserved",
+            expected_limit=2,
+            expected_count=3,
+            expected_action="warn",
+            expected_warning="MICROBATCH LIMIT EXCEEDED",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_microbatch_limit_decision_when_formatting_plan_json_then_metadata_is_preserved(
+    test_case: MicrobatchLimitPlanJsonTestCase,
+) -> None:
+    warning: str = test_case.expected_warning
+    plan: PlanOutput = build_plan_output(
+        model_entries=(
+            build_model_entry(
+                name="events",
+                incremental_mode="microbatch",
+                microbatch_limit=test_case.expected_limit,
+                microbatch_limit_count=test_case.expected_count,
+                microbatch_limit_action=MicrobatchLimitAction.WARN,
+                microbatch_limit_warning=warning,
+            ),
+        )
+    )
+
+    payload: dict[str, object] = json.loads(format_plan_json(plan=plan))
+    microbatch: Any = payload["models"][0]["microbatch_state"]  # type: ignore[index]
+
+    assert microbatch == {
+        "completion_tracking": "universal",
+        "batch_concurrency": 1,
+        "unaccounted_partition_policy": None,
+        "reconciliation": "runtime",
+        "limit": test_case.expected_limit,
+        "count": test_case.expected_count,
+        "action": test_case.expected_action,
+        "warning": test_case.expected_warning,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
@@ -21,6 +21,21 @@ class FutureCursorConfigErrorTestCase:
 
 
 @dataclass(frozen=True)
+class MicrobatchLimitConfigTestCase:
+    description: str
+    limits_toml: str
+    expected_max_batches: int | None
+    expected_action: str
+
+
+@dataclass(frozen=True)
+class MicrobatchLimitConfigErrorTestCase:
+    description: str
+    limits_toml: str
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
 class DiscoverMacroFilesTestCase:
     description: str
     files: dict[str, str]

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
@@ -26,6 +26,8 @@ from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
     LoadProjectCostConfigTestCase,
     LoadRetentionConfigErrorTestCase,
     LoadRetentionConfigTestCase,
+    MicrobatchLimitConfigErrorTestCase,
+    MicrobatchLimitConfigTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.discovery._helpers.helpers import (
     write_project_config_test_files,
@@ -82,6 +84,71 @@ def test_given_future_cursor_config_when_loading_project_then_policy_is_typed(
 
     assert config.cursors.future.max_distance == test_case.expected_max_distance
     assert config.cursors.future.action == test_case.expected_action
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MicrobatchLimitConfigTestCase(
+            description="configured warn limit is typed",
+            limits_toml='max_batches = 24\naction = "warn"',
+            expected_max_batches=24,
+            expected_action="warn",
+        ),
+        MicrobatchLimitConfigTestCase(
+            description="absent max batches disables limit",
+            limits_toml='action = "error"',
+            expected_max_batches=None,
+            expected_action="error",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_microbatch_limit_config_when_loading_project_then_policy_is_typed(
+    test_case: MicrobatchLimitConfigTestCase, tmp_path: Path
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        f'name = "demo"\nadapter = "duckdb"\n[microbatches.limits]\n{test_case.limits_toml}\n',
+        encoding="utf-8",
+    )
+
+    config: ProjectConfig = load_project_config(project_dir=tmp_path)
+
+    assert config.microbatches.limits.max_batches == test_case.expected_max_batches
+    assert config.microbatches.limits.action == test_case.expected_action
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MicrobatchLimitConfigErrorTestCase(
+            description="zero max batches is rejected",
+            limits_toml="max_batches = 0",
+            expected_error_fragment="must be a positive integer",
+        ),
+        MicrobatchLimitConfigErrorTestCase(
+            description="boolean max batches is rejected",
+            limits_toml="max_batches = true",
+            expected_error_fragment="must be a positive integer",
+        ),
+        MicrobatchLimitConfigErrorTestCase(
+            description="unsupported limit action is rejected",
+            limits_toml='max_batches = 2\naction = "cap"',
+            expected_error_fragment="action must be one of: error, warn",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_invalid_microbatch_limit_when_loading_project_then_error_is_raised(
+    test_case: MicrobatchLimitConfigErrorTestCase, tmp_path: Path
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        f'name = "demo"\nadapter = "duckdb"\n[microbatches.limits]\n{test_case.limits_toml}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ProjectConfigError, match=test_case.expected_error_fragment):
+        load_project_config(project_dir=tmp_path)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
@@ -719,6 +719,26 @@ class MicrobatchLookbackTestCase:
 
 
 @dataclass(frozen=True)
+class MicrobatchLimitPlanningTestCase:
+    description: str
+    max_batches: int
+    action: str
+    expected_count: int | None
+    expected_warning: bool
+    plan_action: str = "incremental_delete_insert"
+    range_start: str = "0"
+    range_end: str = "30"
+
+
+@dataclass(frozen=True)
+class MicrobatchLimitPlanningErrorTestCase:
+    description: str
+    max_batches: int
+    action: str
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
 class CursorOverridesValidationTestCase:
     description: str
     start_ts: str | None = None

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_microbatch_limit.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_microbatch_limit.py
@@ -1,0 +1,133 @@
+"""Tests for planner-owned microbatch limit decisions."""
+
+from pathlib import Path
+
+import pytest
+
+from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.compiler.compile.models import (
+    CompiledObjectKey,
+    CompiledRelationLocation,
+)
+from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.planner._helpers.output.plan_entry import _apply_microbatch_limit
+from sqlbuild.compiler.planner.models import CursorBounds, ModelPlanEntry, PlanWarning
+from sqlbuild.compiler.planner.types import (
+    IncrementalMode,
+    MaterializationType,
+    PlanAction,
+    PlanReason,
+)
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction
+from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
+    MicrobatchLimitPlanningErrorTestCase,
+    MicrobatchLimitPlanningTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MicrobatchLimitPlanningTestCase(
+            description="warn preserves complete planner-owned range",
+            max_batches=2,
+            action="warn",
+            expected_count=3,
+            expected_warning=True,
+        ),
+        MicrobatchLimitPlanningTestCase(
+            description="numeric override permits intentional backfill",
+            max_batches=3,
+            action="error",
+            expected_count=3,
+            expected_warning=False,
+        ),
+        MicrobatchLimitPlanningTestCase(
+            description="skipped model does not apply error limit",
+            max_batches=1,
+            action="error",
+            expected_count=None,
+            expected_warning=False,
+            plan_action="skip",
+        ),
+        MicrobatchLimitPlanningTestCase(
+            description="equal-bound full refresh is one batch",
+            max_batches=1,
+            action="error",
+            expected_count=1,
+            expected_warning=False,
+            plan_action="create_table",
+            range_start="10",
+            range_end="10",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_planner_owned_range_when_applying_limit_then_expected_decision_is_preserved(
+    test_case: MicrobatchLimitPlanningTestCase,
+) -> None:
+    entry: ModelPlanEntry = ModelPlanEntry(
+        key=CompiledObjectKey(resource_type=CompiledResourceType.MODEL, name="events"),
+        name="events",
+        relative_path=Path("models/events.sql"),
+        materialization_type=MaterializationType.INCREMENTAL,
+        action=PlanAction(test_case.plan_action),
+        reason=PlanReason.NORMAL_INCREMENTAL,
+        destination=CompiledRelationLocation(None, "main", "events", "main.events"),
+        fingerprint_query_sql="SELECT 1",
+        resolved_sql="SELECT 1",
+        logical_ddl="",
+        incremental_mode=IncrementalMode.MICROBATCH,
+        cursor_type="integer",
+        batch_size="10",
+        microbatch_range=CursorBounds(start=test_case.range_start, end=test_case.range_end),
+    )
+    action: MicrobatchLimitAction = MicrobatchLimitAction(test_case.action)
+
+    limited_entry, warning = _apply_microbatch_limit(
+        entry=entry, max_batches=test_case.max_batches, action=action
+    )
+
+    assert limited_entry.microbatch_limit_count == test_case.expected_count
+    assert (warning is not None) is test_case.expected_warning
+    assert isinstance(warning, PlanWarning) is test_case.expected_warning
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        MicrobatchLimitPlanningErrorTestCase(
+            description="error rejects planner-owned range",
+            max_batches=2,
+            action="error",
+            expected_error_fragment="MICROBATCH LIMIT EXCEEDED",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_excess_planner_owned_range_when_action_is_error_then_planning_fails(
+    test_case: MicrobatchLimitPlanningErrorTestCase,
+) -> None:
+    entry: ModelPlanEntry = ModelPlanEntry(
+        key=CompiledObjectKey(resource_type=CompiledResourceType.MODEL, name="events"),
+        name="events",
+        relative_path=Path("models/events.sql"),
+        materialization_type=MaterializationType.INCREMENTAL,
+        action=PlanAction.INCREMENTAL_DELETE_INSERT,
+        reason=PlanReason.NORMAL_INCREMENTAL,
+        destination=CompiledRelationLocation(None, "main", "events", "main.events"),
+        fingerprint_query_sql="SELECT 1",
+        resolved_sql="SELECT 1",
+        logical_ddl="",
+        incremental_mode=IncrementalMode.MICROBATCH,
+        cursor_type="integer",
+        batch_size="10",
+        microbatch_range=CursorBounds(start="0", end="30"),
+    )
+
+    with pytest.raises(CompileInputError, match=test_case.expected_error_fragment):
+        _apply_microbatch_limit(
+            entry=entry,
+            max_batches=test_case.max_batches,
+            action=MicrobatchLimitAction(test_case.action),
+        )

--- a/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
@@ -108,6 +108,13 @@ class DagsterFutureCursorMetadataTestCase:
 
 
 @dataclass(frozen=True)
+class DagsterMicrobatchLimitMetadataTestCase:
+    description: str
+    execution_status: str
+    expected_microbatch: dict[str, object]
+
+
+@dataclass(frozen=True)
 class DagsterLiveFailureLoggingTestCase:
     description: str
     expected_phase: str

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
@@ -25,6 +25,7 @@ from tests.unit.src.sqlbuild.integrations.dagster._test_types import (
     DagsterCliStreamTestCase,
     DagsterFutureCursorMetadataTestCase,
     DagsterLiveFailureLoggingTestCase,
+    DagsterMicrobatchLimitMetadataTestCase,
 )
 from tests.unit.src.sqlbuild.integrations.dagster.helpers import (
     assert_json_output_file_behavior,
@@ -342,6 +343,127 @@ def test_given_future_cursor_execution_metadata_when_streaming_then_dagster_reta
     materialization: Any = results[0]
     assert materialization.metadata["future_cursor_safety"] == safety
     assert materialization.metadata["future_cursor_safety"]["action"] == test_case.expected_action
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagsterMicrobatchLimitMetadataTestCase(
+            description="microbatch limit metadata",
+            execution_status="success",
+            expected_microbatch={
+                "run_type": "normal",
+                "limit": 2,
+                "count": 3,
+                "action": "warn",
+                "warning": "MICROBATCH LIMIT EXCEEDED",
+            },
+        ),
+        DagsterMicrobatchLimitMetadataTestCase(
+            description="warn limit metadata after skipped pre-hook",
+            execution_status="skipped",
+            expected_microbatch={
+                "run_type": "normal",
+                "limit": 2,
+                "count": 3,
+                "action": "warn",
+                "warning": "MICROBATCH LIMIT EXCEEDED",
+            },
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_microbatch_limit_execution_metadata_when_streaming_then_dagster_retains_structure(
+    test_case: DagsterMicrobatchLimitMetadataTestCase, tmp_path: Path
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    stdout: str = json.dumps(
+        {
+            "version": 1,
+            "command": "build",
+            "status": "success",
+            "summary": {},
+            "assets": [
+                {
+                    "kind": "model",
+                    "name": "orders",
+                    "status": test_case.execution_status,
+                    "microbatch": test_case.expected_microbatch,
+                }
+            ],
+            "checks": [],
+        }
+    )
+    context: Any = type(
+        "SelectedAssetContext",
+        (),
+        {"selected_asset_keys": {dg.AssetKey(["analytics", "orders"])}},
+    )()
+    resource: SqlBuildCliResource = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_fake_sqb_command(root=tmp_path, stdout=stdout),
+        dag_path=str(write_dagster_test_dag(root=tmp_path)),
+    )
+
+    results: list[Any] = list(resource.cli(args=["build"], context=context).stream())
+
+    materialization: Any = results[0]
+    assert materialization.metadata["microbatch"] == test_case.expected_microbatch
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagsterMicrobatchLimitMetadataTestCase(
+            description="warn limit metadata after failed pre-hook",
+            execution_status="failed",
+            expected_microbatch={
+                "run_type": "normal",
+                "limit": 2,
+                "count": 3,
+                "action": "warn",
+                "warning": "MICROBATCH LIMIT EXCEEDED",
+            },
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_warn_limit_metadata_when_cli_fails_then_dagster_failure_retains_evidence(
+    test_case: DagsterMicrobatchLimitMetadataTestCase, tmp_path: Path
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    stdout: str = json.dumps(
+        {
+            "version": 1,
+            "command": "build",
+            "status": "failed",
+            "summary": {},
+            "assets": [
+                {
+                    "kind": "model",
+                    "name": "orders",
+                    "status": test_case.execution_status,
+                    "failed_phase": "pre_hook",
+                    "microbatch": test_case.expected_microbatch,
+                }
+            ],
+            "checks": [],
+        }
+    )
+    resource: SqlBuildCliResource = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_fake_sqb_command(root=tmp_path, stdout=stdout, exit_code=1),
+        dag_path=str(write_dagster_test_dag(root=tmp_path)),
+    )
+
+    with pytest.raises(dg.Failure) as exc_info:
+        list(resource.cli(args=["build"]).stream())
+
+    assert exc_info.value.metadata["microbatch_limits"].value == {
+        "orders": test_case.expected_microbatch
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Large automatic microbatch ranges need an optional project policy that can warn or fail before model side effects, while intentional historical backfills remain possible through an explicit override.

## Changes

- add `[microbatches.limits]` with positive `max_batches` and `error | warn`
- enforce against the exact post-reconciliation per-model batch set
- fail before hooks or model DML, or warn and execute the complete range
- add `--max-microbatches` for intentional plan/build overrides
- preserve limit, final count, action, and warning in plan JSON, execution JSON, failures, skips, and Dagster metadata
- do not support ambiguous partial-range capping

## Verification

- broad affected suite: 1,972 passed
- focused final suite: 157 passed
- `ty check`: passed
- Ruff: passed
- Fensu: 0 faults and 0 warnings
- independent final review: no blocking findings

Linear: CHI-190
