### PR TITLE
fix: allow zero-day future cursor caps

### DIFF
--- a/src/sqlbuild/compiler/compile/_helpers/config/model_validation.py
+++ b/src/sqlbuild/compiler/compile/_helpers/config/model_validation.py
@@ -486,7 +486,7 @@ def _validate_cursor_safety_overrides(
     if cursor_future_max_distance is not None and (
         not isinstance(cursor_future_max_distance, str)
         or (
-            cursor_future_max_distance != CURSOR_POLICY_DISABLED
+            cursor_future_max_distance not in {CURSOR_POLICY_DISABLED, ZERO_DAY_CURSOR_DURATION}
             and duration_pattern.fullmatch(cursor_future_max_distance) is None
         )
     ):

--- a/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
@@ -393,9 +393,13 @@ def _load_cursors(*, payload: object, file_path: Path) -> CursorsConfig:
         file_path=file_path,
     )
     max_distance: str | None = _optional_str(payload=future, key="max_distance")
-    if max_distance is not None and _CURSOR_DURATION_PATTERN.fullmatch(max_distance) is None:
+    if (
+        max_distance is not None
+        and max_distance != ZERO_DAY_CURSOR_DURATION
+        and _CURSOR_DURATION_PATTERN.fullmatch(max_distance) is None
+    ):
         raise ProjectConfigError(
-            "cursors.future.max_distance must be a positive duration like 7d, 12h, or 1mo"
+            "cursors.future.max_distance must be a duration like 0d, 7d, 12h, or 1mo"
         )
     raw_action: str | None = _optional_str(payload=future, key="action")
     try:

--- a/src/sqlbuild/compiler/planner/_helpers/resolve/future_cursor_safety.py
+++ b/src/sqlbuild/compiler/planner/_helpers/resolve/future_cursor_safety.py
@@ -13,6 +13,7 @@ from sqlbuild.compiler.planner.models import (
     FutureCursorSafetyEvidence,
 )
 from sqlbuild.compiler.planner.types import CursorGrain, CursorType
+from sqlbuild.spec.contracts.constants import ZERO_DAY_CURSOR_DURATION
 from sqlbuild.spec.contracts.models import FutureCursorsConfig
 from sqlbuild.spec.contracts.types import FutureCursorAction
 
@@ -37,7 +38,11 @@ def resolve_future_cursor_safety(
         or has_complete_override
     ):
         return bounds
-    duration: Duration | None = Duration.parse(config.max_distance)
+    duration: Duration | None = (
+        Duration()
+        if config.max_distance == ZERO_DAY_CURSOR_DURATION
+        else Duration.parse(config.max_distance)
+    )
     if duration is None:
         raise FutureCursorSafetyError(
             f"invalid cursors.future.max_distance '{config.max_distance}'"

--- a/tests/unit/src/sqlbuild/compiler/compile/test_cursor_start.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/test_cursor_start.py
@@ -77,13 +77,13 @@ def test_given_cursor_start_layers_when_building_compile_inputs_then_model_uses_
                     "MODEL (\nmaterialized incremental\nincremental_strategy delete_insert\n"
                     "cursor event_at\ncursor_type timestamp\ncursor_grain day\n"
                     "cursor_start_max_ahead '0d'\ncursor_start_max_action cap\n"
-                    "cursor_future_max_distance '2d'\ncursor_future_action cap\n"
+                    "cursor_future_max_distance '0d'\ncursor_future_action cap\n"
                     ");\n\nSELECT DATE '2026-01-01' AS event_at"
                 ),
             },
             expected_start_max_ahead="0d",
             expected_start_action="cap",
-            expected_future_max_distance="2d",
+            expected_future_max_distance="0d",
             expected_future_action="cap",
         )
     ],

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
@@ -69,7 +69,13 @@ def test_given_no_cost_config_when_loading_project_then_default_rate_is_flagged(
             future_toml='max_distance = "7d"\naction = "cap"',
             expected_max_distance="7d",
             expected_action="cap",
-        )
+        ),
+        FutureCursorConfigTestCase(
+            description="zero-day future cap policy is typed",
+            future_toml='max_distance = "0d"\naction = "cap"',
+            expected_max_distance="0d",
+            expected_action="cap",
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -184,7 +190,7 @@ def test_given_invalid_microbatch_limit_when_loading_project_then_error_is_raise
         FutureCursorConfigErrorTestCase(
             description="invalid duration",
             future_toml='max_distance = "tomorrow"',
-            expected_error_fragment="max_distance must be a positive duration",
+            expected_error_fragment="max_distance must be a duration",
         ),
         FutureCursorConfigErrorTestCase(
             description="invalid action",

--- a/tests/unit/src/sqlbuild/compiler/planner/main/test_future_cursor_safety.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/main/test_future_cursor_safety.py
@@ -18,6 +18,17 @@ from tests.unit.src.sqlbuild.compiler.planner.main._test_types import FutureCurs
     "test_case",
     [
         FutureCursorSafetyTestCase(
+            description="zero-day cap stops at the invocation day boundary",
+            bounds=CursorBounds("2026-08-30T00:00:00", "2030-01-01T00:00:00"),
+            config=FutureCursorsConfig("0d", FutureCursorAction.CAP),
+            invocation_time=datetime(2026, 9, 1, 12, 0, tzinfo=UTC),
+            cursor_grain=CursorGrain.DAY,
+            has_complete_override=False,
+            expected_start="2026-08-30T00:00:00",
+            expected_end="2026-09-02T00:00:00",
+            expected_has_safety=True,
+        ),
+        FutureCursorSafetyTestCase(
             description="timestamp cap advances equality horizon by one second",
             bounds=CursorBounds("2026-09-01T00:00:00", "2030-01-01T00:00:01"),
             config=FutureCursorsConfig("2d", FutureCursorAction.CAP),


### PR DESCRIPTION
## Why

Day-grain models that cannot produce meaningful future data need to cap execution at the invocation day. Model-level future cursor overrides support positive durations but incorrectly reject `0d`, forcing unnecessary future microbatches or an imprecise workaround.

## Changes

- allow `0d` in project and model future cursor policies
- resolve zero-day caps at the invocation grain boundary
- retain positive-duration validation for unrelated duration settings

## Verification

- 103 targeted cursor configuration and planning tests passed
- `make check-ci` passed, including Ruff, ty, focused contract tests, and Fensu
