### PR TITLE
fix: align incremental writes by column name

### DIFF
--- a/src/sqlbuild/executor/run/_helpers/materializations/incremental.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/incremental.py
@@ -593,13 +593,11 @@ def _execute_dml(
     unique_key: tuple[str, ...] = entry.unique_key
 
     target_col_set: frozenset[str] = frozenset(col.name.lower() for col in target_columns)
-    delta_col_set: frozenset[str] = frozenset(col.name.lower() for col in delta_columns)
     intersection_names: tuple[str, ...] = tuple(
         col.name for col in delta_columns if col.name.lower() in target_col_set
     )
-    columns_match: bool = target_col_set == delta_col_set
-    dml_columns: tuple[str, ...] | None = None if columns_match else intersection_names
-    projection: str = ", ".join(intersection_names) if not columns_match else "*"
+    dml_columns: tuple[str, ...] = intersection_names
+    projection: str = ", ".join(intersection_names)
     dml_sql: str = f"SELECT {projection} FROM {delta_qualified}"
 
     if strategy == IncrementalStrategy.APPEND:

--- a/tests/integration/src/sqlbuild/executor/run/microbatch/test_microbatch_execution.py
+++ b/tests/integration/src/sqlbuild/executor/run/microbatch/test_microbatch_execution.py
@@ -195,8 +195,33 @@ _INT_MODEL_SQL: str = (
                 "CREATE OR REPLACE TABLE main.orders__delta AS SELECT id, event_time, payload",
                 "event_time >= '2026-01-01T00:00:00'",
                 "event_time < '2026-01-01T01:00:00'",
-                "INSERT INTO main.orders SELECT * FROM main.orders__delta",
+                'INSERT INTO main.orders ("id", "event_time", "payload") '
+                "SELECT id, event_time, payload FROM main.orders__delta",
                 "DROP TABLE IF EXISTS main.orders__delta",
+            ),
+        ),
+        MicrobatchSuccessTestCase(
+            description="append aligns identical column sets with different physical order",
+            setup_sql=(
+                _TS_SOURCE_SQL,
+                _TS_SOURCE_DATA,
+                "CREATE TABLE main.orders (payload VARCHAR, id INTEGER, event_time TIMESTAMP)",
+            ),
+            model_sql=_TS_MODEL_SQL,
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="append",
+            cursor_column="event_time",
+            cursor_type="timestamp",
+            batch_size="1h",
+            microbatch_start="2026-01-01T00:00:00",
+            microbatch_end="2026-01-01T03:00:00",
+            expected_row_count=3,
+            expected_query_results=(
+                (
+                    "SELECT id, payload FROM main.orders ORDER BY id",
+                    ((1, "a"), (2, "b"), (3, "c")),
+                ),
             ),
         ),
         MicrobatchSuccessTestCase(


### PR DESCRIPTION
## Why

Incremental DML used `SELECT *` when target and delta contained the same column names, assuming their physical order matched. Reordering existing model columns could therefore insert values into the wrong destination columns and fail with type errors, while dbt's explicit destination column list remained safe.

## Changes

- always project incremental append/delete-insert columns explicitly
- always provide the matching destination column list
- cover identical target and delta column sets with different physical order

## Verification

- 36 microbatch lifecycle integration tests passed
- `make check-ci` passed, including Ruff, ty, focused contract tests, and Fensu
