### PR TITLE
feat: add explicit column contract mode

### DIFF
--- a/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
+++ b/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
@@ -1301,6 +1301,7 @@ Global feature toggles:
 sql_analysis = true
 query_change_tracking = true
 sql_validation = true
+column_contract_mode = "implicit"
 concurrency = 1
 auto_load_sources = true
 table_promotion_mode = "staged"
@@ -1315,6 +1316,7 @@ default_audit_run_scope = "final"
 | `virtual_environments` | `false` | Enable [virtual environments](/concepts/virtual-environments) (versioned model outputs, promotion, rollback, state management). When `false`, the project runs in direct mode. |
 | `query_change_tracking` | `true` | Track query fingerprints for change detection |
 | `sql_validation` | `true` | Validate SQL syntax during compilation |
+| `column_contract_mode` | `implicit` | Controls whether column declarations on models without a `contract` declaration activate static shape/nullability validation. `implicit` preserves that validation; `explicit` treats columns as metadata and audit attachment unless the model declares `contract enforced`. Model-level `contract enforced` and `contract none` override this setting. Explicit type enforcement remains independent. See [Contracts](/concepts/models/contracts). |
 | `concurrency` | `1` | Maximum parallel model execution (currently serial only) |
 | `auto_load_sources` | `true` | Automatically run source loaders before building dependent models during `sqb build`. See [Loaders](/concepts/python-nodes/loaders). |
 | `table_promotion_mode` | adapter default | `staged` (CTAS to staging, audit, then promote) or `immediate` (CTAS directly to target, then audit) |
@@ -2689,7 +2691,7 @@ Physical SQL output order is not currently enforced. Static contract analysis ma
 
 ### Contracts and planning
 
-`contract enforced` treats the complete named-plus-local declaration as the exact output shape. With `contract none`, the default, SQLBuild checks declared columns when static inference is available and permits additional output columns; it does not add a runtime shape requirement. See [Contracts](/concepts/models/contracts).
+`contract enforced` treats the complete named-plus-local declaration as the exact output shape. An unspecified model follows the project's `column_contract_mode`; `contract none` explicitly keeps the resolved columns as metadata, audit attachment, and type-enforcement inputs without activating shape validation. See [Contracts](/concepts/models/contracts).
 
 For models bound to a reusable schema, effective column names, types, nullability, and enum members participate in model version identity. Changing those fields on a parent therefore affects models bound through descendants. Descriptions do not change model identity. Audits have their own audit-gate identities, so audit changes invalidate reusable audit results without changing the model version itself.
 
@@ -2782,12 +2784,22 @@ Source: `concepts/models/contracts.mdx`
 
 Validate required or exact model output schemas.
 
-A model's declared columns describe expected output metadata. The `contract` policy determines whether SQLBuild treats that declaration as an open shape or a complete exact shape.
+A model's declared columns provide output metadata, type enforcement, and column audit attachment. The project `column_contract_mode` and model `contract` policy determine whether those declarations also define a statically validated output shape.
 
-| Value | Behavior |
-|-------|----------|
-| `none` | Statically check declared columns when SQLBuild can infer the output; allow undeclared output columns. This is the default. |
+| Model declaration | Behavior |
+|-------------------|----------|
+| Unspecified | Follow `settings.column_contract_mode`: `implicit` validates declared columns as an open shape; `explicit` treats them as metadata and audit attachment only. |
+| `none` | Do not activate declared-shape or nullability contract validation for this model. Explicit type enforcement remains active. |
 | `enforced` | Treat declared columns as the complete authoritative output shape and enable runtime exact-schema checks on supported materializations. |
+
+The project default is `column_contract_mode = "implicit"`, which preserves SQLBuild's original behavior. Projects that use column declarations primarily for metadata and audits, including migrations from dbt, can opt into explicit contracts:
+
+```toml
+[settings]
+column_contract_mode = "explicit"
+```
+
+Under explicit mode, a model must declare `contract enforced` to activate shape validation. A model-level `contract enforced` or `contract none` always overrides the project mode.
 
 ```sql
 MODEL (
@@ -2806,14 +2818,16 @@ MODEL (
 
 #### Compile time
 
-When SQL analysis can infer the model's output, both contract policies check declared columns against that inference:
+When declared-shape validation is active and SQL analysis can infer the model's output:
 
 - A missing declared column fails.
 - A proven type mismatch fails when type enforcement or an exact contract is active.
 - A declared non-null column fails when its expression is proven nullable.
 - Additional inferred columns fail only for `contract enforced`.
 
-If SQLBuild cannot infer the output shape, these static shape checks cannot run. `contract none` does not add a later runtime requirement. An enforced contract additionally requires a non-empty column declaration.
+If SQLBuild cannot infer the output shape, these static shape checks cannot run. An enforced contract additionally requires a non-empty column declaration and adds runtime requirements on supported materializations.
+
+Type enforcement remains independent. Typed columns continue to receive static type checks and supported runtime casts under explicit mode and `contract none`.
 
 Configuration fields that reference output columns, including `unique_key`, `cursor`, `updated_at`, and `check_columns`, are checked against an enforced declaration.
 
@@ -2855,7 +2869,7 @@ MODEL (
 );
 ```
 
-With `contract enforced`, this requires exactly the resolved `order` columns plus `ingestion_batch_id`. With `contract none`, SQLBuild checks those columns when static inference is available and permits further output. See [Schemas](/concepts/models/schemas).
+With `contract enforced`, this requires exactly the resolved `order` columns plus `ingestion_batch_id`. With `contract none`, the resolved columns remain metadata, audit attachment points, and inputs to explicit type enforcement without activating shape validation. See [Schemas](/concepts/models/schemas).
 
 ### Enum columns
 
@@ -2876,7 +2890,7 @@ Enum member references such as `@enum("market_type").WIN` are a separate feature
 
 ### Related policies
 
-The core default is `contract none`. A repository can enable [`SQBKR401`](/concepts/kata#layers-and-model-grammar) to require enforced contracts through Kata architecture policy.
+The project default is implicit open-shape validation for models that omit `contract`. A repository can select explicit opt-in contracts with `settings.column_contract_mode = "explicit"` or enable [`SQBKR401`](/concepts/kata#layers-and-model-grammar) to require enforced contracts through Kata architecture policy.
 
 Contracts also constrain schema-change behavior. For example, `snapshot_schema_change append_new_columns` is incompatible with `contract enforced` because an unannounced appended column would violate the exact declaration.
 
@@ -3302,7 +3316,7 @@ Table promotion mode is a project setting rather than a `MODEL()` field. Staged 
 | `cursor_type` | `timestamp` or `integer` |
 | `cursor_grain` | Timestamp grain such as `second`, `hour`, or `day` |
 | `cursor_start` | Lower cursor bound |
-| `cursor_filter_inputs` | Upstream names mapped to cursor columns |
+| `cursor_inputs` | Upstream names mapped to cursor columns |
 | `unique_key` | Merge or delete/insert matching columns |
 | `incremental_mode` | Set to `microbatch` for batched execution |
 | `batch_size` | Timestamp duration string such as `1d` or `1h`; use a numeric string such as `"1000"` for an integer cursor |
@@ -4511,7 +4525,7 @@ MODEL (
   cursor last_ordered_at,
   cursor_type timestamp,
   cursor_grain second,
-  cursor_filter_inputs (
+  cursor_inputs (
     fact_orders ordered_at,
   ),
 );
@@ -4564,12 +4578,11 @@ Cursors define the incremental replay boundary. SQLBuild queries `MAX(cursor)` f
 | `cursor_type` | `timestamp` or `integer` |
 | `cursor_grain` | Time grain for timestamp cursors: `second`, `minute`, `hour`, `day`, `month`, `year` |
 | `cursor_start` | Lower bound floor; the cursor will never replay before this value |
-| `cursor_filter_inputs` | Direct ref/source names whose model SQL reads receive cursor filters |
-| `cursor_watermark_inputs` | Authoritative direct or transitive upstream names used to discover available bounds |
+| `cursor_inputs` | Map of upstream ref/source names to their cursor columns |
 
-#### cursor_filter_inputs
+#### cursor_inputs
 
-When a model references multiple upstream inputs, `cursor_filter_inputs` is required to tell SQLBuild which column on each input carries the cursor:
+When a model references multiple upstream inputs, `cursor_inputs` is required to tell SQLBuild which column on each input carries the cursor:
 
 ```sql
 MODEL (
@@ -4578,33 +4591,13 @@ MODEL (
   cursor activity_hour,
   cursor_type timestamp,
   cursor_grain hour,
-  cursor_filter_inputs (
+  cursor_inputs (
     fact_orders ordered_at,
   ),
 );
 ```
 
-By default SQLBuild also uses these relations to determine the replay window. Use `cursor_watermark_inputs` when an expensive view should remain the filtered data input while a compatible physical upstream relation provides the authoritative watermark:
-
-```sql
-MODEL (
-  materialized incremental,
-  incremental_strategy delete_insert,
-  cursor meeting_date,
-  cursor_type timestamp,
-  cursor_grain day,
-  cursor_filter_inputs (
-    market_prices_view meeting_date,
-  ),
-  cursor_watermark_inputs (
-    market_prices_physical meeting_date,
-  ),
-);
-```
-
-Watermark inputs may be transitive upstream models or sources, but cannot be unrelated project nodes. SQLBuild filters only `cursor_filter_inputs`; it never adds a predicate to a relation merely because it supplies a watermark. With multiple watermark inputs, the end is the conservative common watermark: the minimum of their maxima. The declared watermark must never advance beyond data visible through the corresponding filtered reads.
-
-`cursor_inputs` is a deprecated alias for `cursor_filter_inputs` until the next major release. Alias-only models use the same map for filtering and watermark discovery. During migration, `cursor_inputs` may be combined with explicit `cursor_watermark_inputs`; declaring both `cursor_inputs` and `cursor_filter_inputs` is an error.
+SQLBuild uses these to determine the replay window. With multiple listed inputs, the end is the conservative common watermark: the minimum of their maxima. This prevents a faster input from advancing the model beyond data available from a slower input.
 
 On a first build, SQLBuild derives the interval from the declared cursor inputs and cursor policy. If it cannot establish a valid interval, the build fails before mutating the destination.
 
@@ -4619,7 +4612,7 @@ MODEL (
   cursor activity_hour,
   cursor_type timestamp,
   cursor_grain hour,
-  cursor_filter_inputs (
+  cursor_inputs (
     fact_orders ordered_at,
   ),
 );
@@ -4634,15 +4627,14 @@ WHERE ordered_at >= __cursor_start()
 
 In microbatch mode, the intrinsics resolve to each batch's concrete bounds. A microbatch full refresh discovers its range from current inputs while ignoring the old destination watermark.
 
-##### Filtering and watermark membership are independent
+##### Listed inputs bound the window; unlisted inputs do not
 
-`cursor_filter_inputs` exclusively controls which direct model reads receive cursor predicates. `cursor_watermark_inputs` exclusively controls which authoritative upstream relations bound the replay window; when omitted, it defaults to `cursor_filter_inputs`.
+Only the inputs you list in `cursor_inputs` bound the replay window. This is an explicit choice, and it has two consequences worth understanding:
 
-- A relation listed only in `cursor_filter_inputs` is filtered but does not determine availability when explicit watermark inputs are configured.
-- A relation listed only in `cursor_watermark_inputs` determines availability but is not added to model SQL and does not receive a predicate.
-- A direct input absent from `cursor_filter_inputs` is read without an automatic cursor predicate, regardless of watermark membership.
+- **Listed inputs** drive the window. Their new data advances the `MAX`, which is what tells SQLBuild how far to reprocess and which rows of the target to rewrite.
+- **Unlisted inputs are read in full.** SQLBuild does not add a cursor filter to them, and they do not bound the window. This is correct for lookup or dimension tables that have no meaningful cursor column: you do not list them, and SQLBuild reads them whole rather than trying to filter on a column that may not exist.
 
-For `delete_insert` and `merge`, target rows are rewritten within the window derived from watermark inputs. Configure filter membership according to which direct reads need that window, and watermark membership according to which upstream relations authoritatively prove that the window is available.
+The implication for `delete_insert` and `merge`: the target rows that get rewritten are the ones whose cursor falls inside the window derived from the listed inputs. If an unlisted input changes in a way that should affect target rows outside that window, those rows are not rewritten on a normal incremental run. List every input whose new data should drive reprocessing; leave unlisted only the inputs you intend to read in full.
 
 To capture changes that fall outside the normal forward window, see [Lookback](#lookback) for late-arriving data and [Replay on change](#replay-on-change) for model changes.
 
@@ -4674,7 +4666,7 @@ MODEL (
   cursor activity_hour,
   cursor_type timestamp,
   cursor_grain hour,
-  cursor_filter_inputs (
+  cursor_inputs (
     fact_orders ordered_at,
   ),
   incremental_mode microbatch,
@@ -4702,7 +4694,7 @@ MODEL (
   cursor activity_day,
   cursor_type timestamp,
   cursor_grain day,
-  cursor_filter_inputs (
+  cursor_inputs (
     hourly_order_activity activity_hour,
   ),
   incremental_mode microbatch,
@@ -4716,7 +4708,7 @@ MODEL (
   cursor activity_hour,
   cursor_type timestamp,
   cursor_grain hour,
-  cursor_filter_inputs (
+  cursor_inputs (
     daily_activity_rollup activity_day,
   ),
   incremental_mode microbatch,
@@ -11761,7 +11753,7 @@ sqb --project-dir <path> compile [flags]
 When SQL analysis is enabled (default), compile performs static analysis on your models without connecting to the warehouse:
 
 - **Column inference**: Infers output columns from each model's SQL, including through CTEs, subqueries, and JOINs
-- **Column contract validation**: If a model declares columns in its `MODEL()` header, compile checks that every declared column exists in the query output. If a column declares a type and `type_enforcement` is enabled, compile also verifies the inferred type matches the declared type
+- **Column contract validation**: Under the default `settings.column_contract_mode = "implicit"`, a model with declared columns and no model-level `contract` declaration checks that every declared column exists in the statically inferred query output. `explicit` mode requires `contract enforced` to activate shape checks. Explicit type enforcement remains independent and verifies inferred types when possible
 - **Column lineage**: Traces which source columns flow into each output column, including transform classification. See [Column Lineage](/concepts/column-lineage) for details
 
 `sqb compile` checks SQL correctness, contracts, and lineage. [`sqb kata`](/cli/kata) compiles the
@@ -11773,13 +11765,15 @@ automatically by `compile`.
 When a contract violation is found, compile reports it with source-annotated diagnostics:
 
 ```
-error[K001]: required column 'total_cents' missing from model output
+error[K001]: declared column 'total_cents' was not found in statically inferred output for model 'fact_orders'
   model: fact_orders
-  --> models/marts/fact_orders.sql:5:3
-  5 | SELECT order_id, customer_id
-    |        ^^^^^^^^
-  = help: add total_cents to the SELECT list or remove it from MODEL(columns)
+  --> models/marts/fact_orders.sql:6:5
+  6 |     total_cents (),
+    |     ^^^^^^^^^^^
+  = help: add total_cents to the SELECT list or correct/remove MODEL(columns (...)); MODEL(columns (...)) is validated using static SQL analysis because settings.column_contract_mode is "implicit" (the default). If this project intentionally uses columns only for metadata and audits, set [settings] column_contract_mode = "explicit"; models with contract enforced remain validated
 ```
+
+The configuration guidance is an intentional project-policy choice, not a general error suppression. Fix the query or declaration when the model is intended to have a column contract. Diagnostics for `contract enforced` models do not recommend changing the project mode because explicit model contracts remain authoritative.
 
 Diagnostic codes:
 

--- a/src/sqlbuild/compiler/contracts/_helpers/columns.py
+++ b/src/sqlbuild/compiler/contracts/_helpers/columns.py
@@ -32,6 +32,7 @@ _MISSING_DECLARATIONS_CODE: str = "K006"
 def collect_model_column_contract_diagnostics(
     *,
     model: CompiledModel,
+    validate_declared_shape: bool,
     dialect: TypeDialect | str | None = None,
 ) -> tuple[CompilerDiagnostic, ...]:
     """Collect diagnostics for one compiled model's declared column contract."""
@@ -54,16 +55,29 @@ def collect_model_column_contract_diagnostics(
     for declared_column in model.schema_entry.columns:
         inferred_column: InferredColumn | None = inferred_by_name.get(declared_column.name)
         if inferred_column is None:
-            diagnostics.append(_missing_column_diagnostic(model=model, column=declared_column))
+            if validate_declared_shape:
+                diagnostics.append(
+                    _missing_column_diagnostic(
+                        model=model,
+                        column=declared_column,
+                        contract_enforced=contract_enforced,
+                    )
+                )
             continue
-        diagnostics.extend(
-            _nullability_diagnostics(
-                model=model,
-                declared_column=declared_column,
-                inferred_column=inferred_column,
+        if validate_declared_shape:
+            diagnostics.extend(
+                _nullability_diagnostics(
+                    model=model,
+                    declared_column=declared_column,
+                    inferred_column=inferred_column,
+                )
             )
-        )
         if declared_column.type is None:
+            continue
+        type_enforcement: bool = model.schema_entry is not None and bool(
+            model.schema_entry.type_enforcement
+        )
+        if not validate_declared_shape and not type_enforcement:
             continue
         diagnostics.extend(
             _type_diagnostics(
@@ -160,22 +174,45 @@ def _declares_not_null(column: SchemaColumn) -> bool:
     return any(audit.definition_name == NOT_NULL_AUDIT_NAME for audit in column.audits)
 
 
-def _missing_column_diagnostic(*, model: CompiledModel, column: SchemaColumn) -> CompilerDiagnostic:
+def _missing_column_diagnostic(
+    *, model: CompiledModel, column: SchemaColumn, contract_enforced: bool
+) -> CompilerDiagnostic:
+    contract_label: str = "enforced contract column" if contract_enforced else "declared column"
+    declared_in_named_schema: bool = (
+        model.schema_entry is not None
+        and model.schema_entry.model_schema is not None
+        and column.location is not None
+        and column.location.path != model.relative_path
+    )
+    declaration_label: str = (
+        "the named SCHEMA declaration" if declared_in_named_schema else "MODEL(columns (...))"
+    )
+    help_text: str = (
+        f"add {column.name} to the SELECT list or correct {declaration_label}; "
+        "validation is active because this model declares contract enforced"
+        if contract_enforced
+        else (
+            f"add {column.name} to the SELECT list or correct/remove {declaration_label}; "
+            f"{declaration_label} is validated using static SQL analysis because "
+            'settings.column_contract_mode is "implicit" (the default). If this project '
+            "intentionally uses columns only for metadata and audits, set [settings] "
+            'column_contract_mode = "explicit"; models with contract enforced remain validated'
+        )
+    )
     return CompilerDiagnostic(
         phase=DiagnosticPhase.CONTRACT,
         severity=DiagnosticSeverity.ERROR,
         code=_MISSING_COLUMN_CODE,
-        message=f"required column '{column.name}' missing from model output",
+        message=(
+            f"{contract_label} '{column.name}' was not found in statically inferred output "
+            f"for model '{model.name}'"
+        ),
         resource_type=CompiledResourceType.MODEL,
         resource_name=model.name,
         column_name=column.name,
         path=model.relative_path,
         location=column.location,
-        help=(
-            f"add {column.name} to the SELECT list or remove it from the named SCHEMA"
-            if model.schema_entry is not None and model.schema_entry.model_schema is not None
-            else f"add {column.name} to the SELECT list or remove it from MODEL(columns)"
-        ),
+        help=help_text,
     )
 
 
@@ -219,7 +256,7 @@ def _type_diagnostics(
                     column_name=declared_column.name,
                     message="output expression with unproven type",
                 ),
-                help="add an explicit CAST if this contract should be checked statically",
+                help="add an explicit CAST if this declared type should be checked statically",
             ),
         )
 
@@ -235,7 +272,7 @@ def _type_diagnostics(
             code=_TYPE_MISMATCH_CODE,
             message=(
                 f"column '{declared_column.name}' inferred as {inferred_column.type} "
-                f"but contract declares {declared_type}"
+                f"but declared type is {declared_type}"
             ),
             resource_type=CompiledResourceType.MODEL,
             resource_name=model.name,

--- a/src/sqlbuild/compiler/contracts/main/validate.py
+++ b/src/sqlbuild/compiler/contracts/main/validate.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from sqlbuild.adapter.contract.types import TypeDialect
-from sqlbuild.compiler.compile.models import CompiledProject, CompilerDiagnostic
+from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject, CompilerDiagnostic
 from sqlbuild.compiler.contracts._helpers.columns import collect_model_column_contract_diagnostics
 from sqlbuild.compiler.contracts.models import ContractValidationResult
 from sqlbuild.compiler.planner.types import ContractPolicy
+from sqlbuild.spec.contracts.types import ColumnContractMode
 
 
 def evaluate_model_contracts(
@@ -17,13 +18,39 @@ def evaluate_model_contracts(
     """Evaluate model header column contracts against inferred output columns."""
 
     if not any(
-        model.config.values.get("contract") == ContractPolicy.ENFORCED
-        or (model.schema_entry is not None and model.schema_entry.columns)
+        _requires_contract_evaluation(model=model, mode=project.settings.column_contract_mode)
         for model in project.models
     ):
         return ContractValidationResult(diagnostics=())
 
     diagnostics: list[CompilerDiagnostic] = []
     for model in project.models:
-        diagnostics.extend(collect_model_column_contract_diagnostics(model=model, dialect=dialect))
+        if _requires_contract_evaluation(model=model, mode=project.settings.column_contract_mode):
+            diagnostics.extend(
+                collect_model_column_contract_diagnostics(
+                    model=model,
+                    validate_declared_shape=_declared_shape_validation_is_active(
+                        model=model,
+                        mode=project.settings.column_contract_mode,
+                    ),
+                    dialect=dialect,
+                )
+            )
     return ContractValidationResult(diagnostics=tuple(diagnostics))
+
+
+def _requires_contract_evaluation(*, model: CompiledModel, mode: ColumnContractMode) -> bool:
+    if _declared_shape_validation_is_active(model=model, mode=mode):
+        return True
+    return model.schema_entry is not None and bool(model.schema_entry.type_enforcement)
+
+
+def _declared_shape_validation_is_active(*, model: CompiledModel, mode: ColumnContractMode) -> bool:
+    contract: object = model.config.values.get("contract")
+    if contract == ContractPolicy.ENFORCED:
+        return True
+    if contract == ContractPolicy.NONE:
+        return False
+    return mode == ColumnContractMode.IMPLICIT and bool(
+        model.schema_entry is not None and model.schema_entry.columns
+    )

--- a/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
@@ -65,6 +65,7 @@ from sqlbuild.spec.contracts.models import (
     TargetConfig,
 )
 from sqlbuild.spec.contracts.types import (
+    ColumnContractMode,
     FutureCursorAction,
     MicrobatchLimitAction,
     TableType,
@@ -322,6 +323,15 @@ def _load_settings(*, payload: object, file_path: Path) -> SettingsConfig:
         default=True,
     )
     sql_validation: bool = _optional_bool(mapping=mapping, key="sql_validation", default=True)
+    raw_column_contract_mode: object = mapping.get(
+        "column_contract_mode", ColumnContractMode.IMPLICIT.value
+    )
+    try:
+        column_contract_mode: ColumnContractMode = ColumnContractMode(raw_column_contract_mode)
+    except (TypeError, ValueError) as error:
+        raise ProjectConfigError(
+            "settings.column_contract_mode must be one of: implicit, explicit"
+        ) from error
     auto_load_sources: bool = _optional_bool(mapping=mapping, key="auto_load_sources", default=True)
     virtual_environments: bool = _optional_bool(
         mapping=mapping,
@@ -361,6 +371,7 @@ def _load_settings(*, payload: object, file_path: Path) -> SettingsConfig:
         sql_analysis=sql_analysis,
         query_change_tracking=query_change_tracking,
         sql_validation=sql_validation,
+        column_contract_mode=column_contract_mode,
         concurrency=concurrency,
         auto_load_sources=auto_load_sources,
         changes_only=changes_only,

--- a/src/sqlbuild/spec/contracts/models.py
+++ b/src/sqlbuild/spec/contracts/models.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from sqlbuild.cost.constants import DEFAULT_USD_PER_CREDIT
 from sqlbuild.spec.contracts.types import (
+    ColumnContractMode,
     FutureCursorAction,
     MicrobatchLimitAction,
     SourceFreshnessStrategy,
@@ -159,6 +160,7 @@ class SettingsConfig:
     sql_analysis: bool = True
     query_change_tracking: bool = True
     sql_validation: bool = True
+    column_contract_mode: ColumnContractMode = ColumnContractMode.IMPLICIT
     concurrency: int = 1
     auto_load_sources: bool = True
     changes_only: bool = False

--- a/src/sqlbuild/spec/contracts/types.py
+++ b/src/sqlbuild/spec/contracts/types.py
@@ -28,6 +28,13 @@ class MicrobatchLimitAction(StrEnum):
     WARN = "warn"
 
 
+class ColumnContractMode(StrEnum):
+    """Default contract behavior for model column declarations."""
+
+    IMPLICIT = "implicit"
+    EXPLICIT = "explicit"
+
+
 class SourceFreshnessStrategy(StrEnum):
     ADAPTER = "adapter"
     COLUMN = "column"

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/_test_types.py
@@ -22,6 +22,14 @@ class CompileCommandTestCase:
 
 
 @dataclass(frozen=True)
+class CompileColumnContractModeTestCase:
+    description: str
+    mode: str
+    expected_audit_name: str
+    expected_column_name: str
+
+
+@dataclass(frozen=True)
 class CompileDagArtifactTestCase:
     description: str
     dag_path: str

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_command.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_command.py
@@ -15,6 +15,7 @@ from sqlbuild.cli.commands.types import CompileLineageMode
 from sqlbuild.compiler.lineage.types import ColumnLineageMode
 from sqlbuild.compiler.pipeline.models import ProjectGraph
 from tests.unit.src.sqlbuild.cli.commands.main.compile._test_types import (
+    CompileColumnContractModeTestCase,
     CompileCommandTestCase,
     CompileDagArtifactTestCase,
     CompileJsonDiagnosticsTestCase,
@@ -260,12 +261,14 @@ def test_given_python_project_dag_flag_when_running_compile_then_writes_python_d
             expected_stdout_fragments=(
                 "Compile ready  1 model",
                 "orders                   FAIL 1 columns",
-                "error[K001]: required column 'customer_id' missing from model output",
+                "error[K001]: declared column 'customer_id' was not found in statically inferred output",
                 "  model: orders",
                 "  --> models/orders.sql:5:5",
                 "  5 |     customer_id (),",
                 "    |     ^^^^^^^^^^^",
-                "  = help: add customer_id to the SELECT list or remove it from MODEL(columns)",
+                'settings.column_contract_mode is "implicit" (the default)',
+                'column_contract_mode = "explicit"',
+                "models with contract enforced remain validated",
                 "\u2717 Project compiled  1 model, 0 seeds, 0 functions, 1 error, 0 warnings",
                 "  Wrote: target/compiled/",
             ),
@@ -284,7 +287,7 @@ def test_given_python_project_dag_flag_when_running_compile_then_writes_python_d
             description="reports contract and output locations for type diagnostics",
             expected_exit_code=1,
             expected_stdout_fragments=(
-                "error[K002]: column 'amount_cents' inferred as TEXT but contract declares INTEGER",
+                "error[K002]: column 'amount_cents' inferred as TEXT but declared type is INTEGER",
                 "  --> models/orders.sql:4:5",
                 "  4 |     amount_cents (type INTEGER),",
                 "    |     ^^^^^^^^^^^^",
@@ -370,7 +373,10 @@ def test_given_contract_errors_when_running_compile_then_reports_diagnostics(
             expected_exit_code=1,
             expected_code="K001",
             expected_severity="error",
-            expected_message="required column 'customer_id' missing from model output",
+            expected_message=(
+                "declared column 'customer_id' was not found in statically inferred output "
+                "for model 'orders'"
+            ),
             expected_line=5,
             expected_column=5,
             model_sql=(
@@ -431,6 +437,59 @@ def test_given_contract_errors_when_running_compile_json_then_serializes_diagnos
         "end_column": 16,
     }
     assert diagnostics[0]["phase"] == "contract"
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        CompileColumnContractModeTestCase(
+            description="explicit mode retains column audit",
+            mode="explicit",
+            expected_audit_name="not_null",
+            expected_column_name="customer_id",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_explicit_column_contract_mode_when_compiling_column_audit_then_audit_is_retained_without_contract_error(
+    test_case: CompileColumnContractModeTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir: Path = prepare_static_compile_project(tmp_path)
+    project_config_path: Path = project_dir / "sqlbuild_project.toml"
+    project_config_path.write_text(
+        project_config_path.read_text(encoding="utf-8")
+        + f'\n[settings]\ncolumn_contract_mode = "{test_case.mode}"\n',
+        encoding="utf-8",
+    )
+    (project_dir / "models" / "orders.sql").write_text(
+        "MODEL (\n"
+        "  materialized view,\n"
+        "  columns (\n"
+        "    customer_id (audits [not_null]),\n"
+        "  ),\n"
+        ");\n\n"
+        "SELECT 1 AS order_id\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        compile_pipeline,
+        "resolve_adapter",
+        lambda *args, **kwargs: NoConnectDuckDbAdapter(),
+    )
+
+    exit_code: int = run_compile(
+        CompileCommandRequest(project_dir=project_dir, no_sql_validation=True, dag_path="")
+    )
+    dag_payload: dict[str, object] = json.loads(
+        (project_dir / "target" / "sqlbuild_dag.json").read_text(encoding="utf-8")
+    )
+
+    assert exit_code == 0
+    assert len(dag_payload["checks"]) == 1
+    assert dag_payload["checks"][0]["name"] == test_case.expected_audit_name
+    assert dag_payload["checks"][0]["attached_column_name"] == test_case.expected_column_name
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
@@ -273,7 +273,8 @@ class ModelSchemaContractDiagnosticTestCase:
     description: str
     contract: str
     projection: str
-    expected_code: str
+    expected_codes: tuple[str, ...]
+    expected_help_fragment: str
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_model_schemas.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_model_schemas.py
@@ -260,10 +260,11 @@ SELECT
     "test_case",
     [
         ModelSchemaContractDiagnosticTestCase(
-            description="superset contract requires model-local declared columns",
+            description="contract none treats named columns as metadata",
             contract="none",
             projection="1::INTEGER AS order_id, 'OPEN'::VARCHAR AS status",
-            expected_code="K001",
+            expected_codes=(),
+            expected_help_fragment="",
         ),
         ModelSchemaContractDiagnosticTestCase(
             description="exact contract rejects additional output columns",
@@ -272,7 +273,8 @@ SELECT
                 "1::INTEGER AS order_id, 'OPEN'::VARCHAR AS status, "
                 "'declared'::VARCHAR AS local_note, 1 AS extra_column"
             ),
-            expected_code="K005",
+            expected_codes=("K005",),
+            expected_help_fragment="named SCHEMA",
         ),
     ],
     ids=lambda case: case.description,
@@ -318,8 +320,10 @@ SELECT {test_case.projection}
     diagnostics: tuple[CompilerDiagnostic, ...] = evaluate_model_contracts(
         project=project, dialect="duckdb"
     ).diagnostics
-    assert tuple(diagnostic.code for diagnostic in diagnostics) == (test_case.expected_code,)
-    assert "named SCHEMA" in (diagnostics[0].help or "")
+    assert tuple(diagnostic.code for diagnostic in diagnostics) == test_case.expected_codes
+    assert test_case.expected_help_fragment in " ".join(
+        diagnostic.help or "" for diagnostic in diagnostics
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/contracts/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/contracts/_test_types.py
@@ -16,6 +16,7 @@ class ContractValidationTestCase:
     expected_severities: tuple[str, ...]
     expected_messages: tuple[str, ...]
     contract: str | None = None
+    column_contract_mode: str = "implicit"
     declared_not_null_columns: tuple[str, ...] = ()
     declared_nullable_by_column: dict[str, bool | None] | None = None
     inferred_nullability_by_column: dict[str, InferredNullability] | None = None

--- a/tests/unit/src/sqlbuild/compiler/contracts/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/contracts/helpers.py
@@ -17,8 +17,10 @@ from sqlbuild.spec.contracts.models import (
     SchemaAuditInstance,
     SchemaColumn,
     SchemaModelEntry,
+    SettingsConfig,
     SourceLocation,
 )
+from sqlbuild.spec.contracts.types import ColumnContractMode
 
 
 def make_contract_project(
@@ -27,6 +29,7 @@ def make_contract_project(
     inferred_columns: tuple[tuple[str, str | None], ...] | None,
     type_enforcement: bool | None,
     contract: str | None = None,
+    column_contract_mode: str = "implicit",
     model_name: str = "orders",
     column_locations: dict[str, SourceLocation] | None = None,
     declared_not_null_columns: tuple[str, ...] = (),
@@ -44,6 +47,7 @@ def make_contract_project(
         effective_target_name="dev",
         effective_connection={},
         effective_vars={},
+        settings=SettingsConfig(column_contract_mode=ColumnContractMode(column_contract_mode)),
         models=(
             CompiledModel(
                 key=key,

--- a/tests/unit/src/sqlbuild/compiler/contracts/test_validate.py
+++ b/tests/unit/src/sqlbuild/compiler/contracts/test_validate.py
@@ -36,7 +36,68 @@ from tests.unit.src.sqlbuild.compiler.contracts.helpers import make_contract_pro
             type_enforcement=None,
             expected_codes=("K001",),
             expected_severities=("error",),
-            expected_messages=("required column 'customer_id' missing from model output",),
+            expected_messages=(
+                "declared column 'customer_id' was not found in statically inferred output "
+                "for model 'orders'",
+            ),
+        ),
+        ContractValidationTestCase(
+            description="explicit mode treats unspecified columns as metadata",
+            declared_columns=(("customer_id", None),),
+            inferred_columns=(("order_id", None),),
+            type_enforcement=None,
+            column_contract_mode="explicit",
+            expected_codes=(),
+            expected_severities=(),
+            expected_messages=(),
+        ),
+        ContractValidationTestCase(
+            description="contract none overrides implicit mode",
+            declared_columns=(("customer_id", None),),
+            inferred_columns=(("order_id", None),),
+            type_enforcement=None,
+            contract="none",
+            expected_codes=(),
+            expected_severities=(),
+            expected_messages=(),
+        ),
+        ContractValidationTestCase(
+            description="enforced contract overrides explicit mode",
+            declared_columns=(("customer_id", None),),
+            inferred_columns=(),
+            type_enforcement=None,
+            contract="enforced",
+            column_contract_mode="explicit",
+            expected_codes=("K001",),
+            expected_severities=("error",),
+            expected_messages=(
+                "enforced contract column 'customer_id' was not found in statically inferred "
+                "output for model 'orders'",
+            ),
+        ),
+        ContractValidationTestCase(
+            description="type enforcement remains active in explicit mode",
+            declared_columns=(("amount_cents", "INTEGER"),),
+            inferred_columns=(("amount_cents", "VARCHAR"),),
+            type_enforcement=True,
+            column_contract_mode="explicit",
+            expected_codes=("K002",),
+            expected_severities=("error",),
+            expected_messages=(
+                "column 'amount_cents' inferred as VARCHAR but declared type is INTEGER",
+            ),
+        ),
+        ContractValidationTestCase(
+            description="type enforcement remains active with contract none",
+            declared_columns=(("amount_cents", "INTEGER"),),
+            inferred_columns=(("amount_cents", "VARCHAR"),),
+            type_enforcement=True,
+            contract="none",
+            expected_codes=("K002",),
+            expected_severities=("error",),
+            expected_messages=(
+                "column 'amount_cents' inferred as VARCHAR but declared type is INTEGER",
+            ),
         ),
         ContractValidationTestCase(
             description="declared typed column matches inferred type",
@@ -55,7 +116,7 @@ from tests.unit.src.sqlbuild.compiler.contracts.helpers import make_contract_pro
             expected_codes=("K002",),
             expected_severities=("error",),
             expected_messages=(
-                "column 'amount_cents' inferred as VARCHAR but contract declares INTEGER",
+                "column 'amount_cents' inferred as VARCHAR but declared type is INTEGER",
             ),
         ),
         ContractValidationTestCase(
@@ -66,7 +127,7 @@ from tests.unit.src.sqlbuild.compiler.contracts.helpers import make_contract_pro
             expected_codes=("K002",),
             expected_severities=("warning",),
             expected_messages=(
-                "column 'amount_cents' inferred as VARCHAR but contract declares INTEGER",
+                "column 'amount_cents' inferred as VARCHAR but declared type is INTEGER",
             ),
         ),
         ContractValidationTestCase(
@@ -129,7 +190,7 @@ from tests.unit.src.sqlbuild.compiler.contracts.helpers import make_contract_pro
             expected_codes=("K002",),
             expected_severities=("error",),
             expected_messages=(
-                "column 'amount_cents' inferred as VARCHAR but contract declares INTEGER",
+                "column 'amount_cents' inferred as VARCHAR but declared type is INTEGER",
             ),
         ),
         ContractValidationTestCase(
@@ -191,6 +252,7 @@ def test_given_compiled_project_when_validating_contracts_then_returns_expected_
             declared_nullable_by_column=test_case.declared_nullable_by_column,
             inferred_nullability_by_column=test_case.inferred_nullability_by_column,
             contract=test_case.contract,
+            column_contract_mode=test_case.column_contract_mode,
         ),
         dialect=TypeDialect.DUCKDB,
     )

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
@@ -44,6 +44,20 @@ class MicrobatchLimitConfigErrorTestCase:
 
 
 @dataclass(frozen=True)
+class ColumnContractModeConfigTestCase:
+    description: str
+    settings_toml: str
+    expected_mode: str
+
+
+@dataclass(frozen=True)
+class ColumnContractModeConfigErrorTestCase:
+    description: str
+    settings_toml: str
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
 class DiscoverMacroFilesTestCase:
     description: str
     files: dict[str, str]

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
@@ -13,6 +13,8 @@ from sqlbuild.compiler.discovery.exceptions import ProjectConfigError
 from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig
 from sqlbuild.sql_values.types import CollectionRendering
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
+    ColumnContractModeConfigErrorTestCase,
+    ColumnContractModeConfigTestCase,
     FutureCursorConfigErrorTestCase,
     FutureCursorConfigTestCase,
     LoadLocalConfigErrorTestCase,
@@ -1609,3 +1611,49 @@ def test_given_legacy_local_config_file_when_loading_local_config_then_it_raises
 
     with pytest.raises(ValueError, match=test_case.expected_error_fragment):
         load_local_config(project_dir=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ColumnContractModeConfigTestCase("omitted mode uses implicit default", "", "implicit"),
+        ColumnContractModeConfigTestCase(
+            "explicit mode is accepted", 'column_contract_mode = "explicit"', "explicit"
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_column_contract_mode_when_loading_project_then_policy_is_typed(
+    test_case: ColumnContractModeConfigTestCase, tmp_path: Path
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        f'name = "demo"\nadapter = "duckdb"\n[settings]\n{test_case.settings_toml}\n',
+        encoding="utf-8",
+    )
+
+    config: ProjectConfig = load_project_config(project_dir=tmp_path)
+
+    assert config.settings.column_contract_mode == test_case.expected_mode
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ColumnContractModeConfigErrorTestCase(
+            "unsupported mode is rejected",
+            'column_contract_mode = "disabled"',
+            "settings.column_contract_mode must be one of: implicit, explicit",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_invalid_column_contract_mode_when_loading_project_then_error_is_raised(
+    test_case: ColumnContractModeConfigErrorTestCase, tmp_path: Path
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        f'name = "demo"\nadapter = "duckdb"\n[settings]\n{test_case.settings_toml}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ProjectConfigError, match=test_case.expected_error_fragment):
+        load_project_config(project_dir=tmp_path)


### PR DESCRIPTION
## Why

`MODEL(columns (...))` currently activates static shape and nullability validation even when a project uses those declarations only for metadata and native column audits. That forces migrations with incomplete SQL inference into verbose model-level generic audits. The policy also needs to remain distinct from independent type enforcement and explicit exact contracts.

## Changes

- Add `settings.column_contract_mode = "implicit" | "explicit"`, defaulting to backward-compatible `implicit` behavior.
- Make `contract enforced` and `contract none` authoritative model-level overrides.
- Preserve explicit type enforcement and column audit attachment in explicit mode.
- Improve K001 diagnostics to explain static inference, the effective default, intentional migration configuration, and enforced-contract precedence.
- Distinguish reusable `SCHEMA` declarations from model-local columns in remediation.
- Update the bundled SQLBuild agent skill from merged canonical docs.

## Verification

- 141 focused contract, configuration, model-schema, CLI, and audit-attachment tests passed.
- 12 bundled documentation-skill tests passed.
- `uv sync --all-extras` and `make check-ci` passed.
- Ruff, formatting, `ty`, Fensu, and `git diff --check` passed.
- Focused review completed with no findings.
