### PR TITLE
fix: scope Dagster check-only execution

### DIFF
--- a/src/sqlbuild/integrations/dagster/_helpers/invocation.py
+++ b/src/sqlbuild/integrations/dagster/_helpers/invocation.py
@@ -11,6 +11,7 @@ from typing import IO, TYPE_CHECKING, Any, TextIO
 
 from sqlbuild.integrations.dagster.constants import (
     ASSET_SELECTION_COMMANDS,
+    CHECK_COMMAND,
     CHECK_METADATA_EXCLUDED_KEYS,
     CHECK_NAME_SEPARATOR_CHARACTER,
     CLONE_ASSET_EVENT,
@@ -88,10 +89,27 @@ def _with_selected_asset_args(
         return args, (), None
     if not EXPLICIT_SELECTION_FLAGS.isdisjoint(args):
         return args, (), None
-    selected_keys: object = getattr(context, "selected_asset_keys", None)
-    if selected_keys is None:
+    selected_paths: set[tuple[str, ...]] = _selected_asset_paths(context=context)
+    selected_check_keys: set[tuple[tuple[str, ...], str]] = _selected_asset_check_keys(
+        context=context
+    )
+    if args[0] == CHECK_COMMAND and selected_check_keys:
+        check_selectors: tuple[str, ...] = _selected_check_selectors(
+            dag=dag, selected_check_keys=selected_check_keys
+        )
+        if check_selectors:
+            selector_file: Path = _write_selector_file(check_selectors)
+            return (
+                (*args, SELECT_FILE_FLAG, str(selector_file)),
+                check_selectors,
+                selector_file,
+            )
+    if selected_check_keys:
+        selected_paths.update(
+            _selected_check_asset_paths(dag=dag, selected_check_keys=selected_check_keys)
+        )
+    if not selected_paths:
         return args, (), None
-    selected_paths: set[tuple[str, ...]] = {tuple(key.path) for key in selected_keys}
     selectors: list[str] = []
     for node in _sort_nodes_topologically(dag=dag):
         if tuple(str(part) for part in node["asset_key"]) not in selected_paths:
@@ -140,7 +158,7 @@ def _with_selected_scenario_args(
         ):
             continue
         check_name: str = _dagster_check_name(check)
-        if selected_check_keys and not _scenario_check_is_selected(
+        if selected_check_keys and not _check_is_selected(
             check=check,
             check_name=check_name,
             nodes_by_id=nodes_by_id,
@@ -170,7 +188,7 @@ def _has_explicit_scenario_selector(*, args: tuple[str, ...]) -> bool:
     return False
 
 
-def _scenario_check_is_selected(
+def _check_is_selected(
     *,
     check: Mapping[str, Any],
     check_name: str,
@@ -454,6 +472,10 @@ def _build_results_from_execution_payload(
         )
     check: Mapping[str, Any]
     seen_check_outputs: set[tuple[tuple[str, ...], str]] = set()
+    selected_check_keys: set[tuple[tuple[str, ...], str]] = _selected_asset_check_keys(
+        context=context
+    )
+    check_selection_is_explicit: bool = _check_selection_is_explicit(context=context)
     for check in payload.get("checks", ()):  # type: ignore[assignment]
         check_results, seen_check_outputs = _build_check_results_from_execution_check(
             dg=dg,
@@ -462,6 +484,8 @@ def _build_results_from_execution_payload(
             nodes_by_name=nodes_by_name,
             check=check,
             selected_paths=selected_paths,
+            selected_check_keys=selected_check_keys,
+            check_selection_is_explicit=check_selection_is_explicit,
             seen_check_outputs=seen_check_outputs,
         )
         results.extend(check_results)
@@ -478,6 +502,8 @@ def _build_check_results_from_execution_check(
     nodes_by_name: Mapping[tuple[str, str], Mapping[str, Any]],
     check: Mapping[str, Any],
     selected_paths: set[tuple[str, ...]],
+    selected_check_keys: set[tuple[tuple[str, ...], str]],
+    check_selection_is_explicit: bool,
     seen_check_outputs: set[tuple[tuple[str, ...], str]],
 ) -> tuple[tuple[Any, ...], set[tuple[tuple[str, ...], str]]]:
     dag_check: Mapping[str, Any] | None = _dag_check_for_execution_check(dag=dag, check=check)
@@ -496,9 +522,15 @@ def _build_check_results_from_execution_check(
         if node is None:
             continue
         asset_key: Any = dg.AssetKey([str(part) for part in node["asset_key"]])
-        if selected_paths and tuple(asset_key.path) not in selected_paths:
-            continue
         output_key: tuple[tuple[str, ...], str] = (tuple(asset_key.path), check_name)
+        if check_selection_is_explicit and output_key not in selected_check_keys:
+            continue
+        if (
+            not check_selection_is_explicit
+            and selected_paths
+            and output_key[0] not in selected_paths
+        ):
+            continue
         if output_key in seen_check_outputs:
             continue
         seen_check_outputs.add(output_key)
@@ -566,6 +598,55 @@ def _selected_asset_check_keys(*, context: Any) -> set[tuple[tuple[str, ...], st
             continue
         check_keys.add((tuple(str(part) for part in path), str(check_name)))
     return check_keys
+
+
+def _check_selection_is_explicit(*, context: Any) -> bool:
+    return context is not None and getattr(context, "selected_asset_check_keys", None) is not None
+
+
+def _selected_check_asset_paths(
+    *,
+    dag: Mapping[str, Any],
+    selected_check_keys: set[tuple[tuple[str, ...], str]],
+) -> set[tuple[str, ...]]:
+    nodes_by_id: dict[str, Mapping[str, Any]] = {
+        str(node.get("id")): node for node in dag.get("nodes", ())
+    }
+    paths: set[tuple[str, ...]] = set()
+    for check in dag.get("checks", ()):  # type: ignore[assignment]
+        check_name: str = _dagster_check_name(check)
+        if not _check_is_selected(
+            check=check,
+            check_name=check_name,
+            nodes_by_id=nodes_by_id,
+            selected_check_keys=selected_check_keys,
+        ):
+            continue
+        for asset_id in check.get("checked_asset_ids", ()):
+            node: Mapping[str, Any] | None = nodes_by_id.get(str(asset_id))
+            if node is None:
+                continue
+            asset_path: tuple[str, ...] = tuple(str(part) for part in node.get("asset_key", ()))
+            paths.add(asset_path)
+    return paths
+
+
+def _selected_check_selectors(
+    *, dag: Mapping[str, Any], selected_check_keys: set[tuple[tuple[str, ...], str]]
+) -> tuple[str, ...]:
+    nodes_by_id: dict[str, Mapping[str, Any]] = {
+        str(node.get("id")): node for node in dag.get("nodes", ())
+    }
+    selectors: list[str] = []
+    for check in dag.get("checks", ()):  # type: ignore[assignment]
+        if _check_is_selected(
+            check=check,
+            check_name=_dagster_check_name(check),
+            nodes_by_id=nodes_by_id,
+            selected_check_keys=selected_check_keys,
+        ):
+            selectors.append(str(check.get("name")))
+    return tuple(dict.fromkeys(selectors))
 
 
 def _asset_check_only_context(*, context: Any) -> bool:

--- a/src/sqlbuild/integrations/dagster/constants.py
+++ b/src/sqlbuild/integrations/dagster/constants.py
@@ -19,6 +19,7 @@ ASSET_SELECTION_COMMANDS: frozenset[str] = frozenset(
 CLONE_COMMAND: str = "clone"
 CLONE_ASSET_EVENT: str = "asset"
 CHECK_EVENT: str = "check"
+CHECK_COMMAND: str = "check"
 EVENT_OUTPUT_FLAG: str = "--event-output"
 LIVE_EVENT_COMMANDS: frozenset[str] = ASSET_SELECTION_COMMANDS
 VIRTUAL_ENV_FLAG: str = "--virtual-env"

--- a/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
@@ -99,6 +99,8 @@ class DagsterCliJsonStreamTestCase:
     expected_asset_keys: tuple[tuple[str, ...], ...]
     expected_check_names: tuple[str, ...]
     expected_check_severities: tuple[str, ...]
+    selected_check_keys: tuple[tuple[tuple[str, ...], str], ...] = ()
+    check_selection_is_explicit: bool = False
 
 
 @dataclass(frozen=True)
@@ -164,6 +166,7 @@ class DagsterCliSelectionTestCase:
     command_args: tuple[str, ...]
     expected_selectors: tuple[str, ...]
     assert_selector_transport: Callable[..., None]
+    selected_check_keys: tuple[tuple[tuple[str, ...], str], ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/integrations/dagster/helpers.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/helpers.py
@@ -400,6 +400,13 @@ def write_dagster_test_dag(*, root: Path) -> Path:
     return dag_path
 
 
+def write_python_augmented_dagster_test_dag(*, root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    dag_path: Path = root / "sqlbuild_dag.json"
+    dag_path.write_text(json.dumps(build_python_augmented_dagster_test_dag()), encoding="utf-8")
+    return dag_path
+
+
 def assert_select_file_selector_behavior(
     *, command: tuple[str, ...], selectors: tuple[str, ...]
 ) -> None:

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
@@ -31,11 +31,13 @@ from tests.unit.src.sqlbuild.integrations.dagster.helpers import (
     assert_json_output_file_behavior,
     assert_positional_selector_behavior,
     assert_select_file_selector_behavior,
+    build_dagster_test_dag,
     write_blocking_execution_event_command,
     write_blocking_failed_execution_event_command,
     write_blocking_fake_sqb_command,
     write_dagster_test_dag,
     write_fake_sqb_command,
+    write_python_augmented_dagster_test_dag,
 )
 
 dg: Any = pytest.importorskip("dagster")
@@ -239,7 +241,63 @@ def test_given_sqlbuild_cli_resource_with_dag_when_streaming_then_yields_asset_r
             expected_asset_keys=(("analytics", "orders"),),
             expected_check_names=("audit__not_null__order_id",),
             expected_check_severities=("WARN",),
-        )
+        ),
+        DagsterCliJsonStreamTestCase(
+            description="check-only selection emits only selected audit result",
+            command_stdout=(
+                '{"version": 1, "command": "build", "status": "success", '
+                '"summary": {}, '
+                '"assets": [{"kind": "model", "name": "orders", '
+                '"status": "success", "duration_ms": 12}], '
+                '"checks": [{"kind": "audit", "name": "not_null", '
+                '"check_id": "audit:not_null:model:orders:order_id", '
+                '"passed": true, "status": "pass", "severity": "warn", '
+                '"row_count": 0}, '
+                '{"kind": "audit", "name": "freshness", '
+                '"check_id": "audit:freshness:source:raw_orders:loaded_at", '
+                '"passed": true, "status": "pass", "severity": "warn", '
+                '"row_count": 0}]} '
+            ),
+            selected_asset_keys=(),
+            selected_check_keys=((("analytics", "orders"), "audit__not_null__order_id"),),
+            check_selection_is_explicit=True,
+            expected_asset_keys=(),
+            expected_check_names=("audit__not_null__order_id",),
+            expected_check_severities=("WARN",),
+        ),
+        DagsterCliJsonStreamTestCase(
+            description="combined selection retains check outside selected asset paths",
+            command_stdout=(
+                '{"version": 1, "command": "build", "status": "success", '
+                '"summary": {}, '
+                '"assets": [{"kind": "model", "name": "orders", "status": "success"}], '
+                '"checks": [{"kind": "audit", "name": "not_null", '
+                '"check_id": "audit:not_null:model:orders:order_id", '
+                '"passed": true, "status": "pass", "severity": "warn"}]}'
+            ),
+            selected_asset_keys=(("analytics", "customers"),),
+            selected_check_keys=((("analytics", "orders"), "audit__not_null__order_id"),),
+            check_selection_is_explicit=True,
+            expected_asset_keys=(),
+            expected_check_names=("audit__not_null__order_id",),
+            expected_check_severities=("WARN",),
+        ),
+        DagsterCliJsonStreamTestCase(
+            description="explicit empty check selection suppresses audit results",
+            command_stdout=(
+                '{"version": 1, "command": "build", "status": "success", '
+                '"summary": {}, '
+                '"assets": [{"kind": "model", "name": "orders", "status": "success"}], '
+                '"checks": [{"kind": "audit", "name": "not_null", '
+                '"check_id": "audit:not_null:model:orders:order_id", '
+                '"passed": true, "status": "pass", "severity": "warn"}]}'
+            ),
+            selected_asset_keys=(("analytics", "orders"),),
+            check_selection_is_explicit=True,
+            expected_asset_keys=(("analytics", "orders"),),
+            expected_check_names=(),
+            expected_check_severities=(),
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -255,7 +313,14 @@ def test_given_execution_json_when_streaming_then_yields_structured_dagster_even
         {
             "selected_asset_keys": {
                 dg.AssetKey(list(asset_key)) for asset_key in test_case.selected_asset_keys
-            }
+            },
+            "selected_asset_check_keys": (
+                None,
+                {
+                    dg.AssetCheckKey(asset_key=dg.AssetKey(list(asset_key)), name=check_name)
+                    for asset_key, check_name in test_case.selected_check_keys
+                },
+            )[test_case.check_selection_is_explicit],
         },
     )()
     resource: SqlBuildCliResource = SqlBuildCliResource(
@@ -888,6 +953,14 @@ def test_given_sqlbuild_cli_resource_when_waiting_failed_invocation_then_raises_
             expected_selectors=(),
             assert_selector_transport=assert_positional_selector_behavior,
         ),
+        DagsterCliSelectionTestCase(
+            description="selected audit check appends checked model selector",
+            selected_asset_keys=(),
+            selected_check_keys=((("analytics", "orders"), "audit__not_null__order_id"),),
+            command_args=("build",),
+            expected_selectors=("orders",),
+            assert_selector_transport=assert_select_file_selector_behavior,
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -903,7 +976,11 @@ def test_given_selected_dagster_assets_when_invoking_cli_then_applies_sqlbuild_s
         {
             "selected_asset_keys": {
                 dg.AssetKey(list(asset_key)) for asset_key in test_case.selected_asset_keys
-            }
+            },
+            "selected_asset_check_keys": {
+                dg.AssetCheckKey(asset_key=dg.AssetKey(list(asset_key)), name=check_name)
+                for asset_key, check_name in test_case.selected_check_keys
+            },
         },
     )()
     resource: SqlBuildCliResource = SqlBuildCliResource(
@@ -924,3 +1001,109 @@ def test_given_selected_dagster_assets_when_invoking_cli_then_applies_sqlbuild_s
         selectors=test_case.expected_selectors,
     )
     assert_json_output_file_behavior(command=invocation.command)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagsterCliSelectionTestCase(
+            description="selected Python check appends check selector",
+            selected_asset_keys=(),
+            command_args=("check",),
+            expected_selectors=("check_orders_export",),
+            assert_selector_transport=assert_select_file_selector_behavior,
+            selected_check_keys=(
+                (("asset", "orders_export"), "python_check__check_orders_export"),
+            ),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_selected_python_check_when_invoking_check_then_selects_check_identity(
+    test_case: DagsterCliSelectionTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    context: Any = type(
+        "SelectedCheckContext",
+        (),
+        {
+            "selected_asset_keys": set(),
+            "selected_asset_check_keys": {
+                dg.AssetCheckKey(asset_key=dg.AssetKey(list(asset_key)), name=check_name)
+                for asset_key, check_name in test_case.selected_check_keys
+            },
+        },
+    )()
+    resource: SqlBuildCliResource = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_fake_sqb_command(root=tmp_path),
+        dag_path=str(write_python_augmented_dagster_test_dag(root=tmp_path)),
+    )
+
+    invocation: SqlBuildCliInvocation = resource.cli(
+        args=test_case.command_args,
+        context=context,
+    ).wait()
+
+    assert invocation.selection == test_case.expected_selectors
+    test_case.assert_selector_transport(
+        command=invocation.command,
+        selectors=test_case.expected_selectors,
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagsterCliSelectionTestCase(
+            description="selected multi-asset check scopes every checked model",
+            selected_asset_keys=(),
+            command_args=("build",),
+            expected_selectors=("orders", "customers"),
+            assert_selector_transport=assert_select_file_selector_behavior,
+            selected_check_keys=((("analytics", "orders"), "audit__not_null__order_id"),),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_selected_multi_asset_check_when_invoking_build_then_scopes_every_checked_asset(
+    test_case: DagsterCliSelectionTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = tmp_path / "project"
+    project_dir.mkdir()
+    dag: dict[str, Any] = dict(build_dagster_test_dag())
+    checks: list[dict[str, Any]] = [dict(check) for check in dag["checks"]]
+    checks[0]["checked_asset_ids"] = ["model:orders", "model:customers"]
+    dag["checks"] = checks
+    dag_path: Path = tmp_path / "sqlbuild_dag.json"
+    dag_path.write_text(json.dumps(dag), encoding="utf-8")
+    context: Any = type(
+        "SelectedCheckContext",
+        (),
+        {
+            "selected_asset_keys": set(),
+            "selected_asset_check_keys": {
+                dg.AssetCheckKey(asset_key=dg.AssetKey(list(asset_key)), name=check_name)
+                for asset_key, check_name in test_case.selected_check_keys
+            },
+        },
+    )()
+    resource: SqlBuildCliResource = SqlBuildCliResource(
+        project_dir=str(project_dir),
+        sqb_command=write_fake_sqb_command(root=tmp_path),
+        dag_path=str(dag_path),
+    )
+
+    invocation: SqlBuildCliInvocation = resource.cli(
+        args=test_case.command_args,
+        context=context,
+    ).wait()
+
+    assert set(invocation.selection) == set(test_case.expected_selectors)
+    test_case.assert_selector_transport(
+        command=invocation.command,
+        selectors=test_case.expected_selectors,
+    )


### PR DESCRIPTION
## Why

Dagster check-only selection was handled only for scenarios. Selecting an ordinary audit or Python check could leave SQLBuild unscoped and result mapping could emit checks outside Dagster's selected check keys. Exposing migrated dbt audits makes that unsafe and unexpectedly expensive.

## Changes

- Derive build-style selectors from assets checked by selected audit/test keys.
- Expand multi-asset checks to every checked dependency.
- Select standalone Python check identities for `sqb check`.
- Filter JSON and live-event `AssetCheckResult`s by exact selected check keys.
- Keep selected materialization and check scopes independent.
- Treat an explicitly empty check selection as authoritative.

## Verification

- 54 Dagster integration unit tests passed.
- Added regressions for check-only, unrelated result filtering, combined asset/check, explicit-empty, Python-check, and multi-asset selection.
- `uv sync --all-extras` and `make check-ci` passed.
- Ruff, formatting, `ty`, Fensu, and `git diff --check` passed.
- Focused review completed with no remaining findings.
