### PR TITLE
fix: separate audit dependencies from model scheduling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,12 @@
 
 - Run targeted pytest commands with xdist by default: `uv run pytest <paths> -n auto --dist loadfile`.
 - Do not run pytest serially unless diagnosing an xdist-specific failure.
-- Do not run the full local test or CI suite unless the user explicitly requests it.
+- `make test` is the sanctioned broader local unit and integration check. It is normally acceptable
+  when the change warrants broader regression coverage because the target owns the required paths,
+  marker exclusions, xdist settings, and logging.
+- Do not replace `make test` with a raw broad pytest command. Do not run `make test-all`, E2E, dbt,
+  real-warehouse, or the full CI suite locally unless reproducing a specific failure or the user
+  explicitly requests it; rely on CI for those suites.
 - Before pushing, run the exact static CI target with all optional dependencies available: `uv sync --all-extras` followed by `make check-ci`.
 
 ## Subagent Verification
@@ -13,7 +18,9 @@
 - Implementation subagents should run only tests directly covering changed behavior plus targeted lint, type, and architecture checks for touched files.
 - Review subagents are read-only by default. They should inspect the diff and relevant call flow and run only focused tests needed to validate a concrete suspected finding.
 - Follow-up reviews should verify only previously reported findings and affected boundaries rather than repeating the complete review or full suite.
-- Use repository CI for full unit, integration, and end-to-end suites unless the user explicitly requests local full verification or CI is unavailable.
+- `make test` may be used for broader local unit and integration verification; use repository CI for
+  `test-all`, end-to-end, dbt, real-warehouse, and other full suites unless the user explicitly
+  requests local verification or CI is unavailable.
 - State the expected verification scope in subagent prompts and explicitly prohibit unnecessary full-suite runs.
 - Do not delay committing and pushing a focused fix solely to repeat checks already completed successfully by another agent or CI.
 

--- a/src/sqlbuild/cli/commands/_helpers/audit/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/audit/execution.py
@@ -140,6 +140,7 @@ def _build_on_complete(
             canonical_resource_id=audit_resource_id(
                 audit_name=result.audit_name,
                 attachment_kind=result.attachment_kind,
+                attached_target_kind=result.attached_target_kind,
                 attached_target_name=result.attached_target_name,
                 attached_column_name=result.attached_column_name,
             ),

--- a/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
+++ b/src/sqlbuild/cli/output/_helpers/execution_protocol_v1.py
@@ -906,6 +906,11 @@ def _format_audit_checks(
                 "severity": result.severity.value,
                 "row_count": result.row_count,
                 "attachment_kind": result.attachment_kind.value,
+                "attached_target_kind": (
+                    result.attached_target_kind.value
+                    if result.attached_target_kind is not None
+                    else None
+                ),
                 "asset_name": result.attached_target_name,
                 "attached_column_name": result.attached_column_name,
                 "run_scope_phase": result.run_scope_phase.value,
@@ -921,6 +926,7 @@ def _audit_check_id(result: AuditExecutionResult) -> str:
     return audit_resource_id(
         audit_name=result.audit_name,
         attachment_kind=result.attachment_kind,
+        attached_target_kind=result.attached_target_kind,
         attached_target_name=result.attached_target_name,
         attached_column_name=result.attached_column_name,
     )

--- a/src/sqlbuild/cli/output/_helpers/integration_result.py
+++ b/src/sqlbuild/cli/output/_helpers/integration_result.py
@@ -300,6 +300,7 @@ def _audit_check_id(result: AuditExecutionResult) -> str:
     return audit_resource_id(
         audit_name=result.audit_name,
         attachment_kind=result.attachment_kind,
+        attached_target_kind=result.attached_target_kind,
         attached_target_name=result.attached_target_name,
         attached_column_name=result.attached_column_name,
     )

--- a/src/sqlbuild/compiler/planner/_helpers/graph/core.py
+++ b/src/sqlbuild/compiler/planner/_helpers/graph/core.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 from sqlbuild.compiler.compile.models import (
-    CompiledAudit,
     CompiledObjectKey,
     CompiledProject,
     CompiledSqlTest,
 )
 from sqlbuild.compiler.compile.types import (
-    AttachedAuditTargetKind,
     CompiledResourceType,
     SqlTestMode,
 )
@@ -26,24 +24,13 @@ def _key_sort_key(key: CompiledObjectKey) -> tuple[str, str]:
 def build_execution_upstream_deps(
     project: CompiledProject,
 ) -> dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]]:
-    """Return EXECUTION-order edges: lineage plus audit scope-deps and woven SQL test nodes."""
+    """Return execution-order edges from lineage and woven SQL test nodes."""
 
     upstream: dict[CompiledObjectKey, list[CompiledObjectKey]] = {}
     upstream.update({model.key: list(model.deps) for model in project.models})
     upstream.update({source.key: list(source.deps) for source in project.sources})
     upstream.update({seed.key: list(seed.deps) for seed in project.seeds})
     upstream.update({function.key: list(function.deps) for function in project.functions})
-
-    audit: CompiledAudit
-    for audit in project.audits:
-        target_key: CompiledObjectKey | None = _attached_audit_target_key(audit=audit)
-        if target_key is None or target_key not in upstream:
-            continue
-        dep_key: CompiledObjectKey
-        for dep_key in audit.scope_deps:
-            if dep_key == target_key or dep_key in upstream[target_key]:
-                continue
-            upstream[target_key].append(dep_key)
 
     test: CompiledSqlTest
     for test in project.sql_tests:
@@ -64,18 +51,6 @@ def build_execution_edge_origins(
     """Return human-readable origins for execution edges injected beyond pure lineage."""
 
     origins: dict[tuple[CompiledObjectKey, CompiledObjectKey], str] = {}
-    audit: CompiledAudit
-    for audit in project.audits:
-        target_key: CompiledObjectKey | None = _attached_audit_target_key(audit=audit)
-        if target_key is None:
-            continue
-        dep_key: CompiledObjectKey
-        for dep_key in audit.scope_deps:
-            if dep_key == target_key:
-                continue
-            origins[(target_key, dep_key)] = (
-                f"audit '{audit.name}' on '{target_key.name}' reads '{dep_key.name}'"
-            )
     test: CompiledSqlTest
     for test in project.sql_tests:
         for target_key in test.scope_deps:
@@ -83,23 +58,6 @@ def build_execution_edge_origins(
                 f"SQL test '{test.name}' runs before '{target_key.name}'"
             )
     return origins
-
-
-def _attached_audit_target_key(*, audit: CompiledAudit) -> CompiledObjectKey | None:
-    if audit.attached_target_kind is None or audit.attached_target_name is None:
-        return None
-    target_kind: AttachedAuditTargetKind = AttachedAuditTargetKind(audit.attached_target_kind)
-    if target_kind == AttachedAuditTargetKind.MODEL:
-        return CompiledObjectKey(
-            resource_type=CompiledResourceType.MODEL,
-            name=audit.attached_target_name,
-        )
-    if target_kind == AttachedAuditTargetKind.SOURCE:
-        return CompiledObjectKey(
-            resource_type=CompiledResourceType.SOURCE,
-            name=audit.attached_target_name,
-        )
-    return None
 
 
 def _function_scope_deps_for_test(*, test: CompiledSqlTest) -> tuple[CompiledObjectKey, ...]:

--- a/src/sqlbuild/compiler/planner/_helpers/output/audit_entry.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/audit_entry.py
@@ -14,6 +14,7 @@ from sqlbuild.compiler.compile.models import (
     CompiledObjectKey,
     CompiledRelationLocation,
 )
+from sqlbuild.compiler.compile.types import AttachedAuditTargetKind
 from sqlbuild.compiler.planner._helpers.output.audit_scheduling import (
     resolve_attachment_kind,
     resolve_effective_run_scope,
@@ -73,6 +74,11 @@ def plan_audit(
         requested_run_scope=requested_run_scope,
         attached_model_materialization=attached_materialization,
     )
+    attached_target_kind: AttachedAuditTargetKind | None = audit.attached_target_kind
+    if attached_target_kind is None and attachment_kind == AuditAttachmentKind.MODEL:
+        attached_target_kind = AttachedAuditTargetKind.MODEL
+    elif attached_target_kind is None and attachment_kind == AuditAttachmentKind.SOURCE:
+        attached_target_kind = AttachedAuditTargetKind.SOURCE
 
     return AuditPlanEntry(
         key=audit.key,
@@ -84,6 +90,7 @@ def plan_audit(
         requested_run_scope=requested_run_scope,
         effective_run_scope=effective_run_scope,
         scope_deps=audit.scope_deps,
+        attached_target_kind=attached_target_kind,
         attached_target_name=attached_target_name,
         attached_column_name=audit.attached_column_name,
         always_run=audit.always_run,

--- a/src/sqlbuild/compiler/planner/_helpers/output/audit_scheduling.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/audit_scheduling.py
@@ -31,14 +31,17 @@ def resolve_attachment_kind(
 
     if audit.attached_target_kind == AttachedAuditTargetKind.SOURCE:
         _validate_source_attached_audit(audit=audit)
-        return AuditAttachmentKind.SOURCE, audit.attached_target_name
+        if _source_lifecycle_attachment_is_safe(audit=audit):
+            return AuditAttachmentKind.SOURCE, audit.attached_target_name
+        return AuditAttachmentKind.END, audit.attached_target_name
 
     if audit.attached_target_kind == AttachedAuditTargetKind.MODEL:
-        _validate_model_attached_audit(
+        if _model_lifecycle_attachment_is_safe(
             audit=audit,
             upstream_deps=upstream_deps,
-        )
-        return AuditAttachmentKind.MODEL, audit.attached_target_name
+        ):
+            return AuditAttachmentKind.MODEL, audit.attached_target_name
+        return AuditAttachmentKind.END, audit.attached_target_name
 
     return _infer_singular_attachment(
         audit=audit,
@@ -79,12 +82,26 @@ def _validate_source_attached_audit(*, audit: CompiledAudit) -> None:
             )
 
 
-def _validate_model_attached_audit(
+def _source_lifecycle_attachment_is_safe(*, audit: CompiledAudit) -> bool:
+    """Return whether an attached audit only depends on its target source."""
+
+    if audit.attached_target_name is None:
+        raise PlannerInputError(
+            f"audit '{audit.name}': source-attached audit is missing an attached source name"
+        )
+    attached_key: CompiledObjectKey = CompiledObjectKey(
+        resource_type=CompiledResourceType.SOURCE,
+        name=audit.attached_target_name,
+    )
+    return all(dep_key == attached_key for dep_key in audit.scope_deps)
+
+
+def _model_lifecycle_attachment_is_safe(
     *,
     audit: CompiledAudit,
     upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
-) -> None:
-    """Validate that all model refs in a model-attached audit are upstream of the attached model."""
+) -> bool:
+    """Return whether an attached audit can run inside the target model lifecycle."""
 
     if audit.attached_target_name is None:
         raise PlannerInputError(
@@ -97,24 +114,11 @@ def _validate_model_attached_audit(
         key=attached_key, upstream_deps=upstream_deps
     )
 
-    ref: CompileSqlReference
-    for ref in audit.references:
-        if ref.ref_kind != SqlReferenceKind.REF:
-            continue
-        if ref.ref_name == audit.attached_target_name:
-            continue
-        ref_key: CompiledObjectKey = CompiledObjectKey(
-            resource_type=CompiledResourceType.MODEL, name=ref.ref_name
-        )
-        seed_key: CompiledObjectKey = CompiledObjectKey(
-            resource_type=CompiledResourceType.SEED, name=ref.ref_name
-        )
-        if ref_key not in attached_upstream and seed_key not in attached_upstream:
-            raise PlannerInputError(
-                f"audit '{audit.name}': model-attached audit on '{audit.attached_target_name}' "
-                f"references '{ref.ref_name}' which is not upstream of "
-                f"'{audit.attached_target_name}'"
-            )
+    dep_key: CompiledObjectKey
+    for dep_key in audit.scope_deps:
+        if dep_key != attached_key and dep_key not in attached_upstream:
+            return False
+    return True
 
 
 def _infer_singular_attachment(

--- a/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
@@ -11,6 +11,7 @@ from sqlbuild.adapter.contract.models import ColumnInfo, RelationInfo
 from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.main._cursor_roles import resolve_cursor_input_roles
 from sqlbuild.compiler.compile.models import (
+    CompiledAudit,
     CompiledModel,
     CompiledObjectKey,
     CompiledProject,
@@ -19,7 +20,7 @@ from sqlbuild.compiler.compile.models import (
     CompileSqlReference,
     CursorInputRoles,
 )
-from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.compile.types import AttachedAuditTargetKind, CompiledResourceType
 from sqlbuild.compiler.fingerprints.models import Fingerprint
 from sqlbuild.compiler.planner._helpers.graph.source_load_nodes import build_source_load_map
 from sqlbuild.compiler.planner._helpers.output.cursor_type_check import (
@@ -147,9 +148,13 @@ def build_planner_relations_context(
             deferred_locations=effective_deferral.deferred_locations,
             selected_keys=scope.selected_keys,
         )
-    source_map: dict[str, SourceEntry] = build_source_load_map(
+    audit_relation_keys: frozenset[CompiledObjectKey] = _selected_audit_relation_keys(
         project=project,
         selected_keys=scope.selected_keys,
+    )
+    source_map: dict[str, SourceEntry] = build_source_load_map(
+        project=project,
+        selected_keys=scope.selected_keys | audit_relation_keys,
         upstream_deps=scope.upstream_deps if scope.all_keys else None,
     )
     source_read_map: dict[str, SourceEntry] = (
@@ -1528,6 +1533,42 @@ def scope_overlaps(
         if dep in selected_keys:
             return True
     return False
+
+
+def audit_is_selected(
+    *,
+    audit: CompiledAudit,
+    selected_keys: frozenset[CompiledObjectKey],
+) -> bool:
+    """Return whether an audit belongs to the selected logical target scope."""
+
+    if audit.attached_target_kind is not None and audit.attached_target_name is not None:
+        resource_type: CompiledResourceType = (
+            CompiledResourceType.SOURCE
+            if audit.attached_target_kind == AttachedAuditTargetKind.SOURCE
+            else CompiledResourceType.MODEL
+        )
+        target_key: CompiledObjectKey = CompiledObjectKey(
+            resource_type=resource_type,
+            name=audit.attached_target_name,
+        )
+        return target_key in selected_keys
+    return scope_overlaps(scope_deps=audit.scope_deps, selected_keys=selected_keys)
+
+
+def _selected_audit_relation_keys(
+    *,
+    project: CompiledProject,
+    selected_keys: frozenset[CompiledObjectKey],
+) -> frozenset[CompiledObjectKey]:
+    """Return relation keys needed to render selected audits without selecting those relations."""
+
+    relation_keys: set[CompiledObjectKey] = set()
+    audit: CompiledAudit
+    for audit in project.audits:
+        if audit_is_selected(audit=audit, selected_keys=selected_keys):
+            relation_keys.update(audit.scope_deps)
+    return frozenset(relation_keys)
 
 
 def build_model_materializations(

--- a/src/sqlbuild/compiler/planner/_helpers/output/plan_output.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/plan_output.py
@@ -22,6 +22,7 @@ from sqlbuild.compiler.planner._helpers.graph.loader_dag import upstream_loader_
 from sqlbuild.compiler.planner._helpers.graph.source_load_nodes import build_source_load_entries
 from sqlbuild.compiler.planner._helpers.output.audit_entry import plan_audit
 from sqlbuild.compiler.planner._helpers.output.plan_entry import (
+    audit_is_selected,
     build_model_materializations,
     extract_seed_columns,
     scope_overlaps,
@@ -384,7 +385,7 @@ def _build_audit_entries(
     entries: list[AuditPlanEntry] = []
     audit: CompiledAudit
     for audit in project.audits:
-        if not scope_overlaps(scope_deps=audit.scope_deps, selected_keys=scope.selected_keys):
+        if not audit_is_selected(audit=audit, selected_keys=scope.selected_keys):
             continue
         entries.append(
             plan_audit(

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -26,7 +26,7 @@ from sqlbuild.compiler.compile.models import (
     CompiledRelationLocation,
     FunctionReturnColumn,
 )
-from sqlbuild.compiler.compile.types import FunctionLanguage
+from sqlbuild.compiler.compile.types import AttachedAuditTargetKind, FunctionLanguage
 from sqlbuild.compiler.discovery.models import DiscoveredHookFunction, SqlTestParameterDeclaration
 from sqlbuild.compiler.fingerprints.models import Fingerprint
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
@@ -901,6 +901,7 @@ class AuditPlanEntry:
     requested_run_scope: AuditRunScope
     effective_run_scope: AuditRunScope
     scope_deps: tuple[CompiledObjectKey, ...] = field(default_factory=tuple)
+    attached_target_kind: AttachedAuditTargetKind | None = None
     attached_target_name: str | None = None
     attached_column_name: str | None = None
     always_run: bool = False

--- a/src/sqlbuild/executor/auditing/main/_execute.py
+++ b/src/sqlbuild/executor/auditing/main/_execute.py
@@ -100,6 +100,7 @@ def execute_audit(
         row_count=row_count,
         executed_sql=executed_sql,
         run_scope_phase=run_scope_phase,
+        attached_target_kind=audit.attached_target_kind,
         attached_target_name=audit.attached_target_name,
         attached_column_name=audit.attached_column_name,
     )

--- a/src/sqlbuild/executor/auditing/main/resource_id.py
+++ b/src/sqlbuild/executor/auditing/main/resource_id.py
@@ -1,21 +1,27 @@
 """Canonical resource identity for an attached audit execution."""
 
 from sqlbuild.compiler.auditing.types import AuditAttachmentKind
+from sqlbuild.compiler.compile.types import AttachedAuditTargetKind
 
 
 def audit_resource_id(
     *,
     audit_name: str,
     attachment_kind: AuditAttachmentKind,
+    attached_target_kind: AttachedAuditTargetKind | None = None,
     attached_target_name: str | None,
     attached_column_name: str | None,
 ) -> str:
     """Format the stable execution-protocol identity of one attached audit."""
 
+    identity_kind: str = (
+        attached_target_kind.value if attached_target_kind is not None else attachment_kind.value
+    )
+
     parts: tuple[str | None, ...] = (
         "audit",
         audit_name,
-        attachment_kind.value,
+        identity_kind,
         attached_target_name,
         attached_column_name,
     )

--- a/src/sqlbuild/executor/auditing/models.py
+++ b/src/sqlbuild/executor/auditing/models.py
@@ -10,6 +10,7 @@ from sqlbuild.compiler.auditing.types import (
     AuditRunScope,
     AuditSeverity,
 )
+from sqlbuild.compiler.compile.types import AttachedAuditTargetKind
 
 
 @dataclass(frozen=True)
@@ -23,6 +24,7 @@ class AuditExecutionResult:
     row_count: int
     executed_sql: str
     run_scope_phase: AuditRunScope = AuditRunScope.FINAL
+    attached_target_kind: AttachedAuditTargetKind | None = None
     attached_target_name: str | None = None
     attached_column_name: str | None = None
     reused: bool = False

--- a/src/sqlbuild/executor/build/_helpers/end_audits.py
+++ b/src/sqlbuild/executor/build/_helpers/end_audits.py
@@ -36,6 +36,7 @@ def run_end_audits(
             resource_id=audit_resource_id(
                 audit_name=audit.name,
                 attachment_kind=audit.attachment_kind,
+                attached_target_kind=audit.attached_target_kind,
                 attached_target_name=audit.attached_target_name,
                 attached_column_name=audit.attached_column_name,
             ),

--- a/src/sqlbuild/executor/build/_helpers/source_audits.py
+++ b/src/sqlbuild/executor/build/_helpers/source_audits.py
@@ -57,6 +57,7 @@ def run_pending_source_audits(
                 resource_id=audit_resource_id(
                     audit_name=audit.name,
                     attachment_kind=audit.attachment_kind,
+                    attached_target_kind=audit.attached_target_kind,
                     attached_target_name=audit.attached_target_name,
                     attached_column_name=audit.attached_column_name,
                 ),

--- a/src/sqlbuild/executor/pipeline/_helpers/auditing.py
+++ b/src/sqlbuild/executor/pipeline/_helpers/auditing.py
@@ -54,6 +54,7 @@ def run_audit_pipeline(
                 resource_id=audit_resource_id(
                     audit_name=entry.name,
                     attachment_kind=entry.attachment_kind,
+                    attached_target_kind=entry.attached_target_kind,
                     attached_target_name=entry.attached_target_name,
                     attached_column_name=entry.attached_column_name,
                 ),

--- a/src/sqlbuild/executor/run/_helpers/reuse/audit.py
+++ b/src/sqlbuild/executor/run/_helpers/reuse/audit.py
@@ -46,6 +46,7 @@ def reused_final_audit_results_by_binding_key(
             row_count=0,
             executed_sql=audit.resolved_sql,
             run_scope_phase=AuditRunScope.FINAL,
+            attached_target_kind=audit.attached_target_kind,
             attached_target_name=audit.attached_target_name,
             attached_column_name=audit.attached_column_name,
             reused=True,

--- a/tests/e2e/src/sqlbuild/cli/commands/main/audit/test_audit.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/audit/test_audit.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -102,3 +104,92 @@ def test_given_failing_audit_when_running_audit_then_exit_code_is_nonzero(
     expected_fragment: str
     for expected_fragment in test_case.expected_stdout_fragments:
         assert expected_fragment in result.stdout
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        AuditE2ETestCase(
+            description="attached audit reading downstream model runs after its dependencies",
+            expected_exit_code=0,
+            expected_stdout_fragment="PASS=29",
+            expected_stdout_fragments=("stg_orders", "cross_model_consistency"),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_attached_audit_reads_downstream_model_when_building_and_auditing_then_it_runs_once_at_end(
+    test_case: AuditE2ETestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_waffle_shop(tmp_path)
+    model_path: Path = project_dir / "models" / "staging" / "stg_orders.sql"
+    model_sql: str = model_path.read_text(encoding="utf-8")
+    model_path.write_text(
+        model_sql.replace(
+            "  columns (",
+            "  audits [cross_model_consistency (severity error)],\n  columns (",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    audit_path: Path = project_dir / "audits" / "generic" / "cross_model_consistency.sql"
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_path.write_text(
+        'AUDIT (name "cross_model_consistency");\n\n'
+        "SELECT stg.order_id\n"
+        "FROM @relation stg\n"
+        'LEFT JOIN __ref("fact_orders") fact USING (order_id)\n'
+        "WHERE fact.order_id IS NULL\n",
+        encoding="utf-8",
+    )
+
+    build_output_path: Path = tmp_path / "build.json"
+    build_result: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "build", "--json-output", str(build_output_path)),
+        project_dir=project_dir,
+    )
+    audit_output_path: Path = tmp_path / "audit.json"
+    audit_result: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "audit", "--json-output", str(audit_output_path)),
+        project_dir=project_dir,
+    )
+
+    assert build_result.returncode == test_case.expected_exit_code, (
+        build_result.stdout + build_result.stderr
+    )
+    build_payload: dict[str, object] = json.loads(build_output_path.read_text(encoding="utf-8"))
+    build_checks: list[dict[str, object]] = cast(list[dict[str, object]], build_payload["checks"])
+    build_check_names: tuple[object, ...] = tuple(check["name"] for check in build_checks)
+    assert build_check_names.count("cross_model_consistency") == 1
+    matching_build_check: dict[str, object] = build_checks[
+        build_check_names.index("cross_model_consistency")
+    ]
+    assert matching_build_check == {
+        "kind": "audit",
+        "name": "cross_model_consistency",
+        "check_id": "audit:cross_model_consistency:model:stg_orders",
+        "passed": True,
+        "status": "pass",
+        "severity": "error",
+        "row_count": 0,
+        "attachment_kind": "end",
+        "attached_target_kind": "model",
+        "asset_name": "stg_orders",
+        "run_scope_phase": "final",
+        "reused": False,
+    }
+    assert audit_result.returncode == test_case.expected_exit_code, (
+        audit_result.stdout + audit_result.stderr
+    )
+    assert test_case.expected_stdout_fragment in audit_result.stdout
+    audit_payload: dict[str, object] = json.loads(audit_output_path.read_text(encoding="utf-8"))
+    audit_checks: list[dict[str, object]] = cast(list[dict[str, object]], audit_payload["checks"])
+    audit_check_names: tuple[object, ...] = tuple(check["name"] for check in audit_checks)
+    assert audit_check_names.count("cross_model_consistency") == 1
+    matching_audit_check: dict[str, object] = audit_checks[
+        audit_check_names.index("cross_model_consistency")
+    ]
+    assert matching_audit_check == matching_build_check
+    for expected_fragment in test_case.expected_stdout_fragments:
+        assert expected_fragment in audit_result.stdout

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
@@ -27,3 +27,11 @@ class SqlTestCaseExecutionProtocolTestCase:
     expected_decimal_value: str
     expected_fingerprint: str
     expected_text_label: str
+
+
+@dataclass(frozen=True)
+class AuditExecutionProtocolTestCase:
+    description: str
+    expected_check_id: str
+    expected_attachment_kind: str
+    expected_target_kind: str

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_protocol_v1.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_protocol_v1.py
@@ -9,15 +9,23 @@ import pytest
 
 from sqlbuild.cli.commands._helpers.test.sql_progress import format_parameterized_test_label
 from sqlbuild.cli.output._helpers.execution_protocol_v1 import (
+    _format_audit_checks,
     _format_model_assets,
     _format_sql_test_checks,
 )
+from sqlbuild.compiler.auditing.types import (
+    AuditAttachmentKind,
+    AuditOutcome,
+    AuditSeverity,
+)
+from sqlbuild.compiler.compile.types import AttachedAuditTargetKind
 from sqlbuild.compiler.discovery.models import SqlTestParameterDeclaration
 from sqlbuild.compiler.planner.models import (
     CursorInputEvidence,
     FutureCursorSafetyEvidence,
     MaximumStartSafetyEvidence,
 )
+from sqlbuild.executor.auditing.models import AuditExecutionResult
 from sqlbuild.executor.run.models import (
     MicrobatchAccountingInterval,
     ModelExecutionResult,
@@ -29,10 +37,45 @@ from sqlbuild.spec.contracts.types import FutureCursorAction
 from sqlbuild.sql_values.models import SqlLogicalType, SqlValue
 from sqlbuild.sql_values.types import SqlValueKind
 from tests.unit.src.sqlbuild.cli.output._helpers._test_types import (
+    AuditExecutionProtocolTestCase,
     FutureCursorExecutionProtocolTestCase,
     MicrobatchExecutionProtocolTestCase,
     SqlTestCaseExecutionProtocolTestCase,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        AuditExecutionProtocolTestCase(
+            description="end-scheduled audit retains logical model identity",
+            expected_check_id="audit:cross_model_consistency:model:orders",
+            expected_attachment_kind="end",
+            expected_target_kind="model",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_end_scheduled_model_audit_when_formatting_json_then_logical_identity_is_preserved(
+    test_case: AuditExecutionProtocolTestCase,
+) -> None:
+    result: AuditExecutionResult = AuditExecutionResult(
+        audit_name="cross_model_consistency",
+        attachment_kind=AuditAttachmentKind.END,
+        attached_target_kind=AttachedAuditTargetKind.MODEL,
+        attached_target_name="orders",
+        severity=AuditSeverity.ERROR,
+        outcome=AuditOutcome.PASS,
+        row_count=0,
+        executed_sql="SELECT 1 WHERE FALSE",
+    )
+
+    check: dict[str, object] = _format_audit_checks(results=(result,))[0]
+
+    assert check["check_id"] == test_case.expected_check_id
+    assert check["attachment_kind"] == test_case.expected_attachment_kind
+    assert check["attached_target_kind"] == test_case.expected_target_kind
+    assert check["asset_name"] == "orders"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
@@ -675,6 +675,15 @@ class PlanAuditTestCase:
 
 
 @dataclass(frozen=True)
+class PlanAttachedAuditTestCase:
+    description: str
+    attached_target_name: str
+    referenced_model_names: tuple[str, ...]
+    upstream_edges: dict[str, tuple[str, ...]]
+    expected_attachment_kind: AuditAttachmentKind
+
+
+@dataclass(frozen=True)
 class ApplyDeferredTargetsTestCase:
     description: str
     model_target_names: tuple[str, ...]

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/helpers.py
@@ -12,6 +12,7 @@ from typing import ClassVar
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.models import RelationInfo
+from sqlbuild.compiler.compile._helpers.deps.dependencies import audit_scope_deps
 from sqlbuild.compiler.compile._helpers.sql_tests.core import (
     extract_assertion_target_model_names,
 )
@@ -1385,7 +1386,11 @@ def build_scheduling_audit(
     name: str = "test_audit"
     return CompiledAudit(
         key=CompiledObjectKey(resource_type=CompiledResourceType.AUDIT, name=name),
-        scope_deps=(),
+        scope_deps=audit_scope_deps(
+            references=references,
+            attached_target_kind=attached_target_kind,
+            attached_target_name=attached_target_name,
+        ),
         name=name,
         audit_file=stub_file,
         audit_block=stub_block,

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_audit_entry.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_audit_entry.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import pytest
 
+from sqlbuild.compiler.auditing.types import AuditAttachmentKind, AuditRunScope
 from sqlbuild.compiler.compile.models import (
     CompiledAudit,
+    CompiledObjectKey,
     CompiledRelationLocation,
+    CompileSqlReference,
 )
+from sqlbuild.compiler.compile.types import AttachedAuditTargetKind
 from sqlbuild.compiler.planner._helpers.output.audit_entry import plan_audit
 from sqlbuild.compiler.planner.models import AuditPlanEntry
+from sqlbuild.compiler.references.types import SqlReferenceKind
 from sqlbuild.spec.contracts.models import SourceEntry
 from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
+    PlanAttachedAuditTestCase,
     PlanAuditTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.planner._helpers.helpers import (
@@ -17,7 +23,64 @@ from tests.unit.src.sqlbuild.compiler.planner._helpers.helpers import (
     build_audit_from_test_case,
     build_audit_model_locations,
     build_audit_source_map,
+    build_scheduling_audit,
+    build_scheduling_graph,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        PlanAttachedAuditTestCase(
+            description="safe attached audit retains model lifecycle scheduling",
+            attached_target_name="orders",
+            referenced_model_names=("orders", "stg_orders"),
+            upstream_edges={"orders": ("stg_orders",), "stg_orders": ()},
+            expected_attachment_kind=AuditAttachmentKind.MODEL,
+        ),
+        PlanAttachedAuditTestCase(
+            description="downstream-reading attached audit moves to end scheduling",
+            attached_target_name="stg_orders",
+            referenced_model_names=("stg_orders", "orders"),
+            upstream_edges={"orders": ("stg_orders",), "stg_orders": ()},
+            expected_attachment_kind=AuditAttachmentKind.END,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_logically_attached_audit_when_planning_then_scheduling_and_identity_are_independent(
+    test_case: PlanAttachedAuditTestCase,
+) -> None:
+    references: tuple[CompileSqlReference, ...] = tuple(
+        CompileSqlReference(ref_kind=SqlReferenceKind.REF, ref_name=name)
+        for name in test_case.referenced_model_names
+    )
+    audit: CompiledAudit = build_scheduling_audit(
+        references=references,
+        attached_target_kind=AttachedAuditTargetKind.MODEL,
+        attached_target_name=test_case.attached_target_name,
+    )
+    upstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]]
+    downstream: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]]
+    upstream, downstream = build_scheduling_graph(test_case.upstream_edges)
+
+    result: AuditPlanEntry = plan_audit(
+        audit=audit,
+        model_locations=build_audit_model_locations(
+            {name: f"analytics.{name}" for name in test_case.referenced_model_names}
+        ),
+        seed_locations={},
+        source_map={},
+        adapter=PlannerTestAdapter(),
+        upstream_deps=upstream,
+        downstream_deps=downstream,
+        model_materializations={test_case.attached_target_name: "incremental"},
+    )
+
+    assert result.attachment_kind == test_case.expected_attachment_kind
+    assert result.attached_target_kind == AttachedAuditTargetKind.MODEL
+    assert result.attached_target_name == test_case.attached_target_name
+    assert result.effective_run_scope == AuditRunScope.FINAL
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_audit_scheduling.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_audit_scheduling.py
@@ -48,6 +48,24 @@ from tests.unit.src.sqlbuild.compiler.planner._helpers.helpers import (
             expected_attached_name="raw_orders",
         ),
         ResolveAttachmentTestCase(
+            description="source-attached audit with seed dependency moves to END",
+            references=(
+                CompileSqlReference(
+                    ref_kind=SqlReferenceKind.SOURCE,
+                    ref_name="raw_orders",
+                ),
+                CompileSqlReference(
+                    ref_kind=SqlReferenceKind.SEED,
+                    ref_name="valid_order_statuses",
+                ),
+            ),
+            attached_target_kind=AttachedAuditTargetKind.SOURCE,
+            attached_target_name="raw_orders",
+            upstream_edges={},
+            expected_attachment_kind=AuditAttachmentKind.END,
+            expected_attached_name="raw_orders",
+        ),
+        ResolveAttachmentTestCase(
             description="model-attached audit with upstream refs returns MODEL",
             references=(
                 CompileSqlReference(ref_kind=SqlReferenceKind.REF, ref_name="orders"),
@@ -57,6 +75,30 @@ from tests.unit.src.sqlbuild.compiler.planner._helpers.helpers import (
             attached_target_name="orders",
             upstream_edges={"orders": ("stg_orders",), "stg_orders": ()},
             expected_attachment_kind=AuditAttachmentKind.MODEL,
+            expected_attached_name="orders",
+        ),
+        ResolveAttachmentTestCase(
+            description="model-attached audit with downstream ref moves to END",
+            references=(
+                CompileSqlReference(ref_kind=SqlReferenceKind.REF, ref_name="stg_orders"),
+                CompileSqlReference(ref_kind=SqlReferenceKind.REF, ref_name="orders"),
+            ),
+            attached_target_kind=AttachedAuditTargetKind.MODEL,
+            attached_target_name="stg_orders",
+            upstream_edges={"orders": ("stg_orders",), "stg_orders": ()},
+            expected_attachment_kind=AuditAttachmentKind.END,
+            expected_attached_name="stg_orders",
+        ),
+        ResolveAttachmentTestCase(
+            description="model-attached audit with unrelated ref moves to END",
+            references=(
+                CompileSqlReference(ref_kind=SqlReferenceKind.REF, ref_name="orders"),
+                CompileSqlReference(ref_kind=SqlReferenceKind.REF, ref_name="customers"),
+            ),
+            attached_target_kind=AttachedAuditTargetKind.MODEL,
+            attached_target_name="orders",
+            upstream_edges={"orders": (), "customers": ()},
+            expected_attachment_kind=AuditAttachmentKind.END,
             expected_attached_name="orders",
         ),
         ResolveAttachmentTestCase(
@@ -165,28 +207,6 @@ def test_given_audit_refs_when_resolving_attachment_then_returns_expected(
             attached_target_name="raw_orders",
             upstream_edges={"orders": ()},
             expected_error_fragment="must not reference models",
-        ),
-        ResolveAttachmentErrorTestCase(
-            description="model-attached audit referencing downstream model raises",
-            references=(
-                CompileSqlReference(ref_kind=SqlReferenceKind.REF, ref_name="stg_orders"),
-                CompileSqlReference(ref_kind=SqlReferenceKind.REF, ref_name="orders"),
-            ),
-            attached_target_kind=AttachedAuditTargetKind.MODEL,
-            attached_target_name="stg_orders",
-            upstream_edges={"orders": ("stg_orders",), "stg_orders": ()},
-            expected_error_fragment="not upstream of",
-        ),
-        ResolveAttachmentErrorTestCase(
-            description="model-attached audit referencing unrelated model raises",
-            references=(
-                CompileSqlReference(ref_kind=SqlReferenceKind.REF, ref_name="orders"),
-                CompileSqlReference(ref_kind=SqlReferenceKind.REF, ref_name="customers"),
-            ),
-            attached_target_kind=AttachedAuditTargetKind.MODEL,
-            attached_target_name="orders",
-            upstream_edges={"orders": (), "customers": ()},
-            expected_error_fragment="not upstream of",
         ),
     ],
     ids=lambda case: case.description,

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_graph.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_graph.py
@@ -37,12 +37,12 @@ from tests.unit.src.sqlbuild.compiler.planner._helpers.helpers import (
     "test_case",
     [
         BuildUpstreamDepsTestCase(
-            description="adds attached audit source refs to audited model deps",
+            description="keeps attached audit refs out of model deps",
             model_deps={"stg_payments": ("raw_payments",)},
             source_names=("raw_payments", "raw_orders"),
             seed_names=(),
             expected_upstream_keys={
-                "stg_payments": ("raw_payments", "raw_orders"),
+                "stg_payments": ("raw_payments",),
                 "raw_payments": (),
                 "raw_orders": (),
             },
@@ -238,13 +238,11 @@ def test_given_injected_edge_cycle_when_ordering_topologically_then_error_names_
     "test_case",
     [
         ExecutionEdgeOriginsTestCase(
-            description="records audit scope-dep edges with audit and target names",
+            description="does not record audit scope deps as execution edges",
             model_deps={"stg_payments": ("raw_payments",)},
             source_names=("raw_payments", "raw_orders"),
             audit_model_source_deps={"stg_payments": ("raw_orders",)},
-            expected_origin_fragments=(
-                "audit 'stg_payments_audit' on 'stg_payments' reads 'raw_orders'",
-            ),
+            expected_origin_fragments=(),
         ),
     ],
     ids=lambda case: case.description,
@@ -261,9 +259,7 @@ def test_given_audit_scope_deps_when_building_edge_origins_then_names_the_audit(
     )
 
     origin_values: tuple[str, ...] = tuple(sorted(origins.values()))
-    expected_fragment: str
-    for expected_fragment in test_case.expected_origin_fragments:
-        assert any(expected_fragment in value for value in origin_values)
+    assert origin_values == test_case.expected_origin_fragments
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/executor/build/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/build/_helpers/_test_types.py
@@ -13,6 +13,13 @@ from tests.unit.src.sqlbuild.executor.build._helpers.helpers import ModelPlanOve
 
 
 @dataclass(frozen=True)
+class AuditExecutionIndexTestCase:
+    description: str
+    expected_model_audit_count: int
+    expected_end_audit_count: int
+
+
+@dataclass(frozen=True)
 class LifecycleProgressTestCase:
     description: str
     expected_event_types: tuple[str, ...]

--- a/tests/unit/src/sqlbuild/executor/build/_helpers/test_indexes.py
+++ b/tests/unit/src/sqlbuild/executor/build/_helpers/test_indexes.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from sqlbuild.compiler.auditing.types import (
+    AuditAttachmentKind,
+    AuditRunScope,
+    AuditSeverity,
+)
+from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.types import AttachedAuditTargetKind, CompiledResourceType
+from sqlbuild.compiler.planner.models import AuditPlanEntry, PlanOutput
+from sqlbuild.executor.build._helpers.indexes import build_execution_indexes
+from sqlbuild.executor.build.models import BuildIndexes
+from tests.unit.src.sqlbuild.executor.build._helpers._test_types import (
+    AuditExecutionIndexTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        AuditExecutionIndexTestCase(
+            description="end-scheduled model audit is indexed exactly once at end",
+            expected_model_audit_count=0,
+            expected_end_audit_count=1,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_end_scheduled_model_audit_when_building_indexes_then_it_is_not_a_model_gate(
+    test_case: AuditExecutionIndexTestCase,
+) -> None:
+    audit: AuditPlanEntry = AuditPlanEntry(
+        key=CompiledObjectKey(CompiledResourceType.AUDIT, "cross_model_consistency"),
+        name="cross_model_consistency",
+        resolved_sql="SELECT 1 WHERE FALSE",
+        unresolved_sql="SELECT 1 WHERE FALSE",
+        attachment_kind=AuditAttachmentKind.END,
+        attached_target_kind=AttachedAuditTargetKind.MODEL,
+        attached_target_name="orders",
+        severity=AuditSeverity.ERROR,
+        requested_run_scope=AuditRunScope.FINAL,
+        effective_run_scope=AuditRunScope.FINAL,
+    )
+
+    indexes: BuildIndexes = build_execution_indexes(PlanOutput(audit_entries=(audit,)))
+
+    assert sum(len(audits) for audits in indexes.model_audits_by_model.values()) == (
+        test_case.expected_model_audit_count
+    )
+    assert len(indexes.end_audits) == test_case.expected_end_audit_count
+    assert indexes.end_audits[0].attached_target_name == "orders"

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/_test_types.py
@@ -36,6 +36,12 @@ class AuditResourceIdentityTestCase:
 
 
 @dataclass(frozen=True)
+class AuditLogicalIdentityTestCase:
+    description: str
+    expected_id: str
+
+
+@dataclass(frozen=True)
 class ScenarioFailureHelpTestCase:
     """One scenario failure help resolution case."""
 

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/test_auditing.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/test_auditing.py
@@ -14,7 +14,7 @@ from sqlbuild.compiler.auditing.types import (
     AuditSeverity,
 )
 from sqlbuild.compiler.compile.models import CompiledObjectKey
-from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.compile.types import AttachedAuditTargetKind, CompiledResourceType
 from sqlbuild.compiler.planner.models import AuditPlanEntry, PlanOutput
 from sqlbuild.executor.auditing.main.resource_id import audit_resource_id
 from sqlbuild.executor.auditing.models import AuditExecutionResult
@@ -26,6 +26,7 @@ from sqlbuild.observability import (
     invocation_scope,
 )
 from tests.unit.src.sqlbuild.executor.pipeline._helpers._test_types import (
+    AuditLogicalIdentityTestCase,
     AuditPipelineLifecycleTestCase,
     AuditResourceIdentityTestCase,
 )
@@ -165,3 +166,27 @@ def test_given_same_audit_and_column_on_two_targets_when_formatted_then_ids_rema
     assert first_id == test_case.expected_first_id
     assert second_id == test_case.expected_second_id
     assert first_id != second_id
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditLogicalIdentityTestCase(
+            description="end-scheduled model audit retains logical target identity",
+            expected_id="audit:cross_model_consistency:model:orders",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_end_scheduled_attached_audit_when_formatted_then_logical_target_defines_identity(
+    test_case: AuditLogicalIdentityTestCase,
+) -> None:
+    resource_id: str = audit_resource_id(
+        audit_name="cross_model_consistency",
+        attachment_kind=AuditAttachmentKind.END,
+        attached_target_kind=AttachedAuditTargetKind.MODEL,
+        attached_target_name="orders",
+        attached_column_name=None,
+    )
+
+    assert resource_id == test_case.expected_id


### PR DESCRIPTION
## Why

Attached audits copied their read dependencies onto the checked model's execution lineage. Cross-model audits could therefore create artificial model cycles and fail planning before any audit query ran.

## Changes

- Keep audit scope dependencies independent from model execution dependencies.
- Preserve lifecycle gating for audits that only read their target and its upstream resources.
- Schedule model/source audits with downstream, unrelated, or extra dependencies once at the final audit phase.
- Preserve logical checked-target identity separately from execution placement across lifecycle events, JSON output, integrations, and Dagster checks.
- Add planner, executor, protocol, and DuckDB regressions for cross-model scheduling and audit-only execution.

## Verification

- 108 focused planner, executor, protocol, Dagster, and audit E2E tests passed.
- Bounded follow-up review: 20 focused tests passed with no findings.
- Ruff, ty, Fensu, and `git diff --check` passed.
- Full-suite validation is delegated to CI.
