### PR TITLE
fix: preserve grants during Snowflake table type conversion

### DIFF
--- a/src/sqlbuild/executor/build/_helpers/retention.py
+++ b/src/sqlbuild/executor/build/_helpers/retention.py
@@ -84,7 +84,6 @@ def _apply_table_type_entry(
                 adapter.execute(connection=connection, sql=f"DROP TABLE IF EXISTS {copy}")
                 lifecycle.completed(metadata={"changed_count": 1})
         return
-    table_kind: str = "TRANSIENT TABLE" if desired_transient else "TABLE"
     with OperationLifecycle(
         operation_kind="warehouse",
         operation_name="table_type_conversion",
@@ -94,10 +93,22 @@ def _apply_table_type_entry(
             target_kind="relation",
         ),
     ) as lifecycle:
-        adapter.execute(
-            connection=connection,
-            sql=f"CREATE OR REPLACE {table_kind} {copy} AS SELECT * FROM {destination}",
-        )
+        if entry.copy_name.lower() in relations:
+            adapter.execute(connection=connection, sql=f"DROP TABLE IF EXISTS {copy}")
+        if desired_transient:
+            adapter.execute(
+                connection=connection,
+                sql=f"CREATE TRANSIENT TABLE {copy} CLONE {destination} COPY GRANTS",
+            )
+        else:
+            adapter.execute(
+                connection=connection,
+                sql=f"CREATE TABLE {copy} LIKE {destination} COPY GRANTS",
+            )
+            adapter.execute(
+                connection=connection,
+                sql=f"INSERT INTO {copy} SELECT * FROM {destination}",
+            )
         copy_info: RelationInfo | None = _inspect_table_type_entry(
             entry=entry, adapter=adapter, connection=connection
         ).get(entry.copy_name.lower())

--- a/tests/integration/src/sqlbuild/adapters/snowflake/test_table_type_conversion.py
+++ b/tests/integration/src/sqlbuild/adapters/snowflake/test_table_type_conversion.py
@@ -41,7 +41,7 @@ from tests.integration.src.sqlbuild.adapters.snowflake.helpers import (
             desired_type=TableType.PERMANENT,
             downgrade=False,
             expected_is_transient=False,
-            expected_conversion_statement_count=3,
+            expected_conversion_statement_count=4,
         ),
         SnowflakeTableTypeConversionTestCase(
             description="permanent table already at desired type is a no-op",

--- a/tests/unit/src/sqlbuild/executor/build/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/build/_helpers/_test_types.py
@@ -75,6 +75,8 @@ class TableTypeConversionTestCase:
     description: str
     relation_snapshots: tuple[tuple[RelationInfo, ...], ...]
     expected_statements: tuple[str, ...]
+    desired_type: str = "permanent"
+    actual_type: str = "transient"
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/executor/build/_helpers/test_retention.py
+++ b/tests/unit/src/sqlbuild/executor/build/_helpers/test_retention.py
@@ -53,6 +53,13 @@ _COPY: RelationInfo = RelationInfo(
     relation_type="BASE TABLE",
     is_transient=False,
 )
+_TRANSIENT_COPY: RelationInfo = RelationInfo(
+    database="warehouse",
+    schema="analytics",
+    name="__sqb_type_swap__orders",
+    relation_type="BASE TABLE",
+    is_transient=True,
+)
 
 
 @pytest.mark.parametrize(
@@ -196,18 +203,37 @@ def test_given_successful_model_when_reconciling_retention_then_defers_decreases
     "test_case",
     [
         TableTypeConversionTestCase(
-            description="undesired target with stale copy recreates before swap",
+            description="transient target upgrades through grant-preserving permanent copy",
             relation_snapshots=(
                 (_TRANSIENT_TARGET, _COPY),
                 (_COPY,),
             ),
             expected_statements=(
-                "CREATE OR REPLACE TABLE warehouse.analytics.__sqb_type_swap__orders AS SELECT * "
-                "FROM warehouse.analytics.orders",
+                "DROP TABLE IF EXISTS warehouse.analytics.__sqb_type_swap__orders",
+                "CREATE TABLE warehouse.analytics.__sqb_type_swap__orders LIKE "
+                "warehouse.analytics.orders COPY GRANTS",
+                "INSERT INTO warehouse.analytics.__sqb_type_swap__orders SELECT * FROM "
+                "warehouse.analytics.orders",
                 "ALTER TABLE warehouse.analytics.orders SWAP WITH "
                 "warehouse.analytics.__sqb_type_swap__orders",
                 "DROP TABLE IF EXISTS warehouse.analytics.__sqb_type_swap__orders",
             ),
+        ),
+        TableTypeConversionTestCase(
+            description="permanent target downgrades through transient zero-copy clone with grants",
+            relation_snapshots=(
+                (_TARGET,),
+                (_TRANSIENT_COPY,),
+            ),
+            expected_statements=(
+                "CREATE TRANSIENT TABLE warehouse.analytics.__sqb_type_swap__orders CLONE "
+                "warehouse.analytics.orders COPY GRANTS",
+                "ALTER TABLE warehouse.analytics.orders SWAP WITH "
+                "warehouse.analytics.__sqb_type_swap__orders",
+                "DROP TABLE IF EXISTS warehouse.analytics.__sqb_type_swap__orders",
+            ),
+            desired_type="transient",
+            actual_type="permanent",
         ),
         TableTypeConversionTestCase(
             description="desired target with leftover copy only cleans copy",
@@ -237,8 +263,8 @@ def test_given_recoverable_table_type_state_when_converting_then_uses_inspection
             qualified_name="warehouse.analytics.orders",
         ),
         copy_name="__sqb_type_swap__orders",
-        desired_type="permanent",
-        actual_type="transient",
+        desired_type=test_case.desired_type,
+        actual_type=test_case.actual_type,
         source="model",
         downgrade=False,
         downgrade_policy="require_confirmation",
@@ -332,8 +358,10 @@ def test_given_unknown_live_table_type_when_converting_then_fails_closed(
             ),
             expected_error_fragment="not created with the desired type",
             expected_statements=(
-                "CREATE OR REPLACE TABLE warehouse.analytics.__sqb_type_swap__orders AS SELECT * "
-                "FROM warehouse.analytics.orders",
+                "CREATE TABLE warehouse.analytics.__sqb_type_swap__orders LIKE "
+                "warehouse.analytics.orders COPY GRANTS",
+                "INSERT INTO warehouse.analytics.__sqb_type_swap__orders SELECT * FROM "
+                "warehouse.analytics.orders",
             ),
         ),
     ],


### PR DESCRIPTION
## Why

Snowflake table-type conversion used CTAS in both directions. That forced large permanent-to-transient conversions to scan and copy all data, and the replacement table did not preserve explicit object grants. Production correctly blocked before attempting this against HKG and GBR rating tables.

## Changes

- Use `CREATE TRANSIENT TABLE ... CLONE ... COPY GRANTS` for zero-copy permanent-to-transient conversion.
- Use `CREATE TABLE ... LIKE ... COPY GRANTS` followed by `INSERT ... SELECT` for transient-to-permanent conversion, which Snowflake cannot clone.
- Drop a stale deterministic pre-swap copy before recreation so `COPY GRANTS` always reads privileges from the live source.
- Cover both directions, stale-copy recovery, generated SQL, and the adjusted real-Snowflake statement count.
- Track post-swap orphan reconciliation separately in CHI-203.

## Verification

- `uv run pytest tests/unit/src/sqlbuild/executor/build/_helpers/test_retention.py tests/unit/src/sqlbuild/cli/commands/_helpers/build_planning/test_table_type.py tests/unit/src/sqlbuild/adapters/snowflake/test_client.py -n auto --dist loadfile` (61 passed)
- `uv sync --all-extras && make check-ci`
- Read-only implementation review against Snowflake clone and `COPY GRANTS` semantics
