### PR TITLE
fix: avoid build planning for focused commands

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/audit/planning.py
+++ b/src/sqlbuild/cli/commands/_helpers/audit/planning.py
@@ -6,12 +6,14 @@ from sqlbuild.cli.commands._helpers.planning.external_refs import (
     resolve_external_sql_reference_resolver,
 )
 from sqlbuild.cli.commands.models import AuditCommandRequest, AuditInvocation
-from sqlbuild.compiler.pipeline.main.compile import run_compile_pipeline
+from sqlbuild.compiler.pipeline.main.static_command import compile_static_command_context
+from sqlbuild.compiler.pipeline.main.static_result import build_static_pipeline_result
 from sqlbuild.compiler.pipeline.models import (
     CompilePipelineOptions,
     CompilePipelineResult,
+    StaticCommandContext,
 )
-from sqlbuild.runtime.contracts.models import ConnectionHooks
+from sqlbuild.compiler.planner.main.commands.audit import build_audit_command_plan
 
 
 def compile_audit_plan(
@@ -21,34 +23,31 @@ def compile_audit_plan(
 ) -> CompilePipelineResult:
     """Compile the audit plan for the selected scope."""
 
-    return run_compile_pipeline(
+    options: CompilePipelineOptions = CompilePipelineOptions(
+        selected_target=request.selected_target,
+        no_sql_validation=request.no_sql_validation,
+        defer_to=request.defer_to,
+        select=request.select,
+        exclude=request.exclude,
+        connection_config=invocation.connection_config,
+        cli_vars=request.cli_vars,
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
+            project_dir=invocation.effective_project_dir,
+            discovered_inputs=invocation.discovered_inputs,
+        ),
+    )
+    context: StaticCommandContext = compile_static_command_context(
         discovered_inputs=invocation.discovered_inputs,
         adapter=invocation.adapter,
-        options=CompilePipelineOptions(
-            selected_target=request.selected_target,
-            no_sql_validation=request.no_sql_validation,
-            defer_to=request.defer_to,
-            select=request.select,
-            exclude=request.exclude,
-            connection_config=invocation.connection_config,
-            cli_vars=request.cli_vars,
-            external_sql_reference_resolver=resolve_external_sql_reference_resolver(
-                project_dir=invocation.effective_project_dir,
-                discovered_inputs=invocation.discovered_inputs,
-            ),
-        ),
-        hooks=ConnectionHooks(
-            on_progress=invocation.planning_progress.on_progress,
-            on_connection_start=invocation.connection_progress.on_connection_start,
-            on_connection_complete=lambda connection_count, elapsed_seconds: (
-                invocation.connection_progress.on_connection_complete(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
-            on_connection_error=lambda connection_count, elapsed_seconds: (
-                invocation.connection_progress.on_connection_error(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
+        options=options,
+        on_progress=invocation.planning_progress.on_progress,
+    )
+    return build_static_pipeline_result(
+        context=context,
+        plan_output=build_audit_command_plan(
+            project=context.project,
+            adapter=invocation.adapter,
+            scope=context.scope,
+            relations=context.relations,
         ),
     )

--- a/src/sqlbuild/cli/commands/_helpers/check/core.py
+++ b/src/sqlbuild/cli/commands/_helpers/check/core.py
@@ -73,6 +73,23 @@ def resolve_selected_check_names(
     return frozenset(check_names - excluded)
 
 
+def check_dependency_closure(
+    *, graph: PythonNodeGraph, check_names: frozenset[str]
+) -> frozenset[str]:
+    """Return transitive executable Python dependencies of selected checks."""
+
+    dependencies: set[str] = set()
+    pending: list[str] = list(check_names)
+    while pending:
+        name: str = pending.pop()
+        for upstream_name in graph.upstream_deps.get(name, ()):
+            if upstream_name in dependencies:
+                continue
+            dependencies.add(upstream_name)
+            pending.append(upstream_name)
+    return frozenset(dependencies - check_names)
+
+
 def _validate_check_selectors(*, select: tuple[str, ...]) -> None:
     raw_selector: str
     for raw_selector in select:
@@ -174,33 +191,21 @@ def run_check_read_side_dependencies(
     python_graph: PythonNodeGraph,
     lifecycle_plan: PythonSqlRunLifecyclePlan,
     relation_targets: dict[SqlResourceRef, str],
+    validation_refs: frozenset[SqlResourceRef] | None = None,
     providers: ProviderContainer | None = None,
 ) -> tuple[PythonNodeExecutionResult, ...]:
     """Run read-side Python dependencies for checks against existing SQL relations."""
 
     read_side_names: frozenset[str] = lifecycle_plan.read_side_python_node_names
-    if not read_side_names:
-        return ()
-    tracker: Any = create_read_side_python_execution_tracker(
-        python_graph=python_graph,
-        selected_python_names=read_side_names,
-        runtime=PythonNodeRuntime(
-            adapter=adapter,
-            connection_config=connection_config,
-            connection=connection,
-            run_id=pipeline_result.project.run_id,
-            target=pipeline_result.project.effective_target_name,
-            vars=pipeline_result.project.effective_vars,
-            is_reload=False,
-            default_database=adapter.default_database(),
-            default_schema=adapter.default_schema(),
-            relation_targets=relation_targets,
-            providers=providers,
-        ),
+    read_side_refs: frozenset[SqlResourceRef] = _read_side_sql_refs(
+        read_side_names=read_side_names, python_graph=python_graph
+    )
+    refs_to_validate: frozenset[SqlResourceRef] = (
+        validation_refs if validation_refs is not None else read_side_refs
     )
     sql_refs: tuple[SqlResourceRef, ...] = tuple(
         sorted(
-            _read_side_sql_refs(read_side_names=read_side_names, python_graph=python_graph),
+            refs_to_validate,
             key=_sql_ref_sort_key,
         )
     )
@@ -223,6 +228,26 @@ def run_check_read_side_dependencies(
             relation_lookup=relation_lookup,
             ref=sql_ref,
         )
+    if not read_side_names:
+        return ()
+    tracker: Any = create_read_side_python_execution_tracker(
+        python_graph=python_graph,
+        selected_python_names=read_side_names,
+        runtime=PythonNodeRuntime(
+            adapter=adapter,
+            connection_config=connection_config,
+            connection=connection,
+            run_id=pipeline_result.project.run_id,
+            target=pipeline_result.project.effective_target_name,
+            vars=pipeline_result.project.effective_vars,
+            is_reload=False,
+            default_database=adapter.default_database(),
+            default_schema=adapter.default_schema(),
+            relation_targets=relation_targets,
+            providers=providers,
+        ),
+    )
+    for sql_ref in sorted(read_side_refs, key=_sql_ref_sort_key):
         if sql_ref.kind == SqlResourceRefKind.MODEL:
             tracker.record_sql_result(
                 ModelExecutionResult(model_name=sql_ref.name, status=ExecutionStatus.SUCCESS)

--- a/src/sqlbuild/cli/commands/_helpers/check/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/check/execution.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from sqlbuild.cli.commands._helpers.check.core import (
     build_check_relation_targets,
+    check_dependency_closure,
     load_results_by_loader_name,
     record_python_run_state_results,
     resolve_selected_check_names,
@@ -66,8 +67,11 @@ def prepare_check_execution(
     )
     lifecycle_plan: PythonSqlRunLifecyclePlan = build_python_sql_run_lifecycle(
         selection=PythonSqlRunSelection(
-            sql_keys=frozenset(),
-            python_node_names=frozenset(),
+            sql_keys=pipeline_result.plan_output.selected_keys,
+            python_node_names=check_dependency_closure(
+                graph=python_graph,
+                check_names=check_names,
+            ),
         ),
         python_graph=python_graph,
     )
@@ -77,11 +81,15 @@ def prepare_check_execution(
         python_graph=python_graph,
         selected_python_names=check_names,
     )
+    relation_refs: frozenset[SqlResourceRef] = python_graph.selected_sql_refs(
+        selected_names=check_names
+    )
     return CheckExecutionPreparation(
         python_graph=python_graph,
         check_functions=check_functions,
         lifecycle_plan=lifecycle_plan,
         relation_targets=relation_targets,
+        relation_refs=relation_refs,
         default_database=_default_database(invocation=invocation, pipeline_result=pipeline_result),
         default_schema=_default_schema(invocation=invocation, pipeline_result=pipeline_result),
     )
@@ -228,6 +236,7 @@ def _execute_check_read_side(
         python_graph=preparation.python_graph,
         lifecycle_plan=preparation.lifecycle_plan,
         relation_targets=preparation.relation_targets,
+        validation_refs=preparation.relation_refs,
         providers=providers,
     )
     record_python_run_state_results(

--- a/src/sqlbuild/cli/commands/_helpers/check/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/check/execution.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from sqlbuild.cli.commands._helpers.check.core import (
     build_check_relation_targets,
-    check_dependency_closure,
     load_results_by_loader_name,
     record_python_run_state_results,
     resolve_selected_check_names,
@@ -67,11 +66,8 @@ def prepare_check_execution(
     )
     lifecycle_plan: PythonSqlRunLifecyclePlan = build_python_sql_run_lifecycle(
         selection=PythonSqlRunSelection(
-            sql_keys=pipeline_result.plan_output.selected_keys,
-            python_node_names=check_dependency_closure(
-                graph=python_graph,
-                check_names=check_names,
-            ),
+            sql_keys=frozenset(),
+            python_node_names=frozenset(),
         ),
         python_graph=python_graph,
     )

--- a/src/sqlbuild/cli/commands/_helpers/check/planning.py
+++ b/src/sqlbuild/cli/commands/_helpers/check/planning.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
+from sqlbuild.cli.commands._helpers.check.core import (
+    check_dependency_closure,
+    resolve_selected_check_names,
+)
 from sqlbuild.cli.commands._helpers.planning.external_refs import (
     resolve_external_sql_reference_resolver,
 )
 from sqlbuild.cli.commands.models import CheckCommandRequest, CheckInvocation
-from sqlbuild.compiler.pipeline.main.compile import run_compile_pipeline
+from sqlbuild.compiler.compile.models import CompiledObjectKey
+from sqlbuild.compiler.compile.types import CompiledResourceType
+from sqlbuild.compiler.pipeline.main.static_command import compile_static_command_context
+from sqlbuild.compiler.pipeline.main.static_result import build_static_pipeline_result
 from sqlbuild.compiler.pipeline.models import (
     CompilePipelineOptions,
     CompilePipelineResult,
+    StaticCommandContext,
 )
-from sqlbuild.runtime.contracts.models import ConnectionHooks
+from sqlbuild.compiler.planner.main.commands.relation_plan import build_relation_command_plan
+from sqlbuild.compiler.python_nodes.main.graph import build_discovered_python_node_graph
+from sqlbuild.compiler.python_nodes.models import PythonNodeGraph
+from sqlbuild.compiler.python_nodes.types import PythonNodeKind
+from sqlbuild.python_nodes.models import SqlResourceRef
+from sqlbuild.python_nodes.types import SqlResourceRefKind
 
 
 def compile_check_plan(
@@ -19,15 +32,51 @@ def compile_check_plan(
 ) -> CompilePipelineResult:
     """Compile the project for Python check execution."""
 
-    return run_compile_pipeline(
+    python_graph: PythonNodeGraph = build_discovered_python_node_graph(
+        discovered_inputs=invocation.discovered_inputs
+    )
+    check_names: frozenset[str] = resolve_selected_check_names(
+        graph=python_graph,
+        select=request.select,
+        exclude=request.exclude,
+    )
+    required_refs: frozenset[SqlResourceRef] = python_graph.selected_sql_refs(
+        selected_names=check_names
+    )
+    dependency_names: frozenset[str] = check_dependency_closure(
+        graph=python_graph, check_names=check_names
+    )
+    required_loader_names: frozenset[str] = frozenset(
+        name
+        for name in dependency_names
+        if python_graph.nodes_by_name[name].kind == PythonNodeKind.LOADER
+    )
+    required_source_names: frozenset[str] = _required_loader_source_names(
+        invocation=invocation,
+        required_loader_names=required_loader_names,
+    )
+    selected_keys: frozenset[CompiledObjectKey] = frozenset(
+        CompiledObjectKey(
+            resource_type=(
+                CompiledResourceType.MODEL
+                if ref.kind == SqlResourceRefKind.MODEL
+                else CompiledResourceType.SOURCE
+            ),
+            name=ref.name,
+        )
+        for ref in required_refs
+        if ref.kind in {SqlResourceRefKind.MODEL, SqlResourceRefKind.SOURCE}
+    ) | frozenset(
+        CompiledObjectKey(resource_type=CompiledResourceType.SOURCE, name=name)
+        for name in required_source_names
+    )
+    context: StaticCommandContext = compile_static_command_context(
         discovered_inputs=invocation.discovered_inputs,
         adapter=invocation.adapter,
         options=CompilePipelineOptions(
             selected_target=request.selected_target,
             no_sql_validation=request.no_sql_validation,
             source_deferral_enabled=False,
-            select=(),
-            exclude=(),
             connection_config=invocation.connection_config,
             cli_vars=request.cli_vars,
             external_sql_reference_resolver=resolve_external_sql_reference_resolver(
@@ -35,18 +84,26 @@ def compile_check_plan(
                 discovered_inputs=invocation.discovered_inputs,
             ),
         ),
-        hooks=ConnectionHooks(
-            on_progress=invocation.planning_progress.on_progress,
-            on_connection_start=invocation.connection_progress.on_connection_start,
-            on_connection_complete=lambda connection_count, elapsed_seconds: (
-                invocation.connection_progress.on_connection_complete(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
-            on_connection_error=lambda connection_count, elapsed_seconds: (
-                invocation.connection_progress.on_connection_error(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
+        selected_keys=selected_keys,
+        relation_keys=selected_keys,
+        on_progress=invocation.planning_progress.on_progress,
+    )
+    return build_static_pipeline_result(
+        context=context,
+        plan_output=build_relation_command_plan(
+            project=context.project,
+            scope=context.scope,
+            relations=context.relations,
         ),
     )
+
+
+def _required_loader_source_names(
+    *, invocation: CheckInvocation, required_loader_names: frozenset[str]
+) -> frozenset[str]:
+    names: set[str] = set()
+    for source_file in invocation.discovered_inputs.source_files:
+        for source in source_file.source_entries:
+            if source.loader in required_loader_names:
+                names.add(source.name)
+    return frozenset(names)

--- a/src/sqlbuild/cli/commands/_helpers/scenario_capture/capture.py
+++ b/src/sqlbuild/cli/commands/_helpers/scenario_capture/capture.py
@@ -35,20 +35,18 @@ from sqlbuild.cli.commands.models import (
     ScenarioRunOutputContext,
     ScenarioSnapshotLimitInputs,
 )
-from sqlbuild.cli.progress.classes.connection_progress_reporter import ConnectionProgressReporter
 from sqlbuild.cli.progress.classes.planning_progress_reporter import PlanningProgressReporter
 from sqlbuild.cli.progress.main._write_execution_header import write_execution_header
 from sqlbuild.compiler.compile.models import CompiledSqlScenario
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
-from sqlbuild.compiler.pipeline.main.compile import run_compile_pipeline
+from sqlbuild.compiler.pipeline.main.compile_only import run_compile_only_pipeline
 from sqlbuild.compiler.pipeline.models import (
     CompilePipelineOptions,
     CompilePipelineResult,
 )
 from sqlbuild.executor.scenario.models import ScenarioSnapshotCaptureLimits
 from sqlbuild.presentation.main.supports_color import supports_color
-from sqlbuild.runtime.contracts.models import ConnectionHooks
 from sqlbuild.runtime.observability.classes.operation_lifecycle import OperationLifecycle
 from sqlbuild.spec.contracts.main.resolve_effective_adapter_name import (
     resolve_effective_adapter_name,
@@ -101,11 +99,6 @@ def run_scenario_capture(request: ScenarioCaptureCommandRequest) -> int:
     use_color: bool = not no_color and supports_color()
     progress_stream: TextIO = sys.stdout
     target_label: str | None = " ".join(selectors) if selectors else None
-    connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
-        adapter_name=adapter_name,
-        stream=progress_stream,
-        use_color=use_color,
-    )
     planning_progress: PlanningProgressReporter = PlanningProgressReporter(
         stream=progress_stream,
         use_color=use_color,
@@ -122,7 +115,7 @@ def run_scenario_capture(request: ScenarioCaptureCommandRequest) -> int:
     progress_stream.flush()
 
     with OperationLifecycle(operation_kind="project", operation_name="project_compile"):
-        pipeline_result: CompilePipelineResult = run_compile_pipeline(
+        pipeline_result: CompilePipelineResult = run_compile_only_pipeline(
             discovered_inputs=discovered_inputs,
             adapter=adapter,
             options=CompilePipelineOptions(
@@ -133,20 +126,7 @@ def run_scenario_capture(request: ScenarioCaptureCommandRequest) -> int:
                     discovered_inputs=discovered_inputs,
                 ),
             ),
-            hooks=ConnectionHooks(
-                on_progress=planning_progress.on_progress,
-                on_connection_start=connection_progress.on_connection_start,
-                on_connection_complete=lambda connection_count, elapsed_seconds: (
-                    connection_progress.on_connection_complete(
-                        connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                    )
-                ),
-                on_connection_error=lambda connection_count, elapsed_seconds: (
-                    connection_progress.on_connection_error(
-                        connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                    )
-                ),
-            ),
+            on_progress=planning_progress.on_progress,
         )
     scenarios: tuple[CompiledSqlScenario, ...] = select_scenarios(
         project=pipeline_result.project,

--- a/src/sqlbuild/cli/commands/_helpers/scenario_execution/runner.py
+++ b/src/sqlbuild/cli/commands/_helpers/scenario_execution/runner.py
@@ -56,7 +56,7 @@ from sqlbuild.cli.progress.main._write_execution_header import write_execution_h
 from sqlbuild.compiler.compile.models import CompiledSqlScenario
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
-from sqlbuild.compiler.pipeline.main.compile import run_compile_pipeline
+from sqlbuild.compiler.pipeline.main.compile_only import run_compile_only_pipeline
 from sqlbuild.compiler.pipeline.models import (
     CompilePipelineOptions,
     CompilePipelineResult,
@@ -158,11 +158,6 @@ def run_scenario(request: ScenarioTestCommandRequest) -> int:
     use_color: bool = not no_color and supports_color()
     progress_stream: TextIO = sys.stderr if json_output else sys.stdout
     target_label: str | None = " ".join(selectors) if selectors else None
-    connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
-        adapter_name=adapter_name,
-        stream=progress_stream,
-        use_color=use_color,
-    )
     planning_progress: PlanningProgressReporter = PlanningProgressReporter(
         stream=progress_stream,
         use_color=use_color,
@@ -178,7 +173,7 @@ def run_scenario(request: ScenarioTestCommandRequest) -> int:
 
     try:
         with OperationLifecycle(operation_kind="project", operation_name="project_compile"):
-            pipeline_result: CompilePipelineResult = run_compile_pipeline(
+            pipeline_result: CompilePipelineResult = run_compile_only_pipeline(
                 discovered_inputs=discovered_inputs,
                 adapter=adapter,
                 options=CompilePipelineOptions(
@@ -190,20 +185,7 @@ def run_scenario(request: ScenarioTestCommandRequest) -> int:
                         discovered_inputs=discovered_inputs,
                     ),
                 ),
-                hooks=ConnectionHooks(
-                    on_progress=planning_progress.on_progress,
-                    on_connection_start=connection_progress.on_connection_start,
-                    on_connection_complete=lambda connection_count, elapsed_seconds: (
-                        connection_progress.on_connection_complete(
-                            connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                        )
-                    ),
-                    on_connection_error=lambda connection_count, elapsed_seconds: (
-                        connection_progress.on_connection_error(
-                            connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                        )
-                    ),
-                ),
+                on_progress=planning_progress.on_progress,
             )
     finally:
         planning_progress.finish()
@@ -355,18 +337,13 @@ def _sync_local_snapshots(
         progress_stream.flush()
         return 0, capture_results_out
 
-    connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
-        adapter_name=project_adapter_name,
-        stream=progress_stream,
-        use_color=use_color,
-    )
     planning_progress: PlanningProgressReporter = PlanningProgressReporter(
         stream=progress_stream,
         use_color=use_color,
     )
     try:
         with OperationLifecycle(operation_kind="project", operation_name="project_compile"):
-            project_pipeline_result: CompilePipelineResult = run_compile_pipeline(
+            project_pipeline_result: CompilePipelineResult = run_compile_only_pipeline(
                 discovered_inputs=discovered_inputs,
                 adapter=project_adapter,
                 options=CompilePipelineOptions(
@@ -378,20 +355,7 @@ def _sync_local_snapshots(
                         discovered_inputs=discovered_inputs,
                     ),
                 ),
-                hooks=ConnectionHooks(
-                    on_progress=planning_progress.on_progress,
-                    on_connection_start=connection_progress.on_connection_start,
-                    on_connection_complete=lambda connection_count, elapsed_seconds: (
-                        connection_progress.on_connection_complete(
-                            connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                        )
-                    ),
-                    on_connection_error=lambda connection_count, elapsed_seconds: (
-                        connection_progress.on_connection_error(
-                            connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                        )
-                    ),
-                ),
+                on_progress=planning_progress.on_progress,
             )
     finally:
         planning_progress.finish()

--- a/src/sqlbuild/cli/commands/_helpers/seed/planning.py
+++ b/src/sqlbuild/cli/commands/_helpers/seed/planning.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from sqlbuild.cli.commands._helpers.planning.external_refs import (
     resolve_external_sql_reference_resolver,
 )
@@ -11,11 +13,18 @@ from sqlbuild.cli.commands.models import (
     SeedInvocation,
 )
 from sqlbuild.cli.progress.classes.connection_progress_reporter import ConnectionProgressReporter
-from sqlbuild.compiler.pipeline.main.compile import run_compile_pipeline
+from sqlbuild.compiler.compile.models import CompiledSeed
+from sqlbuild.compiler.fingerprints.models import Fingerprint
+from sqlbuild.compiler.pipeline.main.static_command import compile_static_command_context
+from sqlbuild.compiler.pipeline.main.static_result import build_static_pipeline_result
 from sqlbuild.compiler.pipeline.models import (
     CompilePipelineOptions,
     CompilePipelineResult,
+    StaticCommandContext,
 )
+from sqlbuild.compiler.planner.main.commands.seed import build_seed_command_plan
+from sqlbuild.compiler.planner.main.commands.seed_state import read_selected_seed_fingerprints
+from sqlbuild.runtime.contracts.main.open_connection import open_connection_with_hooks
 from sqlbuild.runtime.contracts.models import ConnectionHooks
 
 
@@ -31,32 +40,60 @@ def prepare_seed_execution(
     )
     invocation.progress_stream.write("\n")
     invocation.progress_stream.flush()
-    pipeline_result: CompilePipelineResult = run_compile_pipeline(
+    options: CompilePipelineOptions = CompilePipelineOptions(
+        selected_target=request.selected_target,
+        select=request.select,
+        exclude=request.exclude,
+        connection_config=invocation.connection_config,
+        cli_vars=request.cli_vars,
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
+            project_dir=invocation.effective_project_dir,
+            discovered_inputs=invocation.discovered_inputs,
+        ),
+    )
+    context: StaticCommandContext = compile_static_command_context(
         discovered_inputs=invocation.discovered_inputs,
         adapter=invocation.adapter,
-        options=CompilePipelineOptions(
-            selected_target=request.selected_target,
-            select=request.select,
-            exclude=request.exclude,
-            connection_config=invocation.connection_config,
-            cli_vars=request.cli_vars,
-            external_sql_reference_resolver=resolve_external_sql_reference_resolver(
-                project_dir=invocation.effective_project_dir,
-                discovered_inputs=invocation.discovered_inputs,
-            ),
+        options=options,
+    )
+    selected_seeds: tuple[CompiledSeed, ...] = tuple(
+        seed for seed in context.project.seeds if seed.key in context.scope.selected_keys
+    )
+    hooks: ConnectionHooks = ConnectionHooks(
+        on_connection_start=connection_progress.on_connection_start,
+        on_connection_complete=lambda connection_count, elapsed_seconds: (
+            connection_progress.on_connection_complete(
+                connection_count=connection_count, elapsed_seconds=elapsed_seconds
+            )
         ),
-        hooks=ConnectionHooks(
-            on_connection_start=connection_progress.on_connection_start,
-            on_connection_complete=lambda connection_count, elapsed_seconds: (
-                connection_progress.on_connection_complete(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
-            on_connection_error=lambda connection_count, elapsed_seconds: (
-                connection_progress.on_connection_error(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
+        on_connection_error=lambda connection_count, elapsed_seconds: (
+            connection_progress.on_connection_error(
+                connection_count=connection_count, elapsed_seconds=elapsed_seconds
+            )
+        ),
+    )
+    fingerprints: dict[str, Fingerprint] = {}
+    if selected_seeds:
+        connection: Any = open_connection_with_hooks(
+            adapter=invocation.adapter,
+            connection_config=invocation.connection_config,
+            hooks=hooks,
+        )
+        try:
+            fingerprints = read_selected_seed_fingerprints(
+                adapter=invocation.adapter,
+                connection=connection,
+                seeds=selected_seeds,
+            )
+        finally:
+            invocation.adapter.close(connection)
+    pipeline_result: CompilePipelineResult = build_static_pipeline_result(
+        context=context,
+        plan_output=build_seed_command_plan(
+            project=context.project,
+            scope=context.scope,
+            relations=context.relations,
+            fingerprints=fingerprints,
         ),
     )
     effective_concurrency: int = max(

--- a/src/sqlbuild/cli/commands/_helpers/test/planning.py
+++ b/src/sqlbuild/cli/commands/_helpers/test/planning.py
@@ -6,12 +6,14 @@ from sqlbuild.cli.commands._helpers.planning.external_refs import (
     resolve_external_sql_reference_resolver,
 )
 from sqlbuild.cli.commands.models import TestCommandRequest, TestInvocation
-from sqlbuild.compiler.pipeline.main.compile import run_compile_pipeline
+from sqlbuild.compiler.pipeline.main.static_command import compile_static_command_context
+from sqlbuild.compiler.pipeline.main.static_result import build_static_pipeline_result
 from sqlbuild.compiler.pipeline.models import (
     CompilePipelineOptions,
     CompilePipelineResult,
+    StaticCommandContext,
 )
-from sqlbuild.runtime.contracts.models import ConnectionHooks
+from sqlbuild.compiler.planner.main.commands.sql_test import build_test_command_plan
 
 
 def compile_test_plan(
@@ -21,34 +23,31 @@ def compile_test_plan(
 ) -> CompilePipelineResult:
     """Compile the test plan for the selected scope."""
 
-    return run_compile_pipeline(
+    options: CompilePipelineOptions = CompilePipelineOptions(
+        selected_target=request.selected_target,
+        no_sql_validation=request.no_sql_validation,
+        source_deferral_enabled=False,
+        select=request.select,
+        exclude=request.exclude,
+        connection_config=invocation.connection_config,
+        cli_vars=request.cli_vars,
+        external_sql_reference_resolver=resolve_external_sql_reference_resolver(
+            project_dir=invocation.effective_project_dir,
+            discovered_inputs=invocation.discovered_inputs,
+        ),
+    )
+    context: StaticCommandContext = compile_static_command_context(
         discovered_inputs=invocation.discovered_inputs,
         adapter=invocation.adapter,
-        options=CompilePipelineOptions(
-            selected_target=request.selected_target,
-            no_sql_validation=request.no_sql_validation,
-            source_deferral_enabled=False,
-            select=request.select,
-            exclude=request.exclude,
-            connection_config=invocation.connection_config,
-            cli_vars=request.cli_vars,
-            external_sql_reference_resolver=resolve_external_sql_reference_resolver(
-                project_dir=invocation.effective_project_dir,
-                discovered_inputs=invocation.discovered_inputs,
-            ),
-        ),
-        hooks=ConnectionHooks(
-            on_progress=invocation.planning_progress.on_progress,
-            on_connection_start=invocation.connection_progress.on_connection_start,
-            on_connection_complete=lambda connection_count, elapsed_seconds: (
-                invocation.connection_progress.on_connection_complete(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
-            on_connection_error=lambda connection_count, elapsed_seconds: (
-                invocation.connection_progress.on_connection_error(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
+        options=options,
+        on_progress=invocation.planning_progress.on_progress,
+    )
+    return build_static_pipeline_result(
+        context=context,
+        plan_output=build_test_command_plan(
+            project=context.project,
+            adapter=invocation.adapter,
+            scope=context.scope,
+            relations=context.relations,
         ),
     )

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -430,6 +430,7 @@ class CheckExecutionPreparation:
     check_functions: tuple[DiscoveredCheckFunction, ...]
     lifecycle_plan: PythonSqlRunLifecyclePlan
     relation_targets: dict[SqlResourceRef, str]
+    relation_refs: frozenset[SqlResourceRef]
     default_database: str | None
     default_schema: str | None
 

--- a/src/sqlbuild/compiler/pipeline/main/_compile_phase.py
+++ b/src/sqlbuild/compiler/pipeline/main/_compile_phase.py
@@ -1,0 +1,67 @@
+"""Canonical project compilation phase."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.compiler.compile.main.effective_config import build_effective_connection_config
+from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.compiler.pipeline._helpers.analysis_selection import (
+    resolve_compile_analysis_selection,
+)
+from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
+from sqlbuild.compiler.pipeline.models import CompiledProjectPhaseResult, CompilePipelineOptions
+from sqlbuild.diagnostics.classes.build_phase_timing_tracker import BuildPhaseTimingTracker
+
+
+def compile_project_phase(
+    *,
+    discovered_inputs: DiscoveredProjectInputs,
+    adapter: BaseAdapter,
+    options: CompilePipelineOptions | None = None,
+    on_progress: Callable[[str], None] | None = None,
+) -> CompiledProjectPhaseResult:
+    """Compile a project without opening a warehouse planning connection."""
+
+    resolved_options: CompilePipelineOptions = options or CompilePipelineOptions()
+    effective_config: dict[str, object] = (
+        resolved_options.connection_config
+        if resolved_options.connection_config is not None
+        else build_effective_connection_config(
+            discovered_inputs=discovered_inputs,
+            selected_target=resolved_options.selected_target,
+            cli_vars=resolved_options.cli_vars,
+        )
+    )
+    if on_progress is not None:
+        on_progress("Compiling project...")
+    compile_start: float = time.monotonic()
+    try:
+        project: CompiledProject = build_compiled_project(
+            discovered_inputs=discovered_inputs,
+            adapter=adapter,
+            selected_target=resolved_options.selected_target,
+            no_sql_validation=resolved_options.no_sql_validation,
+            cli_vars=resolved_options.cli_vars,
+            external_sql_reference_resolver=resolved_options.external_sql_reference_resolver,
+            resolved_connection=effective_config,
+            analysis_selection=resolve_compile_analysis_selection(
+                options=resolved_options,
+                discovered_inputs=discovered_inputs,
+            ),
+        )
+    finally:
+        compile_seconds: float = time.monotonic() - compile_start
+        timing_tracker: BuildPhaseTimingTracker | None = BuildPhaseTimingTracker.current()
+        if timing_tracker is not None:
+            timing_tracker.compile_seconds = compile_seconds
+    if on_progress is not None:
+        on_progress(f"Compiled project. ({compile_seconds:.2f}s)")
+    return CompiledProjectPhaseResult(
+        project=project,
+        connection_config=effective_config,
+        compile_seconds=compile_seconds,
+    )

--- a/src/sqlbuild/compiler/pipeline/main/compile.py
+++ b/src/sqlbuild/compiler/pipeline/main/compile.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.models import RelationInfo
-from sqlbuild.compiler.compile.main.effective_config import build_effective_connection_config
 from sqlbuild.compiler.compile.models import (
     CompiledObjectKey,
     CompiledProject,
@@ -22,9 +21,6 @@ from sqlbuild.compiler.graph.main._build_lineage_downstream_deps import (
 from sqlbuild.compiler.graph.main._build_lineage_upstream_deps import (
     build_lineage_upstream_deps,
 )
-from sqlbuild.compiler.pipeline._helpers.analysis_selection import (
-    resolve_compile_analysis_selection,
-)
 from sqlbuild.compiler.pipeline._helpers.deferred_locations import (
     build_deferred_locations,
     gather_deferred_relations,
@@ -33,8 +29,9 @@ from sqlbuild.compiler.pipeline._helpers.deferred_locations import (
 from sqlbuild.compiler.pipeline._helpers.graph import build_static_all_keys
 from sqlbuild.compiler.pipeline._helpers.materializations import load_custom_materializations
 from sqlbuild.compiler.pipeline._helpers.python_plan_entries import build_python_run_plan_outputs
-from sqlbuild.compiler.pipeline.main.compiled_project import build_compiled_project
+from sqlbuild.compiler.pipeline.main._compile_phase import compile_project_phase
 from sqlbuild.compiler.pipeline.models import (
+    CompiledProjectPhaseResult,
     CompilePipelineOptions,
     CompilePipelineResult,
     ProjectGraph,
@@ -79,39 +76,16 @@ def run_compile_pipeline(
     )
     resolved_hooks: ConnectionHooks = hooks if hooks is not None else ConnectionHooks()
     on_progress: Callable[[str], None] | None = resolved_hooks.on_progress
-    effective_config: dict[str, object] = (
-        resolved_options.connection_config
-        if resolved_options.connection_config is not None
-        else build_effective_connection_config(
-            discovered_inputs=discovered_inputs,
-            selected_target=resolved_options.selected_target,
-            cli_vars=resolved_options.cli_vars,
-        )
+    compile_result: CompiledProjectPhaseResult = compile_project_phase(
+        discovered_inputs=discovered_inputs,
+        adapter=adapter,
+        options=resolved_options,
+        on_progress=on_progress,
     )
-    if on_progress is not None:
-        on_progress("Compiling project...")
-    compile_start: float = time.monotonic()
-    try:
-        project: CompiledProject = build_compiled_project(
-            discovered_inputs=discovered_inputs,
-            adapter=adapter,
-            selected_target=resolved_options.selected_target,
-            no_sql_validation=resolved_options.no_sql_validation,
-            cli_vars=resolved_options.cli_vars,
-            external_sql_reference_resolver=resolved_options.external_sql_reference_resolver,
-            resolved_connection=effective_config,
-            analysis_selection=resolve_compile_analysis_selection(
-                options=resolved_options,
-                discovered_inputs=discovered_inputs,
-            ),
-        )
-    finally:
-        compile_seconds: float = time.monotonic() - compile_start
-        timing_tracker: BuildPhaseTimingTracker | None = BuildPhaseTimingTracker.current()
-        if timing_tracker is not None:
-            timing_tracker.compile_seconds = compile_seconds
-    if on_progress is not None:
-        on_progress(f"Compiled project. ({compile_seconds:.2f}s)")
+    effective_config: dict[str, object] = compile_result.connection_config
+    project: CompiledProject = compile_result.project
+    compile_seconds: float = compile_result.compile_seconds
+    timing_tracker: BuildPhaseTimingTracker | None = BuildPhaseTimingTracker.current()
     planning_start: float = time.monotonic()
     connection: Any | None = None
     result: CompilePipelineResult | None = None

--- a/src/sqlbuild/compiler/pipeline/main/compile_only.py
+++ b/src/sqlbuild/compiler/pipeline/main/compile_only.py
@@ -1,0 +1,38 @@
+"""Public compile-only pipeline entrypoint."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.compiler.pipeline.main._compile_phase import compile_project_phase
+from sqlbuild.compiler.pipeline.models import (
+    CompiledProjectPhaseResult,
+    CompilePipelineOptions,
+    CompilePipelineResult,
+)
+from sqlbuild.compiler.planner.models import PlanOutput
+
+
+def run_compile_only_pipeline(
+    *,
+    discovered_inputs: DiscoveredProjectInputs,
+    adapter: BaseAdapter,
+    options: CompilePipelineOptions,
+    on_progress: Callable[[str], None] | None = None,
+) -> CompilePipelineResult:
+    """Compile a project for consumers that construct their own focused plans."""
+
+    compiled: CompiledProjectPhaseResult = compile_project_phase(
+        discovered_inputs=discovered_inputs,
+        adapter=adapter,
+        options=options,
+        on_progress=on_progress,
+    )
+    return CompilePipelineResult(
+        project=compiled.project,
+        plan_output=PlanOutput(),
+        compile_seconds=compiled.compile_seconds,
+        planning_seconds=0.0,
+    )

--- a/src/sqlbuild/compiler/pipeline/main/static_command.py
+++ b/src/sqlbuild/compiler/pipeline/main/static_command.py
@@ -1,0 +1,91 @@
+"""Public static command compilation entrypoint."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledRelationLocation
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.compiler.pipeline._helpers.deferred_locations import (
+    build_deferred_locations,
+    resolve_deferred_target_config,
+)
+from sqlbuild.compiler.pipeline.main._compile_phase import compile_project_phase
+from sqlbuild.compiler.pipeline.models import (
+    CompiledProjectPhaseResult,
+    CompilePipelineOptions,
+    StaticCommandContext,
+)
+from sqlbuild.compiler.planner.main.commands._relations import resolve_static_relation_context
+from sqlbuild.compiler.planner.main.commands._scope import resolve_static_command_scope
+from sqlbuild.compiler.planner.models import (
+    DeferralInputs,
+    PlannerRelationsContext,
+    PlannerScope,
+    PlannerSelection,
+)
+from sqlbuild.spec.contracts.models import TargetConfig
+
+
+def compile_static_command_context(
+    *,
+    discovered_inputs: DiscoveredProjectInputs,
+    adapter: BaseAdapter,
+    options: CompilePipelineOptions,
+    selected_keys: frozenset[CompiledObjectKey] | None = None,
+    relation_keys: frozenset[CompiledObjectKey] | None = None,
+    on_progress: Callable[[str], None] | None = None,
+) -> StaticCommandContext:
+    """Run canonical compile, selector, and relation phases without build planning."""
+
+    compiled: CompiledProjectPhaseResult = compile_project_phase(
+        discovered_inputs=discovered_inputs,
+        adapter=adapter,
+        options=options,
+        on_progress=on_progress,
+    )
+    deferred_locations: dict[str, CompiledRelationLocation] | None = None
+    if options.defer_to is not None:
+        deferred_target: TargetConfig = resolve_deferred_target_config(
+            discovered_inputs=discovered_inputs,
+            defer_to=options.defer_to,
+            current_target_name=compiled.project.effective_target_name,
+        )
+        deferred_locations = build_deferred_locations(
+            project=compiled.project,
+            deferred_target_config=deferred_target,
+            effective_vars=compiled.project.effective_vars,
+            default_schema=adapter.default_schema(),
+            default_database=adapter.default_database(),
+            render_qualified_name=adapter.render_qualified_name,
+        )
+    scope: PlannerScope = resolve_static_command_scope(
+        project=compiled.project,
+        selection=PlannerSelection(
+            select=options.select,
+            exclude=options.exclude,
+            selected_keys=selected_keys,
+        ),
+        auto_load_sources=options.auto_load_sources,
+    )
+    relations: PlannerRelationsContext = resolve_static_relation_context(
+        project=compiled.project,
+        adapter=adapter,
+        scope=scope,
+        deferral=DeferralInputs(
+            deferred_locations=deferred_locations,
+            defer_sources_to=options.defer_sources_to,
+            source_deferral_enabled=options.source_deferral_enabled,
+        ),
+        project_config=discovered_inputs.project_config,
+        local_config=discovered_inputs.local_config,
+        relation_keys=relation_keys,
+    )
+    return StaticCommandContext(
+        project=compiled.project,
+        scope=scope,
+        relations=relations,
+        connection_config=compiled.connection_config,
+        compile_seconds=compiled.compile_seconds,
+    )

--- a/src/sqlbuild/compiler/pipeline/main/static_result.py
+++ b/src/sqlbuild/compiler/pipeline/main/static_result.py
@@ -1,0 +1,19 @@
+"""Public focused-command result assembly entrypoint."""
+
+from __future__ import annotations
+
+from sqlbuild.compiler.pipeline.models import CompilePipelineResult, StaticCommandContext
+from sqlbuild.compiler.planner.models import PlanOutput
+
+
+def build_static_pipeline_result(
+    *, context: StaticCommandContext, plan_output: PlanOutput
+) -> CompilePipelineResult:
+    """Wrap a focused command projection in the established pipeline envelope."""
+
+    return CompilePipelineResult(
+        project=context.project,
+        plan_output=plan_output,
+        compile_seconds=context.compile_seconds,
+        planning_seconds=0.0,
+    )

--- a/src/sqlbuild/compiler/pipeline/models.py
+++ b/src/sqlbuild/compiler/pipeline/models.py
@@ -16,6 +16,8 @@ from sqlbuild.compiler.planner.models import (
     CursorOverrides,
     FunctionPlanEntry,
     ModelPlanEntry,
+    PlannerRelationsContext,
+    PlannerScope,
     PlanOutput,
     SeedPlanEntry,
 )
@@ -86,6 +88,26 @@ class CompilePipelineResult:
     python_plan_entries: tuple[PythonPlanEntry, ...] = field(default_factory=tuple)
     compile_seconds: float | None = None
     planning_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class CompiledProjectPhaseResult:
+    """Canonical project compilation output before command-specific planning."""
+
+    project: CompiledProject
+    connection_config: dict[str, object]
+    compile_seconds: float
+
+
+@dataclass(frozen=True)
+class StaticCommandContext:
+    """Shared compile, selection, and relation phases for focused commands."""
+
+    project: CompiledProject
+    scope: PlannerScope
+    relations: PlannerRelationsContext
+    connection_config: dict[str, object]
+    compile_seconds: float
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/planner/_helpers/command_planning/__init__.py
+++ b/src/sqlbuild/compiler/planner/_helpers/command_planning/__init__.py
@@ -1,0 +1,1 @@
+"""Internal focused-command planning phases."""

--- a/src/sqlbuild/compiler/planner/_helpers/command_planning/seed_state.py
+++ b/src/sqlbuild/compiler/planner/_helpers/command_planning/seed_state.py
@@ -1,0 +1,87 @@
+"""Targeted warehouse identity state for direct seed commands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.adapter.contract.models import RelationInfo
+from sqlbuild.compiler.compile.models import CompiledSeed
+from sqlbuild.compiler.fingerprints.constants import FINGERPRINT_TABLE_NAME, NODE_TYPE_SEED
+from sqlbuild.compiler.fingerprints.main.read import read_latest_fingerprints
+from sqlbuild.compiler.fingerprints.models import Fingerprint, FingerprintSet
+
+
+def read_seed_fingerprints(
+    *, adapter: BaseAdapter, connection: Any, seeds: tuple[CompiledSeed, ...]
+) -> dict[str, Fingerprint]:
+    """Read only fingerprint state required to classify selected direct seeds."""
+
+    names_by_target: dict[tuple[str | None, str], set[str]] = {}
+    for seed in seeds:
+        if seed.destination.schema is None:
+            continue
+        names_by_target.setdefault((seed.destination.database, seed.destination.schema), set()).add(
+            seed.name
+        )
+
+    targets: tuple[tuple[str | None, str], ...] = tuple(
+        sorted(names_by_target, key=lambda target: ((target[0] or ""), target[1]))
+    )
+    relations_by_target: dict[tuple[str | None, str], tuple[RelationInfo, ...]] = (
+        _gather_fingerprint_relations(
+            adapter=adapter,
+            connection=connection,
+            targets=targets,
+        )
+    )
+    fingerprints: dict[str, Fingerprint] = {}
+    for database, schema in targets:
+        names: set[str] = names_by_target[(database, schema)]
+        relations: tuple[RelationInfo, ...] = relations_by_target[(database, schema)]
+        table_exists: bool = any(
+            relation.name.lower() == FINGERPRINT_TABLE_NAME.lower() for relation in relations
+        )
+        fingerprint_set: FingerprintSet = read_latest_fingerprints(
+            connection=connection,
+            execute=adapter.execute,
+            table_exists=table_exists,
+            database=database,
+            schema=schema,
+            render_qualified_name=adapter.render_qualified_name,
+            render_read_latest_sql=adapter.render_read_latest_fingerprints_sql,
+            node_names=tuple(sorted(names)),
+        )
+        fingerprints.update(
+            {
+                name: fingerprint
+                for name, fingerprint in fingerprint_set.fingerprints.items()
+                if fingerprint.node_type == NODE_TYPE_SEED and name in names
+            }
+        )
+    return fingerprints
+
+
+def _gather_fingerprint_relations(
+    *,
+    adapter: BaseAdapter,
+    connection: Any,
+    targets: tuple[tuple[str | None, str], ...],
+) -> dict[tuple[str | None, str], tuple[RelationInfo, ...]]:
+    if not targets:
+        return {}
+    database, schema = targets[0]
+    relations: tuple[RelationInfo, ...] = adapter.list_relations(
+        connection=connection,
+        database=database,
+        schemas=(schema,),
+        names=(FINGERPRINT_TABLE_NAME,),
+    )
+    return {
+        (database, schema): relations,
+        **_gather_fingerprint_relations(
+            adapter=adapter,
+            connection=connection,
+            targets=targets[1:],
+        ),
+    }

--- a/src/sqlbuild/compiler/planner/_helpers/command_planning/static.py
+++ b/src/sqlbuild/compiler/planner/_helpers/command_planning/static.py
@@ -1,0 +1,235 @@
+"""Canonical static planning phases for commands that do not build models."""
+
+from __future__ import annotations
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.fingerprints.models import Fingerprint
+from sqlbuild.compiler.planner._helpers.identity.functions import (
+    build_compiled_function_fingerprint_sql,
+)
+from sqlbuild.compiler.planner._helpers.identity.seed import build_seed_identity
+from sqlbuild.compiler.planner._helpers.output.plan_entry import (
+    build_planner_relations_context,
+    extract_seed_columns,
+)
+from sqlbuild.compiler.planner._helpers.output.plan_output import (
+    build_selected_audit_entries,
+    build_selected_test_entries,
+    plan_function,
+)
+from sqlbuild.compiler.planner._helpers.output.strategy import get_materialization_type
+from sqlbuild.compiler.planner._helpers.planning.scopes import resolve_planner_scopes
+from sqlbuild.compiler.planner.models import (
+    AuditPlanEntry,
+    DeferralInputs,
+    FunctionPlanEntry,
+    PlannerPolicies,
+    PlannerRelationsContext,
+    PlannerScope,
+    PlannerSelection,
+    PlanOutput,
+    PlanWarning,
+    SeedPlanEntry,
+    SqlTestPlanEntry,
+)
+from sqlbuild.compiler.planner.types import PlanReason
+from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig
+
+
+def resolve_static_command_scope_impl(
+    *,
+    project: CompiledProject,
+    selection: PlannerSelection,
+    auto_load_sources: bool = False,
+) -> PlannerScope:
+    """Resolve command selection through the same canonical selector phase as builds."""
+
+    return resolve_planner_scopes(
+        project=project,
+        selection=selection,
+        policies=PlannerPolicies(auto_load_sources=auto_load_sources),
+    ).selected_scope
+
+
+def resolve_static_relation_context_impl(
+    *,
+    project: CompiledProject,
+    adapter: BaseAdapter,
+    scope: PlannerScope,
+    deferral: DeferralInputs | None = None,
+    project_config: ProjectConfig | None = None,
+    local_config: LocalConfig | None = None,
+    relation_keys: frozenset[CompiledObjectKey] | None = None,
+) -> PlannerRelationsContext:
+    """Resolve canonical locations and source routing without warehouse inventory."""
+
+    return build_planner_relations_context(
+        project=project,
+        adapter=adapter,
+        connection=None,
+        scope=scope,
+        deferral=deferral,
+        project_config=project_config,
+        local_config=local_config,
+        known_source_columns={},
+        relation_keys=relation_keys,
+    )
+
+
+def build_audit_command_plan_impl(
+    *,
+    project: CompiledProject,
+    adapter: BaseAdapter,
+    scope: PlannerScope,
+    relations: PlannerRelationsContext,
+) -> PlanOutput:
+    """Project the selected audits from static compile and relation state."""
+
+    model_materializations: dict[str, str] = {
+        model.name: get_materialization_type(model).value for model in project.models
+    }
+    return _base_plan_output(
+        project=project,
+        scope=scope,
+        relations=relations,
+        audit_entries=tuple(
+            build_selected_audit_entries(
+                project=project,
+                adapter=adapter,
+                scope=scope,
+                relations=relations,
+                model_materializations=model_materializations,
+            )
+        ),
+    )
+
+
+def build_test_command_plan_impl(
+    *,
+    project: CompiledProject,
+    adapter: BaseAdapter,
+    scope: PlannerScope,
+    relations: PlannerRelationsContext,
+) -> PlanOutput:
+    """Project selected SQL tests from static compile state."""
+
+    test_entries, warnings = build_selected_test_entries(
+        project=project,
+        adapter=adapter,
+        selected_keys=scope.selected_keys,
+    )
+    test_keys: frozenset[CompiledObjectKey] = frozenset(entry.key for entry in test_entries)
+    function_keys_set: set[CompiledObjectKey] = set()
+    for test_entry in test_entries:
+        function_keys_set.update(test_entry.function_deps)
+    function_keys: frozenset[CompiledObjectKey] = frozenset(function_keys_set)
+    function_entries: tuple[FunctionPlanEntry, ...] = tuple(
+        plan_function(
+            function=function,
+            adapter=adapter,
+            relations=relations,
+            fingerprint_query_sql=build_compiled_function_fingerprint_sql(function),
+        )
+        for function in project.functions
+        if function.key in function_keys
+    )
+    return _base_plan_output(
+        project=project,
+        scope=scope,
+        relations=relations,
+        execution_order=tuple(
+            key for key in scope.execution_order if key in scope.selected_keys | test_keys
+        ),
+        test_entries=tuple(test_entries),
+        function_entries=function_entries,
+        warnings=tuple(warnings),
+    )
+
+
+def build_seed_command_plan_impl(
+    *,
+    project: CompiledProject,
+    scope: PlannerScope,
+    relations: PlannerRelationsContext,
+    fingerprints: dict[str, Fingerprint] | None = None,
+) -> PlanOutput:
+    """Project selected direct seed work and canonical identities."""
+
+    existing: dict[str, Fingerprint] = fingerprints or {}
+    entries: list[SeedPlanEntry] = []
+    for seed in project.seeds:
+        if seed.key not in scope.selected_keys:
+            continue
+        version_hash, metadata_json = build_seed_identity(seed)
+        previous: Fingerprint | None = existing.get(seed.name)
+        reason: PlanReason = (
+            PlanReason.FIRST_RUN
+            if previous is None
+            else PlanReason.CONFIG_CHANGED
+            if previous.version_hash != version_hash
+            else PlanReason.NO_CHANGE
+        )
+        entries.append(
+            SeedPlanEntry(
+                key=seed.key,
+                name=seed.name,
+                destination=seed.destination,
+                file_path=seed.seed_file.file_path,
+                columns=extract_seed_columns(seed),
+                csv_settings=seed.schema_entry.csv_settings,
+                fingerprint_definition=metadata_json,
+                fingerprint_version_hash=version_hash,
+                fingerprint_metadata_json=metadata_json,
+                reason=reason,
+            )
+        )
+    return _base_plan_output(
+        project=project,
+        scope=scope,
+        relations=relations,
+        seed_entries=tuple(entries),
+    )
+
+
+def build_relation_command_plan_impl(
+    *, project: CompiledProject, scope: PlannerScope, relations: PlannerRelationsContext
+) -> PlanOutput:
+    """Project only static relation data for Python checks and scenarios."""
+
+    return _base_plan_output(project=project, scope=scope, relations=relations)
+
+
+def _base_plan_output(
+    *,
+    project: CompiledProject,
+    scope: PlannerScope,
+    relations: PlannerRelationsContext,
+    execution_order: tuple[CompiledObjectKey, ...] | None = None,
+    seed_entries: tuple[SeedPlanEntry, ...] = (),
+    function_entries: tuple[FunctionPlanEntry, ...] = (),
+    audit_entries: tuple[AuditPlanEntry, ...] = (),
+    test_entries: tuple[SqlTestPlanEntry, ...] = (),
+    warnings: tuple[PlanWarning, ...] = (),
+) -> PlanOutput:
+    return PlanOutput(
+        execution_order=(
+            execution_order
+            if execution_order is not None
+            else tuple(key for key in scope.execution_order if key in scope.selected_keys)
+        ),
+        seed_entries=seed_entries,
+        function_entries=function_entries,
+        audit_entries=audit_entries,
+        test_entries=test_entries,
+        selected_keys=scope.selected_keys,
+        warnings=warnings,
+        upstream_deps=scope.upstream_deps,
+        downstream_deps=scope.downstream_deps,
+        model_locations=relations.model_locations,
+        seed_locations=relations.seed_locations,
+        function_locations=relations.function_locations,
+        source_map=relations.source_map,
+        source_read_map=relations.source_read_map,
+        hook_functions=project.hook_functions,
+    )

--- a/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
@@ -132,6 +132,7 @@ def build_planner_relations_context(
     project_config: ProjectConfig | None = None,
     local_config: LocalConfig | None = None,
     known_source_columns: dict[str, tuple[ColumnInfo, ...]] | None = None,
+    relation_keys: frozenset[CompiledObjectKey] | None = None,
 ) -> PlannerRelationsContext:
     """Resolve relation locations and source metadata for plan entry construction."""
 
@@ -154,7 +155,11 @@ def build_planner_relations_context(
     )
     source_map: dict[str, SourceEntry] = build_source_load_map(
         project=project,
-        selected_keys=scope.selected_keys | audit_relation_keys,
+        selected_keys=(
+            relation_keys
+            if relation_keys is not None
+            else scope.selected_keys | audit_relation_keys
+        ),
         upstream_deps=scope.upstream_deps if scope.all_keys else None,
     )
     source_read_map: dict[str, SourceEntry] = (

--- a/src/sqlbuild/compiler/planner/_helpers/output/plan_output.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/plan_output.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.compile.models import (
     CompiledAudit,
@@ -32,6 +34,7 @@ from sqlbuild.compiler.planner._helpers.sql_tests.assembly import plan_test
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.models import (
     AuditPlanEntry,
+    BackfillResult,
     FunctionChangeResult,
     FunctionPlanEntry,
     ModelPlanEntry,
@@ -112,7 +115,7 @@ def build_plan_output(
     model_materializations: dict[str, str] = build_model_materializations(
         model_entry_results.entries
     )
-    audit_entries: list[AuditPlanEntry] = _build_audit_entries(
+    audit_entries: list[AuditPlanEntry] = build_selected_audit_entries(
         project=project,
         adapter=adapter,
         scope=scope,
@@ -121,7 +124,7 @@ def build_plan_output(
     )
     test_entries: list[SqlTestPlanEntry]
     test_warnings: list[PlanWarning]
-    test_entries, test_warnings = _build_test_entries(
+    test_entries, test_warnings = build_selected_test_entries(
         project=project,
         adapter=adapter,
         selected_keys=scope.selected_keys,
@@ -337,31 +340,11 @@ def _build_function_entries(
             continue
         function_change: FunctionChangeResult = changes.functions[function.name]
         entries.append(
-            FunctionPlanEntry(
-                key=function.key,
-                name=function.name,
-                relative_path=function.relative_path,
-                destination=function.destination,
-                arguments=function.arguments,
-                returns=function.returns,
-                body_sql=resolve_function_sql(
-                    adapter=adapter,
-                    function=function,
-                    model_locations=relations.model_locations,
-                    seed_locations=relations.seed_locations,
-                    function_locations=relations.function_locations,
-                    source_map=relations.source_read_map,
-                    source_warehouse_columns=relations.source_warehouse_columns,
-                    star_exclude_keyword=relations.star_exclude_keyword,
-                ),
+            plan_function(
+                function=function,
+                adapter=adapter,
+                relations=relations,
                 fingerprint_query_sql=function_change.fingerprint_sql,
-                fingerprint_destination=function.fingerprint_destination,
-                return_columns=function.return_columns,
-                language=function.language,
-                source_file_path=function.source_file_path,
-                runtime_version=function.runtime_version,
-                entry_point=function.entry_point,
-                packages=function.packages,
                 previous_query_sql=(
                     snapshot.fingerprints.functions[function.name].definition
                     if function.name in snapshot.fingerprints.functions
@@ -374,7 +357,50 @@ def _build_function_entries(
     return entries
 
 
-def _build_audit_entries(
+def plan_function(
+    *,
+    function: CompiledFunction,
+    adapter: BaseAdapter,
+    relations: PlannerRelationsContext,
+    fingerprint_query_sql: str,
+    previous_query_sql: str | None = None,
+    reason: PlanReason = PlanReason.NO_CHANGE,
+    backfill: BackfillResult | None = None,
+) -> FunctionPlanEntry:
+    """Build one canonical function entry from resolved relation inputs."""
+
+    entry: FunctionPlanEntry = FunctionPlanEntry(
+        key=function.key,
+        name=function.name,
+        relative_path=function.relative_path,
+        destination=function.destination,
+        arguments=function.arguments,
+        returns=function.returns,
+        body_sql=resolve_function_sql(
+            adapter=adapter,
+            function=function,
+            model_locations=relations.model_locations,
+            seed_locations=relations.seed_locations,
+            function_locations=relations.function_locations,
+            source_map=relations.source_read_map,
+            source_warehouse_columns=relations.source_warehouse_columns,
+            star_exclude_keyword=relations.star_exclude_keyword,
+        ),
+        fingerprint_query_sql=fingerprint_query_sql,
+        fingerprint_destination=function.fingerprint_destination,
+        return_columns=function.return_columns,
+        language=function.language,
+        source_file_path=function.source_file_path,
+        runtime_version=function.runtime_version,
+        entry_point=function.entry_point,
+        packages=function.packages,
+        previous_query_sql=previous_query_sql,
+        reason=reason,
+    )
+    return entry if backfill is None else replace(entry, backfill=backfill)
+
+
+def build_selected_audit_entries(
     *,
     project: CompiledProject,
     adapter: BaseAdapter,
@@ -402,7 +428,7 @@ def _build_audit_entries(
     return entries
 
 
-def _build_test_entries(
+def build_selected_test_entries(
     *,
     project: CompiledProject,
     adapter: BaseAdapter,

--- a/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
+++ b/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
@@ -75,6 +75,7 @@ def plan_test(
             _plan_direct_logic_test(
                 test=test,
                 function_locations=function_locations,
+                function_deps=_direct_function_deps(test=test, project=project),
                 adapter=adapter,
                 sql_analysis_enabled=sql_analysis_enabled,
             ),
@@ -335,6 +336,7 @@ def _plan_direct_logic_test(
     *,
     test: CompiledSqlTest,
     function_locations: dict[str, CompiledRelationLocation],
+    function_deps: tuple[CompiledObjectKey, ...],
     adapter: BaseAdapter,
     sql_analysis_enabled: bool,
 ) -> SqlTestPlanEntry:
@@ -381,7 +383,30 @@ def _plan_direct_logic_test(
             ),
         ),
         scope_deps=test.scope_deps,
+        function_deps=function_deps,
         sql_analysis_enabled=sql_analysis_enabled,
+    )
+
+
+def _direct_function_deps(
+    *, test: CompiledSqlTest, project: CompiledProject
+) -> tuple[CompiledObjectKey, ...]:
+    if not isinstance(test.payload, CompiledDirectLogicSqlTestPayload):
+        return ()
+    resource_type: CompiledResourceType | None = (
+        CompiledResourceType.UDF
+        if test.payload.mode == SqlTestMode.UDF
+        else CompiledResourceType.TABLE_FN
+        if test.payload.mode == SqlTestMode.TABLE_FN
+        else None
+    )
+    if resource_type is None:
+        return ()
+    tested_names: frozenset[str] = frozenset(test.payload.tested_resource_names)
+    return tuple(
+        function.key
+        for function in project.functions
+        if function.key.resource_type == resource_type and function.name in tested_names
     )
 
 

--- a/src/sqlbuild/compiler/planner/main/commands/__init__.py
+++ b/src/sqlbuild/compiler/planner/main/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Focused command planning entrypoints."""

--- a/src/sqlbuild/compiler/planner/main/commands/_relations.py
+++ b/src/sqlbuild/compiler/planner/main/commands/_relations.py
@@ -1,0 +1,32 @@
+"""Focused-command relation entrypoint."""
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.planner._helpers.command_planning.static import (
+    resolve_static_relation_context_impl,
+)
+from sqlbuild.compiler.planner.models import DeferralInputs, PlannerRelationsContext, PlannerScope
+from sqlbuild.spec.contracts.models import LocalConfig, ProjectConfig
+
+
+def resolve_static_relation_context(
+    *,
+    project: CompiledProject,
+    adapter: BaseAdapter,
+    scope: PlannerScope,
+    deferral: DeferralInputs | None = None,
+    project_config: ProjectConfig | None = None,
+    local_config: LocalConfig | None = None,
+    relation_keys: frozenset[CompiledObjectKey] | None = None,
+) -> PlannerRelationsContext:
+    """Resolve canonical locations and source routing without warehouse inventory."""
+
+    return resolve_static_relation_context_impl(
+        project=project,
+        adapter=adapter,
+        scope=scope,
+        deferral=deferral,
+        project_config=project_config,
+        local_config=local_config,
+        relation_keys=relation_keys,
+    )

--- a/src/sqlbuild/compiler/planner/main/commands/_scope.py
+++ b/src/sqlbuild/compiler/planner/main/commands/_scope.py
@@ -1,0 +1,17 @@
+"""Focused-command scope entrypoint."""
+
+from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.planner._helpers.command_planning.static import (
+    resolve_static_command_scope_impl,
+)
+from sqlbuild.compiler.planner.models import PlannerScope, PlannerSelection
+
+
+def resolve_static_command_scope(
+    *, project: CompiledProject, selection: PlannerSelection, auto_load_sources: bool = False
+) -> PlannerScope:
+    """Resolve command selection through the canonical build selector phase."""
+
+    return resolve_static_command_scope_impl(
+        project=project, selection=selection, auto_load_sources=auto_load_sources
+    )

--- a/src/sqlbuild/compiler/planner/main/commands/audit.py
+++ b/src/sqlbuild/compiler/planner/main/commands/audit.py
@@ -1,0 +1,20 @@
+"""Public focused audit-plan entrypoint."""
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.planner._helpers.command_planning.static import build_audit_command_plan_impl
+from sqlbuild.compiler.planner.models import PlannerRelationsContext, PlannerScope, PlanOutput
+
+
+def build_audit_command_plan(
+    *,
+    project: CompiledProject,
+    adapter: BaseAdapter,
+    scope: PlannerScope,
+    relations: PlannerRelationsContext,
+) -> PlanOutput:
+    """Project selected audits from canonical static state."""
+
+    return build_audit_command_plan_impl(
+        project=project, adapter=adapter, scope=scope, relations=relations
+    )

--- a/src/sqlbuild/compiler/planner/main/commands/relation_plan.py
+++ b/src/sqlbuild/compiler/planner/main/commands/relation_plan.py
@@ -1,0 +1,15 @@
+"""Public relation-only plan entrypoint."""
+
+from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.planner._helpers.command_planning.static import (
+    build_relation_command_plan_impl,
+)
+from sqlbuild.compiler.planner.models import PlannerRelationsContext, PlannerScope, PlanOutput
+
+
+def build_relation_command_plan(
+    *, project: CompiledProject, scope: PlannerScope, relations: PlannerRelationsContext
+) -> PlanOutput:
+    """Project static relation data for Python checks."""
+
+    return build_relation_command_plan_impl(project=project, scope=scope, relations=relations)

--- a/src/sqlbuild/compiler/planner/main/commands/seed.py
+++ b/src/sqlbuild/compiler/planner/main/commands/seed.py
@@ -1,0 +1,20 @@
+"""Public focused seed-plan entrypoint."""
+
+from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.fingerprints.models import Fingerprint
+from sqlbuild.compiler.planner._helpers.command_planning.static import build_seed_command_plan_impl
+from sqlbuild.compiler.planner.models import PlannerRelationsContext, PlannerScope, PlanOutput
+
+
+def build_seed_command_plan(
+    *,
+    project: CompiledProject,
+    scope: PlannerScope,
+    relations: PlannerRelationsContext,
+    fingerprints: dict[str, Fingerprint] | None = None,
+) -> PlanOutput:
+    """Project selected direct seed work and canonical identities."""
+
+    return build_seed_command_plan_impl(
+        project=project, scope=scope, relations=relations, fingerprints=fingerprints
+    )

--- a/src/sqlbuild/compiler/planner/main/commands/seed_state.py
+++ b/src/sqlbuild/compiler/planner/main/commands/seed_state.py
@@ -1,0 +1,16 @@
+"""Public targeted seed-state read entrypoint."""
+
+from typing import Any
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.compiler.compile.models import CompiledSeed
+from sqlbuild.compiler.fingerprints.models import Fingerprint
+from sqlbuild.compiler.planner._helpers.command_planning.seed_state import read_seed_fingerprints
+
+
+def read_selected_seed_fingerprints(
+    *, adapter: BaseAdapter, connection: Any, seeds: tuple[CompiledSeed, ...]
+) -> dict[str, Fingerprint]:
+    """Read only fingerprint state required by selected direct seeds."""
+
+    return read_seed_fingerprints(adapter=adapter, connection=connection, seeds=seeds)

--- a/src/sqlbuild/compiler/planner/main/commands/sql_test.py
+++ b/src/sqlbuild/compiler/planner/main/commands/sql_test.py
@@ -1,0 +1,20 @@
+"""Public focused SQL-test plan entrypoint."""
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.planner._helpers.command_planning.static import build_test_command_plan_impl
+from sqlbuild.compiler.planner.models import PlannerRelationsContext, PlannerScope, PlanOutput
+
+
+def build_test_command_plan(
+    *,
+    project: CompiledProject,
+    adapter: BaseAdapter,
+    scope: PlannerScope,
+    relations: PlannerRelationsContext,
+) -> PlanOutput:
+    """Project selected SQL tests from canonical static state."""
+
+    return build_test_command_plan_impl(
+        project=project, adapter=adapter, scope=scope, relations=relations
+    )

--- a/src/sqlbuild/runtime/event_exporting/classes/finite_priority_event_queue.py
+++ b/src/sqlbuild/runtime/event_exporting/classes/finite_priority_event_queue.py
@@ -4,6 +4,7 @@ import queue
 import threading
 import time
 
+from sqlbuild.runtime.event_exporting.constants import INVOCATION_TERMINAL_EVENT_TYPES
 from sqlbuild.runtime.event_exporting.exceptions import EventExporterInputError
 from sqlbuild.runtime.event_exporting.models import QueuedLifecycleEvent
 
@@ -46,9 +47,14 @@ class FinitePriorityEventQueue:
                 if remaining <= 0:
                     raise queue.Empty
                 self._condition.wait(timeout=remaining)
-            highest: int = max(item.policy.priority for item in self._items)
+            selectable: list[QueuedLifecycleEvent] = [
+                item for item in self._items if not _is_invocation_terminal(item)
+            ]
+            if not selectable:
+                selectable = self._items
+            highest: int = max(item.policy.priority for item in selectable)
             selected: QueuedLifecycleEvent = min(
-                (item for item in self._items if item.policy.priority == highest),
+                (item for item in selectable if item.policy.priority == highest),
                 key=lambda item: item.sequence,
             )
             self._items.remove(selected)
@@ -65,3 +71,7 @@ class FinitePriorityEventQueue:
     def __len__(self) -> int:
         with self._condition:
             return len(self._items)
+
+
+def _is_invocation_terminal(item: QueuedLifecycleEvent) -> bool:
+    return item.event.event_type in INVOCATION_TERMINAL_EVENT_TYPES

--- a/src/sqlbuild/runtime/event_exporting/constants.py
+++ b/src/sqlbuild/runtime/event_exporting/constants.py
@@ -15,6 +15,9 @@ EVENT_EXPORT_SEVERITIES: tuple[str, ...] = ("debug", "info", "warning", "error")
 EVENT_EXPORT_KINDS: frozenset[str] = frozenset(
     {"invocation", "run", "resource", "operation", "statement", "retry"}
 )
+INVOCATION_TERMINAL_EVENT_TYPES: frozenset[str] = frozenset(
+    {"invocation_completed", "invocation_failed"}
+)
 EVENT_EXPORT_SEVERITY_RANKS: Mapping[str, int] = MappingProxyType(
     {severity: index for index, severity in enumerate(EVENT_EXPORT_SEVERITIES)}
 )

--- a/tests/e2e/src/sqlbuild/cli/commands/main/audit/test_audit.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/audit/test_audit.py
@@ -31,10 +31,8 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
             ),
             expected_ordered_stdout_fragments=(
                 "Execution  sqb audit  (concurrency: 1)",
-                "Connecting to duckdb...",
-                "\u2713 Warehouse connected  duckdb  (<time>)",
-                "Inspecting warehouse state...",
-                "Generated plan. (<time>)",
+                "Compiling project...",
+                "Compiled project. (<time>)",
                 "Audit (28 selected, 12 models)",
                 "Connecting to duckdb...",
                 "\u2713 Warehouse connected  duckdb  (<time>)",
@@ -63,6 +61,8 @@ def test_given_waffle_shop_project_when_running_audit_then_all_audits_pass(
     for expected_fragment in test_case.expected_stdout_fragments:
         assert expected_fragment in result.stdout
     assert_fragments_in_order(result.stdout, test_case.expected_ordered_stdout_fragments)
+    assert "Inspecting warehouse state..." not in result.stdout
+    assert "Generated plan." not in result.stdout
 
 
 @pytest.mark.parametrize(

--- a/tests/e2e/src/sqlbuild/cli/commands/main/test/test_test.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/test/test_test.py
@@ -43,10 +43,8 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
             ),
             expected_ordered_stdout_fragments=(
                 "Execution  sqb test  (concurrency: 1)",
-                "Connecting to duckdb...",
-                "\u2713 Warehouse connected  duckdb  (<time>)",
-                "Inspecting warehouse state...",
-                "Generated plan. (<time>)",
+                "Compiling project...",
+                "Compiled project. (<time>)",
                 "Test ready  5 selected, 5 models",
                 "Connecting to duckdb...",
                 "\u2713 Warehouse connected  duckdb  (<time>)",
@@ -80,6 +78,8 @@ def test_given_waffle_shop_project_when_running_test_then_all_tests_pass(
     for expected_fragment in test_case.expected_stdout_fragments:
         assert expected_fragment in result.stdout
     assert_fragments_in_order(result.stdout, test_case.expected_ordered_stdout_fragments)
+    assert "Inspecting warehouse state..." not in result.stdout
+    assert "Generated plan." not in result.stdout
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/check/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/check/_test_types.py
@@ -4,6 +4,14 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
+class CheckPlanningTestCase:
+    description: str
+    expected_names: frozenset[str]
+    ref_kind: str | None = None
+    expected_error_fragment: str | None = None
+
+
+@dataclass(frozen=True)
 class CheckOutputProjectionCase:
     description: str
     expected_first_duration: str

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/check/test_planning.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/check/test_planning.py
@@ -1,0 +1,210 @@
+"""Focused Python check planning tests."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from sqlbuild.adapter.contract.models import RelationLookup
+from sqlbuild.cli.commands._helpers.check import core as check_core
+from sqlbuild.cli.commands._helpers.check.core import check_dependency_closure
+from sqlbuild.cli.commands.exceptions import CliUserError
+from sqlbuild.compiler.compile.models import CompiledProject, CompiledRelationLocation
+from sqlbuild.compiler.pipeline.models import CompilePipelineResult
+from sqlbuild.compiler.planner.models import PlanOutput
+from sqlbuild.compiler.python_nodes.models import PythonSqlRunLifecyclePlan
+from sqlbuild.executor.python_nodes.models import PythonNodeExecutionResult
+from sqlbuild.python_nodes.models import SqlResourceRef
+from sqlbuild.python_nodes.types import SqlResourceRefKind
+from sqlbuild.spec.contracts.models import SourceEntry
+from tests.unit.src.sqlbuild.cli.commands._helpers.check._test_types import (
+    CheckPlanningTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        CheckPlanningTestCase(
+            description="transitive check dependency closure",
+            expected_names=frozenset({"asset", "task", "loader"}),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_check_with_transitive_dependencies_when_planning_then_entire_closure_is_selected(
+    test_case: CheckPlanningTestCase,
+) -> None:
+    graph: Mock = Mock(
+        upstream_deps={
+            "quality_check": ("asset",),
+            "asset": ("task", "loader"),
+            "task": (),
+            "loader": (),
+        }
+    )
+
+    selected: frozenset[str] = check_dependency_closure(
+        graph=graph, check_names=frozenset({"quality_check"})
+    )
+
+    assert selected == test_case.expected_names
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        CheckPlanningTestCase(
+            description="direct model and source refs are validated without dependency execution",
+            expected_names=frozenset({"orders", "raw_orders"}),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_direct_check_sql_refs_when_preflighting_then_refs_are_validated_without_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: CheckPlanningTestCase,
+) -> None:
+    model_ref: SqlResourceRef = SqlResourceRef(SqlResourceRefKind.MODEL, "orders")
+    source_ref: SqlResourceRef = SqlResourceRef(SqlResourceRefKind.SOURCE, "raw_orders")
+    refs: frozenset[SqlResourceRef] = frozenset({model_ref, source_ref})
+    validated: list[SqlResourceRef] = []
+    monkeypatch.setattr(check_core, "build_relation_lookup", lambda **_: Mock())
+    monkeypatch.setattr(
+        check_core,
+        "_validate_check_sql_ref_exists",
+        lambda *, ref, **_: validated.append(ref),
+    )
+    monkeypatch.setattr(
+        check_core,
+        "create_read_side_python_execution_tracker",
+        lambda **_: pytest.fail("direct check refs must not execute as dependencies"),
+    )
+    pipeline_result: CompilePipelineResult = CompilePipelineResult(
+        project=CompiledProject(
+            run_id="check-run",
+            effective_target_name="dev",
+            effective_connection={},
+            effective_vars={},
+        ),
+        plan_output=PlanOutput(
+            model_locations={
+                "orders": CompiledRelationLocation(
+                    database=None,
+                    schema="analytics",
+                    name="orders",
+                    qualified_name="analytics.orders",
+                )
+            },
+            source_map={
+                "raw_orders": SourceEntry(
+                    name="raw_orders",
+                    schema="raw",
+                    table="orders",
+                )
+            },
+        ),
+    )
+
+    results: tuple[PythonNodeExecutionResult, ...] = check_core.run_check_read_side_dependencies(
+        adapter=Mock(),
+        connection_config={},
+        connection=object(),
+        pipeline_result=pipeline_result,
+        python_graph=Mock(),
+        lifecycle_plan=PythonSqlRunLifecyclePlan(
+            ingress_python_node_names=frozenset(),
+            ingress_loader_names=frozenset(),
+            read_side_sql_keys=frozenset(),
+            read_side_python_node_names=frozenset(),
+        ),
+        relation_targets={model_ref: "analytics.orders", source_ref: "raw.orders"},
+        validation_refs=refs,
+    )
+
+    assert results == ()
+    assert frozenset(ref.name for ref in validated) == test_case.expected_names
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        CheckPlanningTestCase(
+            description="missing direct model ref fails focused preflight",
+            expected_names=frozenset({"orders"}),
+            ref_kind="model",
+            expected_error_fragment="model 'orders'",
+        ),
+        CheckPlanningTestCase(
+            description="missing direct source ref fails focused preflight",
+            expected_names=frozenset({"raw_orders"}),
+            ref_kind="source",
+            expected_error_fragment="source 'raw_orders'",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_missing_direct_check_sql_ref_when_preflighting_then_existing_relation_error_is_raised(
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: CheckPlanningTestCase,
+) -> None:
+    assert test_case.ref_kind is not None
+    assert test_case.expected_error_fragment is not None
+    ref: SqlResourceRef = SqlResourceRef(
+        SqlResourceRefKind(test_case.ref_kind),
+        next(iter(test_case.expected_names)),
+    )
+    monkeypatch.setattr(
+        check_core,
+        "build_relation_lookup",
+        lambda **_: RelationLookup(relations_by_key={}),
+    )
+    adapter: Mock = Mock()
+    adapter.render_qualified_name.return_value = "analytics.orders"
+    pipeline_result: CompilePipelineResult = CompilePipelineResult(
+        project=CompiledProject(
+            run_id="check-run",
+            effective_target_name="dev",
+            effective_connection={},
+            effective_vars={},
+        ),
+        plan_output=PlanOutput(
+            model_locations={
+                "orders": CompiledRelationLocation(
+                    database=None,
+                    schema="analytics",
+                    name="orders",
+                    qualified_name="analytics.orders",
+                )
+            },
+            source_map={
+                "raw_orders": SourceEntry(
+                    name="raw_orders",
+                    schema="raw",
+                    table="orders",
+                )
+            },
+        ),
+    )
+
+    with pytest.raises(CliUserError, match=test_case.expected_error_fragment):
+        check_core.run_check_read_side_dependencies(
+            adapter=adapter,
+            connection_config={},
+            connection=object(),
+            pipeline_result=pipeline_result,
+            python_graph=Mock(),
+            lifecycle_plan=PythonSqlRunLifecyclePlan(
+                ingress_python_node_names=frozenset(),
+                ingress_loader_names=frozenset(),
+                read_side_sql_keys=frozenset(),
+                read_side_python_node_names=frozenset(),
+            ),
+            relation_targets={ref: "analytics.orders"},
+            validation_refs=frozenset({ref}),
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/scenario_execution/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/scenario_execution/helpers.py
@@ -39,7 +39,7 @@ def configure_scenario_runner(
     monkeypatch.setattr(runner, "resolve_adapter", lambda **_: Mock())
     monkeypatch.setattr(runner, "resolve_project_connection_config", lambda **_: {})
     monkeypatch.setattr(runner, "resolve_external_sql_reference_resolver", lambda **_: None)
-    monkeypatch.setattr(runner, "run_compile_pipeline", compile_project)
+    monkeypatch.setattr(runner, "run_compile_only_pipeline", compile_project)
     monkeypatch.setattr(runner, "select_scenarios", lambda **_: ())
     monkeypatch.setattr(runner, "run_warehouse_scenarios", lambda **_: 0)
 

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/scenario_execution/test_runner.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/scenario_execution/test_runner.py
@@ -11,7 +11,6 @@ from sqlbuild.cli.commands.models import ScenarioTestCommandRequest
 from sqlbuild.cli.progress.classes.native_progress_projector import NativeProgressProjector
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.observability import EventDispatcher, LifecycleEvent, dispatcher_scope
-from sqlbuild.runtime.contracts.models import ConnectionHooks
 from tests.unit.src.sqlbuild.cli.commands._helpers.scenario_execution._test_types import (
     ScenarioCompilePresentationTestCase,
 )
@@ -50,9 +49,9 @@ def test_given_scenario_compile_when_running_then_presentation_has_one_owner(
     pipeline_result.project.sql_scenarios = ()
 
     def compile_project(**kwargs: Any) -> CompilePipelineResult:
-        hooks: ConnectionHooks = cast(ConnectionHooks, kwargs["hooks"])
-        cast(Any, hooks.on_progress)("Compiling project...")
-        cast(Any, hooks.on_progress)("Compiled project.")
+        on_progress: Any = kwargs["on_progress"]
+        on_progress("Compiling project...")
+        on_progress("Compiled project.")
         return cast(CompilePipelineResult, pipeline_result)
 
     configure_scenario_runner(
@@ -107,8 +106,8 @@ def test_given_scenario_compile_failure_when_running_then_lifecycle_fails_and_pr
     stream: ScenarioProgressStream = ScenarioProgressStream(tty=test_case.tty)
 
     def fail_compile(**kwargs: Any) -> CompilePipelineResult:
-        hooks: ConnectionHooks = cast(ConnectionHooks, kwargs["hooks"])
-        cast(Any, hooks.on_progress)("Compiling project...")
+        on_progress: Any = kwargs["on_progress"]
+        on_progress("Compiling project...")
         raise RuntimeError("compile failed")
 
     configure_scenario_runner(monkeypatch=monkeypatch, stream=stream, compile_project=fail_compile)

--- a/tests/unit/src/sqlbuild/compiler/pipeline/main/test_compile_phase_timings.py
+++ b/tests/unit/src/sqlbuild/compiler/pipeline/main/test_compile_phase_timings.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import pytest
 
 from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.pipeline.main import _compile_phase as compile_phase_module
 from sqlbuild.compiler.pipeline.main import compile as compile_module
 from sqlbuild.compiler.pipeline.models import CompilePipelineOptions, CompilePipelineResult
 from sqlbuild.compiler.planner.models import PlanOutput
@@ -44,9 +45,10 @@ def test_given_slow_planning_connection_when_compiling_then_direct_phases_are_di
     )
     adapter: Mock = Mock()
     monkeypatch.setattr(compile_module.time, "monotonic", monotonic)
-    monkeypatch.setattr(compile_module, "build_compiled_project", Mock(return_value=project))
+    monkeypatch.setattr(compile_phase_module.time, "monotonic", monotonic)
+    monkeypatch.setattr(compile_phase_module, "build_compiled_project", Mock(return_value=project))
     monkeypatch.setattr(
-        compile_module, "resolve_compile_analysis_selection", Mock(return_value=None)
+        compile_phase_module, "resolve_compile_analysis_selection", Mock(return_value=None)
     )
     monkeypatch.setattr(compile_module, "open_connection_with_hooks", Mock(return_value=object()))
     monkeypatch.setattr(compile_module, "_build_result", Mock(return_value=pipeline_result))

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_plan_test.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_plan_test.py
@@ -19,8 +19,14 @@ from sqlbuild.compiler.compile.types import CompiledResourceType, SqlTestMode
 from sqlbuild.compiler.discovery.models import DiscoveredSqlTestBlock, DiscoveredSqlTestFile
 from sqlbuild.compiler.planner._helpers.sql_tests import assembly as sql_test_assembly
 from sqlbuild.compiler.planner._helpers.sql_tests.assembly import plan_test
+from sqlbuild.compiler.planner.main.commands._relations import resolve_static_relation_context
+from sqlbuild.compiler.planner.main.commands._scope import resolve_static_command_scope
+from sqlbuild.compiler.planner.main.commands.sql_test import build_test_command_plan
 from sqlbuild.compiler.planner.models import (
     ChainStep,
+    PlannerScope,
+    PlannerSelection,
+    PlanOutput,
     PlanWarning,
     SqlAnalysisResolvedTestSql,
     SqlTestPlanEntry,
@@ -611,7 +617,9 @@ def test_given_udf_sql_test_when_planning_then_compares_resolved_actual_to_expec
             resource_type=CompiledResourceType.SQL_TEST,
             name="formats cents",
         ),
-        scope_deps=(CompiledObjectKey(resource_type=CompiledResourceType.MODEL, name="orders"),),
+        scope_deps=(
+            CompiledObjectKey(resource_type=CompiledResourceType.UDF, name="format_cents"),
+        ),
         name="formats cents",
         test_file=test_file,
         test_block=test_block,
@@ -632,41 +640,43 @@ def test_given_udf_sql_test_when_planning_then_compares_resolved_actual_to_expec
         ),
     )
 
-    entry, warnings = plan_test(
-        test=sql_test,
-        adapter=DuckDbAdapter(),
-        project=CompiledProject(
-            run_id="test_run",
-            effective_target_name=None,
-            effective_connection={},
-            effective_vars={},
-            functions=(
-                CompiledFunction(
-                    key=CompiledObjectKey(
-                        resource_type=CompiledResourceType.UDF,
-                        name="format_cents",
-                    ),
-                    deps=(),
+    project: CompiledProject = CompiledProject(
+        run_id="test_run",
+        effective_target_name=None,
+        effective_connection={},
+        effective_vars={},
+        functions=(
+            CompiledFunction(
+                key=CompiledObjectKey(
+                    resource_type=CompiledResourceType.UDF,
                     name="format_cents",
-                    relative_path=Path("functions/sql/format_cents.sql"),
-                    arguments=(),
-                    returns="VARCHAR",
-                    body_sql="",
-                    destination=CompiledRelationLocation(
-                        database=None,
-                        schema="main",
-                        name="format_cents",
-                        qualified_name="main.format_cents",
-                    ),
-                    fingerprint_destination=CompiledRelationLocation(
-                        database=None,
-                        schema="main",
-                        name="format_cents__fingerprint",
-                        qualified_name="main.format_cents__fingerprint",
-                    ),
+                ),
+                deps=(),
+                name="format_cents",
+                relative_path=Path("functions/sql/format_cents.sql"),
+                arguments=(),
+                returns="VARCHAR",
+                body_sql="",
+                destination=CompiledRelationLocation(
+                    database=None,
+                    schema="main",
+                    name="format_cents",
+                    qualified_name="main.format_cents",
+                ),
+                fingerprint_destination=CompiledRelationLocation(
+                    database=None,
+                    schema="main",
+                    name="format_cents__fingerprint",
+                    qualified_name="main.format_cents__fingerprint",
                 ),
             ),
         ),
+        sql_tests=(sql_test,),
+    )
+    entry, warnings = plan_test(
+        test=sql_test,
+        adapter=DuckDbAdapter(),
+        project=project,
     )
 
     assert warnings == ()
@@ -675,6 +685,23 @@ def test_given_udf_sql_test_when_planning_then_compares_resolved_actual_to_expec
     assert test_case.expected_actual_fragment in entry.chain[0].resolved_sql
     assert entry.chain[0].expected_cte_sql is not None
     assert test_case.expected_expected_fragment in entry.chain[0].expected_cte_sql
+    assert entry.function_deps == (
+        CompiledObjectKey(resource_type=CompiledResourceType.UDF, name="format_cents"),
+    )
+    scope: PlannerScope = resolve_static_command_scope(
+        project=project, selection=PlannerSelection()
+    )
+    command_plan: PlanOutput = build_test_command_plan(
+        project=project,
+        adapter=DuckDbAdapter(),
+        scope=scope,
+        relations=resolve_static_relation_context(
+            project=project,
+            adapter=DuckDbAdapter(),
+            scope=scope,
+        ),
+    )
+    assert tuple(function.name for function in command_plan.function_entries) == ("format_cents",)
 
 
 @pytest.mark.parametrize(
@@ -737,41 +764,43 @@ def test_given_table_function_sql_test_when_planning_then_compares_resolved_actu
         ),
     )
 
-    entry, warnings = plan_test(
-        test=sql_test,
-        adapter=DuckDbAdapter(),
-        project=CompiledProject(
-            run_id="test_run",
-            effective_target_name=None,
-            effective_connection={},
-            effective_vars={},
-            functions=(
-                CompiledFunction(
-                    key=CompiledObjectKey(
-                        resource_type=CompiledResourceType.TABLE_FN,
-                        name="customer_orders",
-                    ),
-                    deps=(),
+    project: CompiledProject = CompiledProject(
+        run_id="test_run",
+        effective_target_name=None,
+        effective_connection={},
+        effective_vars={},
+        functions=(
+            CompiledFunction(
+                key=CompiledObjectKey(
+                    resource_type=CompiledResourceType.TABLE_FN,
                     name="customer_orders",
-                    relative_path=Path("functions/sql/customer_orders.sql"),
-                    arguments=(),
-                    returns="TABLE",
-                    body_sql="",
-                    destination=CompiledRelationLocation(
-                        database=None,
-                        schema="main",
-                        name="customer_orders",
-                        qualified_name="main.customer_orders",
-                    ),
-                    fingerprint_destination=CompiledRelationLocation(
-                        database=None,
-                        schema="main",
-                        name="customer_orders__fingerprint",
-                        qualified_name="main.customer_orders__fingerprint",
-                    ),
+                ),
+                deps=(),
+                name="customer_orders",
+                relative_path=Path("functions/sql/customer_orders.sql"),
+                arguments=(),
+                returns="TABLE",
+                body_sql="",
+                destination=CompiledRelationLocation(
+                    database=None,
+                    schema="main",
+                    name="customer_orders",
+                    qualified_name="main.customer_orders",
+                ),
+                fingerprint_destination=CompiledRelationLocation(
+                    database=None,
+                    schema="main",
+                    name="customer_orders__fingerprint",
+                    qualified_name="main.customer_orders__fingerprint",
                 ),
             ),
         ),
+        sql_tests=(sql_test,),
+    )
+    entry, warnings = plan_test(
+        test=sql_test,
+        adapter=DuckDbAdapter(),
+        project=project,
     )
 
     assert warnings == ()
@@ -780,6 +809,28 @@ def test_given_table_function_sql_test_when_planning_then_compares_resolved_actu
     assert test_case.expected_actual_fragment in entry.chain[0].resolved_sql
     assert entry.chain[0].expected_cte_sql is not None
     assert test_case.expected_expected_fragment in entry.chain[0].expected_cte_sql
+    assert entry.function_deps == (
+        CompiledObjectKey(
+            resource_type=CompiledResourceType.TABLE_FN,
+            name="customer_orders",
+        ),
+    )
+    scope: PlannerScope = resolve_static_command_scope(
+        project=project, selection=PlannerSelection()
+    )
+    command_plan: PlanOutput = build_test_command_plan(
+        project=project,
+        adapter=DuckDbAdapter(),
+        scope=scope,
+        relations=resolve_static_relation_context(
+            project=project,
+            adapter=DuckDbAdapter(),
+            scope=scope,
+        ),
+    )
+    assert tuple(function.name for function in command_plan.function_entries) == (
+        "customer_orders",
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/planner/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/main/_test_types.py
@@ -33,6 +33,13 @@ class HookFunctionPlanOutputTestCase:
 
 
 @dataclass(frozen=True)
+class StaticCommandPlanningTestCase:
+    description: str
+    expected_names: tuple[str, ...] = ()
+    expected_reason: str | None = None
+
+
+@dataclass(frozen=True)
 class MaximumStartCapTestCase:
     description: str
     target_max: str

--- a/tests/unit/src/sqlbuild/compiler/planner/main/test_static_command_planning.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/main/test_static_command_planning.py
@@ -1,0 +1,238 @@
+"""Focused command planning regressions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from sqlbuild.compiler.compile.models import CompiledProject, CompiledSeed, CompileModelConfig
+from sqlbuild.compiler.discovery.models import DiscoveredSeedFile
+from sqlbuild.compiler.fingerprints.models import Fingerprint
+from sqlbuild.compiler.planner.main.commands._relations import resolve_static_relation_context
+from sqlbuild.compiler.planner.main.commands._scope import resolve_static_command_scope
+from sqlbuild.compiler.planner.main.commands.audit import build_audit_command_plan
+from sqlbuild.compiler.planner.main.commands.seed import build_seed_command_plan
+from sqlbuild.compiler.planner.main.commands.seed_state import read_selected_seed_fingerprints
+from sqlbuild.compiler.planner.main.commands.sql_test import build_test_command_plan
+from sqlbuild.compiler.planner.models import (
+    PlannerRelationsContext,
+    PlannerScope,
+    PlannerSelection,
+    PlanOutput,
+    SeedPlanEntry,
+)
+from sqlbuild.compiler.planner.types import PlanReason
+from tests.unit.src.sqlbuild.compiler.planner._helpers.helpers import (
+    PlannerTestAdapter,
+    build_test_project,
+)
+from tests.unit.src.sqlbuild.compiler.planner.main._test_types import (
+    StaticCommandPlanningTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (StaticCommandPlanningTestCase("focused audit projection", ("orders_audit",)),),
+    ids=lambda case: case.description,
+)
+def test_given_incremental_attached_audit_when_planning_then_no_warehouse_method_is_called(
+    test_case: StaticCommandPlanningTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project: CompiledProject = build_test_project(
+        model_deps={"orders": ()},
+        audit_model_source_deps={"orders": ()},
+    )
+    project = replace(
+        project,
+        models=(
+            replace(
+                project.models[0],
+                config=CompileModelConfig(values={"materialized": "incremental", "cursor": "id"}),
+            ),
+        ),
+    )
+    adapter: PlannerTestAdapter = PlannerTestAdapter()
+    for method_name in ("connect", "execute", "list_relations", "get_columns_for_relations"):
+        monkeypatch.setattr(
+            adapter,
+            method_name,
+            lambda *args, _method_name=method_name, **kwargs: pytest.fail(
+                f"unexpected warehouse call: {_method_name}"
+            ),
+        )
+
+    scope: PlannerScope = resolve_static_command_scope(
+        project=project,
+        selection=PlannerSelection(select=("orders",)),
+    )
+    relations: PlannerRelationsContext = resolve_static_relation_context(
+        project=project,
+        adapter=adapter,
+        scope=scope,
+    )
+    plan: PlanOutput = build_audit_command_plan(
+        project=project,
+        adapter=adapter,
+        scope=scope,
+        relations=relations,
+    )
+
+    assert tuple(entry.name for entry in plan.audit_entries) == test_case.expected_names
+    assert plan.audit_entries[0].attached_target_name == "orders"
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (StaticCommandPlanningTestCase("focused SQL test projection", ("is_valid_order",)),),
+    ids=lambda case: case.description,
+)
+def test_given_sql_test_with_function_dependency_when_planning_then_required_function_is_projected(
+    test_case: StaticCommandPlanningTestCase,
+) -> None:
+    project: CompiledProject = build_test_project(
+        model_deps={"orders": ("is_valid_order",)},
+        sql_test_expected_model_names=("orders",),
+        function_names=("is_valid_order",),
+    )
+    adapter: PlannerTestAdapter = PlannerTestAdapter()
+    scope: PlannerScope = resolve_static_command_scope(
+        project=project,
+        selection=PlannerSelection(),
+    )
+    relations: PlannerRelationsContext = resolve_static_relation_context(
+        project=project,
+        adapter=adapter,
+        scope=scope,
+    )
+
+    plan: PlanOutput = build_test_command_plan(
+        project=project,
+        adapter=adapter,
+        scope=scope,
+        relations=relations,
+    )
+
+    assert tuple(entry.name for entry in plan.test_entries) == ("test_models",)
+    assert tuple(entry.name for entry in plan.function_entries) == test_case.expected_names
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (StaticCommandPlanningTestCase("focused seed identity", expected_reason="no_change"),),
+    ids=lambda case: case.description,
+)
+def test_given_selected_seed_when_planning_then_identity_and_reason_are_preserved(
+    test_case: StaticCommandPlanningTestCase,
+    tmp_path: Path,
+) -> None:
+    seed_path: Path = tmp_path / "countries.csv"
+    seed_path.write_text("code,name\nGB,United Kingdom\n", encoding="utf-8")
+    project: CompiledProject = build_test_project(seed_names=("countries",))
+    project = replace(
+        project,
+        seeds=(
+            replace(
+                project.seeds[0],
+                seed_file=DiscoveredSeedFile(
+                    file_path=seed_path,
+                    relative_path=Path("seeds/countries.csv"),
+                ),
+            ),
+        ),
+    )
+    adapter: PlannerTestAdapter = PlannerTestAdapter()
+    scope: PlannerScope = resolve_static_command_scope(
+        project=project,
+        selection=PlannerSelection(select=("seed:countries",)),
+    )
+    relations: PlannerRelationsContext = resolve_static_relation_context(
+        project=project,
+        adapter=adapter,
+        scope=scope,
+    )
+
+    first_plan: PlanOutput = build_seed_command_plan(
+        project=project,
+        scope=scope,
+        relations=relations,
+    )
+    first_entry: SeedPlanEntry = first_plan.seed_entries[0]
+
+    assert first_entry.reason == PlanReason.FIRST_RUN
+    assert first_entry.fingerprint_version_hash
+    assert '"rows":[["code","name"],["GB","United Kingdom"]]' in (
+        first_entry.fingerprint_metadata_json
+    )
+    current: Fingerprint = Fingerprint(
+        node_type="seed",
+        node_name="countries",
+        target_database=None,
+        target_schema=None,
+        target_name="countries",
+        run_id="previous",
+        definition_hash=first_entry.fingerprint_version_hash,
+        version_hash=first_entry.fingerprint_version_hash,
+        schema_fingerprint="",
+        definition=first_entry.fingerprint_metadata_json,
+        metadata_json=first_entry.fingerprint_metadata_json,
+        ts=datetime.now(UTC),
+    )
+
+    current_plan: PlanOutput = build_seed_command_plan(
+        project=project,
+        scope=scope,
+        relations=relations,
+        fingerprints={"countries": current},
+    )
+
+    assert current_plan.seed_entries[0].reason.value == test_case.expected_reason
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (StaticCommandPlanningTestCase("targeted seed state relation", ("_sqlbuild_fingerprints",)),),
+    ids=lambda case: case.description,
+)
+def test_given_selected_seed_without_state_table_when_reading_reason_then_only_state_relation_is_inspected(
+    test_case: StaticCommandPlanningTestCase,
+    tmp_path: Path,
+) -> None:
+    seed_path: Path = tmp_path / "countries.csv"
+    seed_path.write_text("code\nGB\n", encoding="utf-8")
+    project: CompiledProject = build_test_project(seed_names=("countries",))
+    seed: CompiledSeed = replace(
+        project.seeds[0],
+        seed_file=DiscoveredSeedFile(
+            file_path=seed_path,
+            relative_path=Path("seeds/countries.csv"),
+        ),
+        destination=replace(project.seeds[0].destination, schema="analytics"),
+    )
+    adapter: Mock = Mock()
+    adapter.list_relations.return_value = ()
+    connection: object = object()
+
+    fingerprints: dict[str, Fingerprint] = read_selected_seed_fingerprints(
+        adapter=adapter,
+        connection=connection,
+        seeds=(seed,),
+    )
+
+    assert fingerprints == {}
+    adapter.list_relations.assert_called_once_with(
+        connection=connection,
+        database=None,
+        schemas=("analytics",),
+        names=test_case.expected_names,
+    )
+    adapter.execute.assert_not_called()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/unit/src/sqlbuild/runtime/event_exporting/classes/helpers.py
+++ b/tests/unit/src/sqlbuild/runtime/event_exporting/classes/helpers.py
@@ -86,11 +86,15 @@ def lifecycle_event(index: int = 1, event_type: str = "invocation_started") -> L
 
 
 def queued_event(
-    *, sequence: int, priority: int, eligible: tuple[int, ...] = (0,)
+    *,
+    sequence: int,
+    priority: int,
+    eligible: tuple[int, ...] = (0,),
+    event_type: str = "invocation_started",
 ) -> QueuedLifecycleEvent:
     return QueuedLifecycleEvent(
         sequence,
-        lifecycle_event(sequence),
+        lifecycle_event(sequence, event_type=event_type),
         LifecycleExportPolicy("invocation", "debug", priority),
         eligible,
     )

--- a/tests/unit/src/sqlbuild/runtime/event_exporting/classes/test_priority_queue.py
+++ b/tests/unit/src/sqlbuild/runtime/event_exporting/classes/test_priority_queue.py
@@ -79,6 +79,33 @@ def test_given_equal_priority_items_when_dequeuing_then_fifo_is_preserved(
 
 @pytest.mark.parametrize(
     "test_case",
+    (PriorityQueueTestCase("invocation terminal remains last", (1, 2)),),
+    ids=lambda case: case.description,
+)
+def test_given_queued_work_before_invocation_terminal_when_dequeuing_then_terminal_is_last(
+    test_case: PriorityQueueTestCase,
+) -> None:
+    event_queue: FinitePriorityEventQueue = FinitePriorityEventQueue(capacity=3)
+    statement: QueuedLifecycleEvent = queued_event(
+        sequence=1,
+        priority=0,
+        event_type="invocation_started",
+    )
+    terminal: QueuedLifecycleEvent = queued_event(
+        sequence=2,
+        priority=3,
+        event_type="invocation_completed",
+    )
+    for item in (statement, terminal):
+        assert event_queue.put_nowait(item) == (True, None)
+
+    assert tuple(event_queue.get(timeout=0.01).sequence for _ in (statement, terminal)) == (
+        test_case.expected_sequences
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
     (PriorityQueueTestCase("oldest lowest displacement", (1,)),),
     ids=lambda case: case.description,
 )


### PR DESCRIPTION
## Why

`sqb audit`, `test`, `check`, scenario commands, and direct `seed` entered the full build planner despite not building models. A 1,069-audit Dagster run spent 130.71 seconds inspecting build state, including 118 cursor reads, before its first audit query.

## Changes

- Extract the canonical compile-only phase and reusable static scope/relation planning phases.
- Project focused audit, SQL-test, Python-check, scenario, and direct-seed plans without gathering build snapshots, cursor bounds, freshness, retention, or model actions.
- Keep build, plan, virtual seed, compilation, selectors, deferral, source routing, audit/test assembly, and seed identity on shared canonical implementations.
- Preserve selected-check direct and transitive SQL-ref validation and direct UDF/table-function test setup.
- Add negative warehouse-call, parity, selection, function, check dependency, scenario, and seed-state regressions.

## Verification

- `make test`: 5,842 passed.
- `make check-ci`: formatting, Ruff, ty, strict adapter, and Fensu passed.
- Independent review found and verified fixes for direct function-test setup and direct check SQL-ref validation.
- Focused generated-project checks covered audit, test planning, check, scenario test/capture/local sync, and direct seed.
- Full E2E and external-adapter coverage delegated to CI.

Linear: CHI-200
