### PR TITLE
fix: add bounded standalone audit concurrency

### DIFF
--- a/scripts/fensu_policy/constants.py
+++ b/scripts/fensu_policy/constants.py
@@ -252,6 +252,7 @@ LIFECYCLE_FACTORY_OWNER_PATHS: frozenset[str] = frozenset(
         "src/sqlbuild/observability.py",
         "src/sqlbuild/runtime/observability/classes/operation_lifecycle.py",
         "src/sqlbuild/runtime/observability/classes/resource_attempt_lifecycle.py",
+        "src/sqlbuild/runtime/observability/classes/run_lifecycle.py",
         "src/sqlbuild/runtime/observability/classes/statement_lifecycle.py",
         "src/sqlbuild/runtime/observability/main/create_lifecycle_event.py",
     }

--- a/src/sqlbuild/cli/commands/_helpers/audit/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/audit/execution.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-
 from sqlbuild.cli.commands.models import (
+    AuditCommandRequest,
     AuditExecutionPreparation,
     AuditInvocation,
 )
 from sqlbuild.cli.output.classes.execution_event_writer import ExecutionEventWriter
+from sqlbuild.cli.progress.classes.audit_progress_reporter import AuditProgressReporter
 from sqlbuild.cli.progress.classes.connection_progress_reporter import (
     ConnectionProgressReporter,
 )
@@ -16,39 +16,35 @@ from sqlbuild.cli.progress.classes.native_progress_projector import (
     NativeProgressProjector,
     current_native_progress_projector,
 )
-from sqlbuild.cli.progress.classes.nested_command_progress_callbacks import (
-    NestedCommandProgressCallbacks,
-)
-from sqlbuild.compiler.auditing.types import AuditOutcome
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.models import AuditPlanEntry
-from sqlbuild.executor.auditing.main.resource_id import audit_resource_id
+from sqlbuild.cost.classes.cost_context import CostContext
 from sqlbuild.executor.auditing.models import AuditExecutionResult
-from sqlbuild.executor.pipeline.main.run import run_audit_pipeline
+from sqlbuild.executor.pipeline.main.run import (
+    AuditPipelineCallbacks,
+    run_audit_pipeline_with_callbacks,
+)
 from sqlbuild.presentation.classes.cli_style import CliStyle
 
 
 def prepare_audit_execution(
     *,
+    request: AuditCommandRequest,
     invocation: AuditInvocation,
     pipeline_result: CompilePipelineResult,
 ) -> AuditExecutionPreparation:
     """Prepare nested progress reporting and write the audit section header."""
 
     audit_count: int = len(pipeline_result.plan_output.audit_entries)
-    model_count: int = len(
-        {
-            e.attached_target_name
-            for e in pipeline_result.plan_output.audit_entries
-            if e.attached_target_name
-        }
+    effective_concurrency: int = (
+        request.concurrency
+        if request.concurrency is not None
+        else pipeline_result.project.settings.concurrency
     )
-    header: str = f"Audit ({audit_count} selected, {model_count} models)"
-    style: CliStyle = CliStyle(use_color=invocation.use_color)
-    styled_header: str = style.success_strong(header)
-    progress: NestedCommandProgressCallbacks = NestedCommandProgressCallbacks(
-        total=audit_count,
-        label="audit",
+    worker_count: int = min(effective_concurrency, audit_count)
+    progress: AuditProgressReporter = AuditProgressReporter(
+        entries=pipeline_result.plan_output.audit_entries,
+        worker_limit=worker_count,
         stream=invocation.progress_stream,
         use_color=invocation.use_color,
     )
@@ -56,8 +52,6 @@ def prepare_audit_execution(
     if projector is not None:
         for entry in pipeline_result.plan_output.audit_entries:
             projector.expect_resource_enrichment(resource_name=entry.name)
-    invocation.progress_stream.write(f"\n{styled_header}\n\n")
-    invocation.progress_stream.flush()
     execution_connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
         adapter_name=invocation.adapter_name,
         stream=invocation.progress_stream,
@@ -66,7 +60,24 @@ def prepare_audit_execution(
     return AuditExecutionPreparation(
         progress=progress,
         execution_connection_progress=execution_connection_progress,
+        effective_concurrency=effective_concurrency,
+        worker_count=worker_count,
     )
+
+
+def write_audit_plan_header(
+    *, invocation: AuditInvocation, pipeline_result: CompilePipelineResult
+) -> None:
+    """Write the selected audit section after effective execution settings."""
+
+    entries: tuple[AuditPlanEntry, ...] = pipeline_result.plan_output.audit_entries
+    model_count: int = len(
+        {entry.attached_target_name for entry in entries if entry.attached_target_name}
+    )
+    header: str = f"Audit ({len(entries)} selected, {model_count} models)"
+    styled_header: str = CliStyle(use_color=invocation.use_color).success_strong(header)
+    invocation.progress_stream.write(f"\n{styled_header}\n\n")
+    invocation.progress_stream.flush()
 
 
 def execute_audit_plan(
@@ -78,83 +89,68 @@ def execute_audit_plan(
     """Execute the audit plan with nested progress reporting."""
 
     event_writer: ExecutionEventWriter = ExecutionEventWriter()
-    on_complete: Callable[[AuditExecutionResult], None] = _build_on_complete(
-        progress=preparation.progress,
-        event_writer=event_writer,
-        pipeline_result=pipeline_result,
-    )
-    try:
-        return run_audit_pipeline(
-            plan=pipeline_result.plan_output,
-            connection_config=invocation.connection_config,
-            adapter=invocation.adapter,
-            on_connection_start=preparation.execution_connection_progress.on_connection_start,
-            on_connection_complete=lambda connection_count, elapsed_seconds: (
-                preparation.execution_connection_progress.on_connection_complete(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
-            on_connection_error=lambda connection_count, elapsed_seconds: (
-                preparation.execution_connection_progress.on_connection_error(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
-            on_audit_start=lambda entry: preparation.progress.on_item_start(
-                group_name=entry.attached_target_name or "(unattached)",
-                item_name=_audit_display_name_from_entry(entry),
-            ),
-            on_audit_complete=on_complete,
-            run_id=pipeline_result.project.run_id,
-        )
-    finally:
-        event_writer.close()
-
-
-def _build_on_complete(
-    *,
-    progress: NestedCommandProgressCallbacks,
-    event_writer: ExecutionEventWriter,
-    pipeline_result: CompilePipelineResult,
-) -> Callable[[AuditExecutionResult], None]:
-    def _on_complete(result: AuditExecutionResult) -> None:
-        group_name: str = result.attached_target_name or "(unattached)"
-        status_text: str
-        if result.outcome == AuditOutcome.PASS:
-            status_text = "PASS"
-        elif result.outcome == AuditOutcome.WARN:
-            status_text = "WARN"
-        else:
-            status_text = "FAIL"
-        audit_name: str = result.audit_name
-        if result.attached_column_name is not None:
-            audit_name = f"{result.audit_name} ({result.attached_column_name})"
-        detail: str = ""
-        if result.outcome != AuditOutcome.PASS and result.row_count > 0:
-            row_label: str = "row" if result.row_count == 1 else "rows"
-            detail = f"  {result.row_count} {row_label}"
-        progress.on_item_complete(
-            group_name=group_name,
-            item_name=audit_name,
-            status_text=status_text,
-            detail=detail,
-            canonical_resource_id=audit_resource_id(
-                audit_name=result.audit_name,
-                attachment_kind=result.attachment_kind,
-                attached_target_kind=result.attached_target_kind,
-                attached_target_name=result.attached_target_name,
-                attached_column_name=result.attached_column_name,
-            ),
-        )
-        event_writer.write_build_result(
+    preparation.progress.set_result_callback(
+        lambda result: event_writer.write_build_result(
             result=result,
             plan=pipeline_result.plan_output,
             command="audit",
         )
-
-    return _on_complete
-
-
-def _audit_display_name_from_entry(entry: AuditPlanEntry) -> str:
-    if entry.attached_column_name is not None:
-        return f"{entry.name} ({entry.attached_column_name})"
-    return entry.name
+    )
+    projector: NativeProgressProjector | None = current_native_progress_projector()
+    if projector is not None:
+        projector.configure_resources(
+            ordinals={
+                entry.name: index
+                for index, entry in enumerate(pipeline_result.plan_output.audit_entries, start=1)
+            },
+            total=len(pipeline_result.plan_output.audit_entries),
+        )
+    try:
+        with CostContext.scope(
+            run_id=pipeline_result.project.run_id,
+            resource_type="run",
+            resource_name="audit",
+            ledger_path=(
+                invocation.effective_project_dir
+                / "target"
+                / "executions"
+                / pipeline_result.project.run_id
+                / "statements.jsonl"
+            ),
+            phase="audit",
+        ):
+            return run_audit_pipeline_with_callbacks(
+                plan=pipeline_result.plan_output,
+                connection_config=invocation.connection_config,
+                adapter=invocation.adapter,
+                max_concurrency=preparation.effective_concurrency,
+                callbacks=AuditPipelineCallbacks(
+                    on_connection_start=(
+                        preparation.execution_connection_progress.on_connection_start
+                    ),
+                    on_connection_complete=(
+                        lambda connection_count, elapsed_seconds: (
+                            preparation.execution_connection_progress.on_connection_complete(
+                                connection_count=connection_count,
+                                elapsed_seconds=elapsed_seconds,
+                            )
+                        )
+                    ),
+                    on_connection_error=(
+                        lambda connection_count, elapsed_seconds: (
+                            preparation.execution_connection_progress.on_connection_error(
+                                connection_count=connection_count,
+                                elapsed_seconds=elapsed_seconds,
+                            )
+                        )
+                    ),
+                    on_audit_start=preparation.progress.on_item_start,
+                    on_audit_physical_complete=(preparation.progress.on_item_physical_complete),
+                    on_audit_complete=preparation.progress.on_item_complete,
+                    on_audit_error=preparation.progress.on_item_error,
+                ),
+                run_id=pipeline_result.project.run_id,
+            )
+    finally:
+        preparation.progress.close()
+        event_writer.close()

--- a/src/sqlbuild/cli/commands/_helpers/audit/outputs.py
+++ b/src/sqlbuild/cli/commands/_helpers/audit/outputs.py
@@ -15,6 +15,8 @@ def write_audit_completion_output(
     request: AuditCommandRequest,
     invocation: AuditInvocation,
     results: tuple[AuditExecutionResult, ...],
+    configured_concurrency: int,
+    worker_count: int,
 ) -> None:
     """Write the audit summary footer and optional JSON output."""
 
@@ -36,7 +38,11 @@ def write_audit_completion_output(
     )
     invocation.progress_stream.flush()
     write_execution_json_output(
-        payload=format_audit_execution_json(results=results),
+        payload=format_audit_execution_json(
+            results=results,
+            configured_concurrency=configured_concurrency,
+            worker_count=worker_count,
+        ),
         json_output=request.json_output,
         json_output_path=request.json_output_path,
     )

--- a/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
@@ -248,6 +248,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
                 defer_to=args.defer_to,
                 no_color=args.no_color,
                 selected_target=args.target,
+                concurrency=args.concurrency,
                 select=select,
                 exclude=tuple(args.exclude),
                 cli_vars=args.vars,

--- a/src/sqlbuild/cli/commands/_helpers/entry/parser.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parser.py
@@ -244,6 +244,7 @@ def _add_quality_parsers(
     audit_parser.add_argument("--no-sql-validation", action="store_true", default=False)
     audit_parser.add_argument("--defer-to", default=None)
     audit_parser.add_argument("--target", default=None)
+    audit_parser.add_argument("--concurrency", type=int, default=None)
     audit_parser.add_argument("--json", action="store_true", default=False)
     _ = add_execution_json_output_arg(audit_parser)
     _ = add_select_args(audit_parser)

--- a/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
@@ -41,6 +41,8 @@ def resolve_env_default_concurrency(explicit_concurrency: int | None) -> int | N
     """Return CLI concurrency, falling back to SQLBUILD_CONCURRENCY when unset."""
 
     if explicit_concurrency is not None:
+        if explicit_concurrency < 1:
+            raise argparse.ArgumentTypeError("--concurrency must be >= 1")
         return explicit_concurrency
     raw_value: str | None = os.environ.get(SQLBUILD_CONCURRENCY_ENV_VAR)
     if raw_value is None or raw_value == EMPTY_ENV_VALUE:
@@ -118,7 +120,7 @@ def parse_cli_invocation(
             and not any(option in args.dbt_args for option in DBT_VERBOSE_OPTIONS)
         ):
             args.dbt_args.append("--verbose")
-        if args.command in {CliCommand.BUILD, CliCommand.LOAD, CliCommand.SEED}:
+        if args.command in {CliCommand.AUDIT, CliCommand.BUILD, CliCommand.LOAD, CliCommand.SEED}:
             try:
                 args.concurrency = resolve_env_default_concurrency(args.concurrency)
             except argparse.ArgumentTypeError as error:

--- a/src/sqlbuild/cli/commands/main/execution/_audit.py
+++ b/src/sqlbuild/cli/commands/main/execution/_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from sqlbuild.cli.commands._helpers.audit.execution import (
     execute_audit_plan,
     prepare_audit_execution,
+    write_audit_plan_header,
 )
 from sqlbuild.cli.commands._helpers.audit.invocation import resolve_audit_invocation
 from sqlbuild.cli.commands._helpers.audit.outputs import (
@@ -26,22 +27,24 @@ def run_audit(request: AuditCommandRequest) -> int:
     """Execute the audit command."""
 
     invocation: AuditInvocation = resolve_audit_invocation(request=request)
-    invocation.progress_stream.write("\n")
-    write_execution_header(
-        stream=invocation.progress_stream,
-        command="sqb audit",
-        target=None,
-        concurrency=1,
-        use_color=invocation.use_color,
-    )
     pipeline_result: CompilePipelineResult = compile_audit_plan(
         request=request,
         invocation=invocation,
     )
     preparation: AuditExecutionPreparation = prepare_audit_execution(
+        request=request,
         invocation=invocation,
         pipeline_result=pipeline_result,
     )
+    invocation.progress_stream.write("\n")
+    write_execution_header(
+        stream=invocation.progress_stream,
+        command="sqb audit",
+        target=None,
+        concurrency=preparation.effective_concurrency,
+        use_color=invocation.use_color,
+    )
+    write_audit_plan_header(invocation=invocation, pipeline_result=pipeline_result)
     results: tuple[AuditExecutionResult, ...] = execute_audit_plan(
         invocation=invocation,
         pipeline_result=pipeline_result,
@@ -51,5 +54,7 @@ def run_audit(request: AuditCommandRequest) -> int:
         request=request,
         invocation=invocation,
         results=results,
+        configured_concurrency=preparation.effective_concurrency,
+        worker_count=preparation.worker_count,
     )
     return resolve_audit_exit_code(results)

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -121,6 +121,7 @@ class AuditCommandRequest:
     defer_to: str | None = None
     no_color: bool = False
     selected_target: str | None = None
+    concurrency: int | None = None
     select: tuple[str, ...] = ()
     exclude: tuple[str, ...] = ()
     cli_vars: dict[str, object] | None = None
@@ -147,8 +148,10 @@ class AuditInvocation:
 class AuditExecutionPreparation:
     """Prepared nested progress and execution reporters for audit runs."""
 
-    progress: NestedCommandProgressCallbacks
+    progress: AuditProgressReporter
     execution_connection_progress: ConnectionProgressReporter
+    effective_concurrency: int
+    worker_count: int
 
 
 @dataclass(frozen=True)
@@ -1418,3 +1421,6 @@ from sqlbuild.cli.commands.classes.build_progress_callbacks import (  # noqa: E4
     BuildProgressCallbacks,
 )
 from sqlbuild.cli.commands.classes.cli_namespace import CliNamespace  # noqa: E402,F401
+from sqlbuild.cli.progress.classes.audit_progress_reporter import (  # noqa: E402,F401
+    AuditProgressReporter,
+)

--- a/src/sqlbuild/cli/output/_helpers/execution_result_document.py
+++ b/src/sqlbuild/cli/output/_helpers/execution_result_document.py
@@ -442,7 +442,12 @@ def format_test_execution_json(*, results: tuple[SqlTestExecutionResult, ...]) -
     )
 
 
-def format_audit_execution_json(*, results: tuple[AuditExecutionResult, ...]) -> str:
+def format_audit_execution_json(
+    *,
+    results: tuple[AuditExecutionResult, ...],
+    configured_concurrency: int = 1,
+    worker_count: int | None = None,
+) -> str:
     """Format audit command execution results as JSON."""
 
     results = _terminal_results(results=results)
@@ -457,6 +462,12 @@ def format_audit_execution_json(*, results: tuple[AuditExecutionResult, ...]) ->
             "warn_count": sum(1 for result in results if result.outcome == AuditOutcome.WARN),
             "fail_count": fail_count,
             "total_count": len(results),
+        },
+        execution={
+            "configured_concurrency": configured_concurrency,
+            "worker_count": min(configured_concurrency, len(results))
+            if worker_count is None
+            else worker_count,
         },
     )
 
@@ -520,6 +531,7 @@ def _format_execution_json(
     scenarios: tuple[dict[str, object], ...] = (),
     run_id: str | None = None,
     cost: dict[str, object] | None = None,
+    execution: dict[str, object] | None = None,
 ) -> str:
     projector: TerminalEventIndex | None = current_terminal_event_index()
     terminal: LifecycleEvent | None = None if projector is None else projector.lifecycle_terminal()
@@ -539,6 +551,8 @@ def _format_execution_json(
         payload["run_id"] = run_id
     if cost is not None:
         payload["cost"] = cost
+    if execution is not None:
+        payload["execution"] = execution
     return json.dumps(payload, indent=2) + "\n"
 
 

--- a/src/sqlbuild/cli/output/main/_audit_execution_json.py
+++ b/src/sqlbuild/cli/output/main/_audit_execution_json.py
@@ -8,7 +8,16 @@ from sqlbuild.cli.output._helpers.execution_result_document import (
 from sqlbuild.executor.auditing.models import AuditExecutionResult
 
 
-def format_audit_execution_json(*, results: tuple[AuditExecutionResult, ...]) -> str:
+def format_audit_execution_json(
+    *,
+    results: tuple[AuditExecutionResult, ...],
+    configured_concurrency: int = 1,
+    worker_count: int | None = None,
+) -> str:
     """Format audit command execution results as JSON."""
 
-    return _format_audit_execution_json(results=results)
+    return _format_audit_execution_json(
+        results=results,
+        configured_concurrency=configured_concurrency,
+        worker_count=worker_count,
+    )

--- a/src/sqlbuild/cli/progress/classes/audit_progress_reporter.py
+++ b/src/sqlbuild/cli/progress/classes/audit_progress_reporter.py
@@ -1,0 +1,177 @@
+"""Coordinator-safe progress reporting for standalone concurrent audits."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from typing import TextIO
+
+from sqlbuild.cli.progress.classes.native_progress_projector import (
+    NativeProgressProjector,
+    current_native_progress_projector,
+)
+from sqlbuild.compiler.auditing.types import AuditOutcome
+from sqlbuild.compiler.planner.models import AuditPlanEntry
+from sqlbuild.executor.auditing.main.resource_id import audit_resource_id
+from sqlbuild.executor.auditing.models import AuditExecutionResult
+from sqlbuild.presentation.classes.cli_style import CliStyle
+
+_LABEL_WIDTH: int = 10
+_NAME_WIDTH: int = 50
+
+
+class AuditProgressReporter:
+    """Render aggregate live state and flush completed audit rows in plan order."""
+
+    def __init__(
+        self,
+        *,
+        entries: tuple[AuditPlanEntry, ...],
+        worker_limit: int,
+        stream: TextIO,
+        use_color: bool,
+    ) -> None:
+        self._entries: tuple[AuditPlanEntry, ...] = entries
+        self._worker_limit: int = worker_limit
+        self._stream: TextIO = stream
+        self._style: CliStyle = CliStyle(use_color=use_color)
+        self._is_tty: bool = hasattr(stream, "isatty") and stream.isatty()
+        self._projector: NativeProgressProjector | None = current_native_progress_projector()
+        self._indexes: dict[str, int] = {
+            _entry_resource_id(entry): index for index, entry in enumerate(entries)
+        }
+        self._completed_by_index: dict[int, AuditExecutionResult | None] = {}
+        self._next_index: int = 0
+        self._running: int = 0
+        self._completed: int = 0
+        self._current_group: str | None = None
+        self._lock: threading.RLock = threading.RLock()
+        self._cursor_hidden: bool = False
+        self._on_result: Callable[[AuditExecutionResult], None] | None = None
+
+    def set_result_callback(self, callback: Callable[[AuditExecutionResult], None]) -> None:
+        """Install plan-ordered result enrichment before dispatch starts."""
+
+        self._on_result = callback
+
+    def on_item_start(self, entry: AuditPlanEntry) -> None:
+        """Record a worker start without mutating one-item spinner state."""
+
+        with self._lock:
+            self._running += 1
+            self._render_aggregate()
+
+    def on_item_complete(self, result: AuditExecutionResult) -> None:
+        """Flush every newly contiguous plan-order result row."""
+
+        with self._lock:
+            self._completed_by_index[self._indexes[_result_resource_id(result)]] = result
+            self._flush_ready()
+            self._render_aggregate()
+
+    def on_item_physical_complete(self, result: AuditExecutionResult) -> None:
+        """Update aggregate state immediately without projecting a result row."""
+
+        del result
+        with self._lock:
+            self._running = max(0, self._running - 1)
+            self._completed += 1
+            self._render_aggregate()
+
+    def on_item_error(self, entry: AuditPlanEntry) -> None:
+        """Advance aggregate and ordering state for a fatal audit exception."""
+
+        with self._lock:
+            self._running = max(0, self._running - 1)
+            self._completed += 1
+            self._completed_by_index[self._indexes[_entry_resource_id(entry)]] = None
+            self._flush_ready()
+            self._render_aggregate()
+
+    def close(self) -> None:
+        """Restore the terminal after the final aggregate update."""
+
+        with self._lock:
+            if self._is_tty:
+                self._clear_aggregate()
+                if self._cursor_hidden:
+                    self._stream.write("\033[?25h")
+                    self._cursor_hidden = False
+                self._stream.flush()
+
+    def _flush_ready(self) -> None:
+        while self._next_index in self._completed_by_index:
+            result: AuditExecutionResult | None = self._completed_by_index.pop(self._next_index)
+            self._next_index += 1
+            if result is not None:
+                self._write_result(result)
+
+    def _write_result(self, result: AuditExecutionResult) -> None:
+        if self._is_tty:
+            self._clear_aggregate()
+        group_name: str = result.attached_target_name or "(unattached)"
+        if group_name != self._current_group:
+            prefix: str = "\n" if self._current_group is not None else ""
+            self._stream.write(f"{prefix}{self._style.section(group_name)}\n")
+            self._current_group = group_name
+        status_text: str = {
+            AuditOutcome.PASS: "PASS",
+            AuditOutcome.WARN: "WARN",
+            AuditOutcome.ERROR: "FAIL",
+        }[result.outcome]
+        name: str = result.audit_name
+        if result.attached_column_name is not None:
+            name = f"{name} ({result.attached_column_name})"
+        detail: str = ""
+        if result.outcome != AuditOutcome.PASS and result.row_count > 0:
+            row_label: str = "row" if result.row_count == 1 else "rows"
+            detail = f"  {result.row_count} {row_label}"
+        if self._projector is not None:
+            duration_ms: float | None = self._projector.consume_resource_terminal(
+                resource_name=result.audit_name,
+                resource_id=_result_resource_id(result),
+            )
+            if duration_ms is not None:
+                detail = f"{detail}  {duration_ms / 1000.0:.2f}s"
+        status: str = self._style.status(status=status_text)
+        self._stream.write(f"    {'audit':<{_LABEL_WIDTH}}{name:<{_NAME_WIDTH}} {status}{detail}\n")
+        self._stream.flush()
+        if self._on_result is not None:
+            self._on_result(result)
+
+    def _render_aggregate(self) -> None:
+        if not self._is_tty:
+            return
+        if not self._cursor_hidden:
+            self._stream.write("\033[?25l")
+            self._cursor_hidden = True
+        self._clear_aggregate()
+        self._stream.write(
+            "\r\033[K    audit     "
+            f"running {self._running} | completed {self._completed}/{len(self._entries)} "
+            f"| workers {self._worker_limit}"
+        )
+        self._stream.flush()
+
+    def _clear_aggregate(self) -> None:
+        self._stream.write("\r\033[K")
+
+
+def _entry_resource_id(entry: AuditPlanEntry) -> str:
+    return audit_resource_id(
+        audit_name=entry.name,
+        attachment_kind=entry.attachment_kind,
+        attached_target_kind=entry.attached_target_kind,
+        attached_target_name=entry.attached_target_name,
+        attached_column_name=entry.attached_column_name,
+    )
+
+
+def _result_resource_id(result: AuditExecutionResult) -> str:
+    return audit_resource_id(
+        audit_name=result.audit_name,
+        attachment_kind=result.attachment_kind,
+        attached_target_kind=result.attached_target_kind,
+        attached_target_name=result.attached_target_name,
+        attached_column_name=result.attached_column_name,
+    )

--- a/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/yml/project.py
@@ -440,6 +440,8 @@ def _load_settings(*, payload: object, file_path: Path) -> SettingsConfig:
         else CONFIG_CONCURRENCY_KEY
     )
     concurrency: int = _optional_int(mapping=mapping, key=concurrency_key, default=1)
+    if concurrency < 1:
+        raise ProjectConfigError("settings.concurrency must be >= 1")
     table_promotion_mode: str | None = _optional_str(payload=mapping, key="table_promotion_mode")
     default_audit_severity: str | None = _optional_str(
         payload=mapping, key="default_audit_severity"

--- a/src/sqlbuild/cost/classes/cost_context.py
+++ b/src/sqlbuild/cost/classes/cost_context.py
@@ -32,7 +32,11 @@ class CostContext:
             run_id=run_id,
             resource_type=resource_type,
             resource_name=resource_name,
-            ledger_path=ledger_path,
+            ledger_path=(
+                ledger_path
+                if ledger_path is not None
+                else (None if current is None else current.ledger_path)
+            ),
             phase=phase,
             attempt=attempt,
             on_statement_complete=(

--- a/src/sqlbuild/executor/pipeline/_helpers/auditing.py
+++ b/src/sqlbuild/executor/pipeline/_helpers/auditing.py
@@ -2,20 +2,115 @@
 
 from __future__ import annotations
 
+import queue
+import time
 from collections.abc import Callable
-from typing import Any
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextvars import copy_context
+from dataclasses import dataclass, replace
+from functools import partial
+from typing import Any, cast
 from uuid import uuid4
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.auditing.types import AuditOutcome, AuditRunScope
 from sqlbuild.compiler.planner.models import AuditPlanEntry, PlanOutput
+from sqlbuild.cost.classes.cost_context import CostContext
+from sqlbuild.diagnostics.main.diagnostics_context import diagnostics_context
 from sqlbuild.executor.auditing.main._execute import execute_audit
 from sqlbuild.executor.auditing.main.resource_id import audit_resource_id
 from sqlbuild.executor.auditing.models import AuditExecutionResult
+from sqlbuild.executor.pipeline._helpers.connections import (
+    close_connections,
+    open_worker_connections,
+)
+from sqlbuild.executor.pipeline.exceptions import AuditConcurrencyError, AuditOutcomeError
+from sqlbuild.executor.pipeline.models import AuditPipelineCallbacks
+from sqlbuild.executor.scheduling.main._run_worker import run_worker_with_completion
+from sqlbuild.observability import RunLifecycle, run_scope
 from sqlbuild.runtime.contracts.types import ConnectionElapsedCallback
 from sqlbuild.runtime.observability.classes.resource_attempt_lifecycle import (
     ResourceAttemptLifecycle,
 )
+
+
+@dataclass(frozen=True)
+class _AuditCompletion:
+    index: int
+    result: AuditExecutionResult | None = None
+    error: BaseException | None = None
+
+
+class _AuditProjection:
+    """Indexed terminal state and plan-ordered public projection."""
+
+    def __init__(self, *, entry_count: int) -> None:
+        self.results: list[AuditExecutionResult | None] = [None] * entry_count
+        self.errors: dict[int, BaseException] = {}
+        self._gaps: set[int] = set()
+        self._next_index: int = 0
+
+    def consume(
+        self,
+        *,
+        completion: _AuditCompletion,
+        entries: tuple[AuditPlanEntry, ...],
+        callbacks: AuditPipelineCallbacks,
+    ) -> BaseException | None:
+        first_error: BaseException | None = None
+        try:
+            if completion.error is not None:
+                self.errors[completion.index] = completion.error
+                if callbacks.on_audit_error is not None:
+                    callbacks.on_audit_error(entries[completion.index])
+            elif completion.result is not None:
+                self.results[completion.index] = completion.result
+                if callbacks.on_audit_physical_complete is not None:
+                    callbacks.on_audit_physical_complete(completion.result)
+        except BaseException as error:
+            first_error = error
+        projection_error: BaseException | None = self._project(
+            on_audit_complete=callbacks.on_audit_complete
+        )
+        return first_error if first_error is not None else projection_error
+
+    def add_gaps(
+        self,
+        *,
+        indexes: set[int],
+        on_audit_complete: Callable[[AuditExecutionResult], None] | None,
+    ) -> BaseException | None:
+        self._gaps.update(indexes)
+        return self._project(on_audit_complete=on_audit_complete)
+
+    def project_remaining(
+        self, *, on_audit_complete: Callable[[AuditExecutionResult], None] | None
+    ) -> BaseException | None:
+        return self._project(on_audit_complete=on_audit_complete)
+
+    def ordered_results(self) -> tuple[AuditExecutionResult, ...]:
+        return tuple(result for result in self.results if result is not None)
+
+    def _project(
+        self, *, on_audit_complete: Callable[[AuditExecutionResult], None] | None
+    ) -> BaseException | None:
+        first_error: BaseException | None = None
+        while self._next_index < len(self.results):
+            result: AuditExecutionResult | None = self.results[self._next_index]
+            if result is not None:
+                self._next_index += 1
+                if on_audit_complete is not None:
+                    try:
+                        on_audit_complete(result)
+                    except BaseException as error:
+                        if first_error is None:
+                            first_error = error
+                continue
+            if self._next_index in self.errors or self._next_index in self._gaps:
+                self._next_index += 1
+                continue
+            break
+        return first_error
 
 
 def run_audit_pipeline(
@@ -23,6 +118,7 @@ def run_audit_pipeline(
     plan: PlanOutput,
     connection_config: dict[str, object],
     adapter: BaseAdapter,
+    max_concurrency: int = 1,
     on_connection_start: Callable[[int], None] | None = None,
     on_connection_complete: ConnectionElapsedCallback | None = None,
     on_connection_error: ConnectionElapsedCallback | None = None,
@@ -30,56 +126,382 @@ def run_audit_pipeline(
     on_audit_complete: Callable[[AuditExecutionResult], None] | None = None,
     run_id: str | None = None,
 ) -> tuple[AuditExecutionResult, ...]:
-    """Execute all audits from a compiled plan against existing relations."""
+    """Execute audits while preserving the original optional callback interface."""
 
-    if on_connection_start is not None:
-        on_connection_start(1)
+    return run_audit_pipeline_with_callbacks(
+        plan=plan,
+        connection_config=connection_config,
+        adapter=adapter,
+        max_concurrency=max_concurrency,
+        callbacks=AuditPipelineCallbacks(
+            on_connection_start=on_connection_start,
+            on_connection_complete=on_connection_complete,
+            on_connection_error=on_connection_error,
+            on_audit_start=on_audit_start,
+            on_audit_complete=on_audit_complete,
+        ),
+        run_id=run_id,
+    )
+
+
+def run_audit_pipeline_with_callbacks(
+    *,
+    plan: PlanOutput,
+    connection_config: dict[str, object],
+    adapter: BaseAdapter,
+    max_concurrency: int,
+    callbacks: AuditPipelineCallbacks,
+    run_id: str | None = None,
+) -> tuple[AuditExecutionResult, ...]:
+    """Execute selected audits with bounded workers and split physical/public callbacks."""
+
+    if max_concurrency < 1:
+        raise AuditConcurrencyError("audit concurrency must be >= 1")
+    entries: tuple[AuditPlanEntry, ...] = plan.audit_entries
+    worker_count: int = min(max_concurrency, len(entries))
     canonical_run_id: str = run_id or uuid4().hex
-    import time
-
-    start: float = time.monotonic()
-    try:
-        connection: Any = adapter.connect(connection_config)
-    except Exception:
-        if on_connection_error is not None:
-            on_connection_error(1, elapsed_seconds=time.monotonic() - start)
-        raise
-    if on_connection_complete is not None:
-        on_connection_complete(1, elapsed_seconds=time.monotonic() - start)
-    try:
-        results: list[AuditExecutionResult] = []
-        entry: AuditPlanEntry
-        for entry in plan.audit_entries:
-            with ResourceAttemptLifecycle(
-                resource_id=audit_resource_id(
-                    audit_name=entry.name,
-                    attachment_kind=entry.attachment_kind,
-                    attached_target_kind=entry.attached_target_kind,
-                    attached_target_name=entry.attached_target_name,
-                    attached_column_name=entry.attached_column_name,
+    with run_scope(canonical_run_id) as identity:
+        with diagnostics_context(
+            sqlbuild_invocation_id=identity.invocation_id,
+            sqlbuild_run_id=identity.run_id,
+            sqlbuild_configured_concurrency=max_concurrency,
+            sqlbuild_worker_count=worker_count,
+        ):
+            with (
+                RunLifecycle(
+                    run_kind="audit",
+                    selected_count=len(entries),
+                    configured_concurrency=max_concurrency,
+                    worker_count=worker_count,
+                ) as lifecycle,
+                CostContext.scope(
+                    run_id=canonical_run_id,
+                    resource_type="run",
+                    resource_name="audit",
+                    phase="audit",
                 ),
-                resource_kind="audit",
-                resource_name=entry.name,
-                run_id=canonical_run_id,
-            ) as lifecycle:
-                if on_audit_start is not None:
-                    on_audit_start(entry)
-                result: AuditExecutionResult = execute_audit(
-                    audit=entry,
-                    adapter=adapter,
-                    connection=connection,
-                    model_locations=plan.model_locations,
-                    seed_locations=plan.seed_locations,
-                    source_map=plan.source_map,
-                    relation_overrides=None,
-                    run_scope_phase=AuditRunScope.FINAL,
-                    quality_scope="standalone",
+            ):
+                execution_callbacks: AuditPipelineCallbacks = replace(
+                    callbacks,
+                    on_audit_complete=_AuditCompletionRecorder(
+                        lifecycle=lifecycle,
+                        callback=callbacks.on_audit_complete,
+                    ),
                 )
-                if result.outcome == AuditOutcome.ERROR:
-                    lifecycle.failed()
-            results.append(result)
-            if on_audit_complete is not None:
-                on_audit_complete(result)
-        return tuple(results)
+                results: tuple[AuditExecutionResult, ...] = _run_audits(
+                    entries=entries,
+                    plan=plan,
+                    connection_config=connection_config,
+                    adapter=adapter,
+                    worker_count=worker_count,
+                    callbacks=execution_callbacks,
+                    run_id=canonical_run_id,
+                )
+                lifecycle.completed()
+                return results
+
+
+class _AuditCompletionRecorder:
+    def __init__(
+        self,
+        *,
+        lifecycle: RunLifecycle,
+        callback: Callable[[AuditExecutionResult], None] | None,
+    ) -> None:
+        self._lifecycle: RunLifecycle = lifecycle
+        self._callback: Callable[[AuditExecutionResult], None] | None = callback
+
+    def __call__(self, result: AuditExecutionResult) -> None:
+        if result.outcome == AuditOutcome.PASS:
+            self._lifecycle.record_pass()
+        elif result.outcome == AuditOutcome.WARN:
+            self._lifecycle.record_warning()
+        elif result.outcome == AuditOutcome.ERROR:
+            self._lifecycle.record_failure()
+        else:
+            raise AuditOutcomeError(f"unknown audit outcome: {result.outcome!r}")
+        if self._callback is not None:
+            self._callback(result)
+
+
+def _run_audits(
+    *,
+    entries: tuple[AuditPlanEntry, ...],
+    plan: PlanOutput,
+    connection_config: dict[str, object],
+    adapter: BaseAdapter,
+    worker_count: int,
+    callbacks: AuditPipelineCallbacks,
+    run_id: str,
+) -> tuple[AuditExecutionResult, ...]:
+    if not entries:
+        return ()
+    if callbacks.on_connection_start is not None:
+        callbacks.on_connection_start(worker_count)
+    connection_started: float = time.monotonic()
+    try:
+        connections: tuple[Any, ...] = open_worker_connections(
+            adapter=adapter,
+            connection_config=connection_config,
+            connection_count=worker_count,
+        )
+    except BaseException:
+        if callbacks.on_connection_error is not None:
+            try:
+                callbacks.on_connection_error(
+                    worker_count, elapsed_seconds=time.monotonic() - connection_started
+                )
+            except BaseException:
+                pass
+        raise
+    active_error: BaseException | None = None
+    try:
+        if callbacks.on_connection_complete is not None:
+            callbacks.on_connection_complete(
+                worker_count, elapsed_seconds=time.monotonic() - connection_started
+            )
+        if worker_count == 1:
+            results: tuple[AuditExecutionResult, ...] = _run_serial_audits(
+                entries=entries,
+                plan=plan,
+                adapter=adapter,
+                connection=connections[0],
+                callbacks=callbacks,
+                run_id=run_id,
+            )
+        else:
+            results = _run_concurrent_audits(
+                entries=entries,
+                plan=plan,
+                adapter=adapter,
+                connections=connections,
+                worker_count=worker_count,
+                callbacks=callbacks,
+                run_id=run_id,
+            )
+        return results
+    except BaseException as error:
+        active_error = error
+        raise
     finally:
-        adapter.close(connection)
+        close_connections(adapter=adapter, connections=connections, active_error=active_error)
+
+
+def _run_serial_audits(
+    *,
+    entries: tuple[AuditPlanEntry, ...],
+    plan: PlanOutput,
+    adapter: BaseAdapter,
+    connection: Any,
+    callbacks: AuditPipelineCallbacks,
+    run_id: str,
+) -> tuple[AuditExecutionResult, ...]:
+    results: list[AuditExecutionResult] = []
+    for entry in entries:
+        try:
+            result: AuditExecutionResult = _execute_entry(
+                entry=entry,
+                plan=plan,
+                adapter=adapter,
+                connection=connection,
+                on_audit_start=callbacks.on_audit_start,
+                run_id=run_id,
+            )
+        except BaseException:
+            if callbacks.on_audit_error is not None:
+                callbacks.on_audit_error(entry)
+            raise
+        results.append(result)
+        if callbacks.on_audit_physical_complete is not None:
+            callbacks.on_audit_physical_complete(result)
+        if callbacks.on_audit_complete is not None:
+            callbacks.on_audit_complete(result)
+    return tuple(results)
+
+
+def _run_concurrent_audits(
+    *,
+    entries: tuple[AuditPlanEntry, ...],
+    plan: PlanOutput,
+    adapter: BaseAdapter,
+    connections: tuple[Any, ...],
+    worker_count: int,
+    callbacks: AuditPipelineCallbacks,
+    run_id: str,
+) -> tuple[AuditExecutionResult, ...]:
+    connection_pool: queue.Queue[Any] = queue.Queue()
+    for connection in connections:
+        connection_pool.put(connection)
+    completions: queue.Queue[_AuditCompletion] = queue.Queue()
+    projection: _AuditProjection = _AuditProjection(entry_count=len(entries))
+    futures: dict[int, Future[None]] = {}
+    in_flight: set[int] = set()
+    next_index: int = 0
+    scheduler_error: BaseException | None = None
+    pool: ThreadPoolExecutor = ThreadPoolExecutor(max_workers=worker_count)
+
+    try:
+        while next_index < len(entries) and len(in_flight) < worker_count:
+            futures[next_index] = _submit_audit(
+                pool=pool,
+                index=next_index,
+                entry=entries[next_index],
+                plan=plan,
+                adapter=adapter,
+                connection_pool=connection_pool,
+                completions=completions,
+                on_audit_start=callbacks.on_audit_start,
+                run_id=run_id,
+            )
+            in_flight.add(next_index)
+            next_index += 1
+        while in_flight:
+            try:
+                completion: _AuditCompletion = completions.get()
+            except BaseException as error:
+                scheduler_error = error
+                break
+            in_flight.remove(completion.index)
+            completion_error: BaseException | None = projection.consume(
+                completion=completion,
+                entries=entries,
+                callbacks=callbacks,
+            )
+            if scheduler_error is None and completion_error is not None:
+                scheduler_error = completion_error
+            if not projection.errors and scheduler_error is None and next_index < len(entries):
+                futures[next_index] = _submit_audit(
+                    pool=pool,
+                    index=next_index,
+                    entry=entries[next_index],
+                    plan=plan,
+                    adapter=adapter,
+                    connection_pool=connection_pool,
+                    completions=completions,
+                    on_audit_start=callbacks.on_audit_start,
+                    run_id=run_id,
+                )
+                in_flight.add(next_index)
+                next_index += 1
+            elif projection.errors or scheduler_error is not None:
+                in_flight, canceled = _cancel_not_started(futures=futures, in_flight=in_flight)
+                projection_error: BaseException | None = projection.add_gaps(
+                    indexes=canceled,
+                    on_audit_complete=callbacks.on_audit_complete,
+                )
+                if scheduler_error is None and projection_error is not None:
+                    scheduler_error = projection_error
+        if scheduler_error is not None:
+            in_flight, canceled = _cancel_not_started(futures=futures, in_flight=in_flight)
+            _ = projection.add_gaps(
+                indexes=canceled,
+                on_audit_complete=callbacks.on_audit_complete,
+            )
+    except BaseException as error:
+        if scheduler_error is None:
+            scheduler_error = error
+        in_flight, canceled = _cancel_not_started(futures=futures, in_flight=in_flight)
+        _ = projection.add_gaps(
+            indexes=canceled,
+            on_audit_complete=callbacks.on_audit_complete,
+        )
+    finally:
+        pool.shutdown(wait=True, cancel_futures=True)
+
+    while in_flight:
+        completion = completions.get()
+        in_flight.remove(completion.index)
+        completion_error = projection.consume(
+            completion=completion,
+            entries=entries,
+            callbacks=callbacks,
+        )
+        if scheduler_error is None and completion_error is not None:
+            scheduler_error = completion_error
+    projection_error = projection.project_remaining(
+        on_audit_complete=callbacks.on_audit_complete,
+    )
+    if scheduler_error is None and projection_error is not None:
+        scheduler_error = projection_error
+    if scheduler_error is not None:
+        raise scheduler_error
+    if projection.errors:
+        raise projection.errors[min(projection.errors)]
+    return projection.ordered_results()
+
+
+def _submit_audit(  # noqa: PLR0913
+    *,
+    pool: ThreadPoolExecutor,
+    index: int,
+    entry: AuditPlanEntry,
+    plan: PlanOutput,
+    adapter: BaseAdapter,
+    connection_pool: queue.Queue[Any],
+    completions: queue.Queue[_AuditCompletion],
+    on_audit_start: Callable[[AuditPlanEntry], None] | None,
+    run_id: str,
+) -> Future[None]:
+    worker: Callable[[], None] = partial(
+        run_worker_with_completion,
+        key=index,
+        connection_pool=connection_pool,
+        completion_queue=completions,
+        execute=lambda connection: _execute_entry(
+            entry=entry,
+            plan=plan,
+            adapter=adapter,
+            connection=connection,
+            on_audit_start=on_audit_start,
+            run_id=run_id,
+        ),
+        build_success=lambda key, result: _AuditCompletion(index=key, result=result),
+        build_failure=lambda key, error: _AuditCompletion(index=key, error=error),
+    )
+    return cast(Future[None], pool.submit(copy_context().run, worker))
+
+
+def _cancel_not_started(
+    *, futures: dict[int, Future[None]], in_flight: set[int]
+) -> tuple[set[int], set[int]]:
+    canceled: set[int] = {index for index in in_flight if futures[index].cancel()}
+    return in_flight - canceled, canceled
+
+
+def _execute_entry(
+    *,
+    entry: AuditPlanEntry,
+    plan: PlanOutput,
+    adapter: BaseAdapter,
+    connection: Any,
+    on_audit_start: Callable[[AuditPlanEntry], None] | None,
+    run_id: str,
+) -> AuditExecutionResult:
+    with ResourceAttemptLifecycle(
+        resource_id=audit_resource_id(
+            audit_name=entry.name,
+            attachment_kind=entry.attachment_kind,
+            attached_target_kind=entry.attached_target_kind,
+            attached_target_name=entry.attached_target_name,
+            attached_column_name=entry.attached_column_name,
+        ),
+        resource_kind="audit",
+        resource_name=entry.name,
+        run_id=run_id,
+    ) as lifecycle:
+        if on_audit_start is not None:
+            on_audit_start(entry)
+        result: AuditExecutionResult = execute_audit(
+            audit=entry,
+            adapter=adapter,
+            connection=connection,
+            model_locations=plan.model_locations,
+            seed_locations=plan.seed_locations,
+            source_map=plan.source_map,
+            relation_overrides=None,
+            run_scope_phase=AuditRunScope.FINAL,
+            quality_scope="standalone",
+        )
+        if result.outcome == AuditOutcome.ERROR:
+            lifecycle.failed()
+    return result

--- a/src/sqlbuild/executor/pipeline/exceptions.py
+++ b/src/sqlbuild/executor/pipeline/exceptions.py
@@ -1,0 +1,9 @@
+"""Execution pipeline errors."""
+
+
+class AuditConcurrencyError(RuntimeError):
+    """Raised when standalone audit concurrency is invalid."""
+
+
+class AuditOutcomeError(RuntimeError):
+    """Raised when audit execution returns an unknown quality outcome."""

--- a/src/sqlbuild/executor/pipeline/main/run.py
+++ b/src/sqlbuild/executor/pipeline/main/run.py
@@ -28,6 +28,9 @@ from sqlbuild.executor.build.types import BuildStatus
 from sqlbuild.executor.pipeline._helpers.auditing import (
     run_audit_pipeline as run_audit_pipeline,
 )
+from sqlbuild.executor.pipeline._helpers.auditing import (
+    run_audit_pipeline_with_callbacks as run_audit_pipeline_with_callbacks,
+)
 from sqlbuild.executor.pipeline._helpers.connections import (
     close_connections,
     prepare_build_connections,
@@ -52,7 +55,13 @@ from sqlbuild.executor.pipeline._helpers.settings import resolve_build_inputs
 from sqlbuild.executor.pipeline._helpers.testing import (
     run_test_pipeline as run_test_pipeline,
 )
-from sqlbuild.executor.pipeline.models import BuildConnectionPreparation, ResolvedBuildInputs
+from sqlbuild.executor.pipeline.models import (
+    AuditPipelineCallbacks as AuditPipelineCallbacks,
+)
+from sqlbuild.executor.pipeline.models import (
+    BuildConnectionPreparation,
+    ResolvedBuildInputs,
+)
 from sqlbuild.observability import (
     EventDispatcher,
     create_lifecycle_event,

--- a/src/sqlbuild/executor/pipeline/models.py
+++ b/src/sqlbuild/executor/pipeline/models.py
@@ -2,15 +2,32 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from sqlbuild.compiler.planner.models import AuditPlanEntry
+from sqlbuild.executor.auditing.models import AuditExecutionResult
 from sqlbuild.executor.build.models import (
     BuildCallbacks,
     BuildCustomizations,
     BuildInitialState,
     BuildRuntimeParams,
 )
+from sqlbuild.runtime.contracts.types import ConnectionElapsedCallback
+
+
+@dataclass(frozen=True)
+class AuditPipelineCallbacks:
+    """Optional connection and item callbacks for standalone audit execution."""
+
+    on_connection_start: Callable[[int], None] | None = None
+    on_connection_complete: ConnectionElapsedCallback | None = None
+    on_connection_error: ConnectionElapsedCallback | None = None
+    on_audit_start: Callable[[AuditPlanEntry], None] | None = None
+    on_audit_physical_complete: Callable[[AuditExecutionResult], None] | None = None
+    on_audit_complete: Callable[[AuditExecutionResult], None] | None = None
+    on_audit_error: Callable[[AuditPlanEntry], None] | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/observability.py
+++ b/src/sqlbuild/observability.py
@@ -10,6 +10,7 @@ from sqlbuild.runtime.observability.classes.operation_lifecycle import Operation
 from sqlbuild.runtime.observability.classes.resource_attempt_lifecycle import (
     ResourceAttemptLifecycle,
 )
+from sqlbuild.runtime.observability.classes.run_lifecycle import RunLifecycle as RunLifecycle
 from sqlbuild.runtime.observability.exceptions import ObservabilityValidationError
 from sqlbuild.runtime.observability.main.canonicalize_operation_adapter import (
     canonicalize_operation_adapter,

--- a/src/sqlbuild/runtime/observability/_helpers/validation.py
+++ b/src/sqlbuild/runtime/observability/_helpers/validation.py
@@ -10,6 +10,8 @@ from datetime import UTC, datetime
 from types import MappingProxyType
 
 from sqlbuild.runtime.observability.constants import (
+    AUDIT_RUN_COUNT_FIELDS,
+    CONFIGURED_CONCURRENCY_FIELD,
     DURATION_MS_FIELD,
     EXIT_CODE_FIELD,
     FORBIDDEN_STATEMENT_PAYLOAD_FIELDS,
@@ -32,6 +34,8 @@ from sqlbuild.runtime.observability.constants import (
     RESOURCE_SKIP_CODES,
     RESOURCE_SKIP_MODES,
     RETRY_SCHEDULED_EVENT,
+    RUN_STARTED_EVENT,
+    RUN_TERMINALS,
     STATEMENT_EVENT_PREFIX,
     STRING_PAYLOAD_FIELDS,
 )
@@ -297,3 +301,49 @@ def validate_known_lifecycle_event(*, event: LifecycleEvent) -> None:
             )
     for field_name, value in event.payload.items():
         _validate_payload_field(field_name=field_name, value=value)
+    _validate_run_payload(event=event)
+
+
+def _validate_run_payload(*, event: LifecycleEvent) -> None:
+    payload: Mapping[str, JSONValue] = event.payload
+    if event.event_type == RUN_STARTED_EVENT and CONFIGURED_CONCURRENCY_FIELD in payload:
+        configured: JSONValue = payload[CONFIGURED_CONCURRENCY_FIELD]
+        selected: JSONValue | None = payload.get("selected_count")
+        workers: JSONValue | None = payload.get("worker_count")
+        if not isinstance(configured, int) or isinstance(configured, bool) or configured < 1:
+            raise ObservabilityValidationError(
+                "configured_concurrency must be a positive integer excluding bool"
+            )
+        if not isinstance(selected, int) or isinstance(selected, bool) or selected < 0:
+            raise ObservabilityValidationError(
+                "selected_count must be a nonnegative integer excluding bool"
+            )
+        if not isinstance(workers, int) or isinstance(workers, bool):
+            raise ObservabilityValidationError("worker_count must be an integer excluding bool")
+        if workers != min(configured, selected):
+            raise ObservabilityValidationError(
+                "worker_count must equal min(configured_concurrency, selected_count)"
+            )
+    if event.event_type in RUN_TERMINALS and AUDIT_RUN_COUNT_FIELDS & set(payload):
+        if not AUDIT_RUN_COUNT_FIELDS <= set(payload):
+            raise ObservabilityValidationError(
+                "audit run terminals must include pass_count, warn_count, and fail_count together"
+            )
+        pass_count: int = _required_run_count(payload=payload, field_name="pass_count")
+        warn_count: int = _required_run_count(payload=payload, field_name="warn_count")
+        fail_count: int = _required_run_count(payload=payload, field_name="fail_count")
+        succeeded_count: int = _required_run_count(payload=payload, field_name="succeeded_count")
+        failed_count: int = _required_run_count(payload=payload, field_name="failed_count")
+        if succeeded_count != pass_count + warn_count:
+            raise ObservabilityValidationError("succeeded_count must equal pass_count + warn_count")
+        if failed_count != fail_count:
+            raise ObservabilityValidationError("failed_count must equal fail_count")
+
+
+def _required_run_count(*, payload: Mapping[str, JSONValue], field_name: str) -> int:
+    value: JSONValue | None = payload.get(field_name)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ObservabilityValidationError(
+            f"{field_name} must be a nonnegative integer excluding bool"
+        )
+    return value

--- a/src/sqlbuild/runtime/observability/classes/run_lifecycle.py
+++ b/src/sqlbuild/runtime/observability/classes/run_lifecycle.py
@@ -1,0 +1,132 @@
+"""Canonical lifecycle boundary for one command run."""
+
+from __future__ import annotations
+
+import time
+from types import TracebackType
+
+from sqlbuild.runtime.observability._helpers.dispatcher import current_event_dispatcher
+from sqlbuild.runtime.observability._helpers.factory import create_lifecycle_event
+from sqlbuild.runtime.observability.classes.event_dispatcher import EventDispatcher
+from sqlbuild.runtime.observability.exceptions import ObservabilityValidationError
+from sqlbuild.runtime.observability.types import JSONValue
+
+
+class RunLifecycle:
+    """Publish one run start and exactly one terminal with bounded counts."""
+
+    def __init__(
+        self,
+        *,
+        run_kind: str,
+        selected_count: int,
+        configured_concurrency: int,
+        worker_count: int,
+    ) -> None:
+        _validate_run_bounds(
+            selected_count=selected_count,
+            configured_concurrency=configured_concurrency,
+            worker_count=worker_count,
+        )
+        self._run_kind: str = run_kind
+        self._selected_count: int = selected_count
+        self._configured_concurrency: int = configured_concurrency
+        self._worker_count: int = worker_count
+        self._dispatcher: EventDispatcher | None = None
+        self._started: float = 0.0
+        self._terminal: bool = False
+        self._pass_count: int = 0
+        self._warn_count: int = 0
+        self._fail_count: int = 0
+
+    def __enter__(self) -> RunLifecycle:
+        self._dispatcher = current_event_dispatcher()
+        self._started = time.monotonic()
+        self._publish(
+            event_type="run_started",
+            payload={
+                "run_kind": self._run_kind,
+                "selected_count": self._selected_count,
+                "configured_concurrency": self._configured_concurrency,
+                "worker_count": self._worker_count,
+            },
+        )
+        return self
+
+    def record_pass(self) -> None:
+        self._pass_count += 1
+
+    def record_warning(self) -> None:
+        self._warn_count += 1
+
+    def record_failure(self) -> None:
+        self._fail_count += 1
+
+    def completed(self) -> None:
+        self._publish_terminal(
+            event_type="run_failed" if self._fail_count else "run_completed",
+        )
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_type, traceback
+        if not self._terminal:
+            self._publish_terminal(
+                event_type="run_failed" if exc_value is not None else "run_completed",
+                error=exc_value,
+            )
+
+    def _publish_terminal(
+        self,
+        *,
+        event_type: str,
+        error: BaseException | None = None,
+    ) -> None:
+        if self._terminal:
+            return
+        self._terminal = True
+        payload: dict[str, JSONValue] = {
+            "run_kind": self._run_kind,
+            "duration_ms": int((time.monotonic() - self._started) * 1000),
+            "succeeded_count": self._pass_count + self._warn_count,
+            "failed_count": self._fail_count,
+            "skipped_count": 0,
+            "pass_count": self._pass_count,
+            "warn_count": self._warn_count,
+            "fail_count": self._fail_count,
+        }
+        if error is not None:
+            payload["error_type"] = type(error).__name__
+        self._publish(event_type=event_type, payload=payload)
+
+    def _publish(self, *, event_type: str, payload: dict[str, JSONValue]) -> None:
+        if self._dispatcher is not None:
+            self._dispatcher.publish_lifecycle(
+                create_lifecycle_event(event_type=event_type, payload=payload)
+            )
+
+
+def _validate_run_bounds(
+    *, selected_count: int, configured_concurrency: int, worker_count: int
+) -> None:
+    values: tuple[tuple[str, int], ...] = (
+        ("selected_count", selected_count),
+        ("configured_concurrency", configured_concurrency),
+        ("worker_count", worker_count),
+    )
+    for field_name, value in values:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ObservabilityValidationError(f"{field_name} must be an integer excluding bool")
+    if selected_count < 0:
+        raise ObservabilityValidationError("selected_count must be nonnegative")
+    if configured_concurrency < 1:
+        raise ObservabilityValidationError("configured_concurrency must be positive")
+    expected_worker_count: int = min(configured_concurrency, selected_count)
+    if worker_count != expected_worker_count:
+        raise ObservabilityValidationError(
+            "worker_count must equal min(configured_concurrency, selected_count)"
+        )

--- a/src/sqlbuild/runtime/observability/constants.py
+++ b/src/sqlbuild/runtime/observability/constants.py
@@ -12,6 +12,10 @@ EXIT_CODE_FIELD: str = "exit_code"
 PROCESS_ID_FIELD: str = "process_id"
 SIGNAL_NUMBER_FIELD: str = "signal_number"
 METADATA_FIELD: str = "metadata"
+CONFIGURED_CONCURRENCY_FIELD: str = "configured_concurrency"
+RUN_STARTED_EVENT: str = "run_started"
+RUN_TERMINALS: frozenset[str] = frozenset({"run_completed", "run_failed"})
+AUDIT_RUN_COUNT_FIELDS: frozenset[str] = frozenset({"pass_count", "warn_count", "fail_count"})
 STATEMENT_EVENT_PREFIX: str = "statement_"
 MAX_METADATA_BYTES: int = 4096
 DIAGNOSTIC_SEVERITIES: frozenset[str] = frozenset(
@@ -231,15 +235,20 @@ NONNEGATIVE_INTEGER_PAYLOAD_FIELDS: frozenset[str] = frozenset(
         "batch_size",
         "delay_ms",
         "failed_count",
+        "fail_count",
         "failed_attempt_number",
         "hook_index",
         "next_attempt_number",
         PROCESS_ID_FIELD,
         "row_count",
         "selected_count",
+        "configured_concurrency",
+        "pass_count",
         SIGNAL_NUMBER_FIELD,
         "skipped_count",
         "succeeded_count",
+        "warn_count",
+        "worker_count",
     }
 )
 FORBIDDEN_STATEMENT_PAYLOAD_FIELDS: frozenset[str] = frozenset(
@@ -303,17 +312,39 @@ LIFECYCLE_EVENT_CATALOG_V1: Mapping[str, LifecycleEventDefinition] = MappingProx
         ),
         "run_started": LifecycleEventDefinition.create(
             required_correlations=frozenset({"run_id"}),
-            allowed=frozenset({"run_kind", "selected_count"}),
+            allowed=frozenset(
+                {"run_kind", "selected_count", "configured_concurrency", "worker_count"}
+            ),
         ),
         "run_completed": LifecycleEventDefinition.create(
             required_correlations=frozenset({"run_id"}),
-            allowed=frozenset({"run_kind", "succeeded_count", "failed_count", "skipped_count"})
+            allowed=frozenset(
+                {
+                    "run_kind",
+                    "succeeded_count",
+                    "failed_count",
+                    "skipped_count",
+                    "pass_count",
+                    "warn_count",
+                    "fail_count",
+                }
+            )
             | DURATION_FIELDS,
             terminal=True,
         ),
         "run_failed": LifecycleEventDefinition.create(
             required_correlations=frozenset({"run_id"}),
-            allowed=frozenset({"run_kind", "succeeded_count", "failed_count", "skipped_count"})
+            allowed=frozenset(
+                {
+                    "run_kind",
+                    "succeeded_count",
+                    "failed_count",
+                    "skipped_count",
+                    "pass_count",
+                    "warn_count",
+                    "fail_count",
+                }
+            )
             | DURATION_FIELDS
             | ERROR_FIELDS,
             terminal=True,

--- a/tests/e2e/src/sqlbuild/cli/commands/main/audit/test_audit.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/audit/test_audit.py
@@ -52,7 +52,7 @@ def test_given_waffle_shop_project_when_running_audit_then_all_audits_pass(
     run_sqb(command=("--no-color", "build"), project_dir=project_dir)
 
     result: subprocess.CompletedProcess[str] = run_sqb(
-        command=("--no-color", "audit"), project_dir=project_dir
+        command=("--no-color", "audit", "--concurrency", "1"), project_dir=project_dir
     )
 
     assert result.returncode == test_case.expected_exit_code, result.stdout + result.stderr

--- a/tests/e2e/src/sqlbuild/cli/commands/main/audit/test_audit.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/audit/test_audit.py
@@ -30,9 +30,9 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
                 "\u2713 Warehouse connected  duckdb",
             ),
             expected_ordered_stdout_fragments=(
-                "Execution  sqb audit  (concurrency: 1)",
                 "Compiling project...",
                 "Compiled project. (<time>)",
+                "Execution  sqb audit  (concurrency: 1)",
                 "Audit (28 selected, 12 models)",
                 "Connecting to duckdb...",
                 "\u2713 Warehouse connected  duckdb  (<time>)",
@@ -63,6 +63,66 @@ def test_given_waffle_shop_project_when_running_audit_then_all_audits_pass(
     assert_fragments_in_order(result.stdout, test_case.expected_ordered_stdout_fragments)
     assert "Inspecting warehouse state..." not in result.stdout
     assert "Generated plan." not in result.stdout
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditE2ETestCase(
+            description="serial and concurrent json equivalence",
+            expected_exit_code=0,
+            expected_stdout_fragment="",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_file_backed_project_when_auditing_serial_and_concurrent_then_json_is_equivalent(
+    test_case: AuditE2ETestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_waffle_shop(tmp_path)
+    run_sqb(command=("--no-color", "build"), project_dir=project_dir)
+    serial_path: Path = tmp_path / "audit-serial.json"
+    concurrent_path: Path = tmp_path / "audit-concurrent.json"
+
+    serial_result: subprocess.CompletedProcess[str] = run_sqb(
+        command=(
+            "--no-color",
+            "audit",
+            "--concurrency",
+            "1",
+            "--json-output",
+            str(serial_path),
+        ),
+        project_dir=project_dir,
+    )
+    concurrent_result: subprocess.CompletedProcess[str] = run_sqb(
+        command=(
+            "--no-color",
+            "audit",
+            "--concurrency",
+            "2",
+            "--json-output",
+            str(concurrent_path),
+        ),
+        project_dir=project_dir,
+    )
+
+    assert serial_result.returncode == test_case.expected_exit_code, (
+        serial_result.stdout + serial_result.stderr
+    )
+    assert concurrent_result.returncode == test_case.expected_exit_code, (
+        concurrent_result.stdout + concurrent_result.stderr
+    )
+    serial_payload: dict[str, object] = json.loads(serial_path.read_text(encoding="utf-8"))
+    concurrent_payload: dict[str, object] = json.loads(concurrent_path.read_text(encoding="utf-8"))
+    assert concurrent_payload["checks"] == serial_payload["checks"]
+    assert concurrent_payload["summary"] == serial_payload["summary"]
+    assert serial_payload["execution"] == {"configured_concurrency": 1, "worker_count": 1}
+    assert concurrent_payload["execution"] == {
+        "configured_concurrency": 2,
+        "worker_count": 2,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/_test_types.py
@@ -7,3 +7,12 @@ class VerboseCommandTestCase:
 
     description: str
     expected_argv: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AuditConcurrencyParsingTestCase:
+    description: str
+    argv: tuple[str, ...]
+    environment_value: str | None
+    expected_concurrency: int | None
+    expected_exit_code: int | None

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/test_parsing.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/test_parsing.py
@@ -8,6 +8,7 @@ from sqlbuild.cli.commands._helpers.entry.parser import build_cli_parser
 from sqlbuild.cli.commands._helpers.entry.parsing import parse_cli_invocation
 from sqlbuild.cli.commands.models import ParsedCliInvocation
 from tests.unit.src.sqlbuild.cli.commands._helpers.entry._test_types import (
+    AuditConcurrencyParsingTestCase,
     VerboseCommandTestCase,
 )
 
@@ -55,3 +56,58 @@ def test_given_output_mode_when_parsing_verbose_command_then_normalizes_consiste
     assert (default.args.verbose, default.args.debug) == (False, False)
     assert (verbose.args.verbose, verbose.args.debug) == (True, False)
     assert (debug.args.verbose, debug.args.debug) == (True, True)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditConcurrencyParsingTestCase(
+            description="cli wins over environment",
+            argv=("audit", "--concurrency", "3"),
+            environment_value="7",
+            expected_concurrency=3,
+            expected_exit_code=None,
+        ),
+        AuditConcurrencyParsingTestCase(
+            description="environment fallback",
+            argv=("audit",),
+            environment_value="7",
+            expected_concurrency=7,
+            expected_exit_code=None,
+        ),
+        AuditConcurrencyParsingTestCase(
+            description="zero cli rejected",
+            argv=("audit", "--concurrency", "0"),
+            environment_value=None,
+            expected_concurrency=None,
+            expected_exit_code=2,
+        ),
+        AuditConcurrencyParsingTestCase(
+            description="negative cli rejected",
+            argv=("audit", "--concurrency", "-1"),
+            environment_value=None,
+            expected_concurrency=None,
+            expected_exit_code=2,
+        ),
+        AuditConcurrencyParsingTestCase(
+            description="zero environment rejected",
+            argv=("audit",),
+            environment_value="0",
+            expected_concurrency=None,
+            expected_exit_code=2,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_audit_concurrency_sources_when_parsing_then_precedence_and_validation_apply(
+    test_case: AuditConcurrencyParsingTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SQLBUILD_CONCURRENCY", test_case.environment_value or "")
+
+    parsed: ParsedCliInvocation = parse_cli_invocation(
+        argv=test_case.argv, parser=build_cli_parser()
+    )
+
+    assert parsed.exit_code == test_case.expected_exit_code
+    assert getattr(parsed.args, "concurrency", None) == test_case.expected_concurrency

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -11,6 +11,7 @@ from sqlbuild.cli.commands._helpers.entry.parsing import read_selector_files
 from sqlbuild.cli.commands.exceptions import CliUserError
 from sqlbuild.cli.commands.main.entrypoint.entry import _main_with_dependencies, main
 from sqlbuild.cli.commands.models import (
+    AuditCommandRequest,
     BuildCommandRequest,
     CloneCommandRequest,
     CompileCommandRequest,
@@ -44,6 +45,35 @@ from tests.unit.src.sqlbuild.cli.commands.main.entry.helpers import (
     build_handlers,
     build_json_recording_handler,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        MainTestCase(
+            description="audit concurrency dispatch",
+            argv=["audit", "--concurrency", "4"],
+            expected_exit_code=0,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_audit_concurrency_when_dispatching_then_request_retains_value(
+    test_case: MainTestCase,
+) -> None:
+    received: list[AuditCommandRequest] = []
+
+    def run_audit(request: AuditCommandRequest) -> int:
+        received.append(request)
+        return 0
+
+    exit_code: int = _main_with_dependencies(
+        argv=test_case.argv,
+        handlers=build_handlers(run_audit=run_audit),
+    )
+
+    assert exit_code == test_case.expected_exit_code
+    assert received[0].concurrency == 4
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
@@ -35,3 +35,5 @@ class AuditExecutionProtocolTestCase:
     expected_check_id: str
     expected_attachment_kind: str
     expected_target_kind: str
+    expected_configured_concurrency: int = 1
+    expected_worker_count: int = 1

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_result_document.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_result_document.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from decimal import Decimal
 from pathlib import Path
 
@@ -12,6 +13,7 @@ from sqlbuild.cli.output._helpers.execution_result_document import (
     _format_audit_checks,
     _format_model_assets,
     _format_sql_test_checks,
+    format_audit_execution_json,
 )
 from sqlbuild.compiler.auditing.types import (
     AuditAttachmentKind,
@@ -76,6 +78,51 @@ def test_given_end_scheduled_model_audit_when_formatting_json_then_logical_ident
     assert check["attachment_kind"] == test_case.expected_attachment_kind
     assert check["attached_target_kind"] == test_case.expected_target_kind
     assert check["asset_name"] == "orders"
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditExecutionProtocolTestCase(
+            description="ordered concurrent audit json",
+            expected_check_id="audit:first",
+            expected_attachment_kind="end",
+            expected_target_kind="",
+            expected_configured_concurrency=8,
+            expected_worker_count=2,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_ordered_audits_when_formatting_json_then_metadata_and_check_order_are_preserved(
+    test_case: AuditExecutionProtocolTestCase,
+) -> None:
+    results: tuple[AuditExecutionResult, ...] = tuple(
+        AuditExecutionResult(
+            audit_name=name,
+            attachment_kind=AuditAttachmentKind.END,
+            severity=AuditSeverity.ERROR,
+            outcome=AuditOutcome.PASS,
+            row_count=0,
+            executed_sql="SELECT 1 WHERE FALSE",
+        )
+        for name in ("first", "second")
+    )
+
+    payload: dict[str, object] = json.loads(
+        format_audit_execution_json(
+            results=results,
+            configured_concurrency=test_case.expected_configured_concurrency,
+            worker_count=test_case.expected_worker_count,
+        )
+    )
+
+    assert payload["version"] == 1
+    assert payload["execution"] == {
+        "configured_concurrency": test_case.expected_configured_concurrency,
+        "worker_count": test_case.expected_worker_count,
+    }
+    assert [check["name"] for check in payload["checks"]] == ["first", "second"]  # type: ignore[index]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_yml_project.py
@@ -1012,6 +1012,17 @@ concurrency = "nope"
             expected_error_fragment="Expected 'concurrency' to be an integer when provided",
         ),
         LoadProjectConfigErrorTestCase(
+            description="raises when settings concurrency is below one",
+            project_file_contents="""
+name = "demo"
+adapter = "duckdb"
+
+[settings]
+concurrency = 0
+""".strip(),
+            expected_error_fragment="settings.concurrency must be >= 1",
+        ),
+        LoadProjectConfigErrorTestCase(
             description="raises when microbatch concurrency setting is not a boolean",
             project_file_contents="""
 name = "demo"

--- a/tests/unit/src/sqlbuild/cost/test_context.py
+++ b/tests/unit/src/sqlbuild/cost/test_context.py
@@ -38,6 +38,12 @@ def test_given_parent_cost_context_when_scoping_resource_then_inherits_run_ledge
             attempt=test_case.expected_attempt,
         ):
             actual: CostResourceContext | None = CostContext.current()
+        with CostContext.scope(
+            run_id="child-run",
+            resource_type="run",
+            resource_name="audit",
+        ):
+            nested: CostResourceContext | None = CostContext.current()
 
         restored: CostResourceContext | None = CostContext.current()
 
@@ -50,6 +56,8 @@ def test_given_parent_cost_context_when_scoping_resource_then_inherits_run_ledge
     assert actual.attempt == test_case.expected_attempt
     assert restored is not None
     assert restored.resource_type == "run"
+    assert nested is not None
+    assert nested.ledger_path == test_case.ledger_path
     assert CostContext.current() is None
 
 

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/_test_types.py
@@ -42,6 +42,14 @@ class AuditLogicalIdentityTestCase:
 
 
 @dataclass(frozen=True)
+class AuditConcurrencyTestCase:
+    description: str
+    expected_count: int = 0
+    expected_names: tuple[str, ...] = ()
+    expected_error: str = ""
+
+
+@dataclass(frozen=True)
 class ScenarioFailureHelpTestCase:
     """One scenario failure help resolution case."""
 

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/helpers.py
@@ -10,6 +10,12 @@ from typing import Any, ClassVar
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
 from sqlbuild.adapter.contract.models import ColumnInfo
+from sqlbuild.compiler.auditing.types import (
+    AuditAttachmentKind,
+    AuditOutcome,
+    AuditRunScope,
+    AuditSeverity,
+)
 from sqlbuild.compiler.compile.models import (
     CompiledObjectKey,
     CompiledProject,
@@ -20,6 +26,7 @@ from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.discovery.models import DiscoveredSqlScenarioFile
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.models import (
+    AuditPlanEntry,
     PlanOutput,
     ScenarioExecutionPlan,
     ScenarioGraphPlan,
@@ -28,6 +35,7 @@ from sqlbuild.compiler.planner.models import (
     SeedPlanEntry,
 )
 from sqlbuild.errors.contracts.exceptions import ExecutorInputError
+from sqlbuild.executor.auditing.models import AuditExecutionResult
 from sqlbuild.executor.scenario.constants import SCENARIO_LOCAL_JSONL_INVALID
 from sqlbuild.executor.scenario.models import (
     ScenarioLocalSnapshotLoadResult,
@@ -49,6 +57,35 @@ def lifecycle_events_with_prefix(
 
 def lifecycle_order_with_prefix(*, order: list[str], prefixes: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(filter(lambda item: item.startswith(prefixes), order))
+
+
+def audit_entry(
+    name: str,
+    *,
+    sql: str = "SELECT 1 WHERE FALSE",
+    severity: AuditSeverity = AuditSeverity.ERROR,
+) -> AuditPlanEntry:
+    return AuditPlanEntry(
+        key=CompiledObjectKey(resource_type=CompiledResourceType.AUDIT, name=name),
+        name=name,
+        resolved_sql=sql,
+        unresolved_sql=sql,
+        attachment_kind=AuditAttachmentKind.END,
+        severity=severity,
+        requested_run_scope=AuditRunScope.FINAL,
+        effective_run_scope=AuditRunScope.FINAL,
+    )
+
+
+def audit_result(name: str) -> AuditExecutionResult:
+    return AuditExecutionResult(
+        audit_name=name,
+        attachment_kind=AuditAttachmentKind.END,
+        severity=AuditSeverity.ERROR,
+        outcome=AuditOutcome.PASS,
+        row_count=0,
+        executed_sql="SELECT 1 WHERE FALSE",
+    )
 
 
 class ScenarioPipelineTestAdapter(BaseAdapter):

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/test_auditing.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/test_auditing.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+import queue
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import replace
+from datetime import UTC, datetime
+from io import StringIO
+from itertools import chain, repeat
 from pathlib import Path
+from typing import Any, cast
+from unittest.mock import DEFAULT, Mock
 
 import pytest
 
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.cli.progress.classes.audit_progress_reporter import AuditProgressReporter
 from sqlbuild.compiler.auditing.types import (
     AuditAttachmentKind,
     AuditOutcome,
@@ -16,9 +28,14 @@ from sqlbuild.compiler.auditing.types import (
 from sqlbuild.compiler.compile.models import CompiledObjectKey
 from sqlbuild.compiler.compile.types import AttachedAuditTargetKind, CompiledResourceType
 from sqlbuild.compiler.planner.models import AuditPlanEntry, PlanOutput
+from sqlbuild.cost._helpers.ledger import read_statement_ledger, record_statement
+from sqlbuild.cost.classes.cost_context import CostContext
+from sqlbuild.cost.models import CostResourceContext, StatementLedgerEntry
 from sqlbuild.executor.auditing.main.resource_id import audit_resource_id
 from sqlbuild.executor.auditing.models import AuditExecutionResult
-from sqlbuild.executor.pipeline._helpers.auditing import run_audit_pipeline
+from sqlbuild.executor.pipeline._helpers import auditing
+from sqlbuild.executor.pipeline.exceptions import AuditOutcomeError
+from sqlbuild.executor.pipeline.main.run import run_audit_pipeline
 from sqlbuild.observability import (
     EventDispatcher,
     LifecycleEvent,
@@ -26,14 +43,37 @@ from sqlbuild.observability import (
     invocation_scope,
 )
 from tests.unit.src.sqlbuild.executor.pipeline._helpers._test_types import (
+    AuditConcurrencyTestCase,
     AuditLogicalIdentityTestCase,
     AuditPipelineLifecycleTestCase,
     AuditResourceIdentityTestCase,
 )
 from tests.unit.src.sqlbuild.executor.pipeline._helpers.helpers import (
+    audit_entry,
+    audit_result,
     lifecycle_events_with_prefix,
     lifecycle_order_with_prefix,
 )
+
+
+class _InterruptingCompletionQueue(queue.Queue[Any]):
+    def __init__(self) -> None:
+        super().__init__()
+        self._get_delegate: Mock = Mock(
+            wraps=super().get,
+            side_effect=chain((DEFAULT, KeyboardInterrupt), repeat(DEFAULT)),
+        )
+
+    def get(self, block: bool = True, timeout: float | None = None) -> Any:
+        return self._get_delegate(block, timeout)
+
+
+class _AuditQueueFactory:
+    def __init__(self) -> None:
+        self._queues = iter((queue.Queue(), _InterruptingCompletionQueue()))
+
+    def __call__(self) -> queue.Queue[Any]:
+        return next(self._queues)
 
 
 @pytest.mark.parametrize(
@@ -107,7 +147,9 @@ def test_given_warning_audit_when_run_then_start_and_completed_terminal_wrap_cal
         prefixes=("resource_attempt_", "operation_", "statement_", "callback_"),
     )
     assert lifecycle_order == test_case.expected_order
-    assert events[-1].event_type == test_case.expected_event_type
+    assert events[-2].event_type == test_case.expected_event_type
+    assert events[-1].event_type == "run_completed"
+    assert events[-1].payload["warn_count"] == 1
     assert all(event.run_id == "audit-run" for event in events)
     resource_events: tuple[LifecycleEvent, ...] = lifecycle_events_with_prefix(
         events=events, prefixes=("resource_",)
@@ -190,3 +232,725 @@ def test_given_end_scheduled_attached_audit_when_formatted_then_logical_target_d
     )
 
     assert resource_id == test_case.expected_id
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AuditConcurrencyTestCase(description="empty plan", expected_count=0),),
+    ids=lambda case: case.description,
+)
+def test_given_empty_audit_plan_when_run_concurrently_then_opens_no_connections(
+    test_case: AuditConcurrencyTestCase,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+
+    results: tuple[AuditExecutionResult, ...] = run_audit_pipeline(
+        plan=PlanOutput(),
+        connection_config={},
+        adapter=adapter,
+        max_concurrency=8,
+    )
+
+    assert len(results) == test_case.expected_count
+    adapter.connect.assert_not_called()
+    adapter.close.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditConcurrencyTestCase(
+            description="reversed completion", expected_names=("first", "second", "third")
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_reversed_completion_when_run_concurrently_then_results_remain_plan_ordered(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entries: tuple[AuditPlanEntry, ...] = tuple(
+        audit_entry(name) for name in test_case.expected_names
+    )
+    connections: tuple[object, ...] = (object(), object())
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = connections
+    active_connections: set[int] = set()
+    lock: threading.Lock = threading.Lock()
+    maximum_active: list[int] = [0]
+    completion_order: list[str] = []
+    callback_order: list[str] = []
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        connection: object = kwargs["connection"]
+        assert isinstance(entry, AuditPlanEntry)
+        connection_id: int = id(connection)
+        with lock:
+            assert connection_id not in active_connections
+            active_connections.add(connection_id)
+            maximum_active[0] = max(maximum_active[0], len(active_connections))
+        time.sleep({"first": 0.08, "second": 0.02, "third": 0.01}[entry.name])
+        with lock:
+            active_connections.remove(connection_id)
+            completion_order.append(entry.name)
+        return audit_result(entry.name)
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+
+    results: tuple[AuditExecutionResult, ...] = run_audit_pipeline(
+        plan=PlanOutput(audit_entries=entries),
+        connection_config={},
+        adapter=adapter,
+        max_concurrency=2,
+        on_audit_complete=lambda result: callback_order.append(result.audit_name),
+    )
+
+    assert tuple(result.audit_name for result in results) == test_case.expected_names
+    assert completion_order == ["second", "third", "first"]
+    assert tuple(callback_order) == test_case.expected_names
+    assert maximum_active[0] == 2
+    assert adapter.connect.call_count == 2
+    assert adapter.close.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AuditConcurrencyTestCase(description="multiple errors", expected_error="failure-first"),),
+    ids=lambda case: case.description,
+)
+def test_given_multiple_worker_errors_when_run_then_earliest_plan_error_is_raised_after_drain(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entries: tuple[AuditPlanEntry, ...] = tuple(
+        audit_entry(name) for name in ("first", "second", "never_started")
+    )
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = (object(), object())
+    started: list[str] = []
+    finished: list[str] = []
+    lock: threading.Lock = threading.Lock()
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        with lock:
+            started.append(entry.name)
+        time.sleep({"first": 0.06, "second": 0.01}[entry.name])
+        with lock:
+            finished.append(entry.name)
+        raise RuntimeError(f"failure-{entry.name}")
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+
+    with pytest.raises(RuntimeError, match=test_case.expected_error):
+        run_audit_pipeline(
+            plan=PlanOutput(audit_entries=entries),
+            connection_config={},
+            adapter=adapter,
+            max_concurrency=2,
+        )
+
+    assert set(started) == {"first", "second"}
+    assert set(finished) == {"first", "second"}
+    assert adapter.close.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AuditConcurrencyTestCase(description="keyboard interrupt", expected_count=2),),
+    ids=lambda case: case.description,
+)
+def test_given_worker_keyboard_interrupt_when_run_then_stops_submission_and_closes_after_drain(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entries: tuple[AuditPlanEntry, ...] = tuple(
+        audit_entry(name) for name in ("interrupt", "running", "never_started")
+    )
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = (object(), object())
+    finished_running: threading.Event = threading.Event()
+    actions: dict[str, Callable[[], object]] = {
+        "interrupt": Mock(side_effect=KeyboardInterrupt),
+        "running": finished_running.set,
+    }
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        time.sleep({"interrupt": 0.01, "running": 0.05}[entry.name])
+        actions[entry.name]()
+        return audit_result(entry.name)
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+
+    with pytest.raises(KeyboardInterrupt):
+        run_audit_pipeline(
+            plan=PlanOutput(audit_entries=entries),
+            connection_config={},
+            adapter=adapter,
+            max_concurrency=2,
+        )
+
+    assert finished_running.is_set()
+    assert adapter.close.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditConcurrencyTestCase(
+            description="serial concurrent equivalence",
+            expected_names=("passing", "warning", "error"),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_file_backed_duckdb_audits_when_run_serial_and_concurrent_then_results_are_equivalent(
+    test_case: AuditConcurrencyTestCase,
+    tmp_path: Path,
+) -> None:
+    entries: tuple[AuditPlanEntry, ...] = (
+        audit_entry(test_case.expected_names[0], sql="SELECT 1 WHERE FALSE"),
+        audit_entry(test_case.expected_names[1], sql="SELECT 1", severity=AuditSeverity.WARN),
+        audit_entry(test_case.expected_names[2], sql="SELECT 1"),
+    )
+    plan: PlanOutput = PlanOutput(audit_entries=entries)
+    connection_config: dict[str, object] = {"database": str(tmp_path / "concurrent.duckdb")}
+
+    serial: tuple[AuditExecutionResult, ...] = run_audit_pipeline(
+        plan=plan,
+        connection_config=connection_config,
+        adapter=DuckDbAdapter(),
+        max_concurrency=1,
+    )
+    concurrent: tuple[AuditExecutionResult, ...] = run_audit_pipeline(
+        plan=plan,
+        connection_config=connection_config,
+        adapter=DuckDbAdapter(),
+        max_concurrency=2,
+    )
+
+    assert concurrent == serial
+    assert tuple(result.outcome for result in concurrent) == (
+        AuditOutcome.PASS,
+        AuditOutcome.WARN,
+        AuditOutcome.ERROR,
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditConcurrencyTestCase(
+            description="non tty ordered aggregate progress",
+            expected_names=("first", "second"),
+            expected_count=2,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_reversed_completions_when_reporting_non_tty_then_rows_and_enrichment_are_ordered(
+    test_case: AuditConcurrencyTestCase,
+) -> None:
+    entries: tuple[AuditPlanEntry, ...] = tuple(map(audit_entry, test_case.expected_names))
+    stream: StringIO = StringIO()
+    enriched: list[str] = []
+    reporter: AuditProgressReporter = AuditProgressReporter(
+        entries=entries,
+        worker_limit=test_case.expected_count,
+        stream=stream,
+        use_color=False,
+    )
+    reporter.set_result_callback(lambda result: enriched.append(result.audit_name))
+
+    reporter.on_item_start(entries[0])
+    reporter.on_item_start(entries[1])
+    reporter.on_item_complete(audit_result("second"))
+    reporter.on_item_complete(audit_result("first"))
+
+    assert stream.getvalue().index("first") < stream.getvalue().index("second")
+    assert tuple(enriched) == test_case.expected_names
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AuditConcurrencyTestCase(description="connection callback cleanup", expected_count=2),),
+    ids=lambda case: case.description,
+)
+def test_given_open_connections_when_connection_callback_raises_then_all_close_once_and_error_wins(
+    test_case: AuditConcurrencyTestCase,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = (object(), object())
+    adapter.close.side_effect = RuntimeError("close failure")
+
+    with pytest.raises(LookupError, match="callback failure"):
+        run_audit_pipeline(
+            plan=PlanOutput(audit_entries=(audit_entry("first"), audit_entry("second"))),
+            connection_config={},
+            adapter=adapter,
+            max_concurrency=2,
+            on_connection_complete=Mock(side_effect=LookupError("callback failure")),
+        )
+
+    assert adapter.close.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AuditConcurrencyTestCase(description="partial open cleanup", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_partial_connection_open_when_later_open_fails_then_opened_connection_closes_once(
+    test_case: AuditConcurrencyTestCase,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    opened: object = object()
+    adapter.connect.side_effect = (opened, LookupError("open failure"))
+
+    with pytest.raises(LookupError, match="open failure"):
+        run_audit_pipeline(
+            plan=PlanOutput(audit_entries=(audit_entry("first"), audit_entry("second"))),
+            connection_config={},
+            adapter=adapter,
+            max_concurrency=2,
+            on_connection_error=Mock(side_effect=RuntimeError("connection error callback")),
+        )
+
+    assert adapter.close.call_count == test_case.expected_count
+    adapter.close.assert_called_once_with(opened)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AuditConcurrencyTestCase(description="execution error precedence", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_execution_and_close_errors_when_running_then_execution_error_wins(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.return_value = object()
+    adapter.close.side_effect = RuntimeError("close failure")
+    monkeypatch.setattr(auditing, "execute_audit", Mock(side_effect=LookupError("execute failure")))
+
+    with pytest.raises(LookupError, match="execute failure"):
+        run_audit_pipeline(
+            plan=PlanOutput(audit_entries=(audit_entry("first"),)),
+            connection_config={},
+            adapter=adapter,
+        )
+
+    assert adapter.close.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditConcurrencyTestCase(
+            description="legacy keyword callbacks",
+            expected_names=("first", "second"),
+            expected_count=1,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_legacy_keyword_callbacks_when_running_default_serial_then_callbacks_remain_compatible(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.return_value = object()
+    started: list[str] = []
+    completed: list[str] = []
+    connection_started: list[int] = []
+    connection_completed: list[int] = []
+    monkeypatch.setattr(
+        auditing,
+        "execute_audit",
+        lambda **kwargs: audit_result(cast(AuditPlanEntry, kwargs["audit"]).name),
+    )
+
+    results: tuple[AuditExecutionResult, ...] = run_audit_pipeline(
+        plan=PlanOutput(
+            audit_entries=tuple(audit_entry(name) for name in test_case.expected_names)
+        ),
+        connection_config={},
+        adapter=adapter,
+        on_connection_start=connection_started.append,
+        on_connection_complete=lambda connection_count, elapsed_seconds: (
+            connection_completed.append(connection_count)
+        ),
+        on_connection_error=Mock(),
+        on_audit_start=lambda entry: started.append(entry.name),
+        on_audit_complete=lambda result: completed.append(result.audit_name),
+        run_id="legacy-run",
+    )
+
+    assert tuple(result.audit_name for result in results) == test_case.expected_names
+    assert tuple(started) == test_case.expected_names
+    assert tuple(completed) == test_case.expected_names
+    assert connection_started == [test_case.expected_count]
+    assert connection_completed == [test_case.expected_count]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditConcurrencyTestCase(
+            description="inherited concurrent cost ledger",
+            expected_names=("first", "second"),
+            expected_count=2,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_outer_cost_ledger_when_runtime_dir_is_omitted_then_workers_inherit_valid_ledger(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = (object(), object())
+    ledger_path: Path = tmp_path / "statements.jsonl"
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        with CostContext.resource_scope(resource_type="audit", resource_name=entry.name):
+            context: CostResourceContext | None = CostContext.current()
+            assert context is not None
+            now: datetime = datetime.now(UTC)
+            record_statement(
+                context=context,
+                statement_id=f"statement-{entry.name}",
+                sql="SELECT 1",
+                query_id=None,
+                status="completed",
+                started_at=now,
+                completed_at=now,
+            )
+        return audit_result(entry.name)
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+    with CostContext.scope(
+        run_id="outer-run",
+        resource_type="run",
+        resource_name="outer",
+        ledger_path=ledger_path,
+    ):
+        run_audit_pipeline(
+            plan=PlanOutput(
+                audit_entries=tuple(audit_entry(name) for name in test_case.expected_names)
+            ),
+            connection_config={},
+            adapter=adapter,
+            max_concurrency=2,
+            run_id="audit-run",
+        )
+
+    ledger: tuple[StatementLedgerEntry, ...] = read_statement_ledger(
+        path=ledger_path, run_id="audit-run"
+    )
+    assert len(ledger) == test_case.expected_count
+    assert {entry.resource_name for entry in ledger} == set(test_case.expected_names)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AuditConcurrencyTestCase(description="unknown audit outcome", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_unknown_audit_outcome_when_aggregating_then_it_is_rejected_and_connection_closes(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.return_value = object()
+    invalid: AuditExecutionResult = replace(
+        audit_result("first"), outcome=cast(AuditOutcome, "unknown")
+    )
+    monkeypatch.setattr(auditing, "execute_audit", Mock(return_value=invalid))
+
+    with pytest.raises(AuditOutcomeError, match="unknown audit outcome"):
+        run_audit_pipeline(
+            plan=PlanOutput(audit_entries=(audit_entry("first"),)),
+            connection_config={},
+            adapter=adapter,
+        )
+
+    assert adapter.close.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditConcurrencyTestCase(
+            description="unique concurrent attempts",
+            expected_names=("first", "second", "third"),
+            expected_count=3,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_concurrent_audits_when_lifecycle_publishes_then_attempts_are_unique_and_terminal_once(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = (object(), object())
+    dispatcher: EventDispatcher = EventDispatcher()
+    events: list[LifecycleEvent] = []
+    dispatcher.subscribe_lifecycle(subscriber=events.append, accepts_opaque=False)
+    monkeypatch.setattr(
+        auditing,
+        "execute_audit",
+        lambda **kwargs: audit_result(cast(AuditPlanEntry, kwargs["audit"]).name),
+    )
+
+    with invocation_scope("audit-invocation"), dispatcher_scope(dispatcher):
+        run_audit_pipeline(
+            plan=PlanOutput(
+                audit_entries=tuple(audit_entry(name) for name in test_case.expected_names)
+            ),
+            connection_config={},
+            adapter=adapter,
+            max_concurrency=2,
+            run_id="audit-run",
+        )
+
+    starts: list[LifecycleEvent] = list(
+        filter(lambda event: event.event_type == "resource_attempt_started", events)
+    )
+    terminals: list[LifecycleEvent] = list(
+        filter(
+            lambda event: (
+                event.event_type.startswith("resource_attempt_")
+                and event.event_type != "resource_attempt_started"
+            ),
+            events,
+        )
+    )
+    attempt_ids: set[str | None] = {event.resource_attempt_id for event in starts}
+    assert len(starts) == test_case.expected_count
+    assert len(terminals) == test_case.expected_count
+    assert len(attempt_ids) == test_case.expected_count
+    assert {event.resource_attempt_id for event in terminals} == attempt_ids
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditConcurrencyTestCase(
+            description="success before fatal",
+            expected_names=("success",),
+            expected_error="fatal-second",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_success_before_fatal_when_draining_then_success_projects_and_run_counts_it(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = (object(), object())
+    completed: list[str] = []
+    events: list[LifecycleEvent] = []
+    dispatcher: EventDispatcher = EventDispatcher()
+    dispatcher.subscribe_lifecycle(subscriber=events.append, accepts_opaque=False)
+    actions: dict[str, Callable[[], AuditExecutionResult]] = {
+        "success": lambda: audit_result("success"),
+        "fatal": Mock(side_effect=RuntimeError(test_case.expected_error)),
+    }
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        time.sleep({"success": 0.01, "fatal": 0.05}[entry.name])
+        return actions[entry.name]()
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+    with invocation_scope("audit-invocation"), dispatcher_scope(dispatcher):
+        with pytest.raises(RuntimeError, match=test_case.expected_error):
+            run_audit_pipeline(
+                plan=PlanOutput(audit_entries=(audit_entry("success"), audit_entry("fatal"))),
+                connection_config={},
+                adapter=adapter,
+                max_concurrency=2,
+                on_audit_complete=lambda result: completed.append(result.audit_name),
+            )
+
+    terminal: LifecycleEvent = tuple(
+        filter(lambda event: event.event_type == "run_failed", events)
+    )[0]
+    assert tuple(completed) == test_case.expected_names
+    assert terminal.payload["pass_count"] == 1
+    assert terminal.payload["warn_count"] == 0
+    assert terminal.payload["fail_count"] == 0
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditConcurrencyTestCase(
+            description="fatal before drained success",
+            expected_names=("later_success",),
+            expected_error="fatal-first",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_fatal_before_later_started_success_when_draining_then_gap_allows_projection(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = (object(), object())
+    completed: list[str] = []
+    events: list[LifecycleEvent] = []
+    dispatcher: EventDispatcher = EventDispatcher()
+    dispatcher.subscribe_lifecycle(subscriber=events.append, accepts_opaque=False)
+    actions: dict[str, Callable[[], AuditExecutionResult]] = {
+        "fatal": Mock(side_effect=RuntimeError(test_case.expected_error)),
+        "later_success": lambda: audit_result("later_success"),
+    }
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        time.sleep({"fatal": 0.01, "later_success": 0.05}[entry.name])
+        return actions[entry.name]()
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+    with invocation_scope("audit-invocation"), dispatcher_scope(dispatcher):
+        with pytest.raises(RuntimeError, match=test_case.expected_error):
+            run_audit_pipeline(
+                plan=PlanOutput(audit_entries=(audit_entry("fatal"), audit_entry("later_success"))),
+                connection_config={},
+                adapter=adapter,
+                max_concurrency=2,
+                on_audit_complete=lambda result: completed.append(result.audit_name),
+            )
+
+    terminal: LifecycleEvent = tuple(
+        filter(lambda event: event.event_type == "run_failed", events)
+    )[0]
+    assert tuple(completed) == test_case.expected_names
+    assert terminal.payload["pass_count"] == 1
+    assert terminal.payload["warn_count"] == 0
+    assert terminal.payload["fail_count"] == 0
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditConcurrencyTestCase(
+            description="multiple failures with drained success",
+            expected_names=("third_success",),
+            expected_error="failure-first",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_multiple_failures_and_success_when_drained_then_earliest_error_and_ordered_projection(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = (object(), object(), object())
+    completed: list[str] = []
+    events: list[LifecycleEvent] = []
+    dispatcher: EventDispatcher = EventDispatcher()
+    dispatcher.subscribe_lifecycle(subscriber=events.append, accepts_opaque=False)
+    actions: dict[str, Callable[[], AuditExecutionResult]] = {
+        "first": Mock(side_effect=RuntimeError(test_case.expected_error)),
+        "second": Mock(side_effect=RuntimeError("failure-second")),
+        "third_success": lambda: audit_result("third_success"),
+    }
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        time.sleep({"first": 0.05, "second": 0.01, "third_success": 0.02}[entry.name])
+        return actions[entry.name]()
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+    with invocation_scope("audit-invocation"), dispatcher_scope(dispatcher):
+        with pytest.raises(RuntimeError, match=test_case.expected_error):
+            run_audit_pipeline(
+                plan=PlanOutput(
+                    audit_entries=(
+                        audit_entry("first"),
+                        audit_entry("second"),
+                        audit_entry("third_success"),
+                    )
+                ),
+                connection_config={},
+                adapter=adapter,
+                max_concurrency=3,
+                on_audit_complete=lambda result: completed.append(result.audit_name),
+            )
+
+    terminal: LifecycleEvent = tuple(
+        filter(lambda event: event.event_type == "run_failed", events)
+    )[0]
+    assert tuple(completed) == test_case.expected_names
+    assert terminal.payload["pass_count"] == 1
+    assert terminal.payload["warn_count"] == 0
+    assert terminal.payload["fail_count"] == 0
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AuditConcurrencyTestCase(description="coordinator interrupt", expected_count=2),),
+    ids=lambda case: case.description,
+)
+def test_given_coordinator_keyboard_interrupt_when_waiting_then_workers_drain_and_connections_close(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = (object(), object())
+    started: list[str] = []
+    finished: list[str] = []
+    completed: list[str] = []
+    events: list[LifecycleEvent] = []
+    dispatcher: EventDispatcher = EventDispatcher()
+    dispatcher.subscribe_lifecycle(subscriber=events.append, accepts_opaque=False)
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        started.append(entry.name)
+        time.sleep({"first": 0.01, "second": 0.05}[entry.name])
+        finished.append(entry.name)
+        return audit_result(entry.name)
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+    monkeypatch.setattr(auditing.queue, "Queue", _AuditQueueFactory())
+
+    with invocation_scope("audit-invocation"), dispatcher_scope(dispatcher):
+        with pytest.raises(KeyboardInterrupt):
+            run_audit_pipeline(
+                plan=PlanOutput(audit_entries=(audit_entry("first"), audit_entry("second"))),
+                connection_config={},
+                adapter=adapter,
+                max_concurrency=2,
+                on_audit_complete=lambda result: completed.append(result.audit_name),
+            )
+
+    terminal: LifecycleEvent = tuple(
+        filter(lambda event: event.event_type == "run_failed", events)
+    )[0]
+    assert set(started) == {"first", "second"}
+    assert set(finished) == set(started)
+    assert completed == ["first", "second"]
+    assert terminal.payload["pass_count"] == test_case.expected_count
+    assert terminal.payload["warn_count"] == 0
+    assert terminal.payload["fail_count"] == 0
+    assert adapter.close.call_count == test_case.expected_count

--- a/tests/unit/src/sqlbuild/runtime/observability/_test_types.py
+++ b/tests/unit/src/sqlbuild/runtime/observability/_test_types.py
@@ -98,6 +98,15 @@ class SchemaVersionCase:
 
 
 @dataclass(frozen=True)
+class RunLifecycleErrorCase:
+    description: str
+    selected_count: object
+    configured_concurrency: object
+    worker_count: object
+    expected_error: str
+
+
+@dataclass(frozen=True)
 class ExactJsonCase:
     description: str
     payload: Mapping[str, JSONValue]

--- a/tests/unit/src/sqlbuild/runtime/observability/test_catalog.py
+++ b/tests/unit/src/sqlbuild/runtime/observability/test_catalog.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from sqlbuild.runtime.observability.classes.run_lifecycle import RunLifecycle
 from sqlbuild.runtime.observability.constants import LIFECYCLE_EVENT_CATALOGS
 from sqlbuild.runtime.observability.exceptions import ObservabilityValidationError
 from sqlbuild.runtime.observability.main.canonicalize_operation_adapter import (
@@ -20,6 +21,7 @@ from tests.unit.src.sqlbuild.runtime.observability._test_types import (
     IdempotencyCase,
     LifecycleErrorCase,
     OperationAdapterCase,
+    RunLifecycleErrorCase,
     StatementPrivacyCase,
     TerminalEvidenceCase,
     TerminalSemanticsCase,
@@ -328,6 +330,41 @@ def test_given_catalog_when_looking_up_events_then_authority_is_version_dimensio
             expected_error="excluding bool",
         ),
         LifecycleErrorCase(
+            description="zero configured concurrency is rejected",
+            event_type="run_started",
+            run_id="run-1",
+            payload={
+                "selected_count": 1,
+                "configured_concurrency": 0,
+                "worker_count": 0,
+            },
+            expected_error="configured_concurrency must be a positive integer",
+        ),
+        LifecycleErrorCase(
+            description="worker count above selected count is rejected",
+            event_type="run_started",
+            run_id="run-1",
+            payload={
+                "selected_count": 1,
+                "configured_concurrency": 2,
+                "worker_count": 2,
+            },
+            expected_error="worker_count must equal min",
+        ),
+        LifecycleErrorCase(
+            description="audit run count sum mismatch is rejected",
+            event_type="run_completed",
+            run_id="run-1",
+            payload={
+                "succeeded_count": 1,
+                "failed_count": 0,
+                "pass_count": 1,
+                "warn_count": 1,
+                "fail_count": 0,
+            },
+            expected_error="succeeded_count must equal",
+        ),
+        LifecycleErrorCase(
             description="non-string command is rejected",
             event_type="invocation_started",
             payload={"command": 7},
@@ -365,6 +402,45 @@ def test_given_invalid_catalogued_payload_value_when_constructing_then_it_is_rej
             run_id=test_case.run_id,
             statement_id=test_case.statement_id,
             payload=test_case.payload,
+        )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        RunLifecycleErrorCase(
+            description="boolean selected count",
+            selected_count=True,
+            configured_concurrency=1,
+            worker_count=1,
+            expected_error="selected_count must be an integer excluding bool",
+        ),
+        RunLifecycleErrorCase(
+            description="zero configured concurrency",
+            selected_count=1,
+            configured_concurrency=0,
+            worker_count=0,
+            expected_error="configured_concurrency must be positive",
+        ),
+        RunLifecycleErrorCase(
+            description="physical worker mismatch",
+            selected_count=1,
+            configured_concurrency=2,
+            worker_count=2,
+            expected_error="worker_count must equal min",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_invalid_run_bounds_when_constructing_run_lifecycle_then_it_is_rejected(
+    test_case: RunLifecycleErrorCase,
+) -> None:
+    with pytest.raises(ObservabilityValidationError, match=test_case.expected_error):
+        RunLifecycle(
+            run_kind="audit",
+            selected_count=test_case.selected_count,  # ty: ignore[invalid-argument-type]
+            configured_concurrency=test_case.configured_concurrency,  # ty: ignore[invalid-argument-type]
+            worker_count=test_case.worker_count,  # ty: ignore[invalid-argument-type]
         )
 
 


### PR DESCRIPTION
## Why

Standalone `sqb audit` executed every selected audit serially. The migrated Dagster project selects 1,069 audits, making acceptance and routine audit-only runs operationally impractical even after focused planning removed build-state inspection.

## Changes

- Add `sqb audit --concurrency N` with CLI, environment, effective-project, and serial-default precedence.
- Execute a bounded number of audits with one exclusive warehouse connection per active worker and no scheduler connection.
- Keep submissions bounded, stop scheduling on fatal errors or interruption, drain started work, and preserve deterministic earliest-plan-index failures.
- Preserve plan-ordered results, text output, JSON checks, and integration enrichment while lifecycle events retain truthful wall-clock ordering.
- Add coordinator-safe aggregate progress, run-level lifecycle evidence, propagated cost context, and additive configured/physical concurrency JSON metadata.
- Preserve the public serial audit pipeline interface and quality warning/error aggregation semantics.

## Verification

- `make test`: 5,874 passed.
- `make check-ci`: formatting, Ruff, ty, strict adapter tests, and Fensu passed.
- Focused DuckDB serial/concurrent equivalence E2E: passed.
- Independent review verified connection cleanup, cancellation, lifecycle terminal integrity, context propagation, callback compatibility, fatal-path projection, and deterministic ordering.
- Full E2E and external-adapter concurrency remain CI-owned.

Linear: CHI-201
