### PR TITLE
fix: install skills at repository root

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/skills/update.py
+++ b/src/sqlbuild/cli/commands/_helpers/skills/update.py
@@ -221,17 +221,20 @@ def build_install_targets(
     home_dir: Path | None = None,
 ) -> tuple[SkillInstallTarget, ...]:
     home_path: Path = home_dir if home_dir is not None else Path.home()
+    local_install_root: Path = _find_git_root(project_dir=project_dir) or project_dir
     install_targets: list[SkillInstallTarget] = []
     for target_name in target_names:
         base_path: Path
         if target_name == opencode_skill_target:
             base_path = (
-                home_path / ".config/opencode" if global_install else project_dir / ".opencode"
+                home_path / ".config/opencode"
+                if global_install
+                else local_install_root / ".opencode"
             )
         elif target_name == claude_skill_target:
-            base_path = home_path / ".claude" if global_install else project_dir / ".claude"
+            base_path = home_path / ".claude" if global_install else local_install_root / ".claude"
         else:
-            base_path = home_path / ".agents" if global_install else project_dir / ".agents"
+            base_path = home_path / ".agents" if global_install else local_install_root / ".agents"
         install_targets.append(
             SkillInstallTarget(
                 name=target_name,
@@ -239,6 +242,14 @@ def build_install_targets(
             )
         )
     return tuple(install_targets)
+
+
+def _find_git_root(*, project_dir: Path) -> Path | None:
+    for candidate in (project_dir, *project_dir.parents):
+        marker: Path = candidate / ".git"
+        if marker.is_dir() or marker.is_file():
+            return candidate
+    return None
 
 
 def load_packaged_skill_content() -> str:

--- a/tests/unit/src/sqlbuild/cli/commands/main/skills/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/skills/_test_types.py
@@ -12,6 +12,8 @@ class SkillUpdateTestCase:
     force: bool = False
     expected_written_paths: tuple[Path, ...] = ()
     expected_content_fragment: str = "# SQLBuild Skill"
+    project_path: Path = Path(".")
+    git_marker_is_file: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -29,3 +31,5 @@ class SkillMaintenanceTestCase:
     existing_files: dict[Path, str] = field(default_factory=dict)
     expected_message_fragment: str = ""
     expected_written_paths: tuple[Path, ...] = ()
+    project_path: Path = Path(".")
+    git_marker_is_file: bool | None = None

--- a/tests/unit/src/sqlbuild/cli/commands/main/skills/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/skills/helpers.py
@@ -25,3 +25,23 @@ def prepare_skill_update_project(
     }[project_config is not None]
     write_project_files(project_dir=project_dir, files=project_files)
     write_project_files(project_dir=project_dir, files=existing_files)
+
+
+def _skip_git_marker(*, repository_dir: Path) -> None:
+    _ = repository_dir
+
+
+def _write_git_file(*, repository_dir: Path) -> None:
+    marker: Path = repository_dir / ".git"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("gitdir: elsewhere\n", encoding="utf-8")
+
+
+def _write_git_directory(*, repository_dir: Path) -> None:
+    (repository_dir / ".git").mkdir(parents=True)
+
+
+def write_git_marker(*, repository_dir: Path, marker_is_file: bool | None) -> None:
+    {None: _skip_git_marker, False: _write_git_directory, True: _write_git_file}[marker_is_file](
+        repository_dir=repository_dir
+    )

--- a/tests/unit/src/sqlbuild/cli/commands/main/skills/test_skills.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/skills/test_skills.py
@@ -21,6 +21,7 @@ from tests.unit.src.sqlbuild.cli.commands.main.skills._test_types import (
 from tests.unit.src.sqlbuild.cli.commands.main.skills.helpers import (
     prepare_skill_update_project,
     read_relative_file,
+    write_git_marker,
     write_project_files,
 )
 
@@ -53,6 +54,24 @@ from tests.unit.src.sqlbuild.cli.commands.main.skills.helpers import (
             force=True,
             expected_written_paths=(Path(".opencode/skills/sqlbuild/SKILL.md"),),
         ),
+        SkillUpdateTestCase(
+            description="nested project installs skills at repository root",
+            project_path=Path("repository/sqlbuild_project"),
+            git_marker_is_file=False,
+            expected_written_paths=(
+                Path("repository/.agents/skills/sqlbuild/SKILL.md"),
+                Path("repository/.claude/skills/sqlbuild/SKILL.md"),
+            ),
+        ),
+        SkillUpdateTestCase(
+            description="nested worktree project installs skills at repository root",
+            project_path=Path("worktree/sqlbuild_project"),
+            git_marker_is_file=True,
+            expected_written_paths=(
+                Path("worktree/.agents/skills/sqlbuild/SKILL.md"),
+                Path("worktree/.claude/skills/sqlbuild/SKILL.md"),
+            ),
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -60,14 +79,19 @@ def test_given_skill_update_options_when_updating_then_writes_expected_targets(
     test_case: SkillUpdateTestCase,
     tmp_path: Path,
 ) -> None:
+    project_dir: Path = tmp_path / test_case.project_path
+    write_git_marker(
+        repository_dir=project_dir.parent,
+        marker_is_file=test_case.git_marker_is_file,
+    )
     prepare_skill_update_project(
-        project_dir=tmp_path,
+        project_dir=project_dir,
         project_config=test_case.project_config,
         existing_files=test_case.existing_files,
     )
 
     result: SkillUpdateResult = update_sqlbuild_skills(
-        project_dir=tmp_path,
+        project_dir=project_dir,
         requested_targets=test_case.requested_targets,
         global_install=test_case.global_install,
         force=test_case.force,
@@ -197,6 +221,17 @@ def test_given_skill_frontmatter_when_adding_generated_marker_then_marker_follow
             description="project without configured or installed skills remains quiet",
             project_config='name = "demo"\nadapter = "duckdb"\n',
         ),
+        SkillMaintenanceTestCase(
+            description="nested project auto updates skill at repository root",
+            project_config=(
+                'name = "demo"\nadapter = "duckdb"\n\n[skills]\n'
+                'targets = ["agents"]\nauto_update = true\n'
+            ),
+            project_path=Path("repository/sqlbuild_project"),
+            git_marker_is_file=False,
+            expected_message_fragment="Updated stale SQLBuild skill files",
+            expected_written_paths=(Path("repository/.agents/skills/sqlbuild/SKILL.md"),),
+        ),
     ),
     ids=lambda case: case.description,
 )
@@ -204,13 +239,18 @@ def test_given_project_skill_state_when_maintaining_then_reports_or_updates_owne
     test_case: SkillMaintenanceTestCase,
     tmp_path: Path,
 ) -> None:
+    project_dir: Path = tmp_path / test_case.project_path
+    write_git_marker(
+        repository_dir=project_dir.parent,
+        marker_is_file=test_case.git_marker_is_file,
+    )
     prepare_skill_update_project(
-        project_dir=tmp_path,
+        project_dir=project_dir,
         project_config=test_case.project_config,
         existing_files=test_case.existing_files,
     )
 
-    result: SkillMaintenanceResult = maintain_sqlbuild_skills(project_dir=tmp_path)
+    result: SkillMaintenanceResult = maintain_sqlbuild_skills(project_dir=project_dir)
 
     assert test_case.expected_message_fragment in result.message
     for relative_path in test_case.expected_written_paths:


### PR DESCRIPTION
## Why

SQLBuild currently installs local agent skills inside the SQLBuild project directory. In monorepos where `sqlbuild_project.toml` lives below the Git root, this creates duplicate `.agents` and `.claude` skill trees that repository-level agents do not need.

## Changes

- resolve the nearest enclosing Git root for local skill installation
- support both normal `.git` directories and Git worktree `.git` files
- fall back to the SQLBuild project directory outside a Git repository
- keep configuration lookup, global installs, auto-update, and custom-file protection unchanged

## Verification

- `uv run pytest tests/unit/src/sqlbuild/cli/commands/main/skills/test_skills.py tests/e2e/src/sqlbuild/cli/commands/main/skills/test_skills.py -n auto --dist loadfile` (`18 passed`)
- `uv sync --all-extras`
- `make check-ci`
- verified the nested Dagster project resolves all local targets to the Dagster Git root
