### PR TITLE
fix: collect standalone audit execution errors

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/entry/dispatch_errors.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/dispatch_errors.py
@@ -18,6 +18,7 @@ from sqlbuild.cli.commands.models import (
 )
 from sqlbuild.cli.commands.types import CliCommand
 from sqlbuild.compiler.discovery.exceptions import DiscoveryError
+from sqlbuild.executor.pipeline.exceptions import AuditExecutionError
 from sqlbuild.kata_engine.exceptions import KataError
 from sqlbuild.lint.exceptions import LintError
 from sqlbuild.virtual.state.exceptions import StateBackendError
@@ -50,7 +51,7 @@ def dispatch_and_handle_errors(
             file=sys.stderr,
         )
         return 1
-    except (DiscoveryError, StateBackendError, ValueError) as error:
+    except (AuditExecutionError, DiscoveryError, StateBackendError, ValueError) as error:
         logging.getLogger("sqlbuild.cli").exception("command failed")
         print(
             format_expected_error(error=error, fallback_code="E001", use_color=use_color),

--- a/src/sqlbuild/executor/pipeline/_helpers/auditing.py
+++ b/src/sqlbuild/executor/pipeline/_helpers/auditing.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import queue
+import re
 import time
+from asyncio import CancelledError as AsyncCancelledError
 from collections.abc import Callable
+from concurrent.futures import CancelledError as FutureCancelledError
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextvars import copy_context
 from dataclasses import dataclass, replace
@@ -16,6 +19,7 @@ from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.auditing.types import AuditOutcome, AuditRunScope
 from sqlbuild.compiler.planner.models import AuditPlanEntry, PlanOutput
 from sqlbuild.cost.classes.cost_context import CostContext
+from sqlbuild.diagnostics.classes.diagnostic_record_redactor import DiagnosticRecordRedactor
 from sqlbuild.diagnostics.main.diagnostics_context import diagnostics_context
 from sqlbuild.executor.auditing.main._execute import execute_audit
 from sqlbuild.executor.auditing.main.resource_id import audit_resource_id
@@ -24,8 +28,13 @@ from sqlbuild.executor.pipeline._helpers.connections import (
     close_connections,
     open_worker_connections,
 )
-from sqlbuild.executor.pipeline.exceptions import AuditConcurrencyError, AuditOutcomeError
-from sqlbuild.executor.pipeline.models import AuditPipelineCallbacks
+from sqlbuild.executor.pipeline.exceptions import (
+    AuditConcurrencyError,
+    AuditCoordinatorError,
+    AuditExecutionError,
+    AuditOutcomeError,
+)
+from sqlbuild.executor.pipeline.models import AuditExecutionFailure, AuditPipelineCallbacks
 from sqlbuild.executor.scheduling.main._run_worker import run_worker_with_completion
 from sqlbuild.observability import RunLifecycle, run_scope
 from sqlbuild.runtime.contracts.types import ConnectionElapsedCallback
@@ -187,6 +196,10 @@ def run_audit_pipeline_with_callbacks(
                         lifecycle=lifecycle,
                         callback=callbacks.on_audit_complete,
                     ),
+                    on_audit_error=_AuditErrorRecorder(
+                        lifecycle=lifecycle,
+                        callback=callbacks.on_audit_error,
+                    ),
                 )
                 results: tuple[AuditExecutionResult, ...] = _run_audits(
                     entries=entries,
@@ -222,6 +235,22 @@ class _AuditCompletionRecorder:
             raise AuditOutcomeError(f"unknown audit outcome: {result.outcome!r}")
         if self._callback is not None:
             self._callback(result)
+
+
+class _AuditErrorRecorder:
+    def __init__(
+        self,
+        *,
+        lifecycle: RunLifecycle,
+        callback: Callable[[AuditPlanEntry], None] | None,
+    ) -> None:
+        self._lifecycle: RunLifecycle = lifecycle
+        self._callback: Callable[[AuditPlanEntry], None] | None = callback
+
+    def __call__(self, entry: AuditPlanEntry) -> None:
+        self._lifecycle.record_failure()
+        if self._callback is not None:
+            self._callback(entry)
 
 
 def _run_audits(
@@ -296,8 +325,8 @@ def _run_serial_audits(
     callbacks: AuditPipelineCallbacks,
     run_id: str,
 ) -> tuple[AuditExecutionResult, ...]:
-    results: list[AuditExecutionResult] = []
-    for entry in entries:
+    projection: _AuditProjection = _AuditProjection(entry_count=len(entries))
+    for index, entry in enumerate(entries):
         try:
             result: AuditExecutionResult = _execute_entry(
                 entry=entry,
@@ -307,16 +336,28 @@ def _run_serial_audits(
                 on_audit_start=callbacks.on_audit_start,
                 run_id=run_id,
             )
-        except BaseException:
-            if callbacks.on_audit_error is not None:
-                callbacks.on_audit_error(entry)
-            raise
-        results.append(result)
-        if callbacks.on_audit_physical_complete is not None:
-            callbacks.on_audit_physical_complete(result)
-        if callbacks.on_audit_complete is not None:
-            callbacks.on_audit_complete(result)
-    return tuple(results)
+        except BaseException as error:
+            completion_error: BaseException | None = projection.consume(
+                completion=_AuditCompletion(index=index, error=error),
+                entries=entries,
+                callbacks=callbacks,
+            )
+            stop_error: BaseException | None = _coordinator_stop_error(error)
+            if stop_error is not None:
+                raise stop_error from None
+            if completion_error is not None:
+                raise completion_error from None
+            continue
+        completion_error = projection.consume(
+            completion=_AuditCompletion(index=index, result=result),
+            entries=entries,
+            callbacks=callbacks,
+        )
+        if completion_error is not None:
+            raise completion_error
+    if projection.errors:
+        raise _audit_execution_error(entries=entries, errors=projection.errors)
+    return projection.ordered_results()
 
 
 def _run_concurrent_audits(
@@ -367,9 +408,12 @@ def _run_concurrent_audits(
                 entries=entries,
                 callbacks=callbacks,
             )
+            stop_error: BaseException | None = _coordinator_stop_error(completion.error)
+            if stop_error is not None:
+                scheduler_error = stop_error
             if scheduler_error is None and completion_error is not None:
                 scheduler_error = completion_error
-            if not projection.errors and scheduler_error is None and next_index < len(entries):
+            if scheduler_error is None and next_index < len(entries):
                 futures[next_index] = _submit_audit(
                     pool=pool,
                     index=next_index,
@@ -383,7 +427,7 @@ def _run_concurrent_audits(
                 )
                 in_flight.add(next_index)
                 next_index += 1
-            elif projection.errors or scheduler_error is not None:
+            elif scheduler_error is not None:
                 in_flight, canceled = _cancel_not_started(futures=futures, in_flight=in_flight)
                 projection_error: BaseException | None = projection.add_gaps(
                     indexes=canceled,
@@ -426,7 +470,7 @@ def _run_concurrent_audits(
     if scheduler_error is not None:
         raise scheduler_error
     if projection.errors:
-        raise projection.errors[min(projection.errors)]
+        raise _audit_execution_error(entries=entries, errors=projection.errors)
     return projection.ordered_results()
 
 
@@ -490,7 +534,10 @@ def _execute_entry(
         run_id=run_id,
     ) as lifecycle:
         if on_audit_start is not None:
-            on_audit_start(entry)
+            try:
+                on_audit_start(entry)
+            except BaseException as error:
+                raise AuditCoordinatorError(error) from error
         result: AuditExecutionResult = execute_audit(
             audit=entry,
             adapter=adapter,
@@ -505,3 +552,52 @@ def _execute_entry(
         if result.outcome == AuditOutcome.ERROR:
             lifecycle.failed()
     return result
+
+
+def _audit_execution_error(
+    *, entries: tuple[AuditPlanEntry, ...], errors: dict[int, BaseException]
+) -> AuditExecutionError:
+    failures: tuple[AuditExecutionFailure, ...] = tuple(
+        AuditExecutionFailure(
+            audit_name=entries[index].name,
+            resource_id=audit_resource_id(
+                audit_name=entries[index].name,
+                attachment_kind=entries[index].attachment_kind,
+                attached_target_kind=entries[index].attached_target_kind,
+                attached_target_name=entries[index].attached_target_name,
+                attached_column_name=entries[index].attached_column_name,
+            ),
+            error_type=type(error).__name__,
+            message=_safe_audit_error_message(error),
+        )
+        for index, error in sorted(errors.items())
+    )
+    return AuditExecutionError(failures=failures)
+
+
+def _safe_audit_error_message(error: BaseException) -> str:
+    try:
+        raw_message: str = str(error)
+    except BaseException:
+        return f"Unable to stringify {type(error).__name__}"
+    message: str = " ".join(DiagnosticRecordRedactor.text(raw_message).split())
+    if not message:
+        return "No error detail provided"
+    if re.search(
+        r"\b(?:select|insert|update|delete|merge|with|password|credential|token|secret|rows?)\b",
+        message,
+        re.IGNORECASE,
+    ):
+        return "Error detail redacted"
+    return message[:240]
+
+
+def _coordinator_stop_error(error: BaseException | None) -> BaseException | None:
+    if isinstance(error, AuditCoordinatorError):
+        return error.error
+    if error is not None and (
+        not isinstance(error, Exception)
+        or isinstance(error, (AsyncCancelledError, FutureCancelledError))
+    ):
+        return error
+    return None

--- a/src/sqlbuild/executor/pipeline/exceptions.py
+++ b/src/sqlbuild/executor/pipeline/exceptions.py
@@ -1,5 +1,30 @@
 """Execution pipeline errors."""
 
+from __future__ import annotations
+
+from sqlbuild.executor.pipeline.models import AuditExecutionFailure
+
+
+class AuditExecutionError(RuntimeError):
+    """Raised after every selected standalone audit has been attempted."""
+
+    def __init__(self, *, failures: tuple[AuditExecutionFailure, ...]) -> None:
+        self.failures: tuple[AuditExecutionFailure, ...] = failures
+        lines: list[str] = [f"Standalone audit execution failed ({len(failures)} audits):"]
+        lines.extend(
+            f"  {failure.resource_id}: {failure.error_type}: {failure.message}"
+            for failure in failures
+        )
+        super().__init__("\n".join(lines))
+
+
+class AuditCoordinatorError(BaseException):
+    """Marks callback failures that must stop standalone audit submission."""
+
+    def __init__(self, error: BaseException) -> None:
+        self.error: BaseException = error
+        super().__init__(type(error).__name__)
+
 
 class AuditConcurrencyError(RuntimeError):
     """Raised when standalone audit concurrency is invalid."""

--- a/src/sqlbuild/executor/pipeline/models.py
+++ b/src/sqlbuild/executor/pipeline/models.py
@@ -31,6 +31,16 @@ class AuditPipelineCallbacks:
 
 
 @dataclass(frozen=True)
+class AuditExecutionFailure:
+    """Safe public description of one standalone audit runtime failure."""
+
+    audit_name: str
+    resource_id: str
+    error_type: str
+    message: str
+
+
+@dataclass(frozen=True)
 class ResolvedBuildInputs:
     """Fully-resolved runtime bundles for one build pipeline run."""
 

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/_test_types.py
@@ -123,6 +123,14 @@ class MainErrorRenderingTestCase:
 
 
 @dataclass(frozen=True)
+class AuditAggregateRenderingTestCase:
+    description: str
+    expected_exit_code: int
+    expected_failure_ids: tuple[str, ...]
+    expected_json_filename: str
+
+
+@dataclass(frozen=True)
 class ObservabilityCleanupCase:
     description: str
     expected_original_error: str

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -34,9 +34,12 @@ from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.discovery.exceptions import ProjectConfigError
 from sqlbuild.compiler.lineage.types import ColumnLineageMode
 from sqlbuild.compiler.planner.models import CursorOverrides
+from sqlbuild.executor.pipeline.exceptions import AuditExecutionError
+from sqlbuild.executor.pipeline.models import AuditExecutionFailure
 from sqlbuild.observability import EventDispatcher, ExecutionIdentity, current_execution_identity
 from sqlbuild.runtime.observability.models import LifecycleEvent
 from tests.unit.src.sqlbuild.cli.commands.main.entry._test_types import (
+    AuditAggregateRenderingTestCase,
     MainErrorRenderingTestCase,
     MainTestCase,
     SkillFreshnessNoticeTestCase,
@@ -2727,6 +2730,64 @@ def test_given_expected_cli_errors_when_running_main_then_it_renders_stderr_and_
     assert exit_code == test_case.expected_exit_code
     assert test_case.expected_stderr_fragment in rendered_stderr
     assert rendered_stderr.endswith("\n\n")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditAggregateRenderingTestCase(
+            description="plan ordered aggregate in json mode",
+            expected_exit_code=1,
+            expected_failure_ids=("audit:first:end", "audit:third:end"),
+            expected_json_filename="audit.json",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_audit_aggregate_in_json_mode_when_running_main_then_only_stderr_report_is_written(
+    test_case: AuditAggregateRenderingTestCase,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    json_output_path: Path = tmp_path / test_case.expected_json_filename
+    error: AuditExecutionError = AuditExecutionError(
+        failures=tuple(
+            AuditExecutionFailure(
+                audit_name=resource_id.split(":")[1],
+                resource_id=resource_id,
+                error_type="RuntimeError",
+                message=f"failure {index}",
+            )
+            for index, resource_id in enumerate(test_case.expected_failure_ids, start=1)
+        )
+    )
+
+    def run_audit(request: AuditCommandRequest) -> int:
+        assert request.json_output
+        assert request.json_output_path == json_output_path
+        raise error
+
+    exit_code: int = _main_with_dependencies(
+        argv=[
+            "--project-dir",
+            str(tmp_path),
+            "--no-color",
+            "audit",
+            "--json",
+            "--json-output",
+            str(json_output_path),
+        ],
+        handlers=build_handlers(run_audit=run_audit),
+    )
+    captured: CaptureResult[str] = capsys.readouterr()
+
+    assert exit_code == test_case.expected_exit_code
+    assert captured.out == ""
+    assert captured.err.count("Standalone audit execution failed") == 1
+    assert captured.err.index(test_case.expected_failure_ids[0]) < captured.err.index(
+        test_case.expected_failure_ids[1]
+    )
+    assert not json_output_path.exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/_test_types.py
@@ -50,6 +50,31 @@ class AuditConcurrencyTestCase:
 
 
 @dataclass(frozen=True)
+class AuditStopErrorTestCase:
+    description: str
+    error: BaseException
+    expected_started_names: tuple[str, ...]
+    expected_connection_count: int
+
+
+@dataclass(frozen=True)
+class AuditErrorFormattingTestCase:
+    description: str
+    error: Exception
+    expected_message: str
+
+
+@dataclass(frozen=True)
+class AuditPhysicalCallbackTestCase:
+    description: str
+    max_concurrency: int
+    expected_started_names: tuple[str, ...]
+    expected_possible_started_names: tuple[str, ...]
+    expected_connection_count: int
+    expected_pass_count: int
+
+
+@dataclass(frozen=True)
 class ScenarioFailureHelpTestCase:
     """One scenario failure help resolution case."""
 

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/helpers.py
@@ -6,6 +6,7 @@ import threading
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar
+from unittest.mock import MagicMock
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
@@ -57,6 +58,12 @@ def lifecycle_events_with_prefix(
 
 def lifecycle_order_with_prefix(*, order: list[str], prefixes: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(filter(lambda item: item.startswith(prefixes), order))
+
+
+def unprintable_audit_error() -> RuntimeError:
+    value: MagicMock = MagicMock()
+    value.__str__.side_effect = KeyboardInterrupt
+    return RuntimeError(value)
 
 
 def audit_entry(

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/test_auditing.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/test_auditing.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import queue
 import threading
 import time
 from collections.abc import Callable
+from concurrent.futures import CancelledError as FutureCancelledError
 from dataclasses import replace
 from datetime import UTC, datetime
 from io import StringIO
@@ -34,8 +36,12 @@ from sqlbuild.cost.models import CostResourceContext, StatementLedgerEntry
 from sqlbuild.executor.auditing.main.resource_id import audit_resource_id
 from sqlbuild.executor.auditing.models import AuditExecutionResult
 from sqlbuild.executor.pipeline._helpers import auditing
-from sqlbuild.executor.pipeline.exceptions import AuditOutcomeError
-from sqlbuild.executor.pipeline.main.run import run_audit_pipeline
+from sqlbuild.executor.pipeline.exceptions import AuditExecutionError, AuditOutcomeError
+from sqlbuild.executor.pipeline.main.run import (
+    AuditPipelineCallbacks,
+    run_audit_pipeline,
+    run_audit_pipeline_with_callbacks,
+)
 from sqlbuild.observability import (
     EventDispatcher,
     LifecycleEvent,
@@ -44,15 +50,19 @@ from sqlbuild.observability import (
 )
 from tests.unit.src.sqlbuild.executor.pipeline._helpers._test_types import (
     AuditConcurrencyTestCase,
+    AuditErrorFormattingTestCase,
     AuditLogicalIdentityTestCase,
+    AuditPhysicalCallbackTestCase,
     AuditPipelineLifecycleTestCase,
     AuditResourceIdentityTestCase,
+    AuditStopErrorTestCase,
 )
 from tests.unit.src.sqlbuild.executor.pipeline._helpers.helpers import (
     audit_entry,
     audit_result,
     lifecycle_events_with_prefix,
     lifecycle_order_with_prefix,
+    unprintable_audit_error,
 )
 
 
@@ -319,42 +329,160 @@ def test_given_reversed_completion_when_run_concurrently_then_results_remain_pla
     (AuditConcurrencyTestCase(description="multiple errors", expected_error="failure-first"),),
     ids=lambda case: case.description,
 )
-def test_given_multiple_worker_errors_when_run_then_earliest_plan_error_is_raised_after_drain(
+def test_given_multiple_worker_errors_when_run_then_all_failures_are_plan_ordered_after_drain(
     test_case: AuditConcurrencyTestCase,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     entries: tuple[AuditPlanEntry, ...] = tuple(
-        audit_entry(name) for name in ("first", "second", "never_started")
+        audit_entry(name) for name in ("first", "second", "later_success", "fourth")
     )
     adapter: Mock = Mock(spec=BaseAdapter)
     adapter.connect.side_effect = (object(), object())
     started: list[str] = []
     finished: list[str] = []
     lock: threading.Lock = threading.Lock()
+    actions: dict[str, Callable[[], AuditExecutionResult]] = {
+        "first": Mock(side_effect=RuntimeError("failure-first")),
+        "second": Mock(side_effect=RuntimeError("failure-second")),
+        "later_success": lambda: audit_result("later_success"),
+        "fourth": Mock(side_effect=RuntimeError("failure-fourth")),
+    }
 
     def execute_audit(**kwargs: object) -> AuditExecutionResult:
         entry: object = kwargs["audit"]
         assert isinstance(entry, AuditPlanEntry)
         with lock:
             started.append(entry.name)
-        time.sleep({"first": 0.06, "second": 0.01}[entry.name])
+        time.sleep(
+            {"first": 0.06, "second": 0.01, "later_success": 0.01, "fourth": 0.01}[entry.name]
+        )
         with lock:
             finished.append(entry.name)
-        raise RuntimeError(f"failure-{entry.name}")
+        return actions[entry.name]()
 
     monkeypatch.setattr(auditing, "execute_audit", execute_audit)
 
-    with pytest.raises(RuntimeError, match=test_case.expected_error):
+    completed: list[str] = []
+    with pytest.raises(AuditExecutionError) as raised:
         run_audit_pipeline(
             plan=PlanOutput(audit_entries=entries),
             connection_config={},
             adapter=adapter,
             max_concurrency=2,
+            on_audit_complete=lambda result: completed.append(result.audit_name),
         )
 
-    assert set(started) == {"first", "second"}
-    assert set(finished) == {"first", "second"}
+    assert set(started) == {"first", "second", "later_success", "fourth"}
+    assert set(finished) == set(started)
+    assert tuple(failure.audit_name for failure in raised.value.failures) == (
+        "first",
+        "second",
+        "fourth",
+    )
+    assert test_case.expected_error in str(raised.value)
+    assert str(raised.value).index("failure-first") < str(raised.value).index("failure-second")
+    assert completed == ["later_success"]
     assert adapter.close.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (AuditConcurrencyTestCase(description="serial runtime errors", expected_count=1),),
+    ids=lambda case: case.description,
+)
+def test_given_serial_runtime_errors_when_run_then_all_entries_execute_and_failures_order(
+    test_case: AuditConcurrencyTestCase,
+) -> None:
+    entries: tuple[AuditPlanEntry, ...] = tuple(
+        audit_entry(name) for name in ("first", "later_success", "third")
+    )
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.return_value = object()
+    started: list[str] = []
+    completed: list[str] = []
+    actions: dict[str, Callable[[], AuditExecutionResult]] = {
+        "first": Mock(side_effect=LookupError("failure-first")),
+        "later_success": lambda: audit_result("later_success"),
+        "third": Mock(side_effect=LookupError("failure-third")),
+    }
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        started.append(entry.name)
+        return actions[entry.name]()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+        with pytest.raises(AuditExecutionError) as raised:
+            run_audit_pipeline(
+                plan=PlanOutput(audit_entries=entries),
+                connection_config={},
+                adapter=adapter,
+                max_concurrency=1,
+                on_audit_complete=lambda result: completed.append(result.audit_name),
+            )
+
+    assert started == ["first", "later_success", "third"]
+    assert completed == ["later_success"]
+    assert tuple(failure.audit_name for failure in raised.value.failures) == ("first", "third")
+    assert adapter.close.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        AuditErrorFormattingTestCase(
+            description="unprintable error",
+            error=unprintable_audit_error(),
+            expected_message="Unable to stringify RuntimeError",
+        ),
+        AuditErrorFormattingTestCase(
+            description="uri and api key",
+            error=RuntimeError(
+                "connection postgresql://user:hunter2@host failed api_key=super-secret"
+            ),
+            expected_message=(
+                "connection postgresql://user:[REDACTED]@host failed api_key=[REDACTED]"
+            ),
+        ),
+        AuditErrorFormattingTestCase(
+            description="sql and raw row suppression",
+            error=RuntimeError("SELECT secret FROM raw_table\nrow={'password': 'hunter2'}"),
+            expected_message="Error detail redacted",
+        ),
+        AuditErrorFormattingTestCase(
+            description="single line length bound",
+            error=RuntimeError("x" * 300 + "\n" + "y" * 300),
+            expected_message="x" * 240,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_runtime_error_when_aggregated_then_message_is_safe_and_bounded(
+    test_case: AuditErrorFormattingTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.return_value = object()
+    monkeypatch.setattr(
+        auditing,
+        "execute_audit",
+        Mock(side_effect=test_case.error),
+    )
+
+    with pytest.raises(AuditExecutionError) as raised:
+        run_audit_pipeline(
+            plan=PlanOutput(audit_entries=(audit_entry("safe_name"),)),
+            connection_config={},
+            adapter=adapter,
+        )
+
+    report: str = str(raised.value)
+    assert "safe_name" in report
+    assert raised.value.failures[0].message == test_case.expected_message
+    assert "\n" not in raised.value.failures[0].message
+    assert len(raised.value.failures[0].message) <= 240
 
 
 @pytest.mark.parametrize(
@@ -396,6 +524,269 @@ def test_given_worker_keyboard_interrupt_when_run_then_stops_submission_and_clos
 
     assert finished_running.is_set()
     assert adapter.close.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditStopErrorTestCase(
+            description="serial system exit",
+            error=SystemExit(17),
+            expected_started_names=("stop",),
+            expected_connection_count=1,
+        ),
+        AuditStopErrorTestCase(
+            description="serial asyncio cancellation",
+            error=asyncio.CancelledError("cancel serial"),
+            expected_started_names=("stop",),
+            expected_connection_count=1,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_serial_stop_error_when_run_then_later_audits_are_not_started(
+    test_case: AuditStopErrorTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.return_value = object()
+    started: list[str] = []
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        started.append(entry.name)
+        raise test_case.error
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+
+    with pytest.raises(BaseException) as raised:
+        run_audit_pipeline(
+            plan=PlanOutput(audit_entries=(audit_entry("stop"), audit_entry("never_started"))),
+            connection_config={},
+            adapter=adapter,
+            max_concurrency=1,
+        )
+
+    assert raised.value is test_case.error
+    assert tuple(started) == test_case.expected_started_names
+    assert adapter.close.call_count == test_case.expected_connection_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditStopErrorTestCase(
+            description="concurrent system exit",
+            error=SystemExit(19),
+            expected_started_names=("stop", "running"),
+            expected_connection_count=2,
+        ),
+        AuditStopErrorTestCase(
+            description="concurrent asyncio cancellation",
+            error=asyncio.CancelledError("cancel concurrent"),
+            expected_started_names=("stop", "running"),
+            expected_connection_count=2,
+        ),
+        AuditStopErrorTestCase(
+            description="concurrent future cancellation",
+            error=FutureCancelledError("cancel future"),
+            expected_started_names=("stop", "running"),
+            expected_connection_count=2,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_concurrent_stop_error_when_run_then_active_drains_and_new_work_is_not_submitted(
+    test_case: AuditStopErrorTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = (object(), object())
+    running_started: threading.Event = threading.Event()
+    started: list[str] = []
+
+    def stop_action() -> AuditExecutionResult:
+        running_started.wait(timeout=1)
+        raise test_case.error
+
+    def running_action() -> AuditExecutionResult:
+        running_started.set()
+        time.sleep(0.05)
+        return audit_result("running")
+
+    actions: dict[str, Callable[[], AuditExecutionResult]] = {
+        "stop": stop_action,
+        "running": running_action,
+    }
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        started.append(entry.name)
+        return actions[entry.name]()
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+
+    with pytest.raises(BaseException) as raised:
+        run_audit_pipeline(
+            plan=PlanOutput(
+                audit_entries=(
+                    audit_entry("stop"),
+                    audit_entry("running"),
+                    audit_entry("never_started"),
+                )
+            ),
+            connection_config={},
+            adapter=adapter,
+            max_concurrency=2,
+        )
+
+    assert raised.value is test_case.error
+    assert set(started) == set(test_case.expected_started_names)
+    assert adapter.close.call_count == test_case.expected_connection_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditConcurrencyTestCase(
+            description="audit start callback failure",
+            expected_names=("running",),
+            expected_error="callback failure",
+            expected_count=2,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_start_callback_error_when_run_concurrently_then_it_stops_new_submissions(
+    test_case: AuditConcurrencyTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = (object(), object())
+    running_started: threading.Event = threading.Event()
+    executed: list[str] = []
+
+    def stop_callback() -> None:
+        running_started.wait(timeout=1)
+        raise LookupError(test_case.expected_error)
+
+    callbacks: dict[str, Callable[[], None]] = {
+        "stop": stop_callback,
+        "running": lambda: None,
+    }
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        running_started.set()
+        executed.append(entry.name)
+        time.sleep(0.05)
+        return audit_result(entry.name)
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+
+    with pytest.raises(LookupError, match=test_case.expected_error):
+        run_audit_pipeline(
+            plan=PlanOutput(
+                audit_entries=(
+                    audit_entry("stop"),
+                    audit_entry("running"),
+                    audit_entry("never_started"),
+                )
+            ),
+            connection_config={},
+            adapter=adapter,
+            max_concurrency=2,
+            on_audit_start=lambda entry: callbacks[entry.name](),
+        )
+
+    assert tuple(executed) == test_case.expected_names
+    assert adapter.close.call_count == test_case.expected_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AuditPhysicalCallbackTestCase(
+            description="serial physical callback failure",
+            max_concurrency=1,
+            expected_started_names=("first",),
+            expected_possible_started_names=("first",),
+            expected_connection_count=1,
+            expected_pass_count=1,
+        ),
+        AuditPhysicalCallbackTestCase(
+            description="concurrent physical callback failure",
+            max_concurrency=2,
+            expected_started_names=("first",),
+            expected_possible_started_names=("first", "second"),
+            expected_connection_count=2,
+            expected_pass_count=1,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_physical_callback_error_when_running_then_success_projects_and_counts_in_both_modes(
+    test_case: AuditPhysicalCallbackTestCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter: Mock = Mock(spec=BaseAdapter)
+    adapter.connect.side_effect = tuple(
+        object() for _ in range(test_case.expected_connection_count)
+    )
+    physical_error: LookupError = LookupError("physical callback failure")
+    physical_seen: threading.Event = threading.Event()
+    started: list[str] = []
+    completed: list[str] = []
+    events: list[LifecycleEvent] = []
+    dispatcher: EventDispatcher = EventDispatcher()
+    dispatcher.subscribe_lifecycle(subscriber=events.append, accepts_opaque=False)
+
+    def second_action() -> AuditExecutionResult:
+        physical_seen.wait(timeout=1)
+        raise RuntimeError("drained second failure")
+
+    actions: dict[str, Callable[[], AuditExecutionResult]] = {
+        "first": lambda: audit_result("first"),
+        "second": second_action,
+    }
+
+    def execute_audit(**kwargs: object) -> AuditExecutionResult:
+        entry: object = kwargs["audit"]
+        assert isinstance(entry, AuditPlanEntry)
+        started.append(entry.name)
+        return actions[entry.name]()
+
+    def physical_complete(_result: AuditExecutionResult) -> None:
+        physical_seen.set()
+        raise physical_error
+
+    monkeypatch.setattr(auditing, "execute_audit", execute_audit)
+
+    with invocation_scope("audit-invocation"), dispatcher_scope(dispatcher):
+        with pytest.raises(LookupError) as raised:
+            run_audit_pipeline_with_callbacks(
+                plan=PlanOutput(audit_entries=(audit_entry("first"), audit_entry("second"))),
+                connection_config={},
+                adapter=adapter,
+                max_concurrency=test_case.max_concurrency,
+                callbacks=AuditPipelineCallbacks(
+                    on_audit_physical_complete=physical_complete,
+                    on_audit_complete=lambda result: completed.append(result.audit_name),
+                ),
+            )
+
+    terminal: LifecycleEvent = tuple(
+        filter(lambda event: event.event_type == "run_failed", events)
+    )[0]
+    assert raised.value is physical_error
+    assert set(test_case.expected_started_names).issubset(started)
+    assert set(started).issubset(test_case.expected_possible_started_names)
+    assert completed == ["first"]
+    assert terminal.payload["pass_count"] == test_case.expected_pass_count
+    assert adapter.close.call_count == test_case.expected_connection_count
 
 
 @pytest.mark.parametrize(
@@ -538,7 +929,7 @@ def test_given_execution_and_close_errors_when_running_then_execution_error_wins
     adapter.close.side_effect = RuntimeError("close failure")
     monkeypatch.setattr(auditing, "execute_audit", Mock(side_effect=LookupError("execute failure")))
 
-    with pytest.raises(LookupError, match="execute failure"):
+    with pytest.raises(AuditExecutionError, match="execute failure"):
         run_audit_pipeline(
             plan=PlanOutput(audit_entries=(audit_entry("first"),)),
             connection_config={},
@@ -776,7 +1167,7 @@ def test_given_success_before_fatal_when_draining_then_success_projects_and_run_
 
     monkeypatch.setattr(auditing, "execute_audit", execute_audit)
     with invocation_scope("audit-invocation"), dispatcher_scope(dispatcher):
-        with pytest.raises(RuntimeError, match=test_case.expected_error):
+        with pytest.raises(AuditExecutionError, match=test_case.expected_error):
             run_audit_pipeline(
                 plan=PlanOutput(audit_entries=(audit_entry("success"), audit_entry("fatal"))),
                 connection_config={},
@@ -791,7 +1182,7 @@ def test_given_success_before_fatal_when_draining_then_success_projects_and_run_
     assert tuple(completed) == test_case.expected_names
     assert terminal.payload["pass_count"] == 1
     assert terminal.payload["warn_count"] == 0
-    assert terminal.payload["fail_count"] == 0
+    assert terminal.payload["fail_count"] == 1
 
 
 @pytest.mark.parametrize(
@@ -828,7 +1219,7 @@ def test_given_fatal_before_later_started_success_when_draining_then_gap_allows_
 
     monkeypatch.setattr(auditing, "execute_audit", execute_audit)
     with invocation_scope("audit-invocation"), dispatcher_scope(dispatcher):
-        with pytest.raises(RuntimeError, match=test_case.expected_error):
+        with pytest.raises(AuditExecutionError, match=test_case.expected_error):
             run_audit_pipeline(
                 plan=PlanOutput(audit_entries=(audit_entry("fatal"), audit_entry("later_success"))),
                 connection_config={},
@@ -843,7 +1234,7 @@ def test_given_fatal_before_later_started_success_when_draining_then_gap_allows_
     assert tuple(completed) == test_case.expected_names
     assert terminal.payload["pass_count"] == 1
     assert terminal.payload["warn_count"] == 0
-    assert terminal.payload["fail_count"] == 0
+    assert terminal.payload["fail_count"] == 1
 
 
 @pytest.mark.parametrize(
@@ -853,6 +1244,7 @@ def test_given_fatal_before_later_started_success_when_draining_then_gap_allows_
             description="multiple failures with drained success",
             expected_names=("third_success",),
             expected_error="failure-first",
+            expected_count=3,
         ),
     ),
     ids=lambda case: case.description,
@@ -881,7 +1273,7 @@ def test_given_multiple_failures_and_success_when_drained_then_earliest_error_an
 
     monkeypatch.setattr(auditing, "execute_audit", execute_audit)
     with invocation_scope("audit-invocation"), dispatcher_scope(dispatcher):
-        with pytest.raises(RuntimeError, match=test_case.expected_error):
+        with pytest.raises(AuditExecutionError) as raised:
             run_audit_pipeline(
                 plan=PlanOutput(
                     audit_entries=(
@@ -900,9 +1292,15 @@ def test_given_multiple_failures_and_success_when_drained_then_earliest_error_an
         filter(lambda event: event.event_type == "run_failed", events)
     )[0]
     assert tuple(completed) == test_case.expected_names
+    assert tuple(failure.audit_name for failure in raised.value.failures) == ("first", "second")
     assert terminal.payload["pass_count"] == 1
     assert terminal.payload["warn_count"] == 0
-    assert terminal.payload["fail_count"] == 0
+    assert terminal.payload["fail_count"] == 2
+    attempts: tuple[LifecycleEvent, ...] = lifecycle_events_with_prefix(
+        events=events, prefixes=("resource_attempt_",)
+    )
+    assert len(attempts) == test_case.expected_count * 2
+    assert len({event.resource_attempt_id for event in attempts}) == test_case.expected_count
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Standalone audit execution stopped scheduling after the first query-level runtime error. Independent audits should still run so operators receive the complete set of data-contract and warehouse execution failures from one invocation.

## Changes

- Continue serial and concurrent standalone audits after ordinary query execution exceptions.
- Collect every runtime failure and report them once, in deterministic plan order, after all selected audits are attempted.
- Preserve bounded submissions, one connection per worker, plan-ordered enrichment, truthful lifecycle counts, and no fabricated audit results.
- Keep interruption, cancellation, callback failures, and coordinator failures as stop conditions that cancel unstarted work and drain active workers.
- Redact and bound aggregate failure details before CLI rendering.

## Verification

- `make test`: 5,888 passed.
- `make check-ci`: formatting, Ruff, ty, strict adapter tests, and Fensu passed.
- Independent review verified serial/concurrent parity, cancellation classification, lifecycle counts, error precedence, redaction, and JSON error behavior.

Follow-up to CHI-201.
