### PR TITLE
fix: preserve attached audit instance names

### DIFF
--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -1202,6 +1202,8 @@ def _assemble_compiled_sql_scenario(
 
 
 def _resolve_audit_name(audit_input: CompileAuditInput) -> str:
+    if audit_input.name is not None:
+        return audit_input.name
     if audit_input.audit_block.name is not None:
         return audit_input.audit_block.name
     return audit_input.audit_file.file_path.stem

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/audits.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/audits.py
@@ -405,6 +405,7 @@ def build_attached_audit_input(
         audit_file=definition[0],
         audit_block=definition[1],
         sql_body=expanded_sql_body,
+        name=audit_instance.name,
         references=references,
         attached_target_kind=attached_target_kind,
         attached_target_name=attached_target_name,

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -584,6 +584,7 @@ class CompileAuditInput:
     run_scope: str | None = None
     always_run: bool = False
     declaration_usages: tuple[UsageRecord, ...] = field(default_factory=tuple)
+    name: str | None = None
 
     def __post_init__(self) -> None:
         if self.attached_target_kind is not None:

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
@@ -425,6 +425,12 @@ class AssembleCompiledProjectTestCase:
 
 
 @dataclass(frozen=True)
+class AttachedAuditNameTestCase:
+    description: str
+    expected_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class AssembleCompiledProjectEffectiveTargetTestCase:
     description: str
     project_toml: str

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_assembly.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_assembly.py
@@ -25,6 +25,7 @@ from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
     AssembleCompiledProjectEffectiveTargetTestCase,
     AssembleCompiledProjectTestCase,
     AssembleSqlHookValidationTestCase,
+    AttachedAuditNameTestCase,
     PreservedSeedTargetTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.compile._helpers.helpers import (
@@ -552,6 +553,55 @@ def test_given_compile_inputs_when_assembling_compiled_project_then_returns_expe
         tuple(compiled_sql_test_expected_model_names(t) for t in compiled.sql_tests)
         == test_case.expected_test_expected_model_names
     )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        AttachedAuditNameTestCase(
+            description="named instances of one generic audit",
+            expected_names=("positive revenue", "bounded revenue"),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_named_generic_audit_instances_when_assembling_then_each_name_is_preserved(
+    test_case: AttachedAuditNameTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(
+        tmp_path,
+        base_repo_files()
+        | {
+            "models/orders.sql": """
+MODEL (
+  audits [
+    expression_is_true (name "positive revenue", expression "revenue > 0"),
+    expression_is_true (name "bounded revenue", expression "revenue < 1000"),
+  ],
+);
+
+SELECT 1 AS revenue
+""".strip()
+            + "\n",
+            "audits/generic/expression_is_true.sql": """
+AUDIT ();
+
+SELECT * FROM @relation WHERE NOT (@expression)
+""".strip()
+            + "\n",
+        },
+    )
+    compile_inputs: CompileProjectInputs = build_compile_inputs(
+        discovered_inputs=discover_project_inputs(project_dir=tmp_path),
+        adapter_context=DUCKDB_COMPILE_ADAPTER_CONTEXT,
+        run_id="test_run_id",
+    )
+
+    compiled: CompiledProject = assemble_compiled_project(inputs=compile_inputs)
+
+    assert tuple(audit.name for audit in compiled.audits) == test_case.expected_names
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Generic audit attachments parse an optional instance `name`, but compilation discarded it and used the shared definition name. Reusable templates therefore could not expose independently identifiable audit and Dagster check instances.

## Changes

- Carry attachment-level names through compile inputs.
- Prefer the instance name when assembling a compiled audit while retaining the definition name for template lookup.
- Cover two named instances of one generic template attached to the same model.

## Verification

- `make test`: 5,937 passed.
- `uv sync --all-extras && make check-ci`: formatting, Ruff, ty, strict adapter tests, and Fensu passed.
- Focused compiler tests: 125 passed.
