### PR TITLE
fix: preserve capped microbatch cursor boundaries

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -157,6 +157,31 @@ jobs:
       - name: Run DuckDB E2E tests
         run: make test-e2e-duckdb
 
+  performance:
+    name: Performance guards
+    needs: [changes, lockfile]
+    if: needs.changes.outputs.duckdb == 'true'
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.12.3"
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            Cargo.lock
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Install Python
+        run: uv python install 3.12
+      - name: Install dependencies
+        run: uv sync --locked --all-groups --all-extras
+      - name: Run performance guards
+        run: make test-e2e-performance
+
   postgres:
     name: PostgreSQL integration and E2E tests
     needs: [changes, lockfile]
@@ -193,7 +218,7 @@ jobs:
   verify:
     name: Verify
     if: always()
-    needs: [changes, lockfile, checks, e2e, postgres]
+    needs: [changes, lockfile, checks, e2e, performance, postgres]
     runs-on: ubuntu-24.04
     steps:
       - name: Confirm all required verification jobs passed
@@ -202,6 +227,7 @@ jobs:
           LOCKFILE_RESULT: ${{ needs.lockfile.result }}
           CHECKS_RESULT: ${{ needs.checks.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
+          PERFORMANCE_RESULT: ${{ needs.performance.result }}
           POSTGRES_RESULT: ${{ needs.postgres.result }}
         run: |
           if [[ "${CHANGES_RESULT}" != "success" || \
@@ -210,7 +236,7 @@ jobs:
             echo "Required classification, lockfile, or static checks did not pass" >&2
             exit 1
           fi
-          for result in "${E2E_RESULT}" "${POSTGRES_RESULT}"; do
+          for result in "${E2E_RESULT}" "${PERFORMANCE_RESULT}" "${POSTGRES_RESULT}"; do
             if [[ "${result}" != "success" && "${result}" != "skipped" ]]; then
               echo "A selected verification suite did not pass: ${result}" >&2
               exit 1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: verify verify-quick verify-pg coverage cli-preview rust-check
+.PHONY: verify verify-quick verify-pg coverage cli-preview rust-check test-e2e-performance
 
 format:
 	uv run ruff format .
@@ -66,11 +66,22 @@ test-e2e-duckdb:
 			fi; \
 		}; \
 		run_step "duckdb e2e" env PYTHONUNBUFFERED=1 SQLBUILD_CONCURRENCY=$(SQLBUILD_CONCURRENCY) uv run pytest tests/e2e -m "not real_warehouse and not dbt and not performance" -vv --color=yes -n auto --dist loadfile; \
-		run_step "duckdb performance" env PYTHONUNBUFFERED=1 SQLBUILD_CONCURRENCY=$(SQLBUILD_CONCURRENCY) uv run pytest tests/e2e -m "performance and not real_warehouse and not dbt" -vv --log-cli-level=INFO --color=yes; \
 		exit $$status; \
 	} 2>&1 | tee "$$log"; \
 	status=$${PIPESTATUS[0]}; \
 	echo "TEST_E2E_DUCKDB_EXIT=$$status (log: $$log)" | tee -a "$$log"; \
+	exit $$status
+
+
+test-e2e-performance:
+	@mkdir -p /tmp/opencode
+	@log="/tmp/opencode/test-e2e-performance-$$(date +%Y%m%d-%H%M%S).log"; \
+	echo "Logging to $$log"; \
+	env PYTHONUNBUFFERED=1 SQLBUILD_CONCURRENCY=$(SQLBUILD_CONCURRENCY) uv run pytest tests/e2e \
+		-m "performance and not real_warehouse and not dbt" \
+		-vv --log-cli-level=INFO --color=yes 2>&1 | tee "$$log"; \
+	status=$${PIPESTATUS[0]}; \
+	echo "TEST_E2E_PERFORMANCE_EXIT=$$status (log: $$log)" | tee -a "$$log"; \
 	exit $$status
 
 

--- a/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
+++ b/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
@@ -4790,6 +4790,10 @@ MODEL (
 
 A cap changes only the work selected for that invocation. Deferred batches are not recorded as complete. `cap_from_end` is useful for feeds where keeping the latest projection current is more important than catching up oldest-first; `cap_from_start` is the oldest-first catch-up policy.
 
+For `cap_from_start`, `max_batches` must be large enough to cover the model's ordinary lookback/current buckets and at least one forward batch. SQLBuild rejects a static limit that cannot make forward progress, including when an idempotent strategy uses its implicit one-batch lookback.
+
+When another watermark model consumes a capped model, SQLBuild uses the producer's durable partition-completion facts as the authoritative availability intervals. A configured producer `cursor_end` remains a domain boundary, but neither that declaration nor the target table's physical `MIN`/`MAX` envelope proves that deferred or intervening intervals were materialized. This keeps disjoint `cap_from_end` suffixes disjoint for downstream execution. If completion history is unavailable, the consumer fails closed.
+
 The project can also set an outer safety policy:
 
 ```toml

--- a/src/sqlbuild/compiler/compile/_helpers/config/model_validation.py
+++ b/src/sqlbuild/compiler/compile/_helpers/config/model_validation.py
@@ -16,6 +16,7 @@ from sqlbuild.compiler.compile.constants import (
 )
 from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.models import CompileModelConfig
+from sqlbuild.compiler.planner.constants import CURSOR_GRAIN_BATCH_SIZE
 from sqlbuild.compiler.planner.models import Duration
 from sqlbuild.compiler.planner.types import (
     ContractPolicy,
@@ -267,7 +268,7 @@ def _validate_incremental_batching(
         known_input_names=known_input_names,
         inputs=_CursorInputValidation(values=values, ref_count=ref_count),
     )
-    resolved_limit: int | None = _validate_model_microbatch_limit(
+    resolved_limit, resolved_limit_action = _validate_model_microbatch_limit(
         model_name=model_name,
         max_microbatches=values.max_microbatches,
         microbatch_limit=values.microbatch_limit,
@@ -279,6 +280,9 @@ def _validate_incremental_batching(
             max_microbatches=resolved_limit,
             lookback=values.lookback,
             batch_size=values.batch_size,
+            incremental_strategy=values.strategy,
+            action=resolved_limit_action,
+            cursor_grain=values.cursor_grain,
         )
 
 
@@ -532,16 +536,19 @@ def _validate_model_microbatch_limit(
     max_microbatches: object | None,
     microbatch_limit: object | None,
     microbatch_strategy: str | None,
-) -> int | None:
+) -> tuple[int | None, MicrobatchLimitAction | None]:
     if max_microbatches is not None and microbatch_limit is not None:
         raise CompileInputError(
             f"model '{model_name}': use either max_microbatches or microbatch_limit, not both"
         )
     if microbatch_limit is None:
         return (
-            max_microbatches
-            if isinstance(max_microbatches, int) and not isinstance(max_microbatches, bool)
-            else None
+            (
+                max_microbatches
+                if isinstance(max_microbatches, int) and not isinstance(max_microbatches, bool)
+                else None
+            ),
+            None,
         )
     if not isinstance(microbatch_limit, dict) or set(microbatch_limit) != {
         MICROBATCH_LIMIT_MAX_BATCHES_KEY,
@@ -568,7 +575,7 @@ def _validate_model_microbatch_limit(
             f"model '{model_name}': microbatch_limit is only valid with "
             "microbatch_strategy=watermark"
         )
-    return max_batches
+    return max_batches, MicrobatchLimitAction(action)
 
 
 def _validate_known_cursor_inputs(
@@ -640,27 +647,55 @@ def _validate_watermark_cursor_inputs(
 
 
 def _validate_static_watermark_limit(
-    *, model_name: str, max_microbatches: int, lookback: str | None, batch_size: object | None
+    *,
+    model_name: str,
+    max_microbatches: int,
+    lookback: str | None,
+    batch_size: object | None,
+    incremental_strategy: str | None,
+    action: MicrobatchLimitAction | None,
+    cursor_grain: str | None,
 ) -> None:
+    effective_batch_size: object = batch_size
+    if batch_size == EFFECTIVE_BATCH_SIZE_TOKEN and cursor_grain is not None:
+        effective_batch_size = CURSOR_GRAIN_BATCH_SIZE.get(cursor_grain, batch_size)
+    effective_lookback: str | None = lookback
     if (
-        lookback is None
-        or not isinstance(batch_size, str)
-        or batch_size == EFFECTIVE_BATCH_SIZE_TOKEN
+        effective_lookback is None
+        and action == MicrobatchLimitAction.CAP_FROM_START
+        and incremental_strategy in {IncrementalStrategy.DELETE_INSERT, IncrementalStrategy.MERGE}
+        and isinstance(effective_batch_size, str)
     ):
+        effective_lookback = effective_batch_size
+    if effective_lookback is None or not isinstance(effective_batch_size, str):
         return
-    lookback_duration: Duration | None = Duration.parse(lookback)
-    batch_duration: Duration | None = Duration.parse(batch_size)
-    if (
-        lookback_duration is None
-        or batch_duration is None
-        or lookback_duration.has_calendar_component
-        or batch_duration.has_calendar_component
-        or batch_duration.fixed_seconds == 0
-    ):
+    lookback_duration: Duration | None = Duration.parse(effective_lookback)
+    batch_duration: Duration | None = Duration.parse(effective_batch_size)
+    if lookback_duration is None or batch_duration is None:
+        return
+    if not lookback_duration.has_calendar_component and not batch_duration.has_calendar_component:
+        if batch_duration.fixed_seconds == 0:
+            return
+        lookback_batches: int = (
+            lookback_duration.fixed_seconds + batch_duration.fixed_seconds - 1
+        ) // batch_duration.fixed_seconds
+    elif lookback_duration.fixed_seconds == 0 and batch_duration.fixed_seconds == 0:
+        if batch_duration.total_months == 0:
+            return
+        lookback_batches = (
+            lookback_duration.total_months + batch_duration.total_months - 1
+        ) // batch_duration.total_months
+    else:
+        if action == MicrobatchLimitAction.CAP_FROM_START:
+            raise CompileInputError(
+                f"model '{model_name}': cap_from_start cannot prove forward progress when "
+                "lookback and batch_size mix calendar and fixed duration components; use "
+                "compatible fixed or calendar durations"
+            )
         return
     required: int = (
-        lookback_duration.fixed_seconds + batch_duration.fixed_seconds - 1
-    ) // batch_duration.fixed_seconds + 1
+        lookback_batches + 1 + (1 if action == MicrobatchLimitAction.CAP_FROM_START else 0)
+    )
     if max_microbatches < required:
         raise CompileInputError(
             f"model '{model_name}': max_microbatches {max_microbatches} is below the "

--- a/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
+++ b/src/sqlbuild/compiler/planner/_helpers/output/plan_entry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from typing import Any, cast
+from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.models import ColumnInfo, RelationInfo
@@ -71,7 +71,10 @@ from sqlbuild.compiler.planner.main.execution.effective_microbatch_batch_size im
 from sqlbuild.compiler.planner.main.execution.future_cursor_safety import apply_future_cursor_safety
 from sqlbuild.compiler.planner.main.execution.future_cursor_warning import future_cursor_cap_warning
 from sqlbuild.compiler.planner.main.execution.maximum_start_warning import maximum_start_cap_warning
-from sqlbuild.compiler.planner.main.execution.microbatch_limit import microbatch_limit_warning
+from sqlbuild.compiler.planner.main.execution.microbatch_limit import (
+    _resolve_microbatch_limit_config,
+    microbatch_limit_warning,
+)
 from sqlbuild.compiler.planner.models import (
     BackfillResult,
     ChangeDetectionResult,
@@ -833,8 +836,10 @@ def plan_model_from_change(
             model=model, key="unaccounted_partition_policy"
         ),
         microbatch_range=microbatch_range,
-        microbatch_limit=_get_model_microbatch_limit(model=model)[0],
-        declared_microbatch_limit_action=_get_model_microbatch_limit(model=model)[1],
+        microbatch_limit=_resolve_microbatch_limit_config(values=model.config.values)[0],
+        declared_microbatch_limit_action=_resolve_microbatch_limit_config(
+            values=model.config.values
+        )[1],
         start_cursor_override=start_cursor_override,
         end_cursor_override=end_cursor_override,
         future_cursor_config=effective_future_cursor_config,
@@ -1113,24 +1118,6 @@ def _get_positive_config_int(*, model: CompiledModel, key: str) -> int | None:
     return raw if isinstance(raw, int) and not isinstance(raw, bool) and raw > 0 else None
 
 
-def _get_model_microbatch_limit(
-    *, model: CompiledModel
-) -> tuple[int | None, MicrobatchLimitAction | None]:
-    raw: object | None = model.config.values.get("microbatch_limit")
-    if isinstance(raw, dict):
-        limit_mapping: dict[str, object] = cast(dict[str, object], raw)
-        max_batches: object | None = limit_mapping.get("max_batches")
-        action: object | None = limit_mapping.get("action")
-        if (
-            isinstance(max_batches, int)
-            and not isinstance(max_batches, bool)
-            and max_batches > 0
-            and isinstance(action, str)
-        ):
-            return max_batches, MicrobatchLimitAction(action)
-    return _get_positive_config_int(model=model, key="max_microbatches"), None
-
-
 def _get_check_columns(model: CompiledModel) -> tuple[str, ...]:
     """Extract check_columns from model config as a normalized tuple."""
 
@@ -1242,7 +1229,7 @@ def _compute_microbatch_range(
             relation.cursor_grain for relation in inputs.cursor_input_relations
         ),
     )
-    if downstream_grain is not None and effective_grain != downstream_grain:
+    if cursor_type == CursorType.TIMESTAMP and effective_grain is not None:
         cursor_snapshot = normalize_cursor_snapshot_grain(
             cursor_snapshot=cursor_snapshot,
             cursor_type=cursor_type,
@@ -1577,12 +1564,25 @@ def _build_cursor_input_relations(
             source_map=source_map,
         )
         if relation is not None:
+            producer_limit_action: MicrobatchLimitAction | None = (
+                _resolve_microbatch_limit_config(values=producer_model.config.values)[1]
+                if producer_model is not None
+                else None
+            )
+            producer_has_cap: bool = producer_limit_action in {
+                MicrobatchLimitAction.CAP_FROM_END,
+                MicrobatchLimitAction.CAP_FROM_START,
+            } and _is_compatible_causal_producer(consumer=model, producer=producer_model)
             relations.append(
                 CursorInputRelation(
                     relation=relation,
                     cursor_column=input_cursor_column,
-                    producer_model_name=None,
-                    producer_model_version_hash=None,
+                    producer_model_name=(ref.ref_name if producer_has_cap else None),
+                    producer_model_version_hash=(
+                        fingerprints.models[ref.ref_name].version_hash
+                        if producer_has_cap and ref.ref_name in fingerprints.models
+                        else None
+                    ),
                     cursor_grain=_resolve_cursor_input_grain(
                         ref=ref,
                         models_by_name=models_by_name,
@@ -1597,6 +1597,7 @@ def _build_cursor_input_relations(
                     terminal_cursor_end=(
                         _get_cursor_end(producer_model) if producer_model is not None else None
                     ),
+                    producer_microbatch_limit_action=producer_limit_action,
                 )
             )
     return tuple(relations)
@@ -1920,6 +1921,8 @@ def _clamp_cursor_end(*, bounds: CursorBounds | None, model: CompiledModel) -> C
     cursor_end: str | None = _get_cursor_end(model)
     cursor_type: str | None = _get_config_str(model=model, key="cursor_type")
     if bounds is None or cursor_end is None:
+        return bounds
+    if bounds.start == MICROBATCH_START_SENTINEL or bounds.end == MICROBATCH_END_SENTINEL:
         return bounds
     if _cursor_order_key(value=bounds.start, cursor_type=cursor_type) >= _cursor_order_key(
         value=cursor_end, cursor_type=cursor_type

--- a/src/sqlbuild/compiler/planner/_helpers/resolve/cursor.py
+++ b/src/sqlbuild/compiler/planner/_helpers/resolve/cursor.py
@@ -87,7 +87,7 @@ def compute_cursor_bounds(
         apply_maximum_start_policy,
     )
 
-    return apply_maximum_start_policy(
+    bounds = apply_maximum_start_policy(
         bounds=bounds,
         snapshot=cursor_snapshot,
         cursor_type=cursor_type,
@@ -97,6 +97,11 @@ def compute_cursor_bounds(
         backfill_duration=backfill_duration,
         policy=maximum_start_policy or MaximumStartPolicyInputs(),
         has_start_override=start_cursor_override is not None,
+    )
+    return bounds.clamp_to_availability(
+        ranges=cursor_snapshot.upstream_availability_ranges,
+        cursor_watermark_mode=cursor_snapshot.cursor_watermark_mode,
+        cursor_type=cursor_type,
     )
 
 
@@ -172,6 +177,17 @@ def normalize_cursor_snapshot_grain(
             for physical, terminal in cursor_snapshot.upstream_end_inputs
         ),
         upstream_availability_ends=cursor_snapshot.upstream_availability_ends,
+        upstream_availability_ranges=tuple(
+            (
+                (
+                    _floor_timestamp_string(value=start, grain=effective_grain)
+                    if start is not None
+                    else None
+                ),
+                _floor_timestamp_string(value=end, grain=effective_grain),
+            )
+            for start, end in cursor_snapshot.upstream_availability_ranges
+        ),
     )
 
 

--- a/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
+++ b/src/sqlbuild/compiler/planner/_helpers/warehouse/snapshot.py
@@ -52,6 +52,9 @@ from sqlbuild.compiler.planner._helpers.resolve.lineage import resolve_lineage_r
 from sqlbuild.compiler.planner._helpers.resolve.maximum_start import maximum_allowed_start
 from sqlbuild.compiler.planner.constants import METADATA_NAME_FILTER_LIMIT
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
+from sqlbuild.compiler.planner.main.execution.microbatch_limit import (
+    _resolve_microbatch_limit_config,
+)
 from sqlbuild.compiler.planner.models import (
     CursorInputEvidence,
     CursorOverrides,
@@ -74,6 +77,7 @@ from sqlbuild.compiler.references.types import SqlReferenceKind
 from sqlbuild.compiler.source_freshness.constants import SOURCE_FRESHNESS_TABLE_NAME
 from sqlbuild.diagnostics.main.log_debug_event import log_debug_event
 from sqlbuild.spec.contracts.models import SourceEntry, StartCursorsConfig
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction
 
 _DEBUG_LOGGER: logging.Logger = logging.getLogger("sqlbuild.planner")
 
@@ -99,6 +103,7 @@ class _UpstreamCursorInfo:
     cursor_grain: str | None = None
     terminal_cursor_start: str | None = None
     terminal_cursor_end: str | None = None
+    producer_microbatch_limit_action: MicrobatchLimitAction | None = None
 
 
 @dataclass(frozen=True)
@@ -754,6 +759,13 @@ def _collect_cursor_models(
                         if ref.ref_kind == SqlReferenceKind.REF and ref.ref_name in model_map
                         else None
                     ),
+                    producer_microbatch_limit_action=(
+                        _resolve_microbatch_limit_config(
+                            values=model_map[ref.ref_name].config.values
+                        )[1]
+                        if ref.ref_kind == SqlReferenceKind.REF and ref.ref_name in model_map
+                        else None
+                    ),
                 )
             )
 
@@ -1048,23 +1060,32 @@ def _assemble_cursor_snapshots(
         terminal_ends: list[str] = []
         end_inputs: list[tuple[str | None, str | None]] = []
         availability_ends: list[str] = []
+        availability_ranges: list[tuple[str | None, str]] = []
         upstream: _UpstreamCursorInfo
         for upstream in info.upstreams:
             min_val: str | None = results.get(upstream.tag_min)
             max_val: str | None = results.get(upstream.tag_max)
+            producer_is_capped: bool = upstream.producer_microbatch_limit_action in {
+                MicrobatchLimitAction.CAP_FROM_END,
+                MicrobatchLimitAction.CAP_FROM_START,
+            }
+            terminal_start: str | None = (
+                None if producer_is_capped else upstream.terminal_cursor_start
+            )
+            terminal_end: str | None = None if producer_is_capped else upstream.terminal_cursor_end
             effective_max: str | None = (
                 inclusive_cursor_end(
-                    end=upstream.terminal_cursor_end,
+                    end=terminal_end,
                     cursor_type=info.cursor_type,
                     cursor_grain=upstream.cursor_grain or info.effective_cursor_grain,
                 )
-                if upstream.terminal_cursor_end is not None
+                if terminal_end is not None
                 else max_val
             )
             if min_val is not None:
                 upstream_mins.append(min_val)
-            elif upstream.terminal_cursor_start is not None:
-                upstream_mins.append(upstream.terminal_cursor_start)
+            elif terminal_start is not None:
+                upstream_mins.append(terminal_start)
             elif target_max is None and info.cursor_watermark_mode == CursorWatermarkMode.ALL:
                 unavailable_watermark_tags.append(upstream.tag_min)
             if effective_max is not None:
@@ -1074,22 +1095,19 @@ def _assemble_cursor_snapshots(
                     CursorInputEvidence(
                         relation=upstream.relation,
                         cursor_column=upstream.cursor_column,
-                        minimum=min_val or upstream.terminal_cursor_start,
+                        minimum=min_val or terminal_start,
                         maximum=effective_max,
                     )
                 )
-            elif (
-                upstream.terminal_cursor_end is None
-                and info.cursor_watermark_mode == CursorWatermarkMode.ALL
-            ):
+            elif terminal_end is None and info.cursor_watermark_mode == CursorWatermarkMode.ALL:
                 unavailable_watermark_tags.append(upstream.tag_max)
-            if upstream.terminal_cursor_start is not None:
-                terminal_starts.append(upstream.terminal_cursor_start)
-            if upstream.terminal_cursor_end is not None:
-                terminal_ends.append(upstream.terminal_cursor_end)
-            end_inputs.append((max_val, upstream.terminal_cursor_end))
+            if terminal_start is not None:
+                terminal_starts.append(terminal_start)
+            if terminal_end is not None:
+                terminal_ends.append(terminal_end)
+            end_inputs.append((max_val, terminal_end))
             if info.microbatch_strategy == MicrobatchStrategy.WATERMARK:
-                availability_end: str | None = upstream.terminal_cursor_end
+                availability_end: str | None = terminal_end
                 if availability_end is None and max_val is not None:
                     availability_end = advance_discovered_cursor_end(
                         value=max_val,
@@ -1098,6 +1116,15 @@ def _assemble_cursor_snapshots(
                     )
                 if availability_end is not None:
                     availability_ends.append(availability_end)
+                    availability_ranges.append(
+                        (
+                            min_val
+                            if upstream.producer_microbatch_limit_action
+                            == MicrobatchLimitAction.CAP_FROM_END
+                            else None,
+                            availability_end,
+                        )
+                    )
 
         snapshots[info.model_name] = ModelCursorSnapshot(
             target_max=target_max,
@@ -1115,6 +1142,7 @@ def _assemble_cursor_snapshots(
             upstream_terminal_ends=tuple(terminal_ends),
             upstream_end_inputs=tuple(end_inputs) if terminal_ends else (),
             upstream_availability_ends=tuple(availability_ends),
+            upstream_availability_ranges=tuple(availability_ranges),
         )
 
     return snapshots

--- a/src/sqlbuild/compiler/planner/main/execution/microbatch_limit.py
+++ b/src/sqlbuild/compiler/planner/main/execution/microbatch_limit.py
@@ -1,8 +1,35 @@
 """Microbatch planning limit decisions shared by planner and runtime."""
 
-from __future__ import annotations
+from collections.abc import Mapping
+from typing import cast
 
 from sqlbuild.spec.contracts.types import MicrobatchLimitAction
+
+
+def _resolve_microbatch_limit_config(
+    *, values: Mapping[str, object]
+) -> tuple[int | None, MicrobatchLimitAction | None]:
+    """Return the configured limit and explicit action from validated model values."""
+
+    raw: object | None = values.get("microbatch_limit")
+    if isinstance(raw, dict):
+        raw_config: Mapping[str, object] = cast("Mapping[str, object]", raw)
+        max_batches: object | None = raw_config.get("max_batches")
+        action: object | None = raw_config.get("action")
+        if (
+            isinstance(max_batches, int)
+            and not isinstance(max_batches, bool)
+            and max_batches > 0
+            and isinstance(action, str)
+        ):
+            return max_batches, MicrobatchLimitAction(action)
+    legacy_limit: object | None = values.get("max_microbatches")
+    return (
+        legacy_limit
+        if isinstance(legacy_limit, int) and not isinstance(legacy_limit, bool) and legacy_limit > 0
+        else None,
+        None,
+    )
 
 
 def microbatch_limit_warning(

--- a/src/sqlbuild/compiler/planner/models.py
+++ b/src/sqlbuild/compiler/planner/models.py
@@ -34,6 +34,8 @@ from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.types import (
     BackfillAction,
     ChangeKind,
+    CursorType,
+    CursorWatermarkMode,
     GraphResourceKind,
     LocalNodePlanAction,
     LocalNodePlanReason,
@@ -213,6 +215,7 @@ class ModelCursorSnapshot:
     upstream_terminal_ends: tuple[str, ...] = ()
     upstream_end_inputs: tuple[tuple[str | None, str | None], ...] = ()
     upstream_availability_ends: tuple[str, ...] = ()
+    upstream_availability_ranges: tuple[tuple[str | None, str], ...] = ()
 
     @property
     def watermarks_available(self) -> bool:
@@ -229,6 +232,64 @@ class CursorBounds:
     end: str
     future_safety: FutureCursorSafetyEvidence | None = None
     maximum_start_safety: MaximumStartSafetyEvidence | None = None
+
+    def clamp_to_availability(
+        self,
+        *,
+        ranges: tuple[tuple[str | None, str], ...],
+        cursor_watermark_mode: str,
+        cursor_type: str | None,
+    ) -> CursorBounds:
+        """Intersect these bounds with capped-producer physical availability."""
+
+        if not ranges:
+            return self
+        starts: tuple[str | None, ...]
+        if cursor_watermark_mode == CursorWatermarkMode.ANY:
+            resolved_key: Decimal = self._cursor_order_key(value=self.end, cursor_type=cursor_type)
+            starts = tuple(
+                start
+                for start, end in ranges
+                if self._cursor_order_key(value=end, cursor_type=cursor_type) == resolved_key
+            )
+            if not starts or any(start is None for start in starts):
+                return self
+            availability_start: str = min(
+                (start for start in starts if start is not None),
+                key=lambda value: self._cursor_order_key(value=value, cursor_type=cursor_type),
+            )
+        else:
+            concrete_starts: tuple[str, ...] = tuple(
+                start for start, _ in ranges if start is not None
+            )
+            if not concrete_starts:
+                return self
+            availability_start = max(
+                concrete_starts,
+                key=lambda value: self._cursor_order_key(value=value, cursor_type=cursor_type),
+            )
+        start_key: Decimal = self._cursor_order_key(value=self.start, cursor_type=cursor_type)
+        availability_key: Decimal = self._cursor_order_key(
+            value=availability_start, cursor_type=cursor_type
+        )
+        if start_key >= availability_key:
+            return self
+        end_key: Decimal = self._cursor_order_key(value=self.end, cursor_type=cursor_type)
+        return CursorBounds(
+            start=self.end if availability_key >= end_key else availability_start,
+            end=self.end,
+            future_safety=self.future_safety,
+            maximum_start_safety=self.maximum_start_safety,
+        )
+
+    @staticmethod
+    def _cursor_order_key(*, value: str, cursor_type: str | None) -> Decimal:
+        if cursor_type == CursorType.INTEGER:
+            return Decimal(value)
+        parsed: datetime = datetime.fromisoformat(value)
+        if parsed.tzinfo is not None:
+            parsed = parsed.astimezone(UTC).replace(tzinfo=None)
+        return Decimal(str(parsed.replace(tzinfo=UTC).timestamp()))
 
 
 @dataclass(frozen=True)
@@ -388,6 +449,7 @@ class CursorInputRelation:
     is_runtime_produced: bool = False
     terminal_cursor_start: str | None = None
     terminal_cursor_end: str | None = None
+    producer_microbatch_limit_action: MicrobatchLimitAction | None = None
 
     @property
     def is_runtime_owned(self) -> bool:

--- a/src/sqlbuild/executor/build/classes/build_scheduler.py
+++ b/src/sqlbuild/executor/build/classes/build_scheduler.py
@@ -1019,6 +1019,12 @@ class BuildScheduler:
                     microbatch_event_store, microbatch_scope = self._resolve_microbatch_state(
                         model_entry=model_entry, connection=connection
                     )
+                    causal_dependencies = self._capture_causal_dependencies(
+                        model_entry=model_entry,
+                        connection=connection,
+                        consumer_store=microbatch_event_store,
+                        consumer_scope=microbatch_scope,
+                    )
                     if model_entry.batch_concurrency > 1:
                         microbatch_event_store_resolver = partial(
                             lambda connection, *, entry: self._microbatch_store_for_connection(
@@ -1072,6 +1078,14 @@ class BuildScheduler:
                     on_progress=self._on_sub_progress,
                 )
                 if result.status == ExecutionStatus.SUCCESS:
+                    if microbatch_event_store is not None and causal_dependencies:
+                        result = self._publish_terminal_causal_facts(
+                            model_entry=model_entry,
+                            result=result,
+                            connection=connection,
+                            store=microbatch_event_store,
+                            dependencies=causal_dependencies,
+                        )
                     reconcile_model_retention(
                         plan=self._plan,
                         adapter=self._adapter,

--- a/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
@@ -28,9 +28,12 @@ from sqlbuild.compiler.planner.main.execution.effective_microbatch_batch_size im
 from sqlbuild.compiler.planner.main.execution.future_cursor_warning import future_cursor_cap_warning
 from sqlbuild.compiler.planner.main.execution.inclusive_cursor_end import inclusive_cursor_end
 from sqlbuild.compiler.planner.main.execution.maximum_start_warning import maximum_start_cap_warning
-from sqlbuild.compiler.planner.main.execution.microbatch_limit import microbatch_limit_warning
+from sqlbuild.compiler.planner.main.execution.microbatch_limit import (
+    microbatch_limit_warning,
+)
 from sqlbuild.compiler.planner.models import (
     CursorBounds,
+    CursorInputRelation,
     Duration,
     ModelPlanEntry,
 )
@@ -38,6 +41,7 @@ from sqlbuild.compiler.planner.types import (
     BackfillAction,
     CursorGrain,
     CursorType,
+    CursorWatermarkMode,
     IncrementalStrategy,
     MicrobatchStrategy,
     OnSchemaChange,
@@ -3160,14 +3164,40 @@ def _plan_microbatch_windows(
             batch_size=batch_size,
             effective_grain=effective_grain,
         )
-    work_intervals: tuple[MicrobatchInterval, ...] = merge_causal_intervals(
-        intervals=(
-            *(
-                (MicrobatchInterval(start=microbatch_range.start, end=microbatch_range.end),)
-                if microbatch_range.start != microbatch_range.end
-                else ()
-            ),
-        ),
+    causal_history_status: CausalHistoryStatus | None = _causal_history_status(context=context)
+    if causal_history_status == CausalHistoryStatus.UNKNOWN:
+        return _MicrobatchPlan(
+            early_exit=build_failed_result(
+                entry=entry,
+                phase=ExecutionPhase.STAGING,
+                error=(
+                    "capped producer completion history is unavailable; run the producer "
+                    "successfully before building its watermark consumers"
+                ),
+                warnings=warnings,
+                audit_results=audit_results,
+                statement_recorder=statement_recorder,
+            )
+        )
+    uncapped_any_range: CursorBounds | None = _resolve_uncapped_any_range(
+        context=context,
+        target_qualified=target_qualified,
+        is_full_refresh=is_full_refresh,
+        on_progress=on_progress,
+    )
+    causal_intervals: tuple[MicrobatchInterval, ...] = (
+        _bounded_causal_replay_intervals(
+            context=context,
+            availability=microbatch_range,
+        )
+        if _has_capped_producer_dependencies(context=context)
+        else ()
+    )
+    work_intervals: tuple[MicrobatchInterval, ...] = _resolved_work_intervals(
+        context=context,
+        availability=microbatch_range,
+        causal_intervals=causal_intervals,
+        uncapped_any_range=uncapped_any_range,
         cursor_type=cursor_type,
     )
     computed_batches: tuple[BatchWindow, ...] = _batches_for_intervals(
@@ -3197,12 +3227,125 @@ def _plan_microbatch_windows(
         effective_batch_size=effective_batch_size,
         resolved_range=resolved_range,
         runtime_discovery=runtime_discovery,
-        causal_history_status=None,
-        causal_replay_intervals=(),
+        causal_history_status=causal_history_status,
+        causal_replay_intervals=causal_intervals,
     )
 
 
+def _resolve_uncapped_any_range(
+    *,
+    context: ModelMaterializationContext,
+    target_qualified: str,
+    is_full_refresh: bool,
+    on_progress: Callable[[str], None] | None,
+) -> CursorBounds | None:
+    if (
+        not _has_capped_producer_dependencies(context=context)
+        or context.entry.cursor_watermark_mode != CursorWatermarkMode.ANY
+    ):
+        return None
+    uncapped_inputs: tuple[CursorInputRelation, ...] = tuple(
+        relation
+        for relation in context.entry.cursor_input_relations
+        if relation.producer_model_name is None
+    )
+    if not uncapped_inputs:
+        return None
+    uncapped_entry: ModelPlanEntry = replace(
+        context.entry,
+        cursor_input_relations=uncapped_inputs,
+        microbatch_range=None,
+    )
+    return resolve_runtime_cursor_bounds(
+        adapter=context.adapter,
+        connection=context.connection,
+        target_relation=target_qualified,
+        target_database=context.entry.destination.database,
+        target_schema=context.entry.destination.schema,
+        target_name=context.entry.destination.name,
+        spec=build_runtime_cursor_spec(
+            entry=uncapped_entry,
+            read_destination_cursor=not is_full_refresh,
+        ),
+        on_progress=on_progress,
+        watermark_resolver=context.watermark_resolver,
+    )
+
+
+def _resolved_work_intervals(
+    *,
+    context: ModelMaterializationContext,
+    availability: CursorBounds,
+    causal_intervals: tuple[MicrobatchInterval, ...],
+    uncapped_any_range: CursorBounds | None,
+    cursor_type: str,
+) -> tuple[MicrobatchInterval, ...]:
+    if not _has_capped_producer_dependencies(context=context):
+        return _bounds_intervals(bounds=availability)
+    if context.entry.cursor_watermark_mode == CursorWatermarkMode.ANY:
+        return merge_causal_intervals(
+            intervals=(*_bounds_intervals(bounds=uncapped_any_range), *causal_intervals),
+            cursor_type=cursor_type,
+        )
+    intersections: tuple[MicrobatchInterval, ...] = _bounds_intervals(bounds=availability)
+    for dependency in context.microbatch_causal_dependencies:
+        dependency_intervals: tuple[MicrobatchInterval, ...] = _bounded_dependency_intervals(
+            dependency=dependency,
+            availability=availability,
+            context=context,
+        )
+        intersections = _intersect_interval_sets(
+            left=intersections,
+            right=dependency_intervals,
+            cursor_type=cursor_type,
+        )
+    return intersections
+
+
+def _bounds_intervals(*, bounds: CursorBounds | None) -> tuple[MicrobatchInterval, ...]:
+    if bounds is None or bounds.start == bounds.end:
+        return ()
+    return (MicrobatchInterval(start=bounds.start, end=bounds.end),)
+
+
+def _intersect_interval_sets(
+    *,
+    left: tuple[MicrobatchInterval, ...],
+    right: tuple[MicrobatchInterval, ...],
+    cursor_type: str,
+) -> tuple[MicrobatchInterval, ...]:
+    intersections: list[MicrobatchInterval] = []
+    left_interval: MicrobatchInterval
+    right_interval: MicrobatchInterval
+    for left_interval in left:
+        for right_interval in right:
+            start: str = (
+                right_interval.start
+                if _cursor_lte(
+                    left=left_interval.start,
+                    right=right_interval.start,
+                    cursor_type=cursor_type,
+                )
+                else left_interval.start
+            )
+            end: str = (
+                left_interval.end
+                if _cursor_lte(
+                    left=left_interval.end,
+                    right=right_interval.end,
+                    cursor_type=cursor_type,
+                )
+                else right_interval.end
+            )
+            if _cursor_lte(left=end, right=start, cursor_type=cursor_type):
+                continue
+            intersections.append(MicrobatchInterval(start=start, end=end))
+    return merge_causal_intervals(intervals=tuple(intersections), cursor_type=cursor_type)
+
+
 def _causal_history_status(*, context: ModelMaterializationContext) -> CausalHistoryStatus | None:
+    if not _has_capped_producer_dependencies(context=context):
+        return None
     dependencies: tuple[CausalDependencySnapshot, ...] = context.microbatch_causal_dependencies
     if not dependencies:
         return None
@@ -3211,18 +3354,47 @@ def _causal_history_status(*, context: ModelMaterializationContext) -> CausalHis
     return CausalHistoryStatus.KNOWN
 
 
+def _has_capped_producer_dependencies(*, context: ModelMaterializationContext) -> bool:
+    return any(
+        relation.producer_model_name is not None
+        and relation.producer_microbatch_limit_action
+        in {
+            MicrobatchLimitAction.CAP_FROM_END,
+            MicrobatchLimitAction.CAP_FROM_START,
+        }
+        for relation in context.entry.cursor_input_relations
+    )
+
+
 def _bounded_causal_replay_intervals(
     *, context: ModelMaterializationContext, availability: CursorBounds
 ) -> tuple[MicrobatchInterval, ...]:
     interval_values: list[MicrobatchInterval] = []
     for dependency in context.microbatch_causal_dependencies:
-        if dependency.history_status == CausalHistoryStatus.KNOWN:
-            interval_values.extend(dependency.outstanding.intervals)
-    intervals: tuple[MicrobatchInterval, ...] = tuple(interval_values)
+        interval_values.extend(
+            _bounded_dependency_intervals(
+                dependency=dependency,
+                availability=availability,
+                context=context,
+            )
+        )
+    return merge_causal_intervals(
+        intervals=tuple(interval_values), cursor_type=context.entry.cursor_type or ""
+    )
+
+
+def _bounded_dependency_intervals(
+    *,
+    dependency: CausalDependencySnapshot,
+    availability: CursorBounds,
+    context: ModelMaterializationContext,
+) -> tuple[MicrobatchInterval, ...]:
+    if dependency.history_status != CausalHistoryStatus.KNOWN:
+        return ()
     floor: str | None = context.entry.start_cursor_override or context.entry.cursor_start
     ceiling: str | None = availability.end
     bounded: list[MicrobatchInterval] = []
-    for interval in intervals:
+    for interval in dependency.outstanding.intervals:
         start: str = interval.start
         end: str = interval.end
         if floor is not None and _cursor_lte(

--- a/src/sqlbuild/executor/run/_helpers/validation/cursor_bounds.py
+++ b/src/sqlbuild/executor/run/_helpers/validation/cursor_bounds.py
@@ -39,6 +39,7 @@ from sqlbuild.executor.run.models import RuntimeCursorSpec
 from sqlbuild.executor.run.types import WatermarkResolver
 from sqlbuild.spec.contracts.constants import ZERO_DAY_CURSOR_DURATION
 from sqlbuild.spec.contracts.models import StartCursorsConfig
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction
 
 _TIMESTAMP_GRAIN_ORDER: dict[str, int] = {
     CursorGrain.SECOND: 0,
@@ -168,13 +169,13 @@ def resolve_runtime_cursor_bounds(
     upstream_mins: list[object] = []
     upstream_maxes: list[object] = []
     upstream_availability_ends: list[object] = []
+    upstream_availability_ranges: list[tuple[str | None, str]] = []
     input_evidence: list[CursorInputEvidence] = []
     input_index: int
     physical_input: tuple[tuple[str, str], CursorInputRelation]
     for input_index, physical_input in enumerate(physical_inputs, start=1):
         relation_column, cursor_input = physical_input
-        terminal_start: str | None = cursor_input.terminal_cursor_start
-        terminal_end: str | None = cursor_input.terminal_cursor_end
+        terminal_start, terminal_end = _effective_terminal_bounds(cursor_input=cursor_input)
         input_grain: str | None = cursor_input.cursor_grain or effective_grain
         minimum: object | None
         maximum: object | None
@@ -183,7 +184,11 @@ def resolve_runtime_cursor_bounds(
             connection=connection,
             relation=relation_column[0],
             cursor_column=relation_column[1],
-            read_minimum=read_minimum,
+            read_minimum=(
+                read_minimum
+                or cursor_input.producer_microbatch_limit_action
+                == MicrobatchLimitAction.CAP_FROM_END
+            ),
             query_index=input_index,
             total=len(physical_inputs),
             on_progress=on_progress,
@@ -205,22 +210,20 @@ def resolve_runtime_cursor_bounds(
         if minimum is not None:
             upstream_mins.append(minimum)
         upstream_maxes.append(maximum)
-        if (
-            cursor_type == CursorType.TIMESTAMP
-            and spec.microbatch_strategy == MicrobatchStrategy.WATERMARK
-        ):
-            availability_end: object = (
-                _raw_terminal_bound(value=terminal_end, cursor_type=cursor_type)
-                if terminal_end is not None
-                else _increment_timestamp_bound(
-                    value=_floor_timestamp_bound(
-                        value=maximum,
-                        grain=input_grain or CursorGrain.SECOND,
-                    ),
-                    grain=input_grain or CursorGrain.SECOND,
-                )
-            )
+        availability_end, availability_range = _input_availability(
+            minimum=minimum,
+            maximum=maximum,
+            terminal_end=terminal_end,
+            input_grain=input_grain,
+            effective_grain=effective_grain,
+            cursor_type=cursor_type,
+            microbatch_strategy=spec.microbatch_strategy,
+            producer_limit_action=cursor_input.producer_microbatch_limit_action,
+        )
+        if availability_end is not None:
             upstream_availability_ends.append(availability_end)
+        if availability_range is not None:
+            upstream_availability_ranges.append(availability_range)
         normalized_maximum: str | None = _normalize_bound(value=maximum, is_end=False)
         if normalized_maximum is not None:
             input_evidence.append(
@@ -237,56 +240,18 @@ def resolve_runtime_cursor_bounds(
             )
     if not upstream_maxes:
         return None
-    upstream_min_raw: object | None = (
-        _minimum_bound_raw(
-            values=upstream_mins,
-            cursor_type=cursor_type,
-            effective_grain=effective_grain,
-        )
-        if upstream_mins
-        else None
-    )
-    aggregate: Callable[..., object] = (
-        _maximum_bound_raw
-        if spec.cursor_watermark_mode == CursorWatermarkMode.ANY
-        else _minimum_bound_raw
-    )
-    watermark_timestamp: bool = (
-        cursor_type == CursorType.TIMESTAMP
-        and spec.microbatch_strategy == MicrobatchStrategy.WATERMARK
-    )
-    upstream_max_raw: object = aggregate(
-        values=(upstream_availability_ends if watermark_timestamp else upstream_maxes),
+    start: str | None
+    end: str | None
+    start, end = _resolve_raw_cursor_range(
         cursor_type=cursor_type,
-        effective_grain=(CursorGrain.SECOND if watermark_timestamp else effective_grain),
+        effective_grain=effective_grain,
+        microbatch_strategy=spec.microbatch_strategy,
+        cursor_watermark_mode=spec.cursor_watermark_mode,
+        target_max_raw=target_max_raw,
+        upstream_mins=upstream_mins,
+        upstream_maxes=upstream_maxes,
+        upstream_availability_ends=upstream_availability_ends,
     )
-    if cursor_type == CursorType.TIMESTAMP and effective_grain is not None:
-        start_raw: object | None = (
-            target_max_raw if target_max_raw is not None else upstream_min_raw
-        )
-        if start_raw is None:
-            return None
-        start: str | None = _normalize_bound(
-            value=_floor_timestamp_bound(value=start_raw, grain=effective_grain), is_end=False
-        )
-        end: str | None = _normalize_bound(
-            value=(
-                _floor_timestamp_bound(value=upstream_max_raw, grain=effective_grain)
-                if watermark_timestamp
-                else _increment_timestamp_bound(
-                    value=_floor_timestamp_bound(value=upstream_max_raw, grain=effective_grain),
-                    grain=effective_grain,
-                )
-            ),
-            is_end=False,
-        )
-    else:
-        start: str | None = (
-            _normalize_bound(value=target_max_raw, is_end=False)
-            if target_max_raw is not None
-            else _normalize_bound(value=upstream_min_raw, is_end=False)
-        )
-        end: str | None = _normalize_bound(value=upstream_max_raw, is_end=True)
     if start is None or end is None:
         return None
     if spec.end_cursor_override is not None:
@@ -347,7 +312,7 @@ def resolve_runtime_cursor_bounds(
         ),
         has_start_override=spec.start_cursor_override is not None,
     )
-    return _clamp_cursor_end(
+    bounds = _clamp_cursor_end(
         bounds=apply_future_cursor_safety(
             bounds=bounds,
             cursor_type=cursor_type,
@@ -361,6 +326,132 @@ def resolve_runtime_cursor_bounds(
         ),
         cursor_end=spec.cursor_end,
         cursor_type=cursor_type,
+    )
+    return bounds.clamp_to_availability(
+        ranges=tuple(upstream_availability_ranges),
+        cursor_watermark_mode=spec.cursor_watermark_mode,
+        cursor_type=cursor_type,
+    )
+
+
+def _resolve_raw_cursor_range(
+    *,
+    cursor_type: str | None,
+    effective_grain: str | None,
+    microbatch_strategy: str | None,
+    cursor_watermark_mode: str,
+    target_max_raw: object | None,
+    upstream_mins: list[object],
+    upstream_maxes: list[object],
+    upstream_availability_ends: list[object],
+) -> tuple[str | None, str | None]:
+    upstream_min_raw: object | None = (
+        _minimum_bound_raw(
+            values=upstream_mins,
+            cursor_type=cursor_type,
+            effective_grain=effective_grain,
+        )
+        if upstream_mins
+        else None
+    )
+    aggregate: Callable[..., object] = (
+        _maximum_bound_raw
+        if cursor_watermark_mode == CursorWatermarkMode.ANY
+        else _minimum_bound_raw
+    )
+    watermark_timestamp: bool = (
+        cursor_type == CursorType.TIMESTAMP and microbatch_strategy == MicrobatchStrategy.WATERMARK
+    )
+    upstream_max_raw: object = aggregate(
+        values=(upstream_availability_ends if watermark_timestamp else upstream_maxes),
+        cursor_type=cursor_type,
+        effective_grain=(CursorGrain.SECOND if watermark_timestamp else effective_grain),
+    )
+    if cursor_type != CursorType.TIMESTAMP or effective_grain is None:
+        start: str | None = (
+            _normalize_bound(value=target_max_raw, is_end=False)
+            if target_max_raw is not None
+            else _normalize_bound(value=upstream_min_raw, is_end=False)
+        )
+        return start, _normalize_bound(value=upstream_max_raw, is_end=True)
+    start_raw: object | None = target_max_raw if target_max_raw is not None else upstream_min_raw
+    if start_raw is None:
+        return None, None
+    start = _normalize_bound(
+        value=_floor_timestamp_bound(value=start_raw, grain=effective_grain), is_end=False
+    )
+    end: str | None = _normalize_bound(
+        value=(
+            _floor_timestamp_bound(value=upstream_max_raw, grain=effective_grain)
+            if watermark_timestamp
+            else _increment_timestamp_bound(
+                value=_floor_timestamp_bound(value=upstream_max_raw, grain=effective_grain),
+                grain=effective_grain,
+            )
+        ),
+        is_end=False,
+    )
+    return start, end
+
+
+def _effective_terminal_bounds(
+    *, cursor_input: CursorInputRelation
+) -> tuple[str | None, str | None]:
+    producer_is_capped: bool = cursor_input.producer_microbatch_limit_action in {
+        MicrobatchLimitAction.CAP_FROM_END,
+        MicrobatchLimitAction.CAP_FROM_START,
+    }
+    if producer_is_capped:
+        return None, None
+    return cursor_input.terminal_cursor_start, cursor_input.terminal_cursor_end
+
+
+def _input_availability(
+    *,
+    minimum: object | None,
+    maximum: object,
+    terminal_end: str | None,
+    input_grain: str | None,
+    effective_grain: str | None,
+    cursor_type: str | None,
+    microbatch_strategy: str | None,
+    producer_limit_action: MicrobatchLimitAction | None,
+) -> tuple[object | None, tuple[str | None, str] | None]:
+    watermark_timestamp: bool = (
+        cursor_type == CursorType.TIMESTAMP and microbatch_strategy == MicrobatchStrategy.WATERMARK
+    )
+    if watermark_timestamp:
+        availability_end: object = (
+            _raw_terminal_bound(value=terminal_end, cursor_type=cursor_type)
+            if terminal_end is not None
+            else _increment_timestamp_bound(
+                value=_floor_timestamp_bound(
+                    value=maximum,
+                    grain=input_grain or CursorGrain.SECOND,
+                ),
+                grain=input_grain or CursorGrain.SECOND,
+            )
+        )
+        normalized_end: str | None = _normalize_effective_timestamp_bound(
+            value=availability_end,
+            cursor_type=cursor_type,
+            effective_grain=effective_grain,
+        )
+    else:
+        availability_end = None
+        normalized_end = _normalize_bound(value=maximum, is_end=True)
+    normalized_start: str | None = (
+        _normalize_effective_timestamp_bound(
+            value=minimum,
+            cursor_type=cursor_type,
+            effective_grain=effective_grain,
+        )
+        if minimum is not None and producer_limit_action == MicrobatchLimitAction.CAP_FROM_END
+        else None
+    )
+    return (
+        availability_end,
+        None if normalized_end is None else (normalized_start, normalized_end),
     )
 
 

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/_test_types.py
@@ -61,6 +61,21 @@ class LoaderWatermarkBuildE2ETestCase:
 
 
 @dataclass(frozen=True)
+class CappedMicrobatchBuildE2ETestCase:
+    description: str
+    limit_action: str
+    expected_first_ids: tuple[int, ...]
+    expected_final_ids: tuple[int, ...]
+    run_count: int
+
+
+@dataclass(frozen=True)
+class CappedMicrobatchScenarioE2ETestCase:
+    description: str
+    expected_exit_code: int
+
+
+@dataclass(frozen=True)
 class EnumContractBuildE2ETestCase:
     """Test case for enum-backed contract enforcement."""
 

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/helpers.py
@@ -19,6 +19,86 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
 )
 
 
+def capped_microbatch_project_files(
+    *, limit_action: str, project_limit: str = ""
+) -> dict[str, str]:
+    """Build a direct DuckDB project with one capped producer and consumer."""
+
+    return {
+        "sqlbuild_project.toml": dedent(
+            f"""
+            name = "capped_microbatch"
+            adapter = "duckdb"
+
+            [connection]
+            database = "regression.duckdb"
+            {project_limit}
+            """
+        ).strip()
+        + "\n",
+        "sources/raw.yml": dedent(
+            """
+            sources:
+              - name: raw_events
+                schema: main
+                table: raw_events
+            """
+        ).strip()
+        + "\n",
+        "models/capped_events.sql": dedent(
+            f"""
+            MODEL (
+              materialized incremental,
+              incremental_strategy delete_insert,
+              incremental_mode microbatch,
+              microbatch_strategy watermark,
+              cursor event_time,
+              cursor_type timestamp,
+              cursor_grain day,
+              cursor_start '2026-01-01',
+              cursor_end '2026-01-06',
+              cursor_watermark_mode all,
+              cursor_inputs (
+                raw_events (column event_time, roles [filter, watermark]),
+              ),
+              batch_size 1d,
+              lookback 1d,
+              microbatch_limit (
+                max_batches 3,
+                action {limit_action},
+              ),
+            );
+            SELECT id, event_time
+            FROM __source("raw_events")
+            """
+        ).strip()
+        + "\n",
+        "models/downstream_events.sql": dedent(
+            """
+            MODEL (
+              materialized incremental,
+              incremental_strategy delete_insert,
+              incremental_mode microbatch,
+              microbatch_strategy watermark,
+              cursor event_time,
+              cursor_type timestamp,
+              cursor_grain day,
+              cursor_start '2026-01-01',
+              cursor_watermark_mode all,
+              cursor_inputs (
+                capped_events (column event_time, roles [filter, watermark]),
+              ),
+              batch_size 1d,
+              lookback 1d,
+            );
+            SELECT id, event_time
+            FROM __ref("capped_events")
+            """
+        ).strip()
+        + "\n",
+    }
+
+
 def prepare_defer_clone_project(
     *,
     tmp_path: Path,

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_capped_microbatch_build.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_capped_microbatch_build.py
@@ -1,0 +1,417 @@
+"""DuckDB E2E coverage for capped microbatch dependency graphs."""
+
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from tests.e2e.src.sqlbuild.cli.commands.main.build._test_types import (
+    CappedMicrobatchBuildE2ETestCase,
+    CappedMicrobatchScenarioE2ETestCase,
+)
+from tests.e2e.src.sqlbuild.cli.commands.main.build.helpers import (
+    capped_microbatch_project_files,
+)
+from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
+    prepare_inline_project,
+    query_duckdb,
+    run_sqb,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        CappedMicrobatchBuildE2ETestCase(
+            description="cap from start advances deferred prefix without advancing downstream",
+            limit_action="cap_from_start",
+            expected_first_ids=(1, 2, 3),
+            expected_final_ids=(1, 2, 3, 4, 5),
+            run_count=3,
+        ),
+        CappedMicrobatchBuildE2ETestCase(
+            description="cap from end materializes only latest suffix",
+            limit_action="cap_from_end",
+            expected_first_ids=(3, 4, 5),
+            expected_final_ids=(3, 4, 5),
+            run_count=2,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_external_watermark_and_capped_terminal_model_when_building_then_graph_stays_bounded(
+    tmp_path: Path,
+    test_case: CappedMicrobatchBuildE2ETestCase,
+) -> None:
+    project_dir: Path = prepare_inline_project(
+        tmp_path=tmp_path,
+        project_name="capped_microbatch",
+        repo_files=capped_microbatch_project_files(limit_action=test_case.limit_action),
+    )
+    db_path: Path = project_dir / "regression.duckdb"
+
+    import duckdb
+
+    connection: duckdb.DuckDBPyConnection = duckdb.connect(str(db_path))
+    connection.execute("CREATE TABLE raw_events (id INTEGER, event_time TIMESTAMP)")
+    connection.execute(
+        "INSERT INTO raw_events VALUES "
+        "(1, '2026-01-01 12:00:00'), (2, '2026-01-02 12:00:00'), "
+        "(3, '2026-01-03 12:00:00'), (4, '2026-01-04 12:00:00'), "
+        "(5, '2026-01-05 12:00:00')"
+    )
+    connection.close()
+
+    first_result: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "build"), project_dir=project_dir
+    )
+    assert first_result.returncode == 0, first_result.stdout + first_result.stderr
+    first_rows: list[tuple[object, ...]] = query_duckdb(
+        db_path=db_path,
+        sql="SELECT id FROM main.downstream_events ORDER BY id",
+    )
+    assert tuple(row[0] for row in first_rows) == test_case.expected_first_ids
+    for _ in range(test_case.run_count - 1):
+        repeated_result: subprocess.CompletedProcess[str] = run_sqb(
+            command=("--no-color", "build"), project_dir=project_dir
+        )
+        assert repeated_result.returncode == 0, repeated_result.stdout + repeated_result.stderr
+
+    final_rows: list[tuple[object, ...]] = query_duckdb(
+        db_path=db_path,
+        sql="SELECT id FROM main.downstream_events ORDER BY id",
+    )
+    assert tuple(row[0] for row in final_rows) == test_case.expected_final_ids
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (CappedMicrobatchScenarioE2ETestCase("project warning precedes cap", 0),),
+    ids=lambda case: case.description,
+)
+def test_given_project_warning_outside_model_cap_when_building_then_safety_warns_before_cap_executes(
+    tmp_path: Path, test_case: CappedMicrobatchScenarioE2ETestCase
+) -> None:
+    project_dir: Path = prepare_inline_project(
+        tmp_path=tmp_path,
+        project_name="project_limit_with_model_cap",
+        repo_files=capped_microbatch_project_files(
+            limit_action="cap_from_end",
+            project_limit='[microbatches.limits]\nmax_batches = 2\naction = "warn"',
+        ),
+    )
+    db_path: Path = project_dir / "regression.duckdb"
+
+    import duckdb
+
+    connection: duckdb.DuckDBPyConnection = duckdb.connect(str(db_path))
+    connection.execute("CREATE TABLE raw_events (id INTEGER, event_time TIMESTAMP)")
+    connection.execute(
+        "INSERT INTO raw_events VALUES "
+        "(1, '2026-01-01 12:00:00'), (2, '2026-01-02 12:00:00'), "
+        "(3, '2026-01-03 12:00:00'), (4, '2026-01-04 12:00:00'), "
+        "(5, '2026-01-05 12:00:00')"
+    )
+    connection.close()
+
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "build"), project_dir=project_dir
+    )
+
+    assert result.returncode == test_case.expected_exit_code, result.stdout + result.stderr
+    assert "above the per-model limit of 2 (action=warn)" in result.stdout
+    assert "above the per-model limit of 3 (action=cap_from_end)" in result.stdout
+    rows: list[tuple[object, ...]] = query_duckdb(
+        db_path=db_path,
+        sql="SELECT id FROM main.downstream_events ORDER BY id",
+    )
+    assert tuple(row[0] for row in rows) == (3, 4, 5)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (CappedMicrobatchScenarioE2ETestCase("CLI limit remains hard", 1),),
+    ids=lambda case: case.description,
+)
+def test_given_cli_hard_limit_over_model_cap_when_building_then_invocation_fails_before_execution(
+    tmp_path: Path, test_case: CappedMicrobatchScenarioE2ETestCase
+) -> None:
+    project_dir: Path = prepare_inline_project(
+        tmp_path=tmp_path,
+        project_name="cli_limit_over_model_cap",
+        repo_files=capped_microbatch_project_files(limit_action="cap_from_end"),
+    )
+    db_path: Path = project_dir / "regression.duckdb"
+
+    import duckdb
+
+    connection: duckdb.DuckDBPyConnection = duckdb.connect(str(db_path))
+    connection.execute("CREATE TABLE raw_events (id INTEGER, event_time TIMESTAMP)")
+    connection.execute(
+        "INSERT INTO raw_events VALUES "
+        "(1, '2026-01-01 12:00:00'), (2, '2026-01-02 12:00:00'), "
+        "(3, '2026-01-03 12:00:00'), (4, '2026-01-04 12:00:00'), "
+        "(5, '2026-01-05 12:00:00')"
+    )
+    connection.close()
+
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "build", "--max-microbatches", "2"),
+        project_dir=project_dir,
+    )
+
+    assert result.returncode == test_case.expected_exit_code
+    assert "above the per-model limit of 2 (action=error)" in result.stderr
+    connection = duckdb.connect(str(db_path))
+    try:
+        target_names: set[str] = {
+            row[0]
+            for row in connection.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+            ).fetchall()
+        }
+    finally:
+        connection.close()
+    assert "capped_events" not in target_names
+    assert "downstream_events" not in target_names
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (CappedMicrobatchScenarioE2ETestCase("watermark jump preserves gap", 0),),
+    ids=lambda case: case.description,
+)
+def test_given_cap_from_end_watermark_jump_when_rebuilding_then_downstream_skips_disjoint_gap(
+    tmp_path: Path, test_case: CappedMicrobatchScenarioE2ETestCase
+) -> None:
+    project_files: dict[str, str] = capped_microbatch_project_files(limit_action="cap_from_end")
+    project_files["models/capped_events.sql"] = project_files["models/capped_events.sql"].replace(
+        "cursor_end '2026-01-06'", "cursor_end '2026-01-12'"
+    )
+    project_dir: Path = prepare_inline_project(
+        tmp_path=tmp_path,
+        project_name="cap_from_end_watermark_jump",
+        repo_files=project_files,
+    )
+    db_path: Path = project_dir / "regression.duckdb"
+
+    import duckdb
+
+    connection: duckdb.DuckDBPyConnection = duckdb.connect(str(db_path))
+    connection.execute("CREATE TABLE raw_events (id INTEGER, event_time TIMESTAMP)")
+    connection.execute(
+        "INSERT INTO raw_events VALUES "
+        "(1, '2026-01-01 12:00:00'), (2, '2026-01-02 12:00:00'), "
+        "(3, '2026-01-03 12:00:00'), (4, '2026-01-04 12:00:00'), "
+        "(5, '2026-01-05 12:00:00')"
+    )
+    connection.close()
+
+    initial: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "build"), project_dir=project_dir
+    )
+    assert initial.returncode == test_case.expected_exit_code, initial.stdout + initial.stderr
+
+    connection = duckdb.connect(str(db_path))
+    connection.execute(
+        "INSERT INTO raw_events VALUES "
+        "(9, '2026-01-09 12:00:00'), (10, '2026-01-10 12:00:00'), "
+        "(11, '2026-01-11 12:00:00')"
+    )
+    connection.close()
+    jumped: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "build"), project_dir=project_dir
+    )
+    assert jumped.returncode == test_case.expected_exit_code, jumped.stdout + jumped.stderr
+
+    rows: list[tuple[object, ...]] = query_duckdb(
+        db_path=db_path,
+        sql="SELECT id FROM main.downstream_events ORDER BY id",
+    )
+    assert tuple(row[0] for row in rows) == (3, 4, 5, 9, 10, 11)
+    gap_completions: list[tuple[object, ...]] = query_duckdb(
+        db_path=db_path,
+        sql=(
+            "SELECT partition_start, partition_end FROM main._sqlbuild_microbatches "
+            "WHERE model_name = 'downstream_events' "
+            "AND record_type = 'partition_completion' "
+            "AND partition_start >= '2026-01-06T00:00:00' "
+            "AND partition_end <= '2026-01-09T00:00:00'"
+        ),
+    )
+    assert gap_completions == []
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (CappedMicrobatchScenarioE2ETestCase("bounded any uses uncapped input", 0),),
+    ids=lambda case: case.description,
+)
+def test_given_any_watermarks_and_consumer_end_when_capped_winner_is_later_then_uncapped_input_runs(
+    tmp_path: Path, test_case: CappedMicrobatchScenarioE2ETestCase
+) -> None:
+    project_dir: Path = prepare_inline_project(
+        tmp_path=tmp_path,
+        project_name="capped_any_cursor_end",
+        repo_files={
+            "sqlbuild_project.toml": dedent(
+                """
+                name = "capped_any_cursor_end"
+                adapter = "duckdb"
+
+                [connection]
+                database = "regression.duckdb"
+                """
+            ).strip()
+            + "\n",
+            "sources/raw.yml": dedent(
+                """
+                sources:
+                  - name: raw_late
+                    schema: main
+                    table: raw_late
+                  - name: raw_early
+                    schema: main
+                    table: raw_early
+                """
+            ).strip()
+            + "\n",
+            "models/capped_late.sql": dedent(
+                """
+                MODEL (
+                  materialized incremental,
+                  incremental_strategy delete_insert,
+                  incremental_mode microbatch,
+                  microbatch_strategy watermark,
+                  cursor event_time,
+                  cursor_type timestamp,
+                  cursor_grain day,
+                  cursor_start '2026-01-18',
+                  cursor_end '2026-01-25',
+                  cursor_watermark_mode all,
+                  cursor_inputs (
+                    raw_late (column event_time, roles [filter, watermark]),
+                  ),
+                  batch_size 1d,
+                  lookback 1d,
+                  microbatch_limit (
+                    max_batches 3,
+                    action cap_from_end,
+                  ),
+                );
+                SELECT id, event_time FROM __source("raw_late")
+                """
+            ).strip()
+            + "\n",
+            "models/uncapped_early.sql": dedent(
+                """
+                MODEL (materialized table);
+                SELECT id, event_time FROM __source("raw_early")
+                """
+            ).strip()
+            + "\n",
+            "models/any_consumer.sql": dedent(
+                """
+                MODEL (
+                  materialized incremental,
+                  incremental_strategy delete_insert,
+                  incremental_mode microbatch,
+                  microbatch_strategy watermark,
+                  cursor event_time,
+                  cursor_type timestamp,
+                  cursor_grain day,
+                  cursor_start '2026-01-01',
+                  cursor_end '2026-01-15',
+                  cursor_watermark_mode any,
+                  cursor_inputs (
+                    capped_late (column event_time, roles [filter, watermark]),
+                    uncapped_early (column event_time, roles [filter, watermark]),
+                  ),
+                  batch_size 1d,
+                  lookback 1d,
+                );
+                SELECT id, event_time FROM __ref("capped_late")
+                UNION ALL
+                SELECT id, event_time FROM __ref("uncapped_early")
+                """
+            ).strip()
+            + "\n",
+        },
+    )
+    db_path: Path = project_dir / "regression.duckdb"
+
+    import duckdb
+
+    connection: duckdb.DuckDBPyConnection = duckdb.connect(str(db_path))
+    connection.execute("CREATE TABLE raw_late (id INTEGER, event_time TIMESTAMP)")
+    connection.execute(
+        "INSERT INTO raw_late VALUES "
+        "(18, '2026-01-18 12:00:00'), (19, '2026-01-19 12:00:00'), "
+        "(20, '2026-01-20 12:00:00')"
+    )
+    connection.execute("CREATE TABLE raw_early (id INTEGER, event_time TIMESTAMP)")
+    connection.execute(
+        "INSERT INTO raw_early VALUES (101, '2026-01-01 12:00:00'), (102, '2026-01-14 12:00:00')"
+    )
+    connection.close()
+
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "build"), project_dir=project_dir
+    )
+
+    assert result.returncode == test_case.expected_exit_code, result.stdout + result.stderr
+    rows: list[tuple[object, ...]] = query_duckdb(
+        db_path=db_path,
+        sql="SELECT id FROM main.any_consumer ORDER BY id",
+    )
+    assert tuple(row[0] for row in rows) == (101, 102)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (CappedMicrobatchScenarioE2ETestCase("missing history fails closed", 1),),
+    ids=lambda case: case.description,
+)
+def test_given_capped_producer_without_completion_history_when_building_consumer_then_fails_closed(
+    tmp_path: Path, test_case: CappedMicrobatchScenarioE2ETestCase
+) -> None:
+    project_dir: Path = prepare_inline_project(
+        tmp_path=tmp_path,
+        project_name="missing_capped_history",
+        repo_files=capped_microbatch_project_files(limit_action="cap_from_end"),
+    )
+    db_path: Path = project_dir / "regression.duckdb"
+
+    import duckdb
+
+    connection: duckdb.DuckDBPyConnection = duckdb.connect(str(db_path))
+    connection.execute("CREATE TABLE raw_events (id INTEGER, event_time TIMESTAMP)")
+    connection.execute("CREATE TABLE capped_events (id INTEGER, event_time TIMESTAMP)")
+    connection.execute(
+        "INSERT INTO capped_events VALUES (4, '2026-01-04 12:00:00'), (5, '2026-01-05 12:00:00')"
+    )
+    connection.close()
+
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "build", "--select", "downstream_events"),
+        project_dir=project_dir,
+    )
+
+    assert result.returncode == test_case.expected_exit_code
+    assert "capped producer completion history is unavailable" in result.stdout + result.stderr
+    connection = duckdb.connect(str(db_path))
+    try:
+        target_names: set[str] = {
+            row[0]
+            for row in connection.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+            ).fetchall()
+        }
+    finally:
+        connection.close()
+    assert "downstream_events" not in target_names
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_concurrent_microbatch_build.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_concurrent_microbatch_build.py
@@ -219,7 +219,7 @@ def test_given_opt_in_concurrent_microbatch_when_building_twice_then_records_all
     [ConcurrentMicrobatchBehaviorE2ETestCase(description="failed sibling gap recovers")],
     ids=lambda case: case.description,
 )
-def test_given_later_batches_succeed_when_one_batch_fails_then_next_run_recovers_gap(
+def test_given_later_batches_succeed_when_one_batch_fails_then_next_run_preserves_result(
     test_case: ConcurrentMicrobatchBehaviorE2ETestCase, tmp_path: Path
 ) -> None:
     project_dir: Path = prepare_inline_project(
@@ -317,10 +317,10 @@ def test_given_later_batches_succeed_when_one_batch_fails_then_next_run_recovers
             sql=(
                 "SELECT COUNT(*) FROM main._sqlbuild_microbatches "
                 "WHERE record_type = 'partition_completion' "
-                "AND partition_start > '2026-01-01T03:00:00'"
+                "AND partition_start >= '2026-01-01T03:00:00'"
             ),
         )[0][0]
-        >= 2
+        == 2
     )
 
     connection = duckdb.connect(str(db_path))
@@ -335,29 +335,6 @@ def test_given_later_batches_succeed_when_one_batch_fails_then_next_run_recovers
         db_path=db_path,
         sql="SELECT id, value FROM main.orders ORDER BY id",
     ) == [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7)]
-    assert (
-        query_duckdb(
-            db_path=db_path,
-            sql=(
-                "SELECT COUNT(*) FROM main._sqlbuild_microbatches "
-                "WHERE record_type = 'partition_completion' "
-                "AND completion_type = 'recovery'"
-            ),
-        )[0][0]
-        >= 1
-    )
-    assert (
-        query_duckdb(
-            db_path=db_path,
-            sql=(
-                "SELECT COUNT(*) FROM main._sqlbuild_microbatches "
-                "WHERE record_type = 'partition_completion' "
-                "AND completion_type = 'recovery' "
-                "AND origin_run_id <> execution_run_id"
-            ),
-        )[0][0]
-        >= 1
-    )
     assert query_duckdb(
         db_path=db_path,
         sql=(

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_microbatch_failure_windows.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_microbatch_failure_windows.py
@@ -208,7 +208,7 @@ def test_given_concurrent_delta_audit_failure_when_fixed_then_rejected_partition
         sql=(
             "SELECT COUNT(*) FROM main._sqlbuild_microbatches "
             "WHERE record_type = 'partition_completion' "
-            "AND partition_start = '2026-01-01T02:30:00'"
+            "AND partition_start = '2026-01-01T02:00:00'"
         ),
     )
     execute_duckdb(db_path=db_path, sql="UPDATE raw_events SET payload = '3' WHERE id = 3")
@@ -232,7 +232,7 @@ def test_given_concurrent_delta_audit_failure_when_fixed_then_rejected_partition
             sql=(
                 "SELECT COUNT(*) FROM main._sqlbuild_microbatches "
                 "WHERE record_type = 'partition_completion' "
-                "AND partition_start = '2026-01-01T02:30:00'"
+                "AND partition_start = '2026-01-01T02:00:00'"
             ),
         )[0][0]
         >= 1

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_microbatch_lifecycle.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_microbatch_lifecycle.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 
 from tests.e2e.src.sqlbuild.cli.commands.main.build._test_types import (
+    CappedMicrobatchScenarioE2ETestCase,
     VirtualConcurrentMicrobatchE2ETestCase,
 )
 from tests.e2e.src.sqlbuild.cli.commands.main.build.helpers import (
@@ -86,6 +88,94 @@ def test_given_virtual_history_loss_when_reconciling_then_synthetic_events_stay_
         db_path=warehouse_path,
         sql="SELECT id, value FROM dev__dev.orders ORDER BY id",
     ) == [(1, "1"), (2, "2"), (3, "3"), (4, "4")]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (CappedMicrobatchScenarioE2ETestCase("virtual capped dependency preserves gap", 0),),
+    ids=lambda case: case.description,
+)
+def test_given_virtual_capped_producer_watermark_jump_when_building_then_frontier_preserves_gap(
+    tmp_path: Path, test_case: CappedMicrobatchScenarioE2ETestCase
+) -> None:
+    project_dir, warehouse_path, state_path = prepare_virtual_microbatch_lifecycle_project(
+        tmp_path=tmp_path,
+        project_name="virtual_capped_dependency",
+        model_sql=timestamp_microbatch_model_sql(
+            value_expression="payload",
+            batch_concurrency=1,
+            replay_policy="forward_only",
+            extra_config=(
+                "cursor_start '2026-01-01T00:00:00',\n"
+                "cursor_end '2026-01-01T12:00:00',\n"
+                "microbatch_limit (max_batches 3, action cap_from_end),"
+            ),
+        ),
+    )
+    (project_dir / "models" / "downstream_orders.sql").write_text(
+        dedent(
+            """
+            MODEL (
+              materialized incremental,
+              incremental_strategy delete_insert,
+              incremental_mode microbatch,
+              microbatch_strategy watermark,
+              cursor_watermark_mode all,
+              cursor event_time,
+              cursor_type timestamp,
+              cursor_grain hour,
+              cursor_start '2026-01-01T00:00:00',
+              cursor_inputs (
+                orders (column event_time, roles [filter, watermark]),
+              ),
+              batch_size 1h,
+              lookback 1h,
+            );
+
+            SELECT id, event_time, value FROM __ref("orders")
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    initial: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "build"), project_dir=project_dir
+    )
+    assert initial.returncode == test_case.expected_exit_code, initial.stdout + initial.stderr
+    execute_duckdb(
+        db_path=warehouse_path,
+        sql=(
+            "INSERT INTO raw.raw_events VALUES "
+            "(8, '2026-01-01 08:30:00', '8'), "
+            "(9, '2026-01-01 09:30:00', '9'), "
+            "(10, '2026-01-01 10:30:00', '10')"
+        ),
+    )
+
+    jumped: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "build"), project_dir=project_dir
+    )
+
+    assert jumped.returncode == test_case.expected_exit_code, jumped.stdout + jumped.stderr
+    assert query_duckdb(
+        db_path=warehouse_path,
+        sql="SELECT id FROM dev__dev.downstream_orders ORDER BY id",
+    ) == [(2,), (3,), (4,), (8,), (9,), (10,)]
+    assert (
+        query_duckdb(
+            db_path=state_path,
+            sql=(
+                "SELECT partition_start, partition_end "
+                "FROM sqlbuild_state.microbatch_events "
+                "WHERE model_name = 'downstream_orders' "
+                "AND record_type = 'partition_completion' "
+                "AND partition_start >= '2026-01-01T04:00:00' "
+                "AND partition_end <= '2026-01-01T08:00:00'"
+            ),
+        )
+        == []
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/_test_types.py
@@ -67,6 +67,13 @@ class GatherSelectedCursorScopeTestCase:
 
 
 @dataclass(frozen=True)
+class GatherCappedProducerSnapshotTestCase:
+    description: str
+    expected_availability_ends: tuple[str, ...]
+    expected_availability_ranges: tuple[tuple[str | None, str], ...]
+
+
+@dataclass(frozen=True)
 class GatherOverrideCursorSnapshotTestCase:
     description: str
     expected_target_max: str

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/test_warehouse_snapshot.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/test_warehouse_snapshot.py
@@ -29,6 +29,7 @@ from sqlbuild.compiler.planner.models import (
 )
 from sqlbuild.spec.contracts.models import SchemaColumn, SchemaModelEntry
 from tests.integration.src.sqlbuild.compiler.planner._helpers._test_types import (
+    GatherCappedProducerSnapshotTestCase,
     GatherCursorSnapshotTestCase,
     GatherEmptySnapshotTestCase,
     GatherInvalidCursorScopeTestCase,
@@ -67,6 +68,92 @@ _ORDERS_KEY: CompiledObjectKey = CompiledObjectKey(
 _REVENUE_KEY: CompiledObjectKey = CompiledObjectKey(
     resource_type=CompiledResourceType.MODEL, name="revenue"
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        GatherCappedProducerSnapshotTestCase(
+            description="capped producer uses physical availability",
+            expected_availability_ends=("2025-10-15T00:00:00",),
+            expected_availability_ranges=(("2025-08-15 00:00:00", "2025-10-15T00:00:00"),),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_unselected_capped_terminal_producer_when_gathering_then_physical_range_is_authoritative(
+    adapter: DuckDbAdapter,
+    connection: Any,
+    execute: Any,
+    test_case: GatherCappedProducerSnapshotTestCase,
+) -> None:
+    connection.execute("CREATE TABLE staging.capped_events (event_time TIMESTAMP)")
+    connection.execute("INSERT INTO staging.capped_events VALUES ('2025-08-15'), ('2025-09-15')")
+    connection.execute("CREATE TABLE staging.downstream_events (event_time TIMESTAMP)")
+    connection.execute("INSERT INTO staging.downstream_events VALUES ('2025-01-01')")
+    project: CompiledProject = build_project_with_targets(
+        incremental_models=(
+            _IncrementalModelSpec(
+                name="capped_events",
+                schema="staging",
+                cursor="event_time",
+                ref_names=(),
+                extra_config={
+                    "cursor_type": "timestamp",
+                    "cursor_grain": "month",
+                    "incremental_mode": "microbatch",
+                    "microbatch_strategy": "watermark",
+                    "cursor_start": "2025-01-01",
+                    "cursor_end": "2025-12-01",
+                    "microbatch_limit": {
+                        "max_batches": 2,
+                        "action": "cap_from_end",
+                    },
+                },
+            ),
+            _IncrementalModelSpec(
+                name="downstream_events",
+                schema="staging",
+                cursor="event_time",
+                ref_names=("capped_events",),
+                extra_config={
+                    "cursor_type": "timestamp",
+                    "cursor_grain": "month",
+                    "incremental_mode": "microbatch",
+                    "microbatch_strategy": "watermark",
+                    "cursor_watermark_mode": "all",
+                    "cursor_inputs": {
+                        "capped_events": {
+                            "column": "event_time",
+                            "roles": ["filter", "watermark"],
+                        }
+                    },
+                },
+            ),
+        )
+    )
+    downstream_key: CompiledObjectKey = CompiledObjectKey(
+        resource_type=CompiledResourceType.MODEL,
+        name="downstream_events",
+    )
+
+    snapshot: WarehouseSnapshot = gather_warehouse_snapshot(
+        project=project,
+        adapter=adapter,
+        connection=connection,
+        execute=execute,
+        selected_keys=frozenset(model.key for model in project.models),
+        cursor_scope=CursorSnapshotScope(
+            model_keys=frozenset({downstream_key}),
+            runtime_producer_keys=frozenset({downstream_key}),
+        ),
+    )
+
+    cursor_snapshot: ModelCursorSnapshot = snapshot.cursor_snapshots["downstream_events"]
+    assert cursor_snapshot.upstream_terminal_starts == ()
+    assert cursor_snapshot.upstream_terminal_ends == ()
+    assert cursor_snapshot.upstream_availability_ends == test_case.expected_availability_ends
+    assert cursor_snapshot.upstream_availability_ranges == test_case.expected_availability_ranges
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/src/sqlbuild/executor/build/_test_types.py
+++ b/tests/integration/src/sqlbuild/executor/build/_test_types.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 
 from sqlbuild.executor.build.types import BuildStatus
 from sqlbuild.executor.scheduling.types import ExecutionStatus
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction
 
 
 @dataclass(frozen=True)
@@ -9,6 +10,14 @@ class CausalExecutionTestCase:
     description: str
     expected_status: ExecutionStatus
     expected_minimum_cursor_start: str
+
+
+@dataclass(frozen=True)
+class CappedDependencyExecutionTestCase:
+    description: str
+    limit_action: MicrobatchLimitAction
+    expected_ids: tuple[int, ...]
+    expected_intervals: tuple[tuple[str, str], ...]
 
 
 @dataclass(frozen=True)

--- a/tests/integration/src/sqlbuild/executor/build/concurrent/test_microbatch_concurrency.py
+++ b/tests/integration/src/sqlbuild/executor/build/concurrent/test_microbatch_concurrency.py
@@ -76,7 +76,7 @@ class _TrackingDuckDbAdapter(DuckDbAdapter):
             expected_max_active_batches=3,
             expected_max_active_models=2,
             expected_row_count=6,
-            expected_completion_count=18,
+            expected_completion_count=14,
             expected_unattributed_batches=0,
         )
     ],

--- a/tests/integration/src/sqlbuild/executor/build/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/build/helpers.py
@@ -29,9 +29,69 @@ from sqlbuild.microbatches.classes.direct_store import (
 from sqlbuild.microbatches.exceptions import MicrobatchStateError
 from sqlbuild.microbatches.models import MicrobatchEvent, MicrobatchScope, MicrobatchWriteResult
 from sqlbuild.microbatches.types import MicrobatchEventStore
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction
 from tests.integration.src.sqlbuild.executor.build._test_types import (
     BuildExecutionTestCase,
 )
+
+
+def capped_dependency_producer_sql(*, action: MicrobatchLimitAction) -> str:
+    """Return the timestamp capped-producer model used by graph tests."""
+
+    return dedent(
+        f"""
+        MODEL (
+          materialized incremental,
+          incremental_strategy delete_insert,
+          incremental_mode microbatch,
+          microbatch_strategy watermark,
+          cursor event_time,
+          cursor_type timestamp,
+          cursor_grain day,
+          cursor_start '2026-01-01',
+          cursor_end '2026-01-06',
+          cursor_watermark_mode all,
+          cursor_inputs (
+            raw_events (column event_time, roles [filter, watermark]),
+          ),
+          batch_size 1d,
+          lookback 1d,
+          microbatch_limit (
+            max_batches 3,
+            action {action.value},
+          ),
+        );
+        SELECT id, event_time
+        FROM __source("raw_events")
+        """
+    )
+
+
+def capped_dependency_consumer_sql() -> str:
+    """Return the timestamp consumer model used by capped graph tests."""
+
+    return dedent(
+        """
+        MODEL (
+          materialized incremental,
+          incremental_strategy delete_insert,
+          incremental_mode microbatch,
+          microbatch_strategy watermark,
+          cursor event_time,
+          cursor_type timestamp,
+          cursor_grain day,
+          cursor_start '2026-01-01',
+          cursor_watermark_mode all,
+          cursor_inputs (
+            capped_events (column event_time, roles [filter, watermark]),
+          ),
+          batch_size 1d,
+          lookback 1d,
+        );
+        SELECT id, event_time
+        FROM __ref("capped_events")
+        """
+    )
 
 
 def run_build_for_project(

--- a/tests/integration/src/sqlbuild/executor/build/test_capped_microbatch_dependencies.py
+++ b/tests/integration/src/sqlbuild/executor/build/test_capped_microbatch_dependencies.py
@@ -1,0 +1,206 @@
+"""Integration coverage for capped microbatch producer availability."""
+
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import pytest
+
+from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.executor.build.models import BuildExecutionResult
+from sqlbuild.executor.run.models import ModelExecutionResult
+from sqlbuild.executor.scheduling.types import ExecutionStatus
+from sqlbuild.spec.contracts.types import MicrobatchLimitAction
+from tests.integration.src.sqlbuild.executor.build._test_types import (
+    CappedDependencyExecutionTestCase,
+)
+from tests.integration.src.sqlbuild.executor.build.helpers import (
+    capped_dependency_consumer_sql,
+    capped_dependency_producer_sql,
+    causal_model_result,
+    causal_partition_ranges,
+    run_selected_causal_build,
+    write_build_project_files,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        CappedDependencyExecutionTestCase(
+            description="cap from start exposes only the materialized prefix",
+            limit_action=MicrobatchLimitAction.CAP_FROM_START,
+            expected_ids=(1, 2, 3),
+            expected_intervals=(
+                ("2026-01-01T00:00:00", "2026-01-02T00:00:00"),
+                ("2026-01-02T00:00:00", "2026-01-03T00:00:00"),
+                ("2026-01-03T00:00:00", "2026-01-04T00:00:00"),
+            ),
+        ),
+        CappedDependencyExecutionTestCase(
+            description="cap from end exposes only the materialized suffix",
+            limit_action=MicrobatchLimitAction.CAP_FROM_END,
+            expected_ids=(3, 4, 5),
+            expected_intervals=(
+                ("2026-01-03T00:00:00", "2026-01-04T00:00:00"),
+                ("2026-01-04T00:00:00", "2026-01-05T00:00:00"),
+                ("2026-01-05T00:00:00", "2026-01-06T00:00:00"),
+            ),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_capped_upstream_when_building_mixed_graph_then_downstream_uses_only_physical_range(
+    tmp_path: Path,
+    adapter: DuckDbAdapter,
+    causal_connection: Any,
+    test_case: CappedDependencyExecutionTestCase,
+) -> None:
+    write_build_project_files(
+        project_dir=tmp_path,
+        project_files={
+            "sqlbuild_project.toml": 'name = "capped_dependency"\nadapter = "duckdb"\n',
+            "sources/raw.yml": (
+                "sources:\n  - name: raw_events\n    schema: main\n    table: raw_events\n"
+            ),
+            "models/capped_events.sql": capped_dependency_producer_sql(
+                action=test_case.limit_action
+            ),
+            "models/downstream_events.sql": capped_dependency_consumer_sql(),
+        },
+    )
+    causal_connection.execute("CREATE TABLE main.raw_events (id INTEGER, event_time TIMESTAMP)")
+    causal_connection.execute(
+        "INSERT INTO main.raw_events VALUES "
+        "(1, '2026-01-01 12:00:00'), (2, '2026-01-02 12:00:00'), "
+        "(3, '2026-01-03 12:00:00'), (4, '2026-01-04 12:00:00'), "
+        "(5, '2026-01-05 12:00:00')"
+    )
+
+    result: BuildExecutionResult = run_selected_causal_build(
+        project_dir=tmp_path,
+        adapter=adapter,
+        connection=causal_connection,
+        run_id="capped-mixed-graph",
+        select=(),
+    )
+
+    assert causal_model_result(result, "capped_events").status == ExecutionStatus.SUCCESS
+    downstream: ModelExecutionResult = causal_model_result(result, "downstream_events")
+    assert downstream.status == ExecutionStatus.SUCCESS
+    assert (
+        tuple(
+            row[0]
+            for row in causal_connection.execute(
+                "SELECT id FROM main.downstream_events ORDER BY id"
+            ).fetchall()
+        )
+        == test_case.expected_ids
+    )
+    assert (
+        causal_partition_ranges(
+            causal_connection,
+            model_name="downstream_events",
+            run_id="capped-mixed-graph",
+        )
+        == test_case.expected_intervals
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        CappedDependencyExecutionTestCase(
+            description="integer cap from end propagates exact interval",
+            limit_action=MicrobatchLimitAction.CAP_FROM_END,
+            expected_ids=(3, 4),
+            expected_intervals=(("70", "91"),),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_integer_capped_upstream_when_building_mixed_graph_then_exact_intervals_propagate(
+    tmp_path: Path,
+    adapter: DuckDbAdapter,
+    causal_connection: Any,
+    test_case: CappedDependencyExecutionTestCase,
+) -> None:
+    write_build_project_files(
+        project_dir=tmp_path,
+        project_files={
+            "sqlbuild_project.toml": 'name = "integer_capped_dependency"\nadapter = "duckdb"\n',
+            "sources/raw.yml": (
+                "sources:\n  - name: raw_events\n    schema: main\n    table: raw_events\n"
+            ),
+            "models/capped_events.sql": dedent(
+                f"""
+                MODEL (
+                  materialized incremental,
+                  incremental_strategy delete_insert,
+                  incremental_mode microbatch,
+                  microbatch_strategy watermark,
+                  cursor batch_id,
+                  cursor_type integer,
+                  cursor_start 0,
+                  cursor_end 101,
+                  cursor_watermark_mode all,
+                  cursor_inputs (
+                    raw_events (column batch_id, roles [filter, watermark]),
+                  ),
+                  batch_size "25",
+                  microbatch_limit (max_batches 2, action {test_case.limit_action.value}),
+                );
+                SELECT id, batch_id FROM __source("raw_events")
+                """
+            ),
+            "models/downstream_events.sql": dedent(
+                """
+                MODEL (
+                  materialized incremental,
+                  incremental_strategy delete_insert,
+                  incremental_mode microbatch,
+                  microbatch_strategy watermark,
+                  cursor batch_id,
+                  cursor_type integer,
+                  cursor_start 0,
+                  cursor_watermark_mode all,
+                  cursor_inputs (
+                    capped_events (column batch_id, roles [filter, watermark]),
+                  ),
+                  batch_size "25",
+                );
+                SELECT id, batch_id FROM __ref("capped_events")
+                """
+            ),
+        },
+    )
+    causal_connection.execute("CREATE TABLE main.raw_events (id INTEGER, batch_id INTEGER)")
+    causal_connection.execute(
+        "INSERT INTO main.raw_events VALUES (1, 10), (2, 30), (3, 70), (4, 90)"
+    )
+
+    result: BuildExecutionResult = run_selected_causal_build(
+        project_dir=tmp_path,
+        adapter=adapter,
+        connection=causal_connection,
+        run_id="integer-capped-mixed-graph",
+        select=(),
+    )
+
+    assert causal_model_result(result, "capped_events").status == ExecutionStatus.SUCCESS
+    assert causal_model_result(result, "downstream_events").status == ExecutionStatus.SUCCESS
+    assert causal_connection.execute(
+        "SELECT id FROM main.downstream_events ORDER BY id"
+    ).fetchall() == [(value,) for value in test_case.expected_ids]
+    assert (
+        causal_partition_ranges(
+            causal_connection,
+            model_name="downstream_events",
+            run_id="integer-capped-mixed-graph",
+        )
+        == test_case.expected_intervals
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/integration/src/sqlbuild/executor/run/microbatch/_test_types.py
+++ b/tests/integration/src/sqlbuild/executor/run/microbatch/_test_types.py
@@ -39,6 +39,28 @@ class RuntimeWatermarkGrainTestCase:
 
 
 @dataclass(frozen=True)
+class CappedProducerAvailabilityTestCase:
+    description: str
+    cursor_type: str
+    sql_type: str
+    cursor_grain: str | None
+    producer_values_sql: str
+    target_values_sql: str
+    cursor_start: str
+    cursor_end: str
+    limit_action: MicrobatchLimitAction
+    expected_start: str
+    expected_end: str
+
+
+@dataclass(frozen=True)
+class EmptyCappedProducerTestCase:
+    description: str
+    limit_action: MicrobatchLimitAction
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
 class MicrobatchSuccessTestCase:
     """Test case where microbatch execution succeeds."""
 

--- a/tests/integration/src/sqlbuild/executor/run/microbatch/test_microbatch_execution.py
+++ b/tests/integration/src/sqlbuild/executor/run/microbatch/test_microbatch_execution.py
@@ -641,11 +641,36 @@ def test_given_microbatch_model_when_executing_then_succeeds(
             microbatch_limit_action=MicrobatchLimitAction.CAP_FROM_END,
             expected_microbatch_limit_count=3,
             expected_microbatch_limit_warning=True,
-        )
+        ),
+        MicrobatchSuccessTestCase(
+            description="integer cap from start executes earliest batches only",
+            setup_sql=(
+                _INT_SOURCE_SQL,
+                _INT_SOURCE_DATA,
+                "CREATE TABLE main.orders (id INTEGER, batch_id INTEGER, payload VARCHAR)",
+            ),
+            model_sql=_INT_MODEL_SQL,
+            target_schema="main",
+            target_name="orders",
+            incremental_strategy="delete_insert",
+            cursor_column="batch_id",
+            cursor_type="integer",
+            batch_size="25",
+            microbatch_start="0",
+            microbatch_end="100",
+            expected_row_count=2,
+            expected_batch_count=2,
+            expected_warning_count=1,
+            expected_query_results=(("SELECT id FROM main.orders ORDER BY id", ((1,), (2,))),),
+            microbatch_limit=2,
+            microbatch_limit_action=MicrobatchLimitAction.CAP_FROM_START,
+            expected_microbatch_limit_count=4,
+            expected_microbatch_limit_warning=True,
+        ),
     ],
     ids=lambda case: case.description,
 )
-def test_given_deferred_watermark_range_when_capping_from_end_then_latest_batches_execute(
+def test_given_deferred_watermark_range_when_capping_then_selected_batches_execute(
     test_case: MicrobatchSuccessTestCase,
     adapter: DuckDbAdapter,
     connection: Any,

--- a/tests/integration/src/sqlbuild/executor/run/microbatch/test_microbatch_reconciliation.py
+++ b/tests/integration/src/sqlbuild/executor/run/microbatch/test_microbatch_reconciliation.py
@@ -43,6 +43,8 @@ from sqlbuild.microbatches.models import (
 )
 from sqlbuild.spec.contracts.types import MicrobatchLimitAction
 from tests.integration.src.sqlbuild.executor.run.microbatch._test_types import (
+    CappedProducerAvailabilityTestCase,
+    EmptyCappedProducerTestCase,
     MicrobatchBehaviorTestCase,
     MicrobatchReconciliationChunkTestCase,
     RuntimeWatermarkGrainTestCase,
@@ -80,6 +82,143 @@ class _RecordingEventStore:
 
     def read_model_history(self, scope: MicrobatchScope) -> tuple[MicrobatchEvent, ...]:
         return ()
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        CappedProducerAvailabilityTestCase(
+            description="timestamp cap from start uses physical maximum instead of terminal end",
+            cursor_type="timestamp",
+            sql_type="TIMESTAMP",
+            cursor_grain="month",
+            producer_values_sql="('2025-02-15')",
+            target_values_sql="('2025-01-01')",
+            cursor_start="2025-01-01",
+            cursor_end="2025-12-01",
+            limit_action=MicrobatchLimitAction.CAP_FROM_START,
+            expected_start="2025-01-01T00:00:00",
+            expected_end="2025-03-01T00:00:00",
+        ),
+        CappedProducerAvailabilityTestCase(
+            description="timestamp cap from end intersects physical minimum and maximum",
+            cursor_type="timestamp",
+            sql_type="TIMESTAMP",
+            cursor_grain="month",
+            producer_values_sql="('2025-08-15'), ('2025-09-15')",
+            target_values_sql="('2025-01-01')",
+            cursor_start="2025-01-01",
+            cursor_end="2025-12-01",
+            limit_action=MicrobatchLimitAction.CAP_FROM_END,
+            expected_start="2025-08-01T00:00:00",
+            expected_end="2025-10-01T00:00:00",
+        ),
+        CappedProducerAvailabilityTestCase(
+            description="integer cap from end intersects physical minimum and maximum",
+            cursor_type="integer",
+            sql_type="INTEGER",
+            cursor_grain=None,
+            producer_values_sql="(10), (20)",
+            target_values_sql="(0)",
+            cursor_start="0",
+            cursor_end="100",
+            limit_action=MicrobatchLimitAction.CAP_FROM_END,
+            expected_start="10",
+            expected_end="21",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_capped_terminal_producer_when_resolving_consumer_then_uses_physical_availability(
+    adapter: DuckDbAdapter,
+    connection: Any,
+    test_case: CappedProducerAvailabilityTestCase,
+) -> None:
+    connection.execute(f"CREATE TABLE main.target_events (cursor_value {test_case.sql_type})")
+    connection.execute(f"CREATE TABLE main.producer_events (cursor_value {test_case.sql_type})")
+    connection.execute(f"INSERT INTO main.target_events VALUES {test_case.target_values_sql}")
+    connection.execute(f"INSERT INTO main.producer_events VALUES {test_case.producer_values_sql}")
+
+    bounds: CursorBounds | None = resolve_runtime_cursor_bounds(
+        adapter=adapter,
+        connection=connection,
+        target_relation="main.target_events",
+        target_database=None,
+        target_schema="main",
+        target_name="target_events",
+        spec=RuntimeCursorSpec(
+            cursor_column="cursor_value",
+            cursor_type=test_case.cursor_type,
+            cursor_grain=test_case.cursor_grain,
+            cursor_start=test_case.cursor_start,
+            cursor_input_relations=(
+                CursorInputRelation(
+                    "main.producer_events",
+                    "cursor_value",
+                    cursor_grain=test_case.cursor_grain,
+                    terminal_cursor_start=test_case.cursor_start,
+                    terminal_cursor_end=test_case.cursor_end,
+                    producer_microbatch_limit_action=test_case.limit_action,
+                ),
+            ),
+            cursor_watermark_mode="all",
+            microbatch_strategy="watermark",
+        ),
+    )
+
+    assert bounds == CursorBounds(start=test_case.expected_start, end=test_case.expected_end)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        EmptyCappedProducerTestCase(
+            description="empty cap from start producer",
+            limit_action=MicrobatchLimitAction.CAP_FROM_START,
+            expected_error_fragment="required cursor watermark is empty",
+        ),
+        EmptyCappedProducerTestCase(
+            description="empty cap from end producer",
+            limit_action=MicrobatchLimitAction.CAP_FROM_END,
+            expected_error_fragment="required cursor watermark is empty",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_empty_capped_terminal_producer_when_resolving_all_then_fails_closed(
+    adapter: DuckDbAdapter,
+    connection: Any,
+    test_case: EmptyCappedProducerTestCase,
+) -> None:
+    connection.execute("CREATE TABLE main.target_events (event_time TIMESTAMP)")
+    connection.execute("CREATE TABLE main.producer_events (event_time TIMESTAMP)")
+
+    with pytest.raises(ExecutorInputError, match=test_case.expected_error_fragment):
+        resolve_runtime_cursor_bounds(
+            adapter=adapter,
+            connection=connection,
+            target_relation="main.target_events",
+            target_database=None,
+            target_schema="main",
+            target_name="target_events",
+            spec=RuntimeCursorSpec(
+                cursor_column="event_time",
+                cursor_type="timestamp",
+                cursor_grain="day",
+                cursor_start="2025-01-01",
+                cursor_input_relations=(
+                    CursorInputRelation(
+                        "main.producer_events",
+                        "event_time",
+                        terminal_cursor_start="2025-01-01",
+                        terminal_cursor_end="2025-12-01",
+                        producer_microbatch_limit_action=test_case.limit_action,
+                    ),
+                ),
+                cursor_watermark_mode="all",
+                microbatch_strategy="watermark",
+            ),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
@@ -25,6 +25,26 @@ class AnalysisCacheTestCase:
 
 
 @dataclass(frozen=True)
+class WatermarkLimitValidationTestCase:
+    description: str
+    incremental_strategy: str
+    batch_size: str
+    lookback: str | None
+    max_batches: int
+    action: str
+    expected_error_fragment: str | None
+
+
+@dataclass(frozen=True)
+class AvailabilityStartFloorTestCase:
+    description: str
+    ranges: tuple[tuple[str | None, str], ...]
+    mode: str
+    resolved_end: str
+    expected_start: str | None
+
+
+@dataclass(frozen=True)
 class RetentionValidationErrorTestCase:
     description: str
     config_values: dict[str, object]

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_microbatch_redesign.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_microbatch_redesign.py
@@ -17,10 +17,74 @@ from sqlbuild.executor.run._helpers.validation.cursor_bounds import (
     resolve_effective_timestamp_grain as resolve_runtime_effective_timestamp_grain,
 )
 from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
+    AvailabilityStartFloorTestCase,
     MicrobatchCursorTypeTestCase,
     MicrobatchGrainOwnershipTestCase,
     MicrobatchRedesignBehaviorTestCase,
+    WatermarkLimitValidationTestCase,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        AvailabilityStartFloorTestCase(
+            description="all mode intersects every capped producer lower edge",
+            ranges=(
+                ("2026-01-03", "2026-01-10"),
+                ("2026-01-05", "2026-01-08"),
+                (None, "2026-01-12"),
+            ),
+            mode="all",
+            resolved_end="2026-01-08",
+            expected_start="2026-01-05",
+        ),
+        AvailabilityStartFloorTestCase(
+            description="any mode uses lower edge of producer supplying furthest end",
+            ranges=(
+                (None, "2026-01-08"),
+                ("2026-01-05", "2026-01-12"),
+            ),
+            mode="any",
+            resolved_end="2026-01-12",
+            expected_start="2026-01-05",
+        ),
+        AvailabilityStartFloorTestCase(
+            description="any mode remains unbounded when furthest producer is uncapped",
+            ranges=(
+                ("2026-01-05", "2026-01-08"),
+                (None, "2026-01-12"),
+            ),
+            mode="any",
+            resolved_end="2026-01-12",
+            expected_start="2026-01-01",
+        ),
+        AvailabilityStartFloorTestCase(
+            description="any tied end remains unbounded when one producer is uncapped",
+            ranges=(
+                ("2026-01-05", "2026-01-12"),
+                (None, "2026-01-12"),
+            ),
+            mode="any",
+            resolved_end="2026-01-12",
+            expected_start="2026-01-01",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_producer_availability_ranges_when_clamping_bounds_then_mode_is_respected(
+    test_case: AvailabilityStartFloorTestCase,
+) -> None:
+    assert (
+        CursorBounds(start="2026-01-01", end=test_case.resolved_end)
+        .clamp_to_availability(
+            ranges=test_case.ranges,
+            cursor_watermark_mode=test_case.mode,
+            cursor_type="timestamp",
+        )
+        .start
+        == test_case.expected_start
+    )
 
 
 @pytest.mark.parametrize(
@@ -221,6 +285,145 @@ def test_given_model_limit_below_lookback_when_validating_then_compilation_fails
             ref_count=1,
             known_input_names=frozenset({"events"}),
         )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        WatermarkLimitValidationTestCase(
+            description="fixed lookback cap from start must leave one forward batch",
+            incremental_strategy="delete_insert",
+            batch_size="1d",
+            lookback="1d",
+            max_batches=2,
+            action="cap_from_start",
+            expected_error_fragment="ordinary lookback requirement of 3 batches",
+        ),
+        WatermarkLimitValidationTestCase(
+            description="implicit idempotent lookback cap from start must leave one forward batch",
+            incremental_strategy="delete_insert",
+            batch_size="1d",
+            lookback=None,
+            max_batches=2,
+            action="cap_from_start",
+            expected_error_fragment="ordinary lookback requirement of 3 batches",
+        ),
+        WatermarkLimitValidationTestCase(
+            description="calendar lookback cap from start must leave one forward batch",
+            incremental_strategy="delete_insert",
+            batch_size="1mo",
+            lookback="1mo",
+            max_batches=2,
+            action="cap_from_start",
+            expected_error_fragment="ordinary lookback requirement of 3 batches",
+        ),
+        WatermarkLimitValidationTestCase(
+            description="effective batch cap from start resolves against cursor grain",
+            incremental_strategy="delete_insert",
+            batch_size="effective",
+            lookback=None,
+            max_batches=2,
+            action="cap_from_start",
+            expected_error_fragment="ordinary lookback requirement of 3 batches",
+        ),
+        WatermarkLimitValidationTestCase(
+            description="mixed duration cap from start fails closed",
+            incremental_strategy="delete_insert",
+            batch_size="1d",
+            lookback="1mo",
+            max_batches=10,
+            action="cap_from_start",
+            expected_error_fragment="cannot prove forward progress",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_insufficient_capped_watermark_limit_when_validating_then_error_explains_progress(
+    test_case: WatermarkLimitValidationTestCase,
+) -> None:
+    config: CompileModelConfig = CompileModelConfig(
+        values={
+            "materialized": "incremental",
+            "incremental_strategy": test_case.incremental_strategy,
+            "incremental_mode": "microbatch",
+            "microbatch_strategy": "watermark",
+            "cursor_watermark_mode": "all",
+            "cursor": "event_time",
+            "cursor_type": "timestamp",
+            "cursor_grain": "day",
+            "cursor_inputs": {
+                "events": {
+                    "column": "event_time",
+                    "roles": ["filter", "watermark"],
+                }
+            },
+            "batch_size": test_case.batch_size,
+            "lookback": test_case.lookback,
+            "microbatch_limit": {
+                "max_batches": test_case.max_batches,
+                "action": test_case.action,
+            },
+        }
+    )
+
+    assert test_case.expected_error_fragment is not None
+    with pytest.raises(CompileInputError, match=test_case.expected_error_fragment):
+        validate_incremental_config(
+            config=config,
+            model_name="events",
+            ref_count=1,
+            known_input_names=frozenset({"events"}),
+        )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        WatermarkLimitValidationTestCase(
+            description="cap from end may equal ordinary lookback requirement",
+            incremental_strategy="delete_insert",
+            batch_size="1d",
+            lookback="1d",
+            max_batches=2,
+            action="cap_from_end",
+            expected_error_fragment=None,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_sufficient_cap_from_end_limit_when_validating_then_config_is_accepted(
+    test_case: WatermarkLimitValidationTestCase,
+) -> None:
+    assert test_case.expected_error_fragment is None
+    validate_incremental_config(
+        config=CompileModelConfig(
+            values={
+                "materialized": "incremental",
+                "incremental_strategy": test_case.incremental_strategy,
+                "incremental_mode": "microbatch",
+                "microbatch_strategy": "watermark",
+                "cursor_watermark_mode": "all",
+                "cursor": "event_time",
+                "cursor_type": "timestamp",
+                "cursor_grain": "day",
+                "cursor_inputs": {
+                    "events": {
+                        "column": "event_time",
+                        "roles": ["filter", "watermark"],
+                    }
+                },
+                "batch_size": test_case.batch_size,
+                "lookback": test_case.lookback,
+                "microbatch_limit": {
+                    "max_batches": test_case.max_batches,
+                    "action": test_case.action,
+                },
+            }
+        ),
+        model_name="events",
+        ref_count=1,
+        known_input_names=frozenset({"events"}),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/_test_types.py
@@ -122,6 +122,19 @@ class CursorQueryFailureTestCase:
 
 
 @dataclass(frozen=True)
+class MicrobatchCursorEndPlanTestCase:
+    description: str
+    cursor_type: str
+    cursor_grain: str | None
+    batch_size: str
+    cursor_end: str
+    target_max: str
+    upstream_min: str
+    upstream_max: str
+    expected_microbatch_range: CursorBounds
+
+
+@dataclass(frozen=True)
 class CursorFetchFailureTestCase:
     description: str
     expected_results: dict[str, str]

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/helpers.py
@@ -93,12 +93,47 @@ from sqlbuild.spec.contracts.types import (
 from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
     BuildModelWarningsTestCase,
     IncrementalStrategyErrorTestCase,
+    MicrobatchCursorEndPlanTestCase,
     PlanAuditTestCase,
     PlanScenarioGraphErrorTestCase,
     PlanScenarioGraphTestCase,
     ResolveModelPlanActionTestCase,
     SourceCursorInputColumnsTestCase,
 )
+
+
+def microbatch_model_with_cursor_end(
+    test_case: MicrobatchCursorEndPlanTestCase,
+) -> CompiledModel:
+    """Build a microbatch model with a configured terminal cursor bound."""
+
+    return CompiledModel(
+        key=CompiledObjectKey(resource_type=CompiledResourceType.MODEL, name="orders"),
+        deps=(),
+        name="orders",
+        relative_path=Path("models/orders.sql"),
+        query_sql="SELECT 1",
+        references=(),
+        config=CompileModelConfig(
+            values={
+                "materialized": "incremental",
+                "incremental_strategy": "delete_insert",
+                "incremental_mode": "microbatch",
+                "microbatch_strategy": "watermark",
+                "batch_size": test_case.batch_size,
+                "cursor": "cursor_value",
+                "cursor_type": test_case.cursor_type,
+                "cursor_grain": test_case.cursor_grain,
+                "cursor_end": test_case.cursor_end,
+            }
+        ),
+        destination=CompiledRelationLocation(
+            database=None,
+            schema="main",
+            name="orders",
+            qualified_name="main.orders",
+        ),
+    )
 
 
 class PlannerTestAdapter(BaseAdapter):

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_plan_entry_cursor_overrides.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_plan_entry_cursor_overrides.py
@@ -19,6 +19,7 @@ from sqlbuild.compiler.planner._helpers.output.plan_entry import (
     _compute_plan_cursor_bounds,
     _MicrobatchRangeInputs,
 )
+from sqlbuild.compiler.planner.constants import MICROBATCH_END_SENTINEL, MICROBATCH_START_SENTINEL
 from sqlbuild.compiler.planner.models import (
     BackfillResult,
     CursorBounds,
@@ -29,10 +30,91 @@ from sqlbuild.compiler.planner.models import (
 from sqlbuild.compiler.planner.types import BackfillAction
 from tests.unit.src.sqlbuild.compiler.planner._helpers._test_types import (
     AuthoritativeCursorOverrideTestCase,
+    MicrobatchCursorEndPlanTestCase,
     PlanEntryCursorGrainTestCase,
     PlanEntryCursorOverrideTestCase,
     PlannerOwnedMixedGrainRangeTestCase,
 )
+from tests.unit.src.sqlbuild.compiler.planner._helpers.helpers import (
+    microbatch_model_with_cursor_end,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        MicrobatchCursorEndPlanTestCase(
+            description="timestamp microbatch keeps runtime sentinels and clamps concrete range",
+            cursor_type="timestamp",
+            cursor_grain="month",
+            batch_size="1mo",
+            cursor_end="2025-12-01",
+            target_max="2025-10-01",
+            upstream_min="2025-01-01",
+            upstream_max="2026-02-01",
+            expected_microbatch_range=CursorBounds(start="2025-09-01T00:00:00", end="2025-12-01"),
+        ),
+        MicrobatchCursorEndPlanTestCase(
+            description="integer microbatch keeps runtime sentinels and clamps concrete range",
+            cursor_type="integer",
+            cursor_grain=None,
+            batch_size="5",
+            cursor_end="20",
+            target_max="10",
+            upstream_min="0",
+            upstream_max="30",
+            expected_microbatch_range=CursorBounds(start="10", end="20"),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_planner_owned_microbatch_with_cursor_end_when_planning_then_sentinels_are_deferred(
+    test_case: MicrobatchCursorEndPlanTestCase,
+) -> None:
+    model: CompiledModel = microbatch_model_with_cursor_end(test_case)
+    snapshot: WarehouseSnapshot = WarehouseSnapshot(
+        cursor_snapshots={
+            model.name: ModelCursorSnapshot(
+                target_max=test_case.target_max,
+                upstream_mins=(test_case.upstream_min,),
+                upstream_maxes=(test_case.upstream_max,),
+            )
+        }
+    )
+    backfill: BackfillResult = BackfillResult(action=BackfillAction.FORWARD_ONLY)
+
+    plan_bounds: CursorBounds | None = _compute_plan_cursor_bounds(
+        model=model,
+        snapshot=snapshot,
+        backfill=backfill,
+        full_refresh=False,
+        start_cursor_override=None,
+        end_cursor_override=None,
+        runtime_owned_cursor_bounds=False,
+    )
+    microbatch_range: CursorBounds | None = _compute_microbatch_range(
+        model=model,
+        inputs=_MicrobatchRangeInputs(
+            snapshot=snapshot,
+            backfill=backfill,
+            start_cursor_override=None,
+            end_cursor_override=None,
+            runtime_owned_cursor_bounds=False,
+            cursor_input_relations=(
+                CursorInputRelation(relation="main.raw_orders", cursor_column="cursor_value"),
+            ),
+            future_cursor_config=None,
+            start_cursor_config=None,
+            invocation_time=None,
+            full_refresh=False,
+        ),
+    )
+
+    assert plan_bounds == CursorBounds(
+        start=MICROBATCH_START_SENTINEL,
+        end=MICROBATCH_END_SENTINEL,
+    )
+    assert microbatch_range == test_case.expected_microbatch_range
 
 
 @pytest.mark.parametrize(
@@ -212,7 +294,19 @@ def test_given_runtime_owned_missing_snapshot_when_overrides_complete_then_all_r
                 start="2026-04-03T18:00:00",
                 end="2026-04-05T00:00:00",
             ),
-        )
+        ),
+        PlannerOwnedMixedGrainRangeTestCase(
+            description="planner-owned same-grain input aligns target and watermark bounds",
+            target_max="2026-04-04 14:37:00",
+            upstream_max="2026-04-04 16:37:00",
+            downstream_grain="hour",
+            upstream_grain="hour",
+            batch_size="1h",
+            expected_bounds=CursorBounds(
+                start="2026-04-04T13:00:00",
+                end="2026-04-04T17:00:00",
+            ),
+        ),
     ],
     ids=lambda case: case.description,
 )


### PR DESCRIPTION
## Why

SQLBuild v0.80.0 could parse internal cursor sentinels as timestamps when a bounded watermark model supplied `cursor_end`. Capped producers could also overstate downstream availability across deferred or discontinuous intervals, allowing consumers to treat unmaterialized gaps as complete. `cap_from_start` limits could permanently stall when they did not leave capacity for forward progress.

## Changes

- defer sentinel clamping while preserving concrete `cursor_end` enforcement
- normalize same-grain timestamp snapshots to canonical boundaries
- validate `cap_from_start` against explicit/implicit lookback and effective batch size
- derive downstream work from append-only producer completion and consumer frontier facts
- fail closed when capped history is unavailable and preserve bounded `any` alternatives
- add direct, virtual, timestamp, integer, discontinuous-watermark, and CLI regressions
- align legacy E2E assertions with canonical intervals
- split timing-sensitive performance guards from deterministic DuckDB E2E CI

## Verification

- `make test` — 6,030 passed
- focused compiler/executor matrix — 96 passed
- focused capped CLI E2E matrix — 8 passed
- focused failed-batch E2E regressions — 2 passed
- `make test-e2e-performance` — 7 passed, 1 scheduled-only skipped
- `uv sync --all-extras`; `make check-ci`
- independent correctness review: no blockers
