### PR TITLE
ci: shard deterministic DuckDB E2E checks into semantic jobs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -115,12 +115,30 @@ jobs:
       - name: Run unit and integration tests
         run: make test
 
-  e2e:
-    name: DuckDB E2E tests
+  e2e_shards:
+    name: DuckDB E2E (${{ matrix.name }})
     needs: [changes, lockfile]
     if: needs.changes.outputs.duckdb == 'true'
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: build core
+            target: test-e2e-duckdb-build-core
+          - name: build incremental
+            target: test-e2e-duckdb-build-incremental
+          - name: build virtual
+            target: test-e2e-duckdb-build-virtual
+          - name: CLI data
+            target: test-e2e-duckdb-cli-data
+          - name: CLI commands
+            target: test-e2e-duckdb-cli
+          - name: virtual environments
+            target: test-e2e-duckdb-virtual
+          - name: integrations
+            target: test-e2e-duckdb-integrations
     env:
       PYTEST_XDIST_AUTO_NUM_WORKERS: "4"
     steps:
@@ -154,8 +172,8 @@ jobs:
               f"{os.environ.get('PYTEST_XDIST_AUTO_NUM_WORKERS', '<unset>')}"
           )
           PY
-      - name: Run DuckDB E2E tests
-        run: make test-e2e-duckdb
+      - name: Run DuckDB E2E shard
+        run: make ${{ matrix.target }}
 
   performance:
     name: Performance guards
@@ -218,7 +236,7 @@ jobs:
   verify:
     name: Verify
     if: always()
-    needs: [changes, lockfile, checks, e2e, performance, postgres]
+    needs: [changes, lockfile, checks, e2e_shards, performance, postgres]
     runs-on: ubuntu-24.04
     steps:
       - name: Confirm all required verification jobs passed
@@ -226,7 +244,7 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           LOCKFILE_RESULT: ${{ needs.lockfile.result }}
           CHECKS_RESULT: ${{ needs.checks.result }}
-          E2E_RESULT: ${{ needs.e2e.result }}
+          E2E_SHARDS_RESULT: ${{ needs.e2e_shards.result }}
           PERFORMANCE_RESULT: ${{ needs.performance.result }}
           POSTGRES_RESULT: ${{ needs.postgres.result }}
         run: |
@@ -236,7 +254,7 @@ jobs:
             echo "Required classification, lockfile, or static checks did not pass" >&2
             exit 1
           fi
-          for result in "${E2E_RESULT}" "${PERFORMANCE_RESULT}" "${POSTGRES_RESULT}"; do
+          for result in "${E2E_SHARDS_RESULT}" "${PERFORMANCE_RESULT}" "${POSTGRES_RESULT}"; do
             if [[ "${result}" != "success" && "${result}" != "skipped" ]]; then
               echo "A selected verification suite did not pass: ${result}" >&2
               exit 1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 SHELL := /bin/bash
 
-.PHONY: verify verify-quick verify-pg coverage cli-preview rust-check test-e2e-performance
+.PHONY: verify verify-quick verify-pg coverage cli-preview rust-check \
+	check-e2e-shards test-e2e-duckdb test-e2e-duckdb-build-core \
+	test-e2e-duckdb-build-incremental test-e2e-duckdb-build-virtual \
+	test-e2e-duckdb-cli-data test-e2e-duckdb-cli test-e2e-duckdb-virtual \
+	test-e2e-duckdb-integrations test-e2e-performance
 
 format:
 	uv run ruff format .
@@ -48,10 +52,113 @@ test-all:
 	exit $$status
 
 
-test-e2e-duckdb:
+E2E_DUCKDB_MARKERS := not real_warehouse and not dbt and not performance
+E2E_DUCKDB_PYTEST_ARGS := -m "$(E2E_DUCKDB_MARKERS)" -vv --color=yes -n auto --dist loadfile
+
+E2E_DUCKDB_BUILD_CORE_PATHS := \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/no_tests_no_audits \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_audit_failures.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_build.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_compile_json_behavior.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_dag_json_behavior.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_enum_contract.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_expression_sources.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_lifecycle_commands.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_manifest_artifact_gating.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_no_tests_no_audits_flags.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_plan_command_surface.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_python_hooks.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_query_change_tracking.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_query_propagation.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_remove_column_semantics.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_reusable_model_schemas.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_runtime_artifact_preservation.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_schema_backfill_behavior.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_selector_surface.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_table_function_dependency.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_template_expressions.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_validation_failures.py
+
+E2E_DUCKDB_BUILD_INCREMENTAL_PATHS := \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_append_cursor_build.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_capped_microbatch_build.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_concurrent_microbatch_build.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_cursor_runtime_failures.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_loader_watermark_build.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_microbatch_direct_lifecycle.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_microbatch_failure_windows.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_microbatch_replay_backfill_lifecycle.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_mixed_timestamp_grain_replay.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_model_backed_cursor_build.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_seed_watermark_build.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_snapshot_build.py
+
+E2E_DUCKDB_BUILD_VIRTUAL_PATHS := \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_build_state.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_incremental_build.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_microbatch_lifecycle.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_mode_guard.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_promote.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_python_build.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_rollback.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_seed_build.py \
+	tests/e2e/src/sqlbuild/cli/commands/main/build/test_virtual_source_freshness_build.py
+
+E2E_DUCKDB_CLI_DATA_PATHS := \
+	tests/e2e/src/sqlbuild/cli/commands/main/load \
+	tests/e2e/src/sqlbuild/cli/commands/main/providers \
+	tests/e2e/src/sqlbuild/cli/commands/main/scenario
+
+E2E_DUCKDB_CLI_PATHS := \
+	tests/e2e/scripts/cli_preview \
+	tests/e2e/src/sqlbuild/cli/commands/main/adapters \
+	tests/e2e/src/sqlbuild/cli/commands/main/audit \
+	tests/e2e/src/sqlbuild/cli/commands/main/bigquery \
+	tests/e2e/src/sqlbuild/cli/commands/main/check \
+	tests/e2e/src/sqlbuild/cli/commands/main/compile \
+	tests/e2e/src/sqlbuild/cli/commands/main/databricks \
+	tests/e2e/src/sqlbuild/cli/commands/main/dbt \
+	tests/e2e/src/sqlbuild/cli/commands/main/debug \
+	tests/e2e/src/sqlbuild/cli/commands/main/freshness \
+	tests/e2e/src/sqlbuild/cli/commands/main/init \
+	tests/e2e/src/sqlbuild/cli/commands/main/kata \
+	tests/e2e/src/sqlbuild/cli/commands/main/lineage \
+	tests/e2e/src/sqlbuild/cli/commands/main/motherduck \
+	tests/e2e/src/sqlbuild/cli/commands/main/playground \
+	tests/e2e/src/sqlbuild/cli/commands/main/postgres \
+	tests/e2e/src/sqlbuild/cli/commands/main/query \
+	tests/e2e/src/sqlbuild/cli/commands/main/scope \
+	tests/e2e/src/sqlbuild/cli/commands/main/seed \
+	tests/e2e/src/sqlbuild/cli/commands/main/skills \
+	tests/e2e/src/sqlbuild/cli/commands/main/snowflake \
+	tests/e2e/src/sqlbuild/cli/commands/main/sqlserver \
+	tests/e2e/src/sqlbuild/cli/commands/main/test
+
+E2E_DUCKDB_VIRTUAL_PATHS := \
+	tests/e2e/src/sqlbuild/cli/commands/main/clone \
+	tests/e2e/src/sqlbuild/cli/commands/main/diff \
+	tests/e2e/src/sqlbuild/cli/commands/main/janitor \
+	tests/e2e/src/sqlbuild/cli/commands/main/plan \
+	tests/e2e/src/sqlbuild/cli/commands/main/reconcile \
+	tests/e2e/src/sqlbuild/cli/commands/main/state
+
+E2E_DUCKDB_INTEGRATIONS_PATHS := tests/e2e/src/sqlbuild/integrations
+
+E2E_DUCKDB_PATHS := \
+	$(E2E_DUCKDB_BUILD_CORE_PATHS) \
+	$(E2E_DUCKDB_BUILD_INCREMENTAL_PATHS) \
+	$(E2E_DUCKDB_BUILD_VIRTUAL_PATHS) \
+	$(E2E_DUCKDB_CLI_DATA_PATHS) \
+	$(E2E_DUCKDB_CLI_PATHS) \
+	$(E2E_DUCKDB_VIRTUAL_PATHS) \
+	$(E2E_DUCKDB_INTEGRATIONS_PATHS)
+
+define run_e2e_duckdb
 	@mkdir -p /tmp/opencode
-	@log="/tmp/opencode/test-e2e-duckdb-$$(date +%Y%m%d-%H%M%S).log"; \
+	@log="/tmp/opencode/$(1)-$$(date +%Y%m%d-%H%M%S).log"; \
 	echo "Logging to $$log"; \
+	echo "Reproduce locally: make $(1)"; \
+	echo 'Pytest scope: $(2) -m "$(E2E_DUCKDB_MARKERS)"'; \
 	{ \
 		status=0; \
 		run_step() { \
@@ -65,12 +172,47 @@ test-e2e-duckdb:
 				if [ $$status -eq 0 ]; then status=$$rc; fi; \
 			fi; \
 		}; \
-		run_step "duckdb e2e" env PYTHONUNBUFFERED=1 SQLBUILD_CONCURRENCY=$(SQLBUILD_CONCURRENCY) uv run pytest tests/e2e -m "not real_warehouse and not dbt and not performance" -vv --color=yes -n auto --dist loadfile; \
+		run_step "$(1)" env PYTHONUNBUFFERED=1 SQLBUILD_CONCURRENCY=$(SQLBUILD_CONCURRENCY) uv run pytest $(2) $(E2E_DUCKDB_PYTEST_ARGS); \
 		exit $$status; \
 	} 2>&1 | tee "$$log"; \
 	status=$${PIPESTATUS[0]}; \
 	echo "TEST_E2E_DUCKDB_EXIT=$$status (log: $$log)" | tee -a "$$log"; \
 	exit $$status
+endef
+
+test-e2e-duckdb:
+	$(call run_e2e_duckdb,$@,$(E2E_DUCKDB_PATHS))
+
+test-e2e-duckdb-build-core:
+	$(call run_e2e_duckdb,$@,$(E2E_DUCKDB_BUILD_CORE_PATHS))
+
+test-e2e-duckdb-build-incremental:
+	$(call run_e2e_duckdb,$@,$(E2E_DUCKDB_BUILD_INCREMENTAL_PATHS))
+
+test-e2e-duckdb-build-virtual:
+	$(call run_e2e_duckdb,$@,$(E2E_DUCKDB_BUILD_VIRTUAL_PATHS))
+
+test-e2e-duckdb-cli-data:
+	$(call run_e2e_duckdb,$@,$(E2E_DUCKDB_CLI_DATA_PATHS))
+
+test-e2e-duckdb-cli:
+	$(call run_e2e_duckdb,$@,$(E2E_DUCKDB_CLI_PATHS))
+
+test-e2e-duckdb-virtual:
+	$(call run_e2e_duckdb,$@,$(E2E_DUCKDB_VIRTUAL_PATHS))
+
+test-e2e-duckdb-integrations:
+	$(call run_e2e_duckdb,$@,$(E2E_DUCKDB_INTEGRATIONS_PATHS))
+
+check-e2e-shards:
+	bash scripts/check_e2e_shards.sh \
+		--shard build-core $(E2E_DUCKDB_BUILD_CORE_PATHS) \
+		--shard build-incremental $(E2E_DUCKDB_BUILD_INCREMENTAL_PATHS) \
+		--shard build-virtual $(E2E_DUCKDB_BUILD_VIRTUAL_PATHS) \
+		--shard cli-data $(E2E_DUCKDB_CLI_DATA_PATHS) \
+		--shard cli $(E2E_DUCKDB_CLI_PATHS) \
+		--shard virtual $(E2E_DUCKDB_VIRTUAL_PATHS) \
+		--shard integrations $(E2E_DUCKDB_INTEGRATIONS_PATHS)
 
 
 test-e2e-performance:
@@ -384,7 +526,7 @@ verify-quick:
 	exit $$status
 
 
-check-ci:
+check-ci: check-e2e-shards
 	uv run ruff format --check .
 	uv run ruff check .
 	uv run ty check src tests

--- a/scripts/check_e2e_shards.sh
+++ b/scripts/check_e2e_shards.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly marker_expression="not real_warehouse and not dbt and not performance"
+readonly e2e_root="tests/e2e"
+
+declare -a shard_names=()
+declare -a root_names=()
+declare -a root_shards=()
+declare -A seen_shards=()
+declare -A seen_roots=()
+
+while (( $# > 0 )); do
+  if [[ "$1" != "--shard" || $# -lt 3 ]]; then
+    echo "usage: $0 --shard NAME PATH [PATH ...] [--shard ...]" >&2
+    exit 2
+  fi
+
+  shard="$2"
+  shift 2
+  if [[ -n "${seen_shards[$shard]:-}" ]]; then
+    echo "duplicate shard name: $shard" >&2
+    exit 1
+  fi
+  seen_shards[$shard]=1
+  shard_names+=("$shard")
+
+  path_count=0
+  while (( $# > 0 )) && [[ "$1" != "--shard" ]]; do
+    root="$1"
+    shift
+    ((path_count += 1))
+    if [[ -n "${seen_roots[$root]:-}" ]]; then
+      echo "path is declared more than once: $root" >&2
+      exit 1
+    fi
+    if [[ "$root" != "$e2e_root/"* ]]; then
+      echo "path is outside $e2e_root: $root" >&2
+      exit 1
+    fi
+    if [[ ! -e "$root" ]]; then
+      echo "path does not exist: $root" >&2
+      exit 1
+    fi
+    seen_roots[$root]=1
+    root_names+=("$root")
+    root_shards+=("$shard")
+  done
+  if (( path_count == 0 )); then
+    echo "shard has no paths: $shard" >&2
+    exit 1
+  fi
+done
+
+mkdir -p /tmp/opencode
+collection_file=$(mktemp /tmp/opencode/check-e2e-shards-XXXXXX.log)
+trap 'rm -f "$collection_file"' EXIT
+
+if ! uv run pytest "$e2e_root" --collect-only -q --color=no \
+  -m "$marker_expression" >"$collection_file"; then
+  cat "$collection_file"
+  echo "DuckDB E2E pytest collection failed" >&2
+  exit 1
+fi
+
+declare -A counts=()
+declare -A invalid_files=()
+test_count=0
+while IFS= read -r node_id; do
+  if [[ "$node_id" != "$e2e_root/"*::* ]]; then
+    continue
+  fi
+
+  ((test_count += 1))
+  test_file="${node_id%%::*}"
+  owner_count=0
+  owner=""
+  ownership=""
+  for index in "${!root_names[@]}"; do
+    root="${root_names[$index]}"
+    if [[ "$test_file" == "$root" || "$test_file" == "$root/"* ]]; then
+      ((owner_count += 1))
+      owner="${root_shards[$index]}"
+      ownership+="${ownership:+, }$owner:$root"
+    fi
+  done
+
+  if (( owner_count != 1 )); then
+    invalid_files[$test_file]="${ownership:-none}"
+  else
+    counts[$owner]=$(( ${counts[$owner]:-0} + 1 ))
+  fi
+done <"$collection_file"
+
+if (( test_count == 0 )); then
+  echo "pytest collection returned no deterministic DuckDB E2E tests" >&2
+  exit 1
+fi
+
+if (( ${#invalid_files[@]} > 0 )); then
+  echo "DuckDB E2E shard coverage failed:" >&2
+  for test_file in "${!invalid_files[@]}"; do
+    echo "  - $test_file owners: ${invalid_files[$test_file]}" >&2
+  done
+  exit 1
+fi
+
+echo "DuckDB E2E shard coverage passed ($test_count tests):"
+for shard in "${shard_names[@]}"; do
+  echo "  $shard: ${counts[$shard]:-0}"
+done


### PR DESCRIPTION
## Why

The deterministic DuckDB E2E suite ran as one ~6-minute job of 630 tests; any single failure forced a full-job rerun, slowing feedback (CHI-226).

## Changes

- Seven ownership-based shard Make targets (build-core 101, build-incremental 81, build-virtual 76, cli-data 117, cli 113, virtual 121, integrations 21) sharing marker/xdist/logging conventions; `test-e2e-duckdb` remains the union derived from the same path variables so shard/union cannot drift.
- `scripts/check_e2e_shards.sh` + `make check-e2e-shards` (wired into check-ci): every deterministic E2E test must be owned by exactly one shard; rejects missing/duplicate/out-of-tree paths.
- verify.yml: single E2E job replaced by a seven-entry matrix (fail-fast: false); Verify gate requires the aggregate matrix result.

## Verification

- check-e2e-shards: 630/630 owned exactly once.
- integrations shard executed locally (21 passed); remaining shards collection-validated; YAML parse + fensu clean. CI matrix validates the rest.
