### PR TITLE
fix: show SQL test difference samples

### DIFF
--- a/src/sqlbuild/cli/output/_helpers/execution_result_document.py
+++ b/src/sqlbuild/cli/output/_helpers/execution_result_document.py
@@ -47,7 +47,11 @@ from sqlbuild.executor.scenario.models import (
     ScenarioSnapshotCaptureRunResult,
 )
 from sqlbuild.executor.scenario.types import ScenarioLocalRunStatus
-from sqlbuild.executor.testing.models import SqlTestExecutionResult, StepResult
+from sqlbuild.executor.testing.models import (
+    SqlTestDifferenceSample,
+    SqlTestExecutionResult,
+    StepResult,
+)
 from sqlbuild.executor.testing.types import SqlTestOutcome
 from sqlbuild.runtime.observability.models import LifecycleEvent
 from sqlbuild.sql_values.models import SqlValue
@@ -933,11 +937,24 @@ def _format_sql_test_step(step: StepResult) -> dict[str, object]:
             "actual_row_count": step.actual_row_count,
             "expected_row_count": step.expected_row_count,
             "mismatched_row_count": step.mismatched_row_count,
+            "unexpected_row_count": step.unexpected_row_count,
+            "missing_row_count": step.missing_row_count,
+            "unexpected_samples": _format_sql_test_difference_samples(step.unexpected_samples),
+            "missing_samples": _format_sql_test_difference_samples(step.missing_samples),
             "error_code": step.error_code,
             "error_help": step.error_help,
             "error_message": step.error_message,
         }
     )
+
+
+def _format_sql_test_difference_samples(
+    samples: tuple[SqlTestDifferenceSample, ...],
+) -> list[list[dict[str, str]]] | None:
+    formatted_samples: list[list[dict[str, str]]] = []
+    for sample in samples:
+        formatted_samples.append([{"name": name, "value": value} for name, value in sample.values])
+    return formatted_samples or None
 
 
 def _sql_test_asset_name(result: SqlTestExecutionResult) -> str | None:

--- a/src/sqlbuild/cli/progress/main/_expectation_detail.py
+++ b/src/sqlbuild/cli/progress/main/_expectation_detail.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlbuild.executor.testing.models import StepResult
+from sqlbuild.executor.testing.models import SqlTestDifferenceSample, StepResult
 from sqlbuild.executor.testing.types import SqlTestOutcome
 
 
@@ -16,4 +16,32 @@ def format_expectation_detail(step_result: StepResult) -> str:
     if step_result.model_name.startswith("assertion "):
         row_label: str = "row" if step_result.actual_row_count == 1 else "rows"
         return f"  {step_result.actual_row_count} {row_label}"
-    return f"  {step_result.mismatched_row_count} mismatched"
+    if (
+        step_result.unexpected_row_count is None
+        and step_result.missing_row_count is None
+        and not step_result.unexpected_samples
+        and not step_result.missing_samples
+    ):
+        return f"  {step_result.mismatched_row_count} mismatched"
+    parts: list[str] = [
+        f"unexpected={step_result.unexpected_row_count}",
+        f"missing={step_result.missing_row_count}",
+    ]
+    if step_result.actual_row_count != step_result.expected_row_count:
+        parts.append(
+            f"row counts actual={step_result.actual_row_count} "
+            f"expected={step_result.expected_row_count}"
+        )
+    parts.extend(_format_samples(label="unexpected sample", samples=step_result.unexpected_samples))
+    parts.extend(_format_samples(label="missing sample", samples=step_result.missing_samples))
+    return f"  {'; '.join(parts)}"
+
+
+def _format_samples(*, label: str, samples: tuple[SqlTestDifferenceSample, ...]) -> tuple[str, ...]:
+    """Format already-safe representative rows for terminal output."""
+
+    lines: list[str] = []
+    for index, sample in enumerate(samples, start=1):
+        rendered_values: str = ", ".join(f"{name}={value}" for name, value in sample.values)
+        lines.append(f"{label} {index}: {rendered_values}")
+    return tuple(lines)

--- a/src/sqlbuild/executor/testing/_helpers/difference_samples.py
+++ b/src/sqlbuild/executor/testing/_helpers/difference_samples.py
@@ -1,0 +1,188 @@
+"""Bounded expected-output difference sampling."""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from dataclasses import replace
+from typing import Any, Final
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.adapter.contract.types import TypeDialect
+from sqlbuild.compiler.planner.models import ChainStep, SqlTestPlanEntry
+from sqlbuild.diagnostics.classes.diagnostic_record_redactor import DiagnosticRecordRedactor
+from sqlbuild.diagnostics.main.log_debug_event import log_debug_event
+from sqlbuild.executor.testing._helpers.comparison_sql import format_sql, lift_step_ctes
+from sqlbuild.executor.testing.models import SqlTestDifferenceSample, StepResult
+from sqlbuild.executor.testing.types import SqlTestDifferenceDirection, SqlTestOutcome
+
+_ROW_LIMIT: Final[int] = 3
+_COLUMN_LIMIT: Final[int] = 12
+_VALUE_LIMIT: Final[int] = 120
+_LOGGER: logging.Logger = logging.getLogger("sqlbuild.execution")
+
+
+def add_difference_samples(
+    *,
+    step_results: list[StepResult],
+    test_entry: SqlTestPlanEntry,
+    adapter: BaseAdapter,
+    connection: Any,
+) -> list[StepResult]:
+    """Attach bounded, redacted samples to failed expected-output steps."""
+
+    sampled_results: list[StepResult] = []
+    expected_steps: tuple[ChainStep, ...] = tuple(
+        step for step in test_entry.chain if step.expected_cte_sql is not None
+    )
+    for step_index, step_result in enumerate(step_results):
+        if step_index >= len(expected_steps) or step_result.outcome != SqlTestOutcome.FAIL:
+            sampled_results.append(step_result)
+            continue
+        step: ChainStep = expected_steps[step_index]
+        unexpected_samples: tuple[SqlTestDifferenceSample, ...] = ()
+        missing_samples: tuple[SqlTestDifferenceSample, ...] = ()
+        if step_result.unexpected_row_count is not None and step_result.unexpected_row_count > 0:
+            unexpected_samples = _best_effort_difference_samples(
+                test_entry=test_entry,
+                step=step,
+                direction=SqlTestDifferenceDirection.UNEXPECTED,
+                adapter=adapter,
+                connection=connection,
+            )
+        if step_result.missing_row_count is not None and step_result.missing_row_count > 0:
+            missing_samples = _best_effort_difference_samples(
+                test_entry=test_entry,
+                step=step,
+                direction=SqlTestDifferenceDirection.MISSING,
+                adapter=adapter,
+                connection=connection,
+            )
+        sampled_results.append(
+            replace(
+                step_result,
+                unexpected_samples=unexpected_samples,
+                missing_samples=missing_samples,
+            )
+        )
+    return sampled_results
+
+
+def build_sql_test_difference_sample_sql(
+    *,
+    test_entry: SqlTestPlanEntry,
+    step: ChainStep,
+    direction: SqlTestDifferenceDirection,
+    sample_limit: int,
+    set_difference_operator: str = "EXCEPT",
+    sql_analysis_dialect: str | None = None,
+) -> str:
+    """Build a bounded query for one direction of an expected-output difference."""
+
+    if step.expected_cte_sql is None:
+        return ""
+    lifted_ctes: OrderedDict[str, str] = OrderedDict()
+    actual_sql, lifted_ctes = lift_step_ctes(
+        sql=step.resolved_sql,
+        lifted_ctes=lifted_ctes,
+        sql_analysis_enabled=test_entry.sql_analysis_enabled,
+    )
+    expected_sql, lifted_ctes = lift_step_ctes(
+        sql=step.expected_cte_sql,
+        lifted_ctes=lifted_ctes,
+        sql_analysis_enabled=test_entry.sql_analysis_enabled,
+    )
+    cte_parts: list[str] = [f"{name} AS ({sql})" for name, sql in lifted_ctes.items()]
+    cte_parts.extend((f"__actual AS ({actual_sql})", f"__expected AS ({expected_sql})"))
+    is_unexpected: bool = direction == SqlTestDifferenceDirection.UNEXPECTED
+    left: str = "__actual" if is_unexpected else "__expected"
+    right: str = "__expected" if is_unexpected else "__actual"
+    bounded_select: str = (
+        f"SELECT TOP {sample_limit} *" if sql_analysis_dialect == TypeDialect.TSQL else "SELECT *"
+    )
+    limit_clause: str = "" if sql_analysis_dialect == TypeDialect.TSQL else f" LIMIT {sample_limit}"
+    sql: str = (
+        f"WITH {', '.join(cte_parts)} {bounded_select} FROM ("
+        f"SELECT * FROM {left} {set_difference_operator} SELECT * FROM {right}"
+        f") AS __sqlbuild_difference{limit_clause}"
+    )
+    return format_sql(
+        sql=sql,
+        sql_analysis_dialect=sql_analysis_dialect,
+        sql_analysis_enabled=test_entry.sql_analysis_enabled,
+    )
+
+
+def _fetch_difference_samples(
+    *,
+    test_entry: SqlTestPlanEntry,
+    step: ChainStep,
+    direction: SqlTestDifferenceDirection,
+    adapter: BaseAdapter,
+    connection: Any,
+) -> tuple[SqlTestDifferenceSample, ...]:
+    sql: str = build_sql_test_difference_sample_sql(
+        test_entry=test_entry,
+        step=step,
+        direction=direction,
+        sample_limit=_ROW_LIMIT,
+        set_difference_operator=adapter.render_set_difference_operator(),
+        sql_analysis_dialect=adapter.sql_analysis_dialect(),
+    )
+    cursor: Any = adapter.execute(connection=connection, sql=sql)
+    description: Any | None = getattr(cursor, "description", None)
+    if description is None:
+        return ()
+    column_names: tuple[str, ...] = tuple(str(column[0]) for column in description)
+    if not column_names:
+        return ()
+    rows: list[Any] = cursor.fetchall()
+    samples: list[SqlTestDifferenceSample] = []
+    for row in rows[:_ROW_LIMIT]:
+        values: list[tuple[str, str]] = [
+            (column_name, _safe_sample_value(name=column_name, value=value))
+            for column_name, value in list(zip(column_names, row, strict=False))[:_COLUMN_LIMIT]
+        ]
+        omitted_columns: int = max(0, len(column_names) - _COLUMN_LIMIT)
+        if omitted_columns:
+            values.append(("...", f"{omitted_columns} columns omitted"))
+        samples.append(SqlTestDifferenceSample(values=tuple(values)))
+    return tuple(samples)
+
+
+def _best_effort_difference_samples(
+    *,
+    test_entry: SqlTestPlanEntry,
+    step: ChainStep,
+    direction: SqlTestDifferenceDirection,
+    adapter: BaseAdapter,
+    connection: Any,
+) -> tuple[SqlTestDifferenceSample, ...]:
+    """Return samples when available without replacing a known comparison failure."""
+
+    try:
+        return _fetch_difference_samples(
+            test_entry=test_entry,
+            step=step,
+            direction=direction,
+            adapter=adapter,
+            connection=connection,
+        )
+    except Exception as error:
+        log_debug_event(
+            logger=_LOGGER,
+            message="SQL test difference sampling failed; preserving comparison result",
+            test_name=test_entry.name,
+            model_name=step.model_name,
+            direction=direction.value,
+            sqlbuild_error=DiagnosticRecordRedactor.text(str(error)),
+        )
+        return ()
+
+
+def _safe_sample_value(*, name: str, value: object) -> str:
+    safe_value: object = DiagnosticRecordRedactor.value(name=name, value=value)
+    rendered: str = "NULL" if safe_value is None else " ".join(str(safe_value).split())
+    if len(rendered) <= _VALUE_LIMIT:
+        return rendered
+    return f"{rendered[: _VALUE_LIMIT - 3]}..."

--- a/src/sqlbuild/executor/testing/main/_execute.py
+++ b/src/sqlbuild/executor/testing/main/_execute.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.planner.models import SqlTestPlanEntry
+from sqlbuild.executor.testing._helpers.difference_samples import add_difference_samples
 from sqlbuild.executor.testing.constants import (
     SQL_TEST_ASSERTION_FAILED_CODE,
     SQL_TEST_EXECUTION_ERROR_CODE,
@@ -28,7 +29,7 @@ def execute_sql_test(
     connection: Any,
     quality_scope: str = "standalone",
 ) -> SqlTestExecutionResult:
-    """Execute one SQL unit test as a single comparison query."""
+    """Execute one SQL unit test and collect bounded diagnostics for failed comparisons."""
 
     comparison_sql: str = build_sql_test_comparison_sql(
         test_entry=test_entry,
@@ -83,6 +84,13 @@ def execute_sql_test(
         try:
             cursor: Any = adapter.execute(connection=connection, sql=comparison_sql)
             rows: list[Any] = cursor.fetchall()
+            step_results: list[StepResult] = _build_step_results(rows)
+            step_results = add_difference_samples(
+                step_results=step_results,
+                test_entry=test_entry,
+                adapter=adapter,
+                connection=connection,
+            )
         except Exception as error:
             lifecycle.failed(error=error, error_code=SQL_TEST_EXECUTION_ERROR_CODE)
             error_message = (
@@ -112,7 +120,6 @@ def execute_sql_test(
                 error_message=error_message,
             )
 
-        step_results: list[StepResult] = _build_step_results(rows)
         overall_outcome: SqlTestOutcome = SqlTestOutcome.PASS
         step_result: StepResult
         for step_result in step_results:
@@ -155,9 +162,10 @@ def _build_step_results(rows: list[Any]) -> list[StepResult]:
         model_name: str = str(row[1])
         actual_count: int = int(row[2])
         expected_count: int = int(row[3])
-        mismatched_count: int = int(row[4])
+        unexpected_count: int = int(row[4])
+        missing_count: int = int(row[5])
         outcome: SqlTestOutcome
-        if mismatched_count == 0 and actual_count == expected_count:
+        if unexpected_count == 0 and missing_count == 0 and actual_count == expected_count:
             outcome = SqlTestOutcome.PASS
         else:
             outcome = SqlTestOutcome.FAIL
@@ -167,7 +175,9 @@ def _build_step_results(rows: list[Any]) -> list[StepResult]:
                 outcome=outcome,
                 actual_row_count=actual_count,
                 expected_row_count=expected_count,
-                mismatched_row_count=mismatched_count,
+                mismatched_row_count=unexpected_count,
+                unexpected_row_count=unexpected_count,
+                missing_row_count=missing_count,
             )
         )
     return step_results

--- a/src/sqlbuild/executor/testing/main/comparison_sql.py
+++ b/src/sqlbuild/executor/testing/main/comparison_sql.py
@@ -61,7 +61,10 @@ def build_sql_test_comparison_sql(
             f"(SELECT COUNT(*) FROM {expected_cte}) AS expected_count, "
             f"(SELECT COUNT(*) FROM ("
             f"SELECT * FROM {actual_cte} {set_difference_operator} SELECT * FROM {expected_cte}"
-            f") AS __sqlbuild_mismatch) AS mismatched_count"
+            f") AS __sqlbuild_mismatch) AS unexpected_count, "
+            f"(SELECT COUNT(*) FROM ("
+            f"SELECT * FROM {expected_cte} {set_difference_operator} SELECT * FROM {actual_cte}"
+            f") AS __sqlbuild_missing) AS missing_count"
         )
     assertion_index: int
     for assertion_index, assertion in enumerate(test_entry.assertions, start=len(test_entry.chain)):
@@ -84,7 +87,8 @@ def build_sql_test_comparison_sql(
             f"'assertion {_escape_sql_string(assertion.name)}' AS model_name, "
             f"(SELECT COUNT(*) FROM {assertion_cte}) AS actual_count, "
             "0 AS expected_count, "
-            f"(SELECT COUNT(*) FROM {assertion_cte}) AS mismatched_count"
+            f"(SELECT COUNT(*) FROM {assertion_cte}) AS unexpected_count, "
+            "0 AS missing_count"
         )
     cte_parts: list[str] = [f"{name} AS ({sql})" for name, sql in lifted_ctes.items()]
     cte_parts.extend(comparison_ctes)

--- a/src/sqlbuild/executor/testing/models.py
+++ b/src/sqlbuild/executor/testing/models.py
@@ -11,6 +11,13 @@ from sqlbuild.sql_values.models import SqlValue
 
 
 @dataclass(frozen=True)
+class SqlTestDifferenceSample:
+    """One redacted, size-bounded row from an expected-output difference."""
+
+    values: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
 class StepResult:
     """Outcome of one chain step in a SQL unit test."""
 
@@ -19,6 +26,10 @@ class StepResult:
     actual_row_count: int = 0
     expected_row_count: int = 0
     mismatched_row_count: int = 0
+    unexpected_row_count: int | None = None
+    missing_row_count: int | None = None
+    unexpected_samples: tuple[SqlTestDifferenceSample, ...] = field(default_factory=tuple)
+    missing_samples: tuple[SqlTestDifferenceSample, ...] = field(default_factory=tuple)
     error_code: str | None = None
     error_help: str | None = None
     error_message: str | None = None

--- a/src/sqlbuild/executor/testing/types.py
+++ b/src/sqlbuild/executor/testing/types.py
@@ -9,3 +9,10 @@ class SqlTestOutcome(StrEnum):
     PASS = "pass"
     FAIL = "fail"
     ERROR = "error"
+
+
+class SqlTestDifferenceDirection(StrEnum):
+    """Direction of one expected-output set difference."""
+
+    UNEXPECTED = "unexpected"
+    MISSING = "missing"

--- a/tests/integration/src/sqlbuild/executor/testing/_test_types.py
+++ b/tests/integration/src/sqlbuild/executor/testing/_test_types.py
@@ -8,7 +8,7 @@ class SqlTestExecutionTestCase:
     """Test case for SQL unit test execution."""
 
     description: str
-    chain_steps: tuple[tuple[str, str, str], ...]
+    chain_steps: tuple[tuple[str, str, str | None], ...]
     expected_outcome: SqlTestOutcome
     expected_step_count: int
     expected_failed_models: tuple[str, ...] = field(default_factory=tuple)
@@ -20,6 +20,31 @@ class SqlTestComparisonSqlTestCase:
     """Test case for generated SQL unit-test comparison SQL."""
 
     description: str
-    chain_steps: tuple[tuple[str, str, str], ...]
+    chain_steps: tuple[tuple[str, str, str | None], ...]
     expected_fragments: tuple[str, ...]
     unexpected_fragments: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class SqlTestDifferenceSqlTestCase:
+    """Test case for one dialect's bounded difference SQL."""
+
+    description: str
+    dialect: str
+    expected_fragment: str
+    unexpected_fragment: str
+
+
+@dataclass(frozen=True)
+class SqlTestDiagnosticsTestCase:
+    """Test case for expected-output difference diagnostics."""
+
+    description: str
+    chain_steps: tuple[tuple[str, str, str | None], ...]
+    expected_actual_count: int
+    expected_expected_count: int
+    expected_unexpected_count: int
+    expected_missing_count: int
+    expected_sample_count: int
+    expect_redaction: bool = False
+    expect_truncation: bool = False

--- a/tests/integration/src/sqlbuild/executor/testing/helpers.py
+++ b/tests/integration/src/sqlbuild/executor/testing/helpers.py
@@ -19,7 +19,7 @@ from tests.integration.src.sqlbuild.executor.testing._test_types import (
 def build_sql_test_plan_entry(
     *,
     name: str,
-    chain_steps: tuple[tuple[str, str, str], ...],
+    chain_steps: tuple[tuple[str, str, str | None], ...],
 ) -> SqlTestPlanEntry:
     """Build a SqlTestPlanEntry from (model_name, resolved_sql, expected_cte_sql) tuples."""
 

--- a/tests/integration/src/sqlbuild/executor/testing/test_sql_test_execution.py
+++ b/tests/integration/src/sqlbuild/executor/testing/test_sql_test_execution.py
@@ -7,11 +7,19 @@ from typing import Any
 import pytest
 
 from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.adapters.sqlserver.classes.sqlserver_adapter import SqlServerAdapter
+from sqlbuild.compiler.planner.models import SqlTestPlanEntry
+from sqlbuild.executor.testing._helpers.difference_samples import (
+    build_sql_test_difference_sample_sql,
+)
+from sqlbuild.executor.testing.main._execute import execute_sql_test
 from sqlbuild.executor.testing.main.comparison_sql import build_sql_test_comparison_sql
-from sqlbuild.executor.testing.models import SqlTestExecutionResult
-from sqlbuild.executor.testing.types import SqlTestOutcome
+from sqlbuild.executor.testing.models import SqlTestExecutionResult, StepResult
+from sqlbuild.executor.testing.types import SqlTestDifferenceDirection, SqlTestOutcome
 from tests.integration.src.sqlbuild.executor.testing._test_types import (
     SqlTestComparisonSqlTestCase,
+    SqlTestDiagnosticsTestCase,
+    SqlTestDifferenceSqlTestCase,
     SqlTestExecutionTestCase,
 )
 from tests.integration.src.sqlbuild.executor.testing.helpers import (
@@ -24,6 +32,20 @@ from tests.integration.src.sqlbuild.executor.testing.helpers import (
 class TinySqlLimitDuckDbAdapter(DuckDbAdapter):
     def recommended_max_sql_length(self) -> int | None:
         return 80
+
+
+class FailingDifferenceSampleDuckDbAdapter(DuckDbAdapter):
+    def execute(self, *, connection: Any, sql: str) -> Any:
+        if "__sqlbuild_difference" in sql:
+            raise RuntimeError("controlled difference sampling failure")
+        return super().execute(connection=connection, sql=sql)
+
+
+class DescriptionlessDifferenceSampleDuckDbAdapter(DuckDbAdapter):
+    def execute(self, *, connection: Any, sql: str) -> Any:
+        if "__sqlbuild_difference" in sql:
+            return object()
+        return super().execute(connection=connection, sql=sql)
 
 
 @pytest.mark.parametrize(
@@ -94,6 +116,40 @@ def test_given_sql_test_chain_when_building_comparison_sql_then_uses_readable_ct
     unexpected_fragment: str
     for unexpected_fragment in test_case.unexpected_fragments:
         assert unexpected_fragment not in comparison_sql
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SqlTestDifferenceSqlTestCase(
+            description="sqlserver uses TOP for bounded samples",
+            dialect="tsql",
+            expected_fragment="SELECT TOP 3",
+            unexpected_fragment="LIMIT 3",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_sqlserver_dialect_when_building_sample_sql_then_uses_bounded_top_query(
+    test_case: SqlTestDifferenceSqlTestCase,
+) -> None:
+    entry: SqlTestPlanEntry = build_sql_test_plan_entry(
+        name="test_model",
+        chain_steps=(("orders", "SELECT 2 AS id", "SELECT 1 AS id"),),
+    )
+
+    dialect: str | None = SqlServerAdapter().sql_analysis_dialect()
+    assert dialect == test_case.dialect
+    sample_sql: str = build_sql_test_difference_sample_sql(
+        test_entry=entry,
+        step=entry.chain[0],
+        direction=SqlTestDifferenceDirection.UNEXPECTED,
+        sample_limit=3,
+        sql_analysis_dialect=dialect,
+    )
+
+    assert test_case.expected_fragment in sample_sql
+    assert test_case.unexpected_fragment not in sample_sql
 
 
 @pytest.mark.parametrize(
@@ -244,6 +300,193 @@ def test_given_mismatching_sql_when_executing_test_then_fails(
 
     assert result.outcome == test_case.expected_outcome
     verify_test_result(result=result, test_case=test_case)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SqlTestDiagnosticsTestCase(
+            description="two-way differences are bounded redacted and truncated",
+            chain_steps=(
+                ("intermediate_orders", "SELECT 1 AS id", None),
+                (
+                    "orders",
+                    " UNION ALL ".join(
+                        f"SELECT {index} AS id, '{'x' * 160}{index}' AS detail, "
+                        f"'actual-token-{index}' AS access_token"
+                        for index in range(1, 5)
+                    ),
+                    " UNION ALL ".join(
+                        f"SELECT {index} AS id, 'expected-{index}' AS detail, "
+                        f"'expected-token-{index}' AS access_token"
+                        for index in range(1, 5)
+                    ),
+                ),
+            ),
+            expected_actual_count=4,
+            expected_expected_count=4,
+            expected_unexpected_count=4,
+            expected_missing_count=4,
+            expected_sample_count=3,
+            expect_redaction=True,
+            expect_truncation=True,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_two_way_mismatch_when_executing_test_then_samples_are_bounded_and_redacted(
+    test_case: SqlTestDiagnosticsTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+) -> None:
+    entry: SqlTestPlanEntry = build_sql_test_plan_entry(
+        name="bounded_diagnostics",
+        chain_steps=test_case.chain_steps,
+    )
+
+    result: SqlTestExecutionResult = execute_sql_test(
+        test_entry=entry,
+        adapter=adapter,
+        connection=connection,
+    )
+
+    assert result.outcome == SqlTestOutcome.FAIL
+    assert len(result.step_results) == 1
+    assert result.step_results[0].model_name == "orders"
+    step: StepResult = result.step_results[0]
+    assert step.actual_row_count == test_case.expected_actual_count
+    assert step.expected_row_count == test_case.expected_expected_count
+    assert step.unexpected_row_count == test_case.expected_unexpected_count
+    assert step.missing_row_count == test_case.expected_missing_count
+    assert len(step.unexpected_samples) == test_case.expected_sample_count
+    assert len(step.missing_samples) == test_case.expected_sample_count
+    unexpected_values: dict[str, str] = dict(step.unexpected_samples[0].values)
+    missing_values: dict[str, str] = dict(step.missing_samples[0].values)
+    assert (unexpected_values["access_token"] == "[REDACTED]") == test_case.expect_redaction
+    assert (missing_values["access_token"] == "[REDACTED]") == test_case.expect_redaction
+    assert unexpected_values["detail"].endswith("...") == test_case.expect_truncation
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SqlTestDiagnosticsTestCase(
+            description="duplicates differ only by total row count",
+            chain_steps=(("orders", "SELECT 1 AS id UNION ALL SELECT 1 AS id", "SELECT 1 AS id"),),
+            expected_actual_count=2,
+            expected_expected_count=1,
+            expected_unexpected_count=0,
+            expected_missing_count=0,
+            expected_sample_count=0,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_only_duplicate_count_differs_when_executing_then_row_counts_explain_failure(
+    test_case: SqlTestDiagnosticsTestCase,
+    adapter: DuckDbAdapter,
+    connection: Any,
+) -> None:
+    entry: SqlTestPlanEntry = build_sql_test_plan_entry(
+        name="duplicate_diagnostics",
+        chain_steps=test_case.chain_steps,
+    )
+
+    result: SqlTestExecutionResult = execute_sql_test(
+        test_entry=entry,
+        adapter=adapter,
+        connection=connection,
+    )
+
+    step: StepResult = result.step_results[0]
+    assert result.outcome == SqlTestOutcome.FAIL
+    assert step.actual_row_count == test_case.expected_actual_count
+    assert step.expected_row_count == test_case.expected_expected_count
+    assert step.unexpected_row_count == test_case.expected_unexpected_count
+    assert step.missing_row_count == test_case.expected_missing_count
+    assert len(step.unexpected_samples) == test_case.expected_sample_count
+    assert len(step.missing_samples) == test_case.expected_sample_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SqlTestDiagnosticsTestCase(
+            description="sampling failure preserves known comparison failure",
+            chain_steps=(("orders", "SELECT 2 AS id", "SELECT 1 AS id"),),
+            expected_actual_count=1,
+            expected_expected_count=1,
+            expected_unexpected_count=1,
+            expected_missing_count=1,
+            expected_sample_count=0,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_sample_query_failure_when_executing_then_comparison_failure_is_preserved(
+    test_case: SqlTestDiagnosticsTestCase,
+    connection: Any,
+) -> None:
+    entry: SqlTestPlanEntry = build_sql_test_plan_entry(
+        name="sampling_failure",
+        chain_steps=test_case.chain_steps,
+    )
+
+    result: SqlTestExecutionResult = execute_sql_test(
+        test_entry=entry,
+        adapter=FailingDifferenceSampleDuckDbAdapter(),
+        connection=connection,
+    )
+
+    step: StepResult = result.step_results[0]
+    assert result.outcome == SqlTestOutcome.FAIL
+    assert step.outcome == SqlTestOutcome.FAIL
+    assert step.actual_row_count == test_case.expected_actual_count
+    assert step.expected_row_count == test_case.expected_expected_count
+    assert step.unexpected_row_count == test_case.expected_unexpected_count
+    assert step.missing_row_count == test_case.expected_missing_count
+    assert len(step.unexpected_samples) == test_case.expected_sample_count
+    assert len(step.missing_samples) == test_case.expected_sample_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SqlTestDiagnosticsTestCase(
+            description="descriptionless sample cursor produces no empty records",
+            chain_steps=(("orders", "SELECT 2 AS id", "SELECT 1 AS id"),),
+            expected_actual_count=1,
+            expected_expected_count=1,
+            expected_unexpected_count=1,
+            expected_missing_count=1,
+            expected_sample_count=0,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_descriptionless_sample_cursor_when_executing_then_empty_records_are_omitted(
+    test_case: SqlTestDiagnosticsTestCase,
+    connection: Any,
+) -> None:
+    entry: SqlTestPlanEntry = build_sql_test_plan_entry(
+        name="descriptionless_sampling",
+        chain_steps=test_case.chain_steps,
+    )
+
+    result: SqlTestExecutionResult = execute_sql_test(
+        test_entry=entry,
+        adapter=DescriptionlessDifferenceSampleDuckDbAdapter(),
+        connection=connection,
+    )
+
+    step: StepResult = result.step_results[0]
+    assert result.outcome == SqlTestOutcome.FAIL
+    assert step.actual_row_count == test_case.expected_actual_count
+    assert step.expected_row_count == test_case.expected_expected_count
+    assert step.unexpected_row_count == test_case.expected_unexpected_count
+    assert step.missing_row_count == test_case.expected_missing_count
+    assert len(step.unexpected_samples) == test_case.expected_sample_count
+    assert len(step.missing_samples) == test_case.expected_sample_count
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
@@ -30,6 +30,15 @@ class SqlTestCaseExecutionProtocolTestCase:
 
 
 @dataclass(frozen=True)
+class SqlTestDifferenceOutputTestCase:
+    """Expected structured fields for SQL test difference output."""
+
+    description: str
+    expected_unexpected_count: int
+    expected_missing_count: int
+
+
+@dataclass(frozen=True)
 class AuditExecutionProtocolTestCase:
     description: str
     expected_check_id: str

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_result_document.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_result_document.py
@@ -13,6 +13,7 @@ from sqlbuild.cli.output._helpers.execution_result_document import (
     _format_audit_checks,
     _format_model_assets,
     _format_sql_test_checks,
+    _format_sql_test_step,
     format_audit_execution_json,
 )
 from sqlbuild.compiler.auditing.types import (
@@ -33,7 +34,11 @@ from sqlbuild.executor.run.models import (
     ModelExecutionResult,
 )
 from sqlbuild.executor.scheduling.types import ExecutionStatus
-from sqlbuild.executor.testing.models import SqlTestExecutionResult
+from sqlbuild.executor.testing.models import (
+    SqlTestDifferenceSample,
+    SqlTestExecutionResult,
+    StepResult,
+)
 from sqlbuild.executor.testing.types import SqlTestOutcome
 from sqlbuild.spec.contracts.types import FutureCursorAction
 from sqlbuild.sql_values.models import SqlLogicalType, SqlValue
@@ -43,7 +48,45 @@ from tests.unit.src.sqlbuild.cli.output._helpers._test_types import (
     FutureCursorExecutionProtocolTestCase,
     MicrobatchExecutionProtocolTestCase,
     SqlTestCaseExecutionProtocolTestCase,
+    SqlTestDifferenceOutputTestCase,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SqlTestDifferenceOutputTestCase(
+            description="two-way samples remain structured",
+            expected_unexpected_count=1,
+            expected_missing_count=1,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_difference_samples_when_formatting_json_then_structured_diagnostics_are_preserved(
+    test_case: SqlTestDifferenceOutputTestCase,
+) -> None:
+    step: StepResult = StepResult(
+        model_name="orders",
+        outcome=SqlTestOutcome.FAIL,
+        unexpected_row_count=test_case.expected_unexpected_count,
+        missing_row_count=test_case.expected_missing_count,
+        unexpected_samples=(
+            SqlTestDifferenceSample(values=(("id", "2"), ("status", "unexpected"))),
+        ),
+        missing_samples=(SqlTestDifferenceSample(values=(("id", "1"), ("status", "expected"))),),
+    )
+
+    payload: dict[str, object] = _format_sql_test_step(step)
+
+    assert payload["unexpected_row_count"] == test_case.expected_unexpected_count
+    assert payload["missing_row_count"] == test_case.expected_missing_count
+    assert payload["unexpected_samples"] == [
+        [{"name": "id", "value": "2"}, {"name": "status", "value": "unexpected"}]
+    ]
+    assert payload["missing_samples"] == [
+        [{"name": "id", "value": "1"}, {"name": "status", "value": "expected"}]
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/progress/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/progress/main/_test_types.py
@@ -1,0 +1,14 @@
+"""Test case types for expectation detail formatting."""
+
+from dataclasses import dataclass
+
+from sqlbuild.executor.testing.models import StepResult
+
+
+@dataclass(frozen=True)
+class ExpectationDetailTestCase:
+    """One expected-output detail formatting case."""
+
+    description: str
+    step_result: StepResult
+    expected_fragments: tuple[str, ...]

--- a/tests/unit/src/sqlbuild/cli/progress/main/test_expectation_detail.py
+++ b/tests/unit/src/sqlbuild/cli/progress/main/test_expectation_detail.py
@@ -1,0 +1,64 @@
+"""Tests for SQL expected-output diagnostic formatting."""
+
+import pytest
+
+from sqlbuild.cli.progress.main._expectation_detail import format_expectation_detail
+from sqlbuild.executor.testing.models import SqlTestDifferenceSample, StepResult
+from sqlbuild.executor.testing.types import SqlTestOutcome
+from tests.unit.src.sqlbuild.cli.progress.main._test_types import ExpectationDetailTestCase
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        ExpectationDetailTestCase(
+            description="two-way samples show directional rows",
+            step_result=StepResult(
+                model_name="orders",
+                outcome=SqlTestOutcome.FAIL,
+                actual_row_count=2,
+                expected_row_count=1,
+                mismatched_row_count=1,
+                unexpected_row_count=1,
+                missing_row_count=1,
+                unexpected_samples=(
+                    SqlTestDifferenceSample(values=(("id", "2"), ("status", "unexpected"))),
+                ),
+                missing_samples=(
+                    SqlTestDifferenceSample(values=(("id", "1"), ("status", "expected"))),
+                ),
+            ),
+            expected_fragments=(
+                "unexpected=1",
+                "missing=1",
+                "row counts actual=2 expected=1",
+                "unexpected sample 1: id=2, status=unexpected",
+                "missing sample 1: id=1, status=expected",
+            ),
+        ),
+        ExpectationDetailTestCase(
+            description="duplicate-only difference shows row counts",
+            step_result=StepResult(
+                model_name="orders",
+                outcome=SqlTestOutcome.FAIL,
+                actual_row_count=2,
+                expected_row_count=1,
+                unexpected_row_count=0,
+                missing_row_count=0,
+            ),
+            expected_fragments=(
+                "unexpected=0",
+                "missing=0",
+                "row counts actual=2 expected=1",
+            ),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_failure_when_formatting_expectation_then_diagnostics_are_shown(
+    test_case: ExpectationDetailTestCase,
+) -> None:
+    detail: str = format_expectation_detail(test_case.step_result)
+
+    for expected_fragment in test_case.expected_fragments:
+        assert expected_fragment in detail


### PR DESCRIPTION
## Why

Native SQL model tests reported only aggregate mismatch counts. Diagnosing a failure required opening generated SQL, querying the internal actual CTE manually, and comparing it with expected values. CHI-237 tracks broader test usability work; this PR delivers the highest-value first slice.

## Changes

- Count both unexpected (`actual EXCEPT expected`) and missing (`expected EXCEPT actual`) rows.
- Fetch up to three representative rows per failing direction, bounded to 12 columns and 120 characters per value.
- Pass samples through the existing diagnostic redaction boundary.
- Render directional counts and samples in terminal and structured output.
- Preserve explicit actual/expected counts for duplicate-cardinality failures.
- Treat sample collection as best-effort so diagnostics cannot turn a known test failure into an execution error.
- Generate `TOP` for T-SQL and `LIMIT` for other supported dialects.
- Skip sampling for intermediate multi-model steps without expected output and for cursors without column metadata.

## Verification

- `20 passed` across focused executor, progress, and structured-output tests.
- Focused Ruff formatting/lint and `ty` checks passed.
- `uv sync --all-extras && make check-ci` passed.
- Fensu reported 0 faults.
- Independent review and focused follow-up verification found no remaining blockers.
