### PR TITLE
fix: run chained SQL tests concurrently

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/dispatch.py
@@ -224,6 +224,7 @@ def dispatch_cli_command(*, args: CliNamespace, handlers: CliEntrypointHandlers)
                 cli_vars=args.vars,
                 json_output=args.json,
                 json_output_path=args.json_output,
+                concurrency=args.concurrency,
             )
         )
     if args.command == CliCommand.CHECK:

--- a/src/sqlbuild/cli/commands/_helpers/entry/parser.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parser.py
@@ -226,6 +226,7 @@ def _add_quality_parsers(
     test_parser.add_argument("--no-sql-validation", action="store_true", default=False)
     test_parser.add_argument("--json", action="store_true", default=False)
     test_parser.add_argument("--target", default=None)
+    test_parser.add_argument("--concurrency", type=int, default=None)
     _ = add_execution_json_output_arg(test_parser)
     _ = add_select_args(test_parser)
     _ = add_vars_args(test_parser)

--- a/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parsing.py
@@ -120,7 +120,13 @@ def parse_cli_invocation(
             and not any(option in args.dbt_args for option in DBT_VERBOSE_OPTIONS)
         ):
             args.dbt_args.append("--verbose")
-        if args.command in {CliCommand.AUDIT, CliCommand.BUILD, CliCommand.LOAD, CliCommand.SEED}:
+        if args.command in {
+            CliCommand.AUDIT,
+            CliCommand.BUILD,
+            CliCommand.LOAD,
+            CliCommand.SEED,
+            CliCommand.TEST,
+        }:
             try:
                 args.concurrency = resolve_env_default_concurrency(args.concurrency)
             except argparse.ArgumentTypeError as error:

--- a/src/sqlbuild/cli/commands/_helpers/test/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/test/execution.py
@@ -11,6 +11,7 @@ from sqlbuild.cli.commands._helpers.test.sql_progress import (
     test_outcome_status,
 )
 from sqlbuild.cli.commands.models import (
+    TestCommandRequest,
     TestExecutionPreparation,
     TestInvocation,
 )
@@ -28,6 +29,7 @@ from sqlbuild.cli.progress.classes.nested_command_progress_callbacks import (
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from sqlbuild.compiler.planner.models import SqlTestPlanEntry
 from sqlbuild.executor.pipeline.main.run import run_test_pipeline
+from sqlbuild.executor.pipeline.models import TestPipelineCallbacks
 from sqlbuild.executor.testing.main.resource_id import sql_test_resource_id
 from sqlbuild.executor.testing.models import SqlTestExecutionResult
 from sqlbuild.presentation.classes.cli_style import CliStyle
@@ -37,12 +39,18 @@ from sqlbuild.presentation.main.surface_header import format_surface_header
 
 def prepare_test_execution(
     *,
+    request: TestCommandRequest,
     invocation: TestInvocation,
     pipeline_result: CompilePipelineResult,
 ) -> TestExecutionPreparation:
     """Prepare nested progress reporting and write the test section header."""
 
     test_count: int = len(pipeline_result.plan_output.test_entries)
+    effective_concurrency: int = resolve_test_concurrency(
+        request=request,
+        pipeline_result=pipeline_result,
+    )
+    worker_count: int = min(effective_concurrency, test_count)
     model_names: set[str] = set()
     for entry in pipeline_result.plan_output.test_entries:
         for step in entry.chain:
@@ -80,6 +88,22 @@ def prepare_test_execution(
         progress=progress,
         execution_connection_progress=execution_connection_progress,
         preflight_progress=preflight_progress,
+        effective_concurrency=effective_concurrency,
+        worker_count=worker_count,
+    )
+
+
+def resolve_test_concurrency(
+    *,
+    request: TestCommandRequest,
+    pipeline_result: CompilePipelineResult,
+) -> int:
+    """Resolve CLI override before the project-wide concurrency setting."""
+
+    return (
+        request.concurrency
+        if request.concurrency is not None
+        else pipeline_result.project.settings.concurrency
     )
 
 
@@ -102,29 +126,32 @@ def execute_test_plan(
             plan=pipeline_result.plan_output,
             connection_config=invocation.connection_config,
             adapter=invocation.adapter,
-            on_connection_start=preparation.execution_connection_progress.on_connection_start,
-            on_connection_complete=lambda connection_count, elapsed_seconds: (
-                preparation.execution_connection_progress.on_connection_complete(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
-            on_connection_error=lambda connection_count, elapsed_seconds: (
-                preparation.execution_connection_progress.on_connection_error(
-                    connection_count=connection_count, elapsed_seconds=elapsed_seconds
-                )
-            ),
-            on_progress=preparation.preflight_progress.report_preflight_progress,
-            on_test_start=lambda entry: preparation.progress.on_item_start(
-                group_name=_test_group_name_from_entry(entry),
-                item_name=format_parameterized_test_label(
-                    name=entry.name,
-                    source_path=entry.source_path,
-                    parameter_schema=entry.parameter_schema,
-                    parameter_values=entry.parameter_values,
+            max_concurrency=preparation.effective_concurrency,
+            callbacks=TestPipelineCallbacks(
+                on_connection_start=(preparation.execution_connection_progress.on_connection_start),
+                on_connection_complete=lambda connection_count, elapsed_seconds: (
+                    preparation.execution_connection_progress.on_connection_complete(
+                        connection_count=connection_count, elapsed_seconds=elapsed_seconds
+                    )
                 ),
-                canonical_resource_name=entry.name,
+                on_connection_error=lambda connection_count, elapsed_seconds: (
+                    preparation.execution_connection_progress.on_connection_error(
+                        connection_count=connection_count, elapsed_seconds=elapsed_seconds
+                    )
+                ),
+                on_progress=preparation.preflight_progress.report_preflight_progress,
+                on_test_start=lambda entry: preparation.progress.on_item_start(
+                    group_name=_test_group_name_from_entry(entry),
+                    item_name=format_parameterized_test_label(
+                        name=entry.name,
+                        source_path=entry.source_path,
+                        parameter_schema=entry.parameter_schema,
+                        parameter_values=entry.parameter_values,
+                    ),
+                    canonical_resource_name=entry.name,
+                ),
+                on_test_complete=on_complete,
             ),
-            on_test_complete=on_complete,
             run_id=pipeline_result.project.run_id,
         )
     finally:
@@ -174,6 +201,9 @@ def _build_on_complete(
 
 
 def _test_group_name_from_entry(entry: SqlTestPlanEntry) -> str:
+    for step in entry.chain:
+        if step.expected_cte_sql is not None:
+            return step.model_name
     if entry.chain:
         return entry.chain[0].model_name
     return "(unknown)"

--- a/src/sqlbuild/cli/commands/main/execution/_test.py
+++ b/src/sqlbuild/cli/commands/main/execution/_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from sqlbuild.cli.commands._helpers.test.execution import (
     execute_test_plan,
     prepare_test_execution,
+    resolve_test_concurrency,
 )
 from sqlbuild.cli.commands._helpers.test.invocation import resolve_test_invocation
 from sqlbuild.cli.commands._helpers.test.outputs import (
@@ -27,19 +28,20 @@ def run_test(request: TestCommandRequest) -> int:
     """Execute the test command."""
 
     invocation: TestInvocation = resolve_test_invocation(request=request)
+    pipeline_result: CompilePipelineResult = compile_test_plan(
+        request=request,
+        invocation=invocation,
+    )
     invocation.progress_stream.write("\n")
     write_execution_header(
         stream=invocation.progress_stream,
         command="sqb test",
         target=None,
-        concurrency=1,
+        concurrency=resolve_test_concurrency(request=request, pipeline_result=pipeline_result),
         use_color=invocation.use_color,
     )
-    pipeline_result: CompilePipelineResult = compile_test_plan(
-        request=request,
-        invocation=invocation,
-    )
     preparation: TestExecutionPreparation = prepare_test_execution(
+        request=request,
         invocation=invocation,
         pipeline_result=pipeline_result,
     )

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -1262,6 +1262,7 @@ class TestCommandRequest:
     cli_vars: dict[str, object] | None = None
     json_output: bool = False
     json_output_path: Path | None = None
+    concurrency: int | None = None
 
 
 @dataclass(frozen=True)
@@ -1312,6 +1313,8 @@ class TestExecutionPreparation:
     progress: NestedCommandProgressCallbacks
     execution_connection_progress: ConnectionProgressReporter
     preflight_progress: TransientStatusReporter
+    effective_concurrency: int
+    worker_count: int
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
+++ b/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
@@ -102,10 +102,11 @@ def plan_test(
     expected_names: tuple[str, ...] = tuple(
         dict.fromkeys((*model_payload.expected_model_names, *assertion_target_names))
     )
-    ordered_names: tuple[str, ...] = _topo_sort_expected(
+    ordered_names: tuple[str, ...] = _topo_sort_model_chain(
         expected_names=expected_names,
         model_map=model_map,
         model_query_overrides=model_payload.model_query_overrides,
+        mock_ref_names=frozenset(mock_refs),
     )
 
     warnings: list[PlanWarning] = []
@@ -723,30 +724,14 @@ def _build_helper_with_clause(
     return "WITH " + ", ".join(parts)
 
 
-def _topo_sort_expected(
+def _topo_sort_model_chain(
     *,
     expected_names: tuple[str, ...],
     model_map: dict[str, CompiledModel],
     model_query_overrides: dict[str, str],
+    mock_ref_names: frozenset[str],
 ) -> tuple[str, ...]:
-    """Sort expected model names in dependency order."""
-
-    expected_set: frozenset[str] = frozenset(expected_names)
-    deps: dict[str, set[str]] = {}
-    name: str
-    for name in expected_names:
-        model: CompiledModel | None = model_map.get(name)
-        if model is None:
-            deps[name] = set()
-            continue
-        query_sql: str = model_query_overrides.get(name, model.query_sql)
-        model_refs: set[str] = set()
-        match: re.Match[str]
-        for match in _REF_PATTERN.finditer(query_sql):
-            ref_name: str = match.group(1)
-            if ref_name in expected_set:
-                model_refs.add(ref_name)
-        deps[name] = model_refs
+    """Sort asserted models and their unmocked model dependencies in execution order."""
 
     ordered: list[str] = []
     visited: set[str] = set()
@@ -755,9 +740,17 @@ def _topo_sort_expected(
         if node in seen:
             return seen, result
         seen = seen | {node}
-        dep: str
-        for dep in sorted(deps.get(node, set())):
-            seen, result = _visit(node=dep, seen=seen, result=result)
+        model: CompiledModel | None = model_map.get(node)
+        if model is not None:
+            query_sql: str = model_query_overrides.get(node, model.query_sql)
+            dependency_names: set[str] = {
+                match.group(1)
+                for match in _REF_PATTERN.finditer(query_sql)
+                if match.group(1) not in mock_ref_names and match.group(1) in model_map
+            }
+            dependency_name: str
+            for dependency_name in sorted(dependency_names):
+                seen, result = _visit(node=dependency_name, seen=seen, result=result)
         return seen, [*result, node]
 
     for name in sorted(expected_names):

--- a/src/sqlbuild/executor/pipeline/_helpers/testing.py
+++ b/src/sqlbuild/executor/pipeline/_helpers/testing.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import queue
+import threading
 import time
 from collections.abc import Callable, Iterable
-from typing import Any
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextvars import copy_context
+from dataclasses import dataclass, field
+from typing import Any, cast
 from uuid import uuid4
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
@@ -18,13 +23,17 @@ from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.planner.models import FunctionPlanEntry, PlanOutput, SqlTestPlanEntry
 from sqlbuild.executor.build.models import FunctionExecutionResult
 from sqlbuild.executor.functions.main._execute import execute_function
+from sqlbuild.executor.pipeline._helpers.connections import (
+    close_connections,
+    open_worker_connections,
+)
+from sqlbuild.executor.pipeline.models import TestPipelineCallbacks
 from sqlbuild.executor.scheduling.types import ExecutionStatus
 from sqlbuild.executor.testing.constants import SQL_TEST_EXECUTION_ERROR_CODE
 from sqlbuild.executor.testing.main._execute import execute_sql_test
 from sqlbuild.executor.testing.main.resource_id import sql_test_resource_id
 from sqlbuild.executor.testing.models import SqlTestExecutionResult, StepResult
 from sqlbuild.executor.testing.types import SqlTestOutcome
-from sqlbuild.runtime.contracts.types import ConnectionElapsedCallback
 from sqlbuild.runtime.observability.classes.operation_lifecycle import OperationLifecycle
 from sqlbuild.runtime.observability.classes.resource_attempt_lifecycle import (
     ResourceAttemptLifecycle,
@@ -32,37 +41,59 @@ from sqlbuild.runtime.observability.classes.resource_attempt_lifecycle import (
 from sqlbuild.runtime.observability.models import OperationAttributes
 
 
+@dataclass
+class _AuthoredStartCoordinator:
+    condition: threading.Condition = field(default_factory=threading.Condition)
+    next_index: int = 0
+
+    def wait(self, *, index: int) -> None:
+        with self.condition:
+            _ = self.condition.wait_for(lambda: self.next_index == index)
+            self.next_index += 1
+            self.condition.notify_all()
+
+
 def run_test_pipeline(
     *,
     plan: PlanOutput,
     connection_config: dict[str, object],
     adapter: BaseAdapter,
-    on_connection_start: Callable[[int], None] | None = None,
-    on_connection_complete: ConnectionElapsedCallback | None = None,
-    on_connection_error: ConnectionElapsedCallback | None = None,
-    on_progress: Callable[[str], None] | None = None,
-    on_test_start: Callable[[SqlTestPlanEntry], None] | None = None,
-    on_test_complete: Callable[[SqlTestExecutionResult], None] | None = None,
+    callbacks: TestPipelineCallbacks | None = None,
     run_id: str | None = None,
+    max_concurrency: int = 1,
 ) -> tuple[SqlTestExecutionResult, ...]:
     """Execute all SQL unit tests from a compiled plan."""
 
-    if on_connection_start is not None:
-        on_connection_start(1)
+    entries: tuple[SqlTestPlanEntry, ...] = plan.test_entries
+    if not entries:
+        return ()
+    resolved_callbacks: TestPipelineCallbacks = callbacks or TestPipelineCallbacks()
+    worker_count: int = min(max(1, max_concurrency), len(entries))
+    if resolved_callbacks.on_connection_start is not None:
+        resolved_callbacks.on_connection_start(worker_count)
     canonical_run_id: str = run_id or uuid4().hex
     start: float = time.monotonic()
     try:
-        connection: Any = adapter.connect(connection_config)
-    except Exception:
-        if on_connection_error is not None:
-            on_connection_error(1, elapsed_seconds=time.monotonic() - start)
+        connections: tuple[Any, ...] = open_worker_connections(
+            adapter=adapter,
+            connection_config=connection_config,
+            connection_count=worker_count,
+        )
+    except BaseException:
+        if resolved_callbacks.on_connection_error is not None:
+            resolved_callbacks.on_connection_error(
+                worker_count, elapsed_seconds=time.monotonic() - start
+            )
         raise
-    if on_connection_complete is not None:
-        on_connection_complete(1, elapsed_seconds=time.monotonic() - start)
+    if resolved_callbacks.on_connection_complete is not None:
+        resolved_callbacks.on_connection_complete(
+            worker_count, elapsed_seconds=time.monotonic() - start
+        )
+    active_error: BaseException | None = None
     try:
         preflight_start: float = time.monotonic()
-        if on_progress is not None:
-            on_progress("Preparing test functions...")
+        if resolved_callbacks.on_progress is not None:
+            resolved_callbacks.on_progress("Preparing test functions...")
         missing_functions_by_test: dict[CompiledObjectKey, tuple[str, ...]] = {}
         if any(entry.function_deps for entry in plan.test_entries):
             with OperationLifecycle(
@@ -71,47 +102,167 @@ def run_test_pipeline(
                 metadata={"item_count": len(plan.test_entries)},
                 attributes=OperationAttributes(phase="setup", target_kind="sql_test"),
             ):
-                missing_functions_by_test = _prepare_test_functions(
-                    plan=plan,
-                    adapter=adapter,
-                    connection=connection,
-                )
-        if on_progress is not None:
-            on_progress(f"Prepared test functions. ({time.monotonic() - preflight_start:.2f}s)")
-        results: list[SqlTestExecutionResult] = []
-        entry: SqlTestPlanEntry
-        for entry in plan.test_entries:
-            missing_functions: tuple[str, ...] = missing_functions_by_test.get(entry.key, ())
-            resource_name: str = _test_resource_name(entry)
-            with ResourceAttemptLifecycle(
-                resource_id=sql_test_resource_id(
-                    test_name=entry.name,
-                    source_path=entry.source_path,
-                    block_index=entry.block_index,
-                    case_name=entry.case_name,
-                ),
-                resource_kind="test",
-                resource_name=resource_name,
-                run_id=canonical_run_id,
-            ) as lifecycle:
-                if on_test_start is not None:
-                    on_test_start(entry)
-                result: SqlTestExecutionResult = (
-                    _build_missing_function_result(
-                        test_entry=entry,
-                        missing_functions=missing_functions,
+                connection: Any
+                for connection in connections:
+                    connection_missing: dict[CompiledObjectKey, tuple[str, ...]] = (
+                        _prepare_test_functions(
+                            plan=plan,
+                            adapter=adapter,
+                            connection=connection,
+                        )
                     )
-                    if missing_functions
-                    else execute_sql_test(test_entry=entry, adapter=adapter, connection=connection)
-                )
-                if result.outcome != SqlTestOutcome.PASS:
-                    lifecycle.failed(error_code=result.error_code)
-            results.append(result)
+                    test_key: CompiledObjectKey
+                    missing_names: tuple[str, ...]
+                    for test_key, missing_names in connection_missing.items():
+                        missing_functions_by_test[test_key] = tuple(
+                            dict.fromkeys(
+                                (*missing_functions_by_test.get(test_key, ()), *missing_names)
+                            )
+                        )
+        if resolved_callbacks.on_progress is not None:
+            resolved_callbacks.on_progress(
+                f"Prepared test functions. ({time.monotonic() - preflight_start:.2f}s)"
+            )
+        results: tuple[SqlTestExecutionResult, ...] = _run_tests(
+            entries=entries,
+            adapter=adapter,
+            connections=connections,
+            worker_count=worker_count,
+            missing_functions_by_test=missing_functions_by_test,
+            on_test_start=resolved_callbacks.on_test_start,
+            on_test_complete=resolved_callbacks.on_test_complete,
+            run_id=canonical_run_id,
+        )
+        return results
+    except BaseException as error:
+        active_error = error
+        raise
+    finally:
+        close_connections(adapter=adapter, connections=connections, active_error=active_error)
+
+
+def _run_tests(
+    *,
+    entries: tuple[SqlTestPlanEntry, ...],
+    adapter: BaseAdapter,
+    connections: tuple[Any, ...],
+    worker_count: int,
+    missing_functions_by_test: dict[CompiledObjectKey, tuple[str, ...]],
+    on_test_start: Callable[[SqlTestPlanEntry], None] | None,
+    on_test_complete: Callable[[SqlTestExecutionResult], None] | None,
+    run_id: str,
+) -> tuple[SqlTestExecutionResult, ...]:
+    if worker_count == 1:
+        serial_results: list[SqlTestExecutionResult] = []
+        for entry in entries:
+            result: SqlTestExecutionResult = _execute_test_entry(
+                entry=entry,
+                adapter=adapter,
+                connection=connections[0],
+                missing_functions=missing_functions_by_test.get(entry.key, ()),
+                on_test_start=on_test_start,
+                before_test_start=None,
+                run_id=run_id,
+            )
+            serial_results.append(result)
             if on_test_complete is not None:
                 on_test_complete(result)
-        return tuple(results)
+        return tuple(serial_results)
+
+    connection_pool: queue.Queue[Any] = queue.Queue()
+    for connection in connections:
+        connection_pool.put(connection)
+    start_coordinator: _AuthoredStartCoordinator = _AuthoredStartCoordinator()
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        submitted_futures: list[Future[SqlTestExecutionResult]] = []
+        for index, entry in enumerate(entries):
+            submitted_futures.append(
+                cast(
+                    Future[SqlTestExecutionResult],
+                    executor.submit(
+                        copy_context().run,
+                        _execute_test_entry_with_pooled_connection,
+                        entry=entry,
+                        adapter=adapter,
+                        connection_pool=connection_pool,
+                        missing_functions=missing_functions_by_test.get(entry.key, ()),
+                        on_test_start=on_test_start,
+                        before_test_start=lambda index=index: start_coordinator.wait(index=index),
+                        run_id=run_id,
+                    ),
+                )
+            )
+        concurrent_results: list[SqlTestExecutionResult] = []
+        for future in submitted_futures:
+            result = future.result()
+            concurrent_results.append(result)
+            if on_test_complete is not None:
+                on_test_complete(result)
+        return tuple(concurrent_results)
+
+
+def _execute_test_entry_with_pooled_connection(
+    *,
+    entry: SqlTestPlanEntry,
+    adapter: BaseAdapter,
+    connection_pool: queue.Queue[Any],
+    missing_functions: tuple[str, ...],
+    on_test_start: Callable[[SqlTestPlanEntry], None] | None,
+    before_test_start: Callable[[], None] | None,
+    run_id: str,
+) -> SqlTestExecutionResult:
+    connection: Any = connection_pool.get()
+    try:
+        return _execute_test_entry(
+            entry=entry,
+            adapter=adapter,
+            connection=connection,
+            missing_functions=missing_functions,
+            on_test_start=on_test_start,
+            before_test_start=before_test_start,
+            run_id=run_id,
+        )
     finally:
-        adapter.close(connection)
+        connection_pool.put(connection)
+
+
+def _execute_test_entry(
+    *,
+    entry: SqlTestPlanEntry,
+    adapter: BaseAdapter,
+    connection: Any,
+    missing_functions: tuple[str, ...],
+    on_test_start: Callable[[SqlTestPlanEntry], None] | None,
+    before_test_start: Callable[[], None] | None,
+    run_id: str,
+) -> SqlTestExecutionResult:
+    with ResourceAttemptLifecycle(
+        resource_id=sql_test_resource_id(
+            test_name=entry.name,
+            source_path=entry.source_path,
+            block_index=entry.block_index,
+            case_name=entry.case_name,
+        ),
+        resource_kind="test",
+        resource_name=_test_resource_name(entry),
+        run_id=run_id,
+    ) as lifecycle:
+        if before_test_start is not None:
+            before_test_start()
+        if on_test_start is not None:
+            on_test_start(entry)
+        result: SqlTestExecutionResult = (
+            _build_missing_function_result(
+                test_entry=entry,
+                missing_functions=missing_functions,
+            )
+            if missing_functions
+            else execute_sql_test(test_entry=entry, adapter=adapter, connection=connection)
+        )
+        if result.outcome != SqlTestOutcome.PASS:
+            lifecycle.failed(error_code=result.error_code)
+        return result
 
 
 def _test_resource_name(entry: SqlTestPlanEntry) -> str:

--- a/src/sqlbuild/executor/pipeline/_helpers/testing.py
+++ b/src/sqlbuild/executor/pipeline/_helpers/testing.py
@@ -102,23 +102,11 @@ def run_test_pipeline(
                 metadata={"item_count": len(plan.test_entries)},
                 attributes=OperationAttributes(phase="setup", target_kind="sql_test"),
             ):
-                connection: Any
-                for connection in connections:
-                    connection_missing: dict[CompiledObjectKey, tuple[str, ...]] = (
-                        _prepare_test_functions(
-                            plan=plan,
-                            adapter=adapter,
-                            connection=connection,
-                        )
-                    )
-                    test_key: CompiledObjectKey
-                    missing_names: tuple[str, ...]
-                    for test_key, missing_names in connection_missing.items():
-                        missing_functions_by_test[test_key] = tuple(
-                            dict.fromkeys(
-                                (*missing_functions_by_test.get(test_key, ()), *missing_names)
-                            )
-                        )
+                missing_functions_by_test = _prepare_test_functions(
+                    plan=plan,
+                    adapter=adapter,
+                    connection=connections[0],
+                )
         if resolved_callbacks.on_progress is not None:
             resolved_callbacks.on_progress(
                 f"Prepared test functions. ({time.monotonic() - preflight_start:.2f}s)"

--- a/src/sqlbuild/executor/pipeline/models.py
+++ b/src/sqlbuild/executor/pipeline/models.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from sqlbuild.compiler.planner.models import AuditPlanEntry
+from sqlbuild.compiler.planner.models import AuditPlanEntry, SqlTestPlanEntry
 from sqlbuild.executor.auditing.models import AuditExecutionResult
 from sqlbuild.executor.build.models import (
     BuildCallbacks,
@@ -14,6 +14,7 @@ from sqlbuild.executor.build.models import (
     BuildInitialState,
     BuildRuntimeParams,
 )
+from sqlbuild.executor.testing.models import SqlTestExecutionResult
 from sqlbuild.runtime.contracts.types import ConnectionElapsedCallback
 
 
@@ -28,6 +29,18 @@ class AuditPipelineCallbacks:
     on_audit_physical_complete: Callable[[AuditExecutionResult], None] | None = None
     on_audit_complete: Callable[[AuditExecutionResult], None] | None = None
     on_audit_error: Callable[[AuditPlanEntry], None] | None = None
+
+
+@dataclass(frozen=True)
+class TestPipelineCallbacks:
+    """Optional connection, setup, and item callbacks for SQL test execution."""
+
+    on_connection_start: Callable[[int], None] | None = None
+    on_connection_complete: ConnectionElapsedCallback | None = None
+    on_connection_error: ConnectionElapsedCallback | None = None
+    on_progress: Callable[[str], None] | None = None
+    on_test_start: Callable[[SqlTestPlanEntry], None] | None = None
+    on_test_complete: Callable[[SqlTestExecutionResult], None] | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/executor/testing/_helpers/comparison_sql.py
+++ b/src/sqlbuild/executor/testing/_helpers/comparison_sql.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from typing import Any
 
 from sqlbuild.adapter.contract.types import BuiltinAdapter
+from sqlbuild.compiler.planner.models import ChainStep, SqlTestPlanEntry
 from sqlbuild.compiler.sql_analysis.main.import_polyglot_sql import import_polyglot_sql
 from sqlbuild.diagnostics.main.log_debug_event import log_debug_event
 from sqlbuild.executor.testing.constants import SQL_TEST_BACKTICK_IDENTIFIER_QUOTE
@@ -92,6 +93,64 @@ def unique_cte_suffix(
     return f"{base_suffix}_{count}", updated_counts
 
 
+def build_chain_comparison_parts(
+    *,
+    test_entry: SqlTestPlanEntry,
+    set_difference_operator: str,
+) -> tuple[OrderedDict[str, str], list[str], list[str], dict[str, int]]:
+    """Build actual/expected CTEs only for explicitly asserted model steps."""
+
+    lifted_ctes: OrderedDict[str, str] = OrderedDict()
+    comparison_ctes: list[str] = []
+    select_parts: list[str] = []
+    cte_name_counts: dict[str, int] = {}
+    step_index: int
+    step: ChainStep
+    for step_index, step in enumerate(test_entry.chain):
+        cte_suffix: str
+        cte_suffix, cte_name_counts = unique_cte_suffix(
+            model_name=step.model_name,
+            cte_name_counts=cte_name_counts,
+        )
+        actual_cte: str = f"__actual__{cte_suffix}"
+        expected_cte: str = f"__expected__{cte_suffix}"
+        if step.expected_cte_sql is None and not _assertion_uses_actual(
+            actual_cte=actual_cte,
+            test_entry=test_entry,
+        ):
+            continue
+        actual_sql: str
+        actual_sql, lifted_ctes = lift_step_ctes(
+            sql=step.resolved_sql,
+            lifted_ctes=lifted_ctes,
+            sql_analysis_enabled=test_entry.sql_analysis_enabled,
+        )
+        comparison_ctes.append(f"{actual_cte} AS ({actual_sql})")
+        if step.expected_cte_sql is None:
+            continue
+        expected_sql: str
+        expected_sql, lifted_ctes = lift_step_ctes(
+            sql=step.expected_cte_sql,
+            lifted_ctes=lifted_ctes,
+            sql_analysis_enabled=test_entry.sql_analysis_enabled,
+        )
+        comparison_ctes.append(f"{expected_cte} AS ({expected_sql})")
+        select_parts.append(
+            "SELECT "
+            f"{step_index} AS step_index, "
+            f"'{_escape_sql_string(step.model_name)}' AS model_name, "
+            f"(SELECT COUNT(*) FROM {actual_cte}) AS actual_count, "
+            f"(SELECT COUNT(*) FROM {expected_cte}) AS expected_count, "
+            f"(SELECT COUNT(*) FROM ("
+            f"SELECT * FROM {actual_cte} {set_difference_operator} SELECT * FROM {expected_cte}"
+            f") AS __sqlbuild_mismatch) AS unexpected_count, "
+            f"(SELECT COUNT(*) FROM ("
+            f"SELECT * FROM {expected_cte} {set_difference_operator} SELECT * FROM {actual_cte}"
+            f") AS __sqlbuild_missing) AS missing_count"
+        )
+    return lifted_ctes, comparison_ctes, select_parts, cte_name_counts
+
+
 def _split_top_level_with(sql: str) -> tuple[tuple[tuple[str, str], ...], str] | None:
     """Split top-level WITH CTEs from a SQL statement with Polyglot if available."""
 
@@ -156,6 +215,16 @@ def _split_top_level_with(sql: str) -> tuple[tuple[tuple[str, str], ...], str] |
             protected_identifiers=protected_identifiers,
         ),
     )
+
+
+def _assertion_uses_actual(*, actual_cte: str, test_entry: SqlTestPlanEntry) -> bool:
+    return any(
+        actual_cte.lower() in assertion.resolved_sql.lower() for assertion in test_entry.assertions
+    )
+
+
+def _escape_sql_string(value: str) -> str:
+    return value.replace("'", "''")
 
 
 def _sanitize_cte_suffix(model_name: str) -> str:

--- a/src/sqlbuild/executor/testing/main/_execute.py
+++ b/src/sqlbuild/executor/testing/main/_execute.py
@@ -36,7 +36,10 @@ def execute_sql_test(
         set_difference_operator=adapter.render_set_difference_operator(),
         sql_analysis_dialect=adapter.sql_analysis_dialect(),
     )
-    error_model_name: str = test_entry.chain[0].model_name if test_entry.chain else test_entry.name
+    error_model_name: str = next(
+        (step.model_name for step in test_entry.chain if step.expected_cte_sql is not None),
+        test_entry.name,
+    )
     try:
         validate_unit_test_sql_length(
             sql=comparison_sql,

--- a/src/sqlbuild/executor/testing/main/comparison_sql.py
+++ b/src/sqlbuild/executor/testing/main/comparison_sql.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
-
-from sqlbuild.compiler.planner.models import ChainStep, SqlTestPlanEntry
+from sqlbuild.compiler.planner.models import SqlTestPlanEntry
 from sqlbuild.executor.testing._helpers.comparison_sql import (
+    build_chain_comparison_parts,
     format_sql,
     lift_step_ctes,
     unique_cte_suffix,
@@ -23,49 +22,10 @@ def build_sql_test_comparison_sql(
     if not test_entry.chain and not test_entry.assertions:
         return ""
 
-    lifted_ctes: OrderedDict[str, str] = OrderedDict()
-    comparison_ctes: list[str] = []
-    select_parts: list[str] = []
-    cte_name_counts: dict[str, int] = {}
-    step_index: int
-    step: ChainStep
-    for step_index, step in enumerate(test_entry.chain):
-        cte_suffix: str
-        cte_suffix, cte_name_counts = unique_cte_suffix(
-            model_name=step.model_name,
-            cte_name_counts=cte_name_counts,
-        )
-        actual_cte: str = f"__actual__{cte_suffix}"
-        expected_cte: str = f"__expected__{cte_suffix}"
-        actual_sql: str
-        actual_sql, lifted_ctes = lift_step_ctes(
-            sql=step.resolved_sql,
-            lifted_ctes=lifted_ctes,
-            sql_analysis_enabled=test_entry.sql_analysis_enabled,
-        )
-        comparison_ctes.append(f"{actual_cte} AS ({actual_sql})")
-        if step.expected_cte_sql is None:
-            continue
-        expected_sql: str
-        expected_sql, lifted_ctes = lift_step_ctes(
-            sql=step.expected_cte_sql,
-            lifted_ctes=lifted_ctes,
-            sql_analysis_enabled=test_entry.sql_analysis_enabled,
-        )
-        comparison_ctes.append(f"{expected_cte} AS ({expected_sql})")
-        select_parts.append(
-            "SELECT "
-            f"{step_index} AS step_index, "
-            f"'{_escape_sql_string(step.model_name)}' AS model_name, "
-            f"(SELECT COUNT(*) FROM {actual_cte}) AS actual_count, "
-            f"(SELECT COUNT(*) FROM {expected_cte}) AS expected_count, "
-            f"(SELECT COUNT(*) FROM ("
-            f"SELECT * FROM {actual_cte} {set_difference_operator} SELECT * FROM {expected_cte}"
-            f") AS __sqlbuild_mismatch) AS unexpected_count, "
-            f"(SELECT COUNT(*) FROM ("
-            f"SELECT * FROM {expected_cte} {set_difference_operator} SELECT * FROM {actual_cte}"
-            f") AS __sqlbuild_missing) AS missing_count"
-        )
+    lifted_ctes, comparison_ctes, select_parts, cte_name_counts = build_chain_comparison_parts(
+        test_entry=test_entry,
+        set_difference_operator=set_difference_operator,
+    )
     assertion_index: int
     for assertion_index, assertion in enumerate(test_entry.assertions, start=len(test_entry.chain)):
         assertion_suffix: str

--- a/tests/e2e/src/sqlbuild/cli/commands/main/test/test_test.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/test/test_test.py
@@ -32,8 +32,8 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
             expected_exit_code=0,
             expected_stdout_fragment="PASS=5",
             expected_stdout_fragments=(
-                "Execution  sqb test  (concurrency: 1)",
-                "Connecting to duckdb...",
+                "Execution  sqb test  (concurrency: 5)",
+                "Connecting to duckdb (5 connections)...",
                 "\u2713 Warehouse connected  duckdb",
                 "expect  expected stg_orders",
                 "expect  expected fact_orders",
@@ -42,11 +42,11 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
                 "expect  expected table_fn returns_customer_orders",
             ),
             expected_ordered_stdout_fragments=(
-                "Execution  sqb test  (concurrency: 1)",
                 "Compiling project...",
                 "Compiled project. (<time>)",
+                "Execution  sqb test  (concurrency: 5)",
                 "Test ready  5 selected, 5 models",
-                "Connecting to duckdb...",
+                "Connecting to duckdb (5 connections)...",
                 "\u2713 Warehouse connected  duckdb  (<time>)",
                 "Preparing test functions...",
                 "Prepared test functions. (<time>)",
@@ -69,7 +69,7 @@ def test_given_waffle_shop_project_when_running_test_then_all_tests_pass(
     assert build_result.returncode == 0, build_result.stdout + build_result.stderr
 
     result: subprocess.CompletedProcess[str] = run_sqb(
-        command=("--no-color", "test"), project_dir=project_dir
+        command=("--no-color", "test", "--concurrency", "5"), project_dir=project_dir
     )
 
     assert result.returncode == test_case.expected_exit_code, result.stdout + result.stderr

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_execute_chain.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_execute_chain.py
@@ -170,6 +170,29 @@ SELECT 1
             },
         ),
         ExecuteChainTestCase(
+            description="final model expectation executes the complete unmocked model chain",
+            model_queries={
+                "A": 'SELECT id, amount FROM __source("raw")',
+                "B": 'SELECT id, amount * 2 AS doubled FROM __ref("A")',
+                "C": 'SELECT id, doubled + 1 AS final FROM __ref("B")',
+            },
+            mock_ref_ctes={},
+            mock_source_ctes={
+                "raw": "SELECT 1 AS id, 50 AS amount",
+            },
+            helper_ctes={},
+            expected_model_names=("C",),
+            expected_cte_bodies={
+                "C": "SELECT 1 AS id, 101 AS final",
+            },
+            expected_chain_length=3,
+            expected_results={
+                "A": ((1, 50),),
+                "B": ((1, 100),),
+                "C": ((1, 101),),
+            },
+        ),
+        ExecuteChainTestCase(
             description=("helper cte feeds into mock and result is executable"),
             model_queries={
                 "orders": ('SELECT id, amount FROM __ref("raw_orders")'),

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/test_parsing.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/test_parsing.py
@@ -76,6 +76,13 @@ def test_given_output_mode_when_parsing_verbose_command_then_normalizes_consiste
             expected_exit_code=None,
         ),
         AuditConcurrencyParsingTestCase(
+            description="test command cli override",
+            argv=("test", "--concurrency", "5"),
+            environment_value=None,
+            expected_concurrency=5,
+            expected_exit_code=None,
+        ),
+        AuditConcurrencyParsingTestCase(
             description="zero cli rejected",
             argv=("audit", "--concurrency", "0"),
             environment_value=None,

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_plan_test.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_plan_test.py
@@ -299,6 +299,27 @@ from tests.unit.src.sqlbuild.compiler.planner._helpers.sql_test_assembly.helpers
             },
         ),
         PlanTestChainTestCase(
+            description="final model expectation resolves the complete unmocked model chain",
+            model_queries={
+                "A": 'SELECT id FROM __source("raw")',
+                "B": 'SELECT id, id * 2 AS doubled FROM __ref("A")',
+                "C": 'SELECT id, doubled + 1 AS final FROM __ref("B")',
+            },
+            mock_ref_ctes={},
+            mock_source_ctes={
+                "raw": "SELECT 1 AS id",
+            },
+            helper_ctes={},
+            expected_model_names=("C",),
+            expected_chain_length=3,
+            expected_sql_fragments={
+                "C": "doubled + 1 AS final",
+            },
+            expected_cte_bodies={
+                "C": "SELECT 1 AS id, 3 AS final",
+            },
+        ),
+        PlanTestChainTestCase(
             description="helper ctes included in mock subquery",
             model_queries={
                 "orders": 'SELECT id, amount FROM __ref("raw")',

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/_test_types.py
@@ -22,6 +22,14 @@ class SqlTestOperationLifecycleTestCase:
 
 
 @dataclass(frozen=True)
+class SqlTestConcurrencyTestCase:
+    description: str
+    test_count: int
+    max_concurrency: int
+    expected_connection_count: int
+
+
+@dataclass(frozen=True)
 class AuditPipelineLifecycleTestCase:
     description: str
     expected_event_type: str

--- a/tests/unit/src/sqlbuild/executor/pipeline/_helpers/test_testing.py
+++ b/tests/unit/src/sqlbuild/executor/pipeline/_helpers/test_testing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 
 import pytest
@@ -13,8 +14,11 @@ from sqlbuild.compiler.compile.models import (
 )
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner.models import ChainStep, PlanOutput, SqlTestPlanEntry
+from sqlbuild.executor.pipeline._helpers import testing as testing_pipeline
 from sqlbuild.executor.pipeline._helpers.testing import run_test_pipeline
+from sqlbuild.executor.pipeline.models import TestPipelineCallbacks as PipelineCallbacks
 from sqlbuild.executor.testing.models import SqlTestExecutionResult
+from sqlbuild.executor.testing.types import SqlTestOutcome
 from sqlbuild.observability import (
     EventDispatcher,
     LifecycleEvent,
@@ -22,6 +26,7 @@ from sqlbuild.observability import (
     invocation_scope,
 )
 from tests.unit.src.sqlbuild.executor.pipeline._helpers._test_types import (
+    SqlTestConcurrencyTestCase,
     SqlTestFunctionPreflightTestCase,
     SqlTestOperationLifecycleTestCase,
 )
@@ -91,8 +96,10 @@ def test_given_sql_test_with_missing_function_when_running_pipeline_then_returns
             plan=plan,
             connection_config={"database": str(tmp_path / "test.duckdb")},
             adapter=DuckDbAdapter(),
-            on_test_start=lambda _entry: order.append("callback_start"),
-            on_test_complete=lambda _result: order.append("callback_complete"),
+            callbacks=PipelineCallbacks(
+                on_test_start=lambda _entry: order.append("callback_start"),
+                on_test_complete=lambda _result: order.append("callback_complete"),
+            ),
             run_id="test-run",
         )
 
@@ -189,3 +196,77 @@ def test_given_parameterized_chain_when_running_then_one_operation_owns_statemen
     assert all(
         event.resource_attempt_id == operation_events[0].resource_attempt_id for event in events
     )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SqlTestConcurrencyTestCase(
+            description="two workers overlap using isolated connections",
+            test_count=2,
+            max_concurrency=2,
+            expected_connection_count=2,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_concurrent_workers_when_running_tests_then_execution_overlaps_on_isolated_connections(
+    test_case: SqlTestConcurrencyTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entries: tuple[SqlTestPlanEntry, ...] = tuple(
+        SqlTestPlanEntry(
+            key=CompiledObjectKey(
+                resource_type=CompiledResourceType.SQL_TEST,
+                name=f"test_{index}",
+            ),
+            name=f"test_{index}",
+            chain=(
+                ChainStep(
+                    model_name=f"model_{index}",
+                    resolved_sql=f"SELECT {index} AS value",
+                    expected_cte_sql=f"SELECT {index} AS value",
+                ),
+            ),
+        )
+        for index in range(test_case.test_count)
+    )
+    overlap_barrier: threading.Barrier = threading.Barrier(test_case.expected_connection_count)
+    connection_ids: list[int] = []
+    connection_ids_lock: threading.Lock = threading.Lock()
+
+    def execute_with_overlap(
+        *, test_entry: SqlTestPlanEntry, adapter: DuckDbAdapter, connection: object
+    ) -> SqlTestExecutionResult:
+        del adapter
+        with connection_ids_lock:
+            connection_ids.append(id(connection))
+        overlap_barrier.wait(timeout=2)
+        return SqlTestExecutionResult(
+            test_name=test_entry.name,
+            outcome=SqlTestOutcome.PASS,
+        )
+
+    monkeypatch.setattr(testing_pipeline, "execute_sql_test", execute_with_overlap)
+    completed_names: list[str] = []
+    started_names: list[str] = []
+
+    results: tuple[SqlTestExecutionResult, ...] = run_test_pipeline(
+        plan=PlanOutput(test_entries=entries),
+        connection_config={"database": str(tmp_path / "test.duckdb")},
+        adapter=DuckDbAdapter(),
+        max_concurrency=test_case.max_concurrency,
+        callbacks=PipelineCallbacks(
+            on_test_start=lambda entry: started_names.append(entry.name),
+            on_test_complete=lambda result: completed_names.append(result.test_name),
+        ),
+    )
+
+    expected_names: tuple[str, ...] = tuple(
+        f"test_{index}" for index in range(test_case.test_count)
+    )
+    assert tuple(result.test_name for result in results) == expected_names
+    assert started_names == list(expected_names)
+    assert completed_names == list(expected_names)
+    assert len(set(connection_ids)) == test_case.expected_connection_count

--- a/tests/unit/src/sqlbuild/executor/testing/main/helpers.py
+++ b/tests/unit/src/sqlbuild/executor/testing/main/helpers.py
@@ -48,6 +48,27 @@ def build_comparison_test_entry_with_helper_ctes(
     )
 
 
+def build_transitive_comparison_test_entry() -> SqlTestPlanEntry:
+    return SqlTestPlanEntry(
+        key=CompiledObjectKey(
+            resource_type=CompiledResourceType.SQL_TEST,
+            name="final_orders_chain",
+        ),
+        name="final_orders_chain",
+        chain=(
+            ChainStep(
+                model_name="stg_orders",
+                resolved_sql="WITH shared AS (SELECT 1 AS order_id) SELECT * FROM shared",
+            ),
+            ChainStep(
+                model_name="final_orders",
+                resolved_sql=("WITH shared AS (SELECT 1 AS order_id) SELECT order_id FROM shared"),
+                expected_cte_sql="SELECT 1 AS order_id",
+            ),
+        ),
+    )
+
+
 def build_table_function_test_entry(
     *,
     sql_analysis_enabled: bool = True,

--- a/tests/unit/src/sqlbuild/executor/testing/main/test_comparison_sql.py
+++ b/tests/unit/src/sqlbuild/executor/testing/main/test_comparison_sql.py
@@ -14,6 +14,7 @@ from tests.unit.src.sqlbuild.executor.testing.main.helpers import (
     build_comparison_test_entry,
     build_comparison_test_entry_with_helper_ctes,
     build_table_function_test_entry,
+    build_transitive_comparison_test_entry,
 )
 
 
@@ -175,6 +176,30 @@ def test_given_matching_helper_ctes_when_building_comparison_sql_then_lifts_once
     for expected_fragment in test_case.expected_fragments:
         assert expected_fragment in comparison_sql
     assert comparison_sql.lower().count("input_values as") == 1
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        BuildComparisonSqlTestCase(
+            description="unasserted transitive step is omitted",
+            adapter_name="duckdb",
+            expected_fragments=("__actual__final_orders AS", "__expected__final_orders AS"),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_unasserted_transitive_steps_when_building_comparison_then_emits_only_expected_model(
+    test_case: BuildComparisonSqlTestCase,
+) -> None:
+    comparison_sql: str = build_sql_test_comparison_sql(
+        test_entry=build_transitive_comparison_test_entry(),
+    )
+
+    for expected_fragment in test_case.expected_fragments:
+        assert expected_fragment in comparison_sql
+    assert "__actual__stg_orders AS" not in comparison_sql
+    assert comparison_sql.lower().count("shared as") == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

SQLBuild 0.82.3 left unmocked intermediate `__ref()` calls unresolved when a multi-model test asserted only the final model. After resolving the chain, comparison SQL also emitted redundant unasserted intermediate CTEs, causing collisions and excessive optimizer work. Separately, `sqb test` ignored project concurrency and always used one connection.

## Changes

- Traverse unmocked model dependencies from expected/assertion targets to fixture boundaries.
- Emit comparison CTEs only for explicitly expected models or assertion inputs.
- Report execution errors and progress against the asserted model.
- Add `sqb test --concurrency` with CLI/environment override then project-setting precedence.
- Execute tests concurrently on isolated worker connections while preserving authored start, completion, and result order.
- Prepare connection-scoped test functions on every worker.

## Verification

- `make check-ci`
- `make test` — 6,219 passed
- Focused planner, comparison, CLI parsing, pipeline concurrency, and DuckDB execution tests — 68 passed
- DuckDB CLI project: two tests passed with project concurrency 2
- Snowflake: final-only three-model chain passed in 5.59s; assertion query 0.23s
- Confirmed a recursive Dagster cluster chain exceeds a 20s Snowflake statement ceiling even when run manually after full inlining; those cases require scenario-style physical boundaries rather than a larger timeout
