### PR TITLE
fix: bound and accelerate SQL test compilation

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/compile/target_writer.py
+++ b/src/sqlbuild/cli/commands/_helpers/compile/target_writer.py
@@ -7,10 +7,11 @@ from pathlib import Path
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.cli.commands.models import WrittenTarget
+from sqlbuild.cli.paths.main._sql_test_output_path import sql_test_output_path
 from sqlbuild.compiler.compile.models import CompiledProject
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.planner.main.execution.sql_test_assembly import build_sql_test_plan_entry
-from sqlbuild.compiler.planner.models import AuditPlanEntry, PlanOutput, SqlTestPlanEntry
+from sqlbuild.compiler.planner.models import AuditPlanEntry, PlanOutput
 from sqlbuild.executor.testing.main.comparison_sql import build_sql_test_comparison_sql
 
 _COMPILED_DIR: str = "compiled"
@@ -22,7 +23,6 @@ _AUDITS_DIR: str = "audits"
 _GENERIC_DIR: str = "generic"
 _SINGULAR_DIR: str = "singular"
 _TESTS_DIR: str = "tests"
-_CHAIN_DIR: str = "_chain_"
 _MANIFEST_FILE: str = "manifest.json"
 _SQL_FILE_SUFFIX: str = ".sql"
 
@@ -223,7 +223,7 @@ def _write_tests(
 
     managed_paths: set[Path] = set()
     for entry in plan_output.test_entries:
-        test_path: Path = target_dir / _COMPILED_DIR / _TESTS_DIR / _test_output_path(entry)
+        test_path: Path = target_dir / _COMPILED_DIR / _TESTS_DIR / sql_test_output_path(entry)
         _write_sql(
             path=test_path,
             sql=build_sql_test_comparison_sql(
@@ -252,7 +252,7 @@ def _write_static_tests(
             adapter=adapter,
             sql_analysis_enabled=project.settings.sql_analysis,
         )
-        test_path: Path = target_dir / _COMPILED_DIR / _TESTS_DIR / _test_output_path(entry)
+        test_path: Path = target_dir / _COMPILED_DIR / _TESTS_DIR / sql_test_output_path(entry)
         _write_sql(
             path=test_path,
             sql=build_sql_test_comparison_sql(
@@ -359,20 +359,3 @@ def _static_audit_file_name(
     if attached_target_name is not None and attached_column_name is not None:
         return f"{name}__{attached_column_name}{_SQL_FILE_SUFFIX}"
     return f"{name}{_SQL_FILE_SUFFIX}"
-
-
-def _test_folder(entry: SqlTestPlanEntry) -> Path:
-    """Determine the SQL-native test output folder."""
-
-    model_names: list[str] = [step.model_name for step in entry.chain]
-    unique_names: list[str] = sorted(set(model_names))
-    if len(unique_names) <= 1:
-        return Path(unique_names[0] if unique_names else entry.name)
-    return Path(_CHAIN_DIR) / "__".join(unique_names)
-
-
-def _test_output_path(entry: SqlTestPlanEntry) -> Path:
-    if entry.case_name is None or entry.source_path is None:
-        return _test_folder(entry) / f"{entry.name}{_SQL_FILE_SUFFIX}"
-    source_path: Path = entry.source_path.with_suffix("")
-    return source_path / f"block_{entry.block_index}__{entry.case_name}{_SQL_FILE_SUFFIX}"

--- a/src/sqlbuild/cli/paths/_helpers/artifact_path.py
+++ b/src/sqlbuild/cli/paths/_helpers/artifact_path.py
@@ -1,0 +1,40 @@
+"""Stable, filesystem-safe CLI artifact paths."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from sqlbuild.compiler.planner.models import SqlTestPlanEntry
+
+_CHAIN_DIR: str = "_chain_"
+_SQL_FILE_SUFFIX: str = ".sql"
+_MAX_CHAIN_COMPONENT_BYTES: int = 200
+_CHAIN_DIGEST_LENGTH: int = 12
+_CHAIN_EDGE_NAME_BYTES: int = 80
+
+
+def build_sql_test_output_path(entry: SqlTestPlanEntry) -> Path:
+    """Return a readable test path with bounded chain directory components."""
+
+    if entry.case_name is None or entry.source_path is None:
+        return _test_folder(entry) / f"{entry.name}{_SQL_FILE_SUFFIX}"
+    source_path: Path = entry.source_path.with_suffix("")
+    return source_path / f"block_{entry.block_index}__{entry.case_name}{_SQL_FILE_SUFFIX}"
+
+
+def _test_folder(entry: SqlTestPlanEntry) -> Path:
+    unique_names: list[str] = sorted({step.model_name for step in entry.chain})
+    if len(unique_names) <= 1:
+        return Path(unique_names[0] if unique_names else entry.name)
+    chain_name: str = "__".join(unique_names)
+    if len(chain_name.encode()) <= _MAX_CHAIN_COMPONENT_BYTES:
+        return Path(_CHAIN_DIR) / chain_name
+    digest: str = hashlib.sha256(chain_name.encode()).hexdigest()[:_CHAIN_DIGEST_LENGTH]
+    first_name: str = _truncate_utf8(value=unique_names[0], max_bytes=_CHAIN_EDGE_NAME_BYTES)
+    last_name: str = _truncate_utf8(value=unique_names[-1], max_bytes=_CHAIN_EDGE_NAME_BYTES)
+    return Path(_CHAIN_DIR) / f"{first_name}__{last_name}__{digest}"
+
+
+def _truncate_utf8(*, value: str, max_bytes: int) -> str:
+    return value.encode()[:max_bytes].decode(errors="ignore")

--- a/src/sqlbuild/cli/paths/main/_sql_test_output_path.py
+++ b/src/sqlbuild/cli/paths/main/_sql_test_output_path.py
@@ -1,0 +1,12 @@
+"""SQL test artifact path entrypoint."""
+
+from pathlib import Path
+
+from sqlbuild.cli.paths._helpers.artifact_path import build_sql_test_output_path
+from sqlbuild.compiler.planner.models import SqlTestPlanEntry
+
+
+def sql_test_output_path(entry: SqlTestPlanEntry) -> Path:
+    """Return the filesystem-safe target path for one SQL test artifact."""
+
+    return build_sql_test_output_path(entry)

--- a/src/sqlbuild/cli/target_artifacts/_helpers/runtime.py
+++ b/src/sqlbuild/cli/target_artifacts/_helpers/runtime.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapter.contract.models import LifeCycleEvent
 from sqlbuild.adapter.contract.types import LifeCycleEventKind
+from sqlbuild.cli.paths.main._sql_test_output_path import sql_test_output_path
 from sqlbuild.compiler.compile.types import FunctionLanguage
 from sqlbuild.compiler.planner.models import (
     FunctionPlanEntry,
@@ -26,7 +27,6 @@ _MODELS_DIR: str = "models"
 _FUNCTIONS_DIR: str = "functions"
 _TESTS_DIR: str = "tests"
 _CHECKS_DIR: str = "checks"
-_CHAIN_DIR: str = "_chain_"
 _SQL_FILE_SUFFIX: str = ".sql"
 
 
@@ -118,7 +118,7 @@ def write_test_runtime_target(
         )
         if entry_key not in result_keys:
             continue
-        test_run_path: Path = run_dir / _TESTS_DIR / _test_output_path(entry)
+        test_run_path: Path = run_dir / _TESTS_DIR / sql_test_output_path(entry)
         _write_sql(
             path=test_run_path,
             sql=build_sql_test_comparison_sql(
@@ -181,21 +181,6 @@ def _function_output_path(*, relative_path: Path, language: FunctionLanguage) ->
     ):
         return Path(*parts).with_suffix(_SQL_FILE_SUFFIX)
     return (Path(_FUNCTIONS_DIR) / language_dir / relative_path).with_suffix(_SQL_FILE_SUFFIX)
-
-
-def _test_output_path(entry: SqlTestPlanEntry) -> Path:
-    if entry.case_name is None or entry.source_path is None:
-        return _test_folder(entry) / f"{entry.name}{_SQL_FILE_SUFFIX}"
-    source_path: Path = entry.source_path.with_suffix("")
-    return source_path / f"block_{entry.block_index}__{entry.case_name}{_SQL_FILE_SUFFIX}"
-
-
-def _test_folder(entry: SqlTestPlanEntry) -> Path:
-    model_names: list[str] = [step.model_name for step in entry.chain]
-    unique_names: list[str] = sorted(set(model_names))
-    if len(unique_names) <= 1:
-        return Path(unique_names[0] if unique_names else entry.name)
-    return Path(_CHAIN_DIR) / "__".join(unique_names)
 
 
 def _format_statement(statement: str) -> str:

--- a/src/sqlbuild/compiler/compile/_helpers/scenarios/core.py
+++ b/src/sqlbuild/compiler/compile/_helpers/scenarios/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 from sqlbuild.compiler.compile._helpers.analysis.ctes import (
     extract_top_level_ctes_with_sql_analysis,
 )
@@ -77,6 +79,7 @@ def extract_sql_scenario_expected_model_names(*, sql: str, file_label: str) -> t
     )
 
 
+@lru_cache(maxsize=4096)
 def _extract_sql_scenario_ctes_with_scanner(
     *, sql: str, file_label: str
 ) -> tuple[CompileSqlScenarioCte, ...]:

--- a/src/sqlbuild/compiler/compile/_helpers/sql_tests/core.py
+++ b/src/sqlbuild/compiler/compile/_helpers/sql_tests/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 from sqlbuild.compiler.compile._helpers.analysis.ctes import (
     extract_top_level_ctes_with_sql_analysis,
 )
@@ -121,6 +123,7 @@ def extract_assertion_target_model_names(*, assertion_sql: tuple[str, ...]) -> t
     return tuple(dict.fromkeys(targets))
 
 
+@lru_cache(maxsize=4096)
 def _extract_sql_test_ctes_with_scanner(
     *, sql: str, file_label: str
 ) -> tuple[CompileSqlTestCte, ...]:

--- a/src/sqlbuild/compiler/planner/_helpers/sql_tests/analysis_assembly.py
+++ b/src/sqlbuild/compiler/planner/_helpers/sql_tests/analysis_assembly.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from collections import OrderedDict
-from copy import deepcopy
+from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any
 
 from sqlbuild.compiler.compile.constants import (
@@ -20,10 +21,31 @@ from sqlbuild.compiler.planner._helpers.scenario.relations import (
 )
 from sqlbuild.compiler.planner.models import SqlAnalysisResolvedTestSql
 from sqlbuild.compiler.references.types import SqlReferenceKind
+from sqlbuild.compiler.sql_analysis.constants import SQL_IDENTIFIER_PREFIX
 from sqlbuild.compiler.sql_analysis.main.import_polyglot_sql import import_polyglot_sql
 from sqlbuild.diagnostics.main.log_debug_event import log_debug_event
 
 _DEBUG_LOGGER: logging.Logger = logging.getLogger("sqlbuild.planner")
+
+
+@dataclass(frozen=True)
+class _TestSqlAnalysisTemplate:
+    existing_cte_names: frozenset[str]
+    marker_calls: tuple[tuple[str, str], ...]
+    cte_body_sql: str
+
+
+class _TemplateMarkerTargetResolver:
+    def __init__(self, targets: tuple[tuple[str, str, str], ...]) -> None:
+        self._targets: dict[tuple[str, str], str] = {
+            (function_name, referenced_name): target
+            for function_name, referenced_name, target in targets
+        }
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(self, *, function_name: str, referenced_name: str) -> str | None:
+        self.calls.append((function_name, referenced_name))
+        return self._targets.get((function_name, referenced_name))
 
 
 class _TestAssemblyState:
@@ -190,13 +212,21 @@ def try_resolve_test_model_sql_with_sql_analysis(
     polyglot_module: Any | None = import_polyglot_sql()
     if polyglot_module is None:
         return None
-    parsed_dict: dict[str, Any] | None = _try_parse_test_query(
-        polyglot_module=polyglot_module,
-        query_sql=query_sql,
+    marker_targets: tuple[tuple[str, str, str], ...] = _test_marker_targets(
+        mock_refs=mock_refs,
+        mock_sources=mock_sources,
+        mock_seeds=mock_seeds,
+        mock_dbt_refs=mock_dbt_refs,
+        function_locations=function_locations,
+        resolved_chain=resolved_chain,
     )
-    if parsed_dict is None:
+    template: _TestSqlAnalysisTemplate | None = _analyze_test_query_template(
+        query_sql=query_sql,
+        marker_targets=marker_targets,
+    )
+    if template is None:
         return None
-    state: _TestAssemblyState = _TestAssemblyState(_collect_existing_cte_names(parsed_dict))
+    state: _TestAssemblyState = _TestAssemblyState(set(template.existing_cte_names))
     target_for_marker: _TestMarkerResolver = _TestMarkerResolver(
         state=state,
         mock_refs=mock_refs,
@@ -208,25 +238,88 @@ def try_resolve_test_model_sql_with_sql_analysis(
         resolved_chain=resolved_chain,
         file_label=file_label,
     )
+    for function_name, referenced_name in template.marker_calls:
+        _ = target_for_marker(
+            function_name=function_name,
+            referenced_name=referenced_name,
+        )
+    return _assemble_resolved_test_sql(
+        cte_body_sql=template.cte_body_sql,
+        generated_ctes=state.ctes,
+        reachable_mocks=state.reached,
+    )
+
+
+def _test_marker_targets(
+    *,
+    mock_refs: dict[str, str],
+    mock_sources: dict[str, str],
+    mock_seeds: dict[str, str],
+    mock_dbt_refs: dict[str, str],
+    function_locations: dict[str, str],
+    resolved_chain: dict[str, SqlAnalysisResolvedTestSql],
+) -> tuple[tuple[str, str, str], ...]:
+    targets: list[tuple[str, str, str]] = []
+    targets.extend(
+        (SqlReferenceKind.REF.function_name, name, f"{REF_TEST_CTE_PREFIX}{name}")
+        for name in set(mock_refs) | set(resolved_chain)
+    )
+    targets.extend(
+        (SqlReferenceKind.SOURCE.function_name, name, f"{SOURCE_TEST_CTE_PREFIX}{name}")
+        for name in mock_sources
+    )
+    targets.extend(
+        (SqlReferenceKind.SEED.function_name, name, f"{SEED_TEST_CTE_PREFIX}{name}")
+        for name in mock_seeds
+    )
+    targets.extend(
+        (SqlReferenceKind.DBT_REF.function_name, name, f"{DBT_REF_TEST_CTE_PREFIX}{name}")
+        for name in mock_dbt_refs
+    )
+    targets.extend(_function_marker_targets(function_locations=function_locations))
+    return tuple(sorted(targets))
+
+
+def _function_marker_targets(
+    *, function_locations: dict[str, str]
+) -> tuple[tuple[str, str, str], ...]:
+    targets: list[tuple[str, str, str]] = []
+    for name, location in function_locations.items():
+        targets.append((SqlReferenceKind.UDF.function_name, name, location))
+        targets.append((SqlReferenceKind.TABLE_FUNCTION.function_name, name, location))
+    return tuple(targets)
+
+
+@lru_cache(maxsize=4096)
+def _analyze_test_query_template(
+    *, query_sql: str, marker_targets: tuple[tuple[str, str, str], ...]
+) -> _TestSqlAnalysisTemplate | None:
+    polyglot_module: Any | None = import_polyglot_sql()
+    if polyglot_module is None:
+        return None
+    parsed_dict: dict[str, Any] | None = _try_parse_test_query(
+        polyglot_module=polyglot_module,
+        query_sql=query_sql,
+    )
+    if parsed_dict is None:
+        return None
+    target_for_marker: _TemplateMarkerTargetResolver = _TemplateMarkerTargetResolver(marker_targets)
     _replace_relation_markers_in_polyglot_dict(
         node=parsed_dict,
         polyglot_module=polyglot_module,
         sql_analysis_dialect=None,
         target_for_marker=target_for_marker,
     )
-    outer_sql: str | None = _render_test_outer_sql(
+    cte_body_sql: str | None = _generate_one(
         polyglot_module=polyglot_module,
-        parsed_dict=parsed_dict,
+        expression=parsed_dict,
     )
-    if outer_sql is None:
+    if cte_body_sql is None:
         return None
-
-    return _assemble_resolved_test_sql(
-        polyglot_module=polyglot_module,
-        parsed_dict=parsed_dict,
-        generated_ctes=state.ctes,
-        outer_sql=outer_sql,
-        reachable_mocks=state.reached,
+    return _TestSqlAnalysisTemplate(
+        existing_cte_names=frozenset(_collect_existing_cte_names(parsed_dict)),
+        marker_calls=tuple(target_for_marker.calls),
+        cte_body_sql=cte_body_sql,
     )
 
 
@@ -243,55 +336,73 @@ def _try_parse_test_query(*, polyglot_module: Any, query_sql: str) -> dict[str, 
     return parsed.to_dict()
 
 
-def _render_test_outer_sql(*, polyglot_module: Any, parsed_dict: dict[str, Any]) -> str | None:
-    transformed_without_with: dict[str, Any] = deepcopy(parsed_dict)
-    without_with_select: dict[str, Any] | None = _root_select(transformed_without_with)
-    if without_with_select is not None:
-        without_with_select["with"] = None
-    return _generate_one(polyglot_module=polyglot_module, expression=transformed_without_with)
-
-
 def _assemble_resolved_test_sql(
     *,
-    polyglot_module: Any,
-    parsed_dict: dict[str, Any],
+    cte_body_sql: str,
     generated_ctes: OrderedDict[str, str],
-    outer_sql: str,
     reachable_mocks: set[str],
 ) -> SqlAnalysisResolvedTestSql | None:
-    cte_parts: list[str] = [f"{name} AS ({sql})" for name, sql in generated_ctes.items()]
-    transformed_select: dict[str, Any] | None = _root_select(parsed_dict)
-    transformed_with: dict[str, Any] | None = (
-        transformed_select.get("with") if transformed_select is not None else None
-    )
-    if isinstance(transformed_with, dict):
-        cte: dict[str, Any]
-        for cte in transformed_with.get("ctes", ()):
-            cte_name: str | None = _cte_name(cte)
-            cte_sql: str | None = _generate_one(
-                polyglot_module=polyglot_module,
-                expression={"cte": cte},
-            )
-            if cte_name is not None and cte_sql is not None:
-                cte_parts.append(cte_sql)
-    cte_body_sql: str | None = _generate_one(
-        polyglot_module=polyglot_module, expression=parsed_dict
-    )
-    if cte_body_sql is None:
-        return None
-    if not cte_parts:
+    if not generated_ctes:
         return SqlAnalysisResolvedTestSql(
             resolved_sql=cte_body_sql,
             cte_body_sql=cte_body_sql,
             generated_ctes=generated_ctes,
             reachable_mock_names=frozenset(reachable_mocks),
         )
+    generated_cte_sql: str = ", ".join(f"{name} AS ({sql})" for name, sql in generated_ctes.items())
+    leading_with_end: int | None = _leading_with_prefix_end(cte_body_sql)
+    resolved_sql: str = (
+        f"{cte_body_sql[:leading_with_end]}{generated_cte_sql}, {cte_body_sql[leading_with_end:]}"
+        if leading_with_end is not None
+        else f"WITH {generated_cte_sql} {cte_body_sql}"
+    )
     return SqlAnalysisResolvedTestSql(
-        resolved_sql=f"WITH {', '.join(cte_parts)} {outer_sql}",
+        resolved_sql=resolved_sql,
         cte_body_sql=cte_body_sql,
         generated_ctes=generated_ctes,
         reachable_mock_names=frozenset(reachable_mocks),
     )
+
+
+def _leading_with_prefix_end(sql: str) -> int | None:
+    index: int = _skip_leading_ignorable(sql=sql, start=0)
+    with_end: int | None = _keyword_end(sql=sql, start=index, keyword="WITH")
+    if with_end is None:
+        return None
+    index = _skip_leading_ignorable(sql=sql, start=with_end)
+    recursive_end: int | None = _keyword_end(sql=sql, start=index, keyword="RECURSIVE")
+    if recursive_end is not None:
+        index = _skip_leading_ignorable(sql=sql, start=recursive_end)
+    return index
+
+
+def _skip_leading_ignorable(*, sql: str, start: int) -> int:
+    index: int = start
+    while index < len(sql):
+        if sql[index].isspace():
+            index += 1
+            continue
+        if sql.startswith("--", index):
+            newline_index: int = sql.find("\n", index + 2)
+            index = len(sql) if newline_index == -1 else newline_index + 1
+            continue
+        if sql.startswith("/*", index):
+            comment_end: int = sql.find("*/", index + 2)
+            if comment_end == -1:
+                return index
+            index = comment_end + 2
+            continue
+        return index
+    return index
+
+
+def _keyword_end(*, sql: str, start: int, keyword: str) -> int | None:
+    end: int = start + len(keyword)
+    if sql[start:end].upper() != keyword:
+        return None
+    if end < len(sql) and (sql[end].isalnum() or sql[end] == SQL_IDENTIFIER_PREFIX):
+        return None
+    return end
 
 
 def _collect_existing_cte_names(parsed_dict: dict[str, Any]) -> set[str]:
@@ -315,14 +426,6 @@ def _collect_existing_cte_names(parsed_dict: dict[str, Any]) -> set[str]:
 def _root_select(parsed_dict: dict[str, Any]) -> dict[str, Any] | None:
     select_payload: Any | None = parsed_dict.get("select")
     return select_payload if isinstance(select_payload, dict) else None
-
-
-def _cte_name(cte: dict[str, Any]) -> str | None:
-    alias: Any | None = cte.get("alias")
-    if not isinstance(alias, dict):
-        return None
-    name: Any | None = alias.get("name")
-    return str(name) if name is not None else None
 
 
 def _generate_one(*, polyglot_module: Any, expression: Any) -> str | None:

--- a/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
+++ b/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.compile.constants import (
@@ -31,6 +32,11 @@ from sqlbuild.compiler.planner._helpers.resolve.refs import (
 from sqlbuild.compiler.planner._helpers.sql_tests.analysis_assembly import (
     try_resolve_test_model_sql_with_sql_analysis,
 )
+from sqlbuild.compiler.planner._helpers.sql_tests.comments import (
+    replace_uncommented_pattern,
+    uncommented_matches_by_pattern,
+    uncommented_pattern_matches,
+)
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.models import (
     ChainStep,
@@ -55,7 +61,55 @@ _DBT_REF_PATTERN: re.Pattern[str] = re.compile(
     rf'{reference_call_prefix_pattern_text(SqlReferenceKind.DBT_REF)}"([^"]+)"'
     r'(?:,\s*"([^"]+)")?\)'
 )
+_TABLE_FUNCTION_PATTERN: re.Pattern[str] = re.compile(
+    reference_call_prefix_pattern_text(SqlReferenceKind.TABLE_FUNCTION)
+)
 _LEADING_WITH_PATTERN: re.Pattern[str] = re.compile(r"^\s*WITH\b", re.IGNORECASE)
+
+
+@dataclass
+class _TextualChainResolver:
+    model_names: tuple[str, ...]
+    model_map: dict[str, CompiledModel]
+    test: CompiledSqlTest
+    mock_refs: dict[str, str]
+    mock_sources: dict[str, str]
+    mock_seeds: dict[str, str]
+    mock_dbt_refs: dict[str, str]
+    helper_ctes: tuple[CompileSqlTestCte, ...]
+    function_locations: dict[str, CompiledRelationLocation]
+    adapter: BaseAdapter
+    resolved: dict[str, str] = field(default_factory=dict)
+    step_sql: dict[str, str] = field(default_factory=dict)
+    reachable_mocks: set[str] = field(default_factory=set)
+
+    def ensure_through(self, count: int) -> None:
+        for model_name in self.model_names[:count]:
+            if model_name in self.resolved:
+                continue
+            model: CompiledModel | None = self.model_map.get(model_name)
+            if model is None:
+                continue
+            sql: str
+            reached: frozenset[str]
+            sql, reached = _resolve_test_model_sql(
+                query_sql=_resolve_test_model_query_sql(model=model, test=self.test),
+                mock_refs=self.mock_refs,
+                mock_sources=self.mock_sources,
+                mock_seeds=self.mock_seeds,
+                mock_dbt_refs=self.mock_dbt_refs,
+                helper_ctes=self.helper_ctes,
+                resolved_chain=self.resolved,
+                function_locations=self.function_locations,
+                adapter=self.adapter,
+            )
+            self.reachable_mocks.update(reached)
+            self.step_sql[model_name] = sql
+            self.resolved[model_name] = f"({sql})"
+
+    def resolve_all(self) -> dict[str, str]:
+        self.ensure_through(len(self.model_names))
+        return self.resolved
 
 
 def plan_test(
@@ -88,6 +142,11 @@ def plan_test(
     function_locations: dict[str, CompiledRelationLocation] = {
         function.name: function.destination for function in project.functions
     }
+    qualified_function_locations: dict[str, str] = {
+        name: target.qualified_name
+        for name, target in function_locations.items()
+        if target.qualified_name is not None
+    }
     mock_refs: dict[str, str] = _extract_mock_refs(test)
     mock_sources: dict[str, str] = _extract_mock_sources(test)
     mock_seeds: dict[str, str] = _extract_mock_seeds(test)
@@ -111,13 +170,25 @@ def plan_test(
 
     warnings: list[PlanWarning] = []
     reachable_mocks: set[str] = set()
-    resolved: dict[str, str] = {}
     sql_analysis_resolved: dict[str, SqlAnalysisResolvedTestSql] = {}
     function_deps: list[CompiledObjectKey] = []
+    textual_chain: _TextualChainResolver = _TextualChainResolver(
+        model_names=ordered_names,
+        model_map=model_map,
+        test=test,
+        mock_refs=mock_refs,
+        mock_sources=mock_sources,
+        mock_seeds=mock_seeds,
+        mock_dbt_refs=mock_dbt_refs,
+        helper_ctes=helper_ctes,
+        function_locations=function_locations,
+        adapter=adapter,
+    )
 
     chain_steps: list[ChainStep] = []
+    model_index: int
     model_name: str
-    for model_name in ordered_names:
+    for model_index, model_name in enumerate(ordered_names):
         model: CompiledModel | None = model_map.get(model_name)
         if model is None:
             warnings.append(
@@ -137,21 +208,7 @@ def plan_test(
         )
 
         query_sql: str = _resolve_test_model_query_sql(model=model, test=test)
-        step_sql: str
-        step_reachable_mocks: frozenset[str]
-        step_sql, step_reachable_mocks = _resolve_test_model_sql(
-            query_sql=query_sql,
-            mock_refs=mock_refs,
-            mock_sources=mock_sources,
-            mock_seeds=mock_seeds,
-            mock_dbt_refs=mock_dbt_refs,
-            helper_ctes=helper_ctes,
-            resolved_chain=resolved,
-            function_locations=function_locations,
-            adapter=adapter,
-        )
-        reachable_mocks.update(step_reachable_mocks)
-        resolved_value: str = f"({step_sql})"
+        step_sql: str | None = None
         if sql_analysis_enabled:
             sql_analysis_sql: SqlAnalysisResolvedTestSql | None = (
                 try_resolve_test_model_sql_with_sql_analysis(
@@ -160,11 +217,7 @@ def plan_test(
                     mock_sources=mock_sources,
                     mock_seeds=mock_seeds,
                     mock_dbt_refs=mock_dbt_refs,
-                    function_locations={
-                        name: target.qualified_name
-                        for name, target in function_locations.items()
-                        if target.qualified_name is not None
-                    },
+                    function_locations=qualified_function_locations,
                     helper_ctes=helper_ctes,
                     resolved_chain=sql_analysis_resolved,
                     file_label=str(test.test_file.relative_path),
@@ -174,6 +227,9 @@ def plan_test(
                 step_sql = sql_analysis_sql.resolved_sql
                 sql_analysis_resolved[model_name] = sql_analysis_sql
                 reachable_mocks.update(sql_analysis_sql.reachable_mock_names)
+        if step_sql is None:
+            textual_chain.ensure_through(model_index + 1)
+            step_sql = textual_chain.step_sql[model_name]
 
         unresolved_warnings: tuple[PlanWarning, ...] = _validate_resolved_sql(
             resolved_sql=step_sql,
@@ -181,8 +237,6 @@ def plan_test(
             model_name=model_name,
         )
         warnings.extend(unresolved_warnings)
-
-        resolved[model_name] = resolved_value
 
         expected_cte_sql: str = expected_map.get(model_name, "")
         chain_steps.append(
@@ -197,12 +251,14 @@ def plan_test(
         assertion_map=assertion_map,
         test=test,
         function_locations=function_locations,
+        qualified_function_locations=qualified_function_locations,
         helper_ctes=helper_ctes,
-        resolved_chain=resolved,
+        textual_chain=textual_chain,
         sql_analysis_resolved=sql_analysis_resolved,
         adapter=adapter,
         sql_analysis_enabled=sql_analysis_enabled,
     )
+    reachable_mocks.update(textual_chain.reachable_mocks)
 
     unreachable_ref: str
     for unreachable_ref in sorted(set(mock_refs) - reachable_mocks):
@@ -275,8 +331,9 @@ def _build_assertion_steps(
     assertion_map: dict[str, str],
     test: CompiledSqlTest,
     function_locations: dict[str, CompiledRelationLocation],
+    qualified_function_locations: dict[str, str],
     helper_ctes: tuple[CompileSqlTestCte, ...],
-    resolved_chain: dict[str, str],
+    textual_chain: _TextualChainResolver,
     sql_analysis_resolved: dict[str, SqlAnalysisResolvedTestSql],
     adapter: BaseAdapter,
     sql_analysis_enabled: bool,
@@ -298,11 +355,7 @@ def _build_assertion_steps(
                     mock_sources=mock_sources,
                     mock_seeds=mock_seeds,
                     mock_dbt_refs=mock_dbt_refs,
-                    function_locations={
-                        name: target.qualified_name
-                        for name, target in function_locations.items()
-                        if target.qualified_name is not None
-                    },
+                    function_locations=qualified_function_locations,
                     helper_ctes=helper_ctes,
                     resolved_chain=sql_analysis_resolved,
                     file_label=str(test.test_file.relative_path),
@@ -315,7 +368,7 @@ def _build_assertion_steps(
         if resolved_assertion_sql is None:
             resolved_assertion_sql = _resolve_assertion_sql(
                 sql=assertion_sql,
-                resolved_chain=resolved_chain,
+                resolved_chain=textual_chain.resolve_all(),
                 mock_refs=mock_refs,
                 mock_sources=mock_sources,
                 mock_seeds=mock_seeds,
@@ -422,7 +475,7 @@ def _extract_assertion_ref_targets(*, assertion_map: dict[str, str]) -> tuple[st
     sql: str
     for sql in assertion_map.values():
         match: re.Match[str]
-        for match in _REF_PATTERN.finditer(sql):
+        for match in uncommented_pattern_matches(pattern=_REF_PATTERN, sql=sql):
             targets.append(match.group(1))
     return tuple(dict.fromkeys(targets))
 
@@ -477,7 +530,7 @@ def _build_assertion_chain_ctes(
     cte_parts: list[str] = []
     seen_names: set[str] = set()
     match: re.Match[str]
-    for match in _REF_PATTERN.finditer(assertion_sql):
+    for match in uncommented_pattern_matches(pattern=_REF_PATTERN, sql=assertion_sql):
         name: str = match.group(1)
         if name in seen_names or name not in resolved_chain:
             continue
@@ -534,24 +587,26 @@ def _resolve_test_model_sql(
 ) -> tuple[str, frozenset[str]]:
     """Replace refs and sources in model SQL and return it with reached mock names."""
 
+    ref_matches: tuple[re.Match[str], ...]
+    source_matches: tuple[re.Match[str], ...]
+    seed_matches: tuple[re.Match[str], ...]
+    dbt_ref_matches: tuple[re.Match[str], ...]
+    ref_matches, source_matches, seed_matches, dbt_ref_matches = uncommented_matches_by_pattern(
+        patterns=(_REF_PATTERN, _SOURCE_PATTERN, _SEED_PATTERN, _DBT_REF_PATTERN),
+        sql=query_sql,
+    )
     reachable_mocks: set[str] = {
         match.group(1)
-        for match in _REF_PATTERN.finditer(query_sql)
+        for match in ref_matches
         if match.group(1) in mock_refs and match.group(1) not in resolved_chain
     }
     reachable_mocks.update(
-        match.group(1)
-        for match in _SOURCE_PATTERN.finditer(query_sql)
-        if match.group(1) in mock_sources
+        match.group(1) for match in source_matches if match.group(1) in mock_sources
     )
-    reachable_mocks.update(
-        match.group(1)
-        for match in _SEED_PATTERN.finditer(query_sql)
-        if match.group(1) in mock_seeds
-    )
+    reachable_mocks.update(match.group(1) for match in seed_matches if match.group(1) in mock_seeds)
     reachable_mocks.update(
         name
-        for match in _DBT_REF_PATTERN.finditer(query_sql)
+        for match in dbt_ref_matches
         if (name := _dbt_ref_fixture_name(package_name=match.group(1), model_name=match.group(2)))
         in mock_dbt_refs
     )
@@ -601,10 +656,18 @@ def _resolve_test_model_sql(
             )
         return match.group(0)
 
-    result: str = _REF_PATTERN.sub(_replace_ref, query_sql)
-    result = _SOURCE_PATTERN.sub(_replace_source, result)
-    result = _SEED_PATTERN.sub(_replace_seed, result)
-    result = _DBT_REF_PATTERN.sub(_replace_dbt_ref, result)
+    result: str = replace_uncommented_pattern(
+        pattern=_REF_PATTERN, replacement=_replace_ref, sql=query_sql
+    )
+    result = replace_uncommented_pattern(
+        pattern=_SOURCE_PATTERN, replacement=_replace_source, sql=result
+    )
+    result = replace_uncommented_pattern(
+        pattern=_SEED_PATTERN, replacement=_replace_seed, sql=result
+    )
+    result = replace_uncommented_pattern(
+        pattern=_DBT_REF_PATTERN, replacement=_replace_dbt_ref, sql=result
+    )
     result = resolve_udf_references(
         query_sql=result,
         function_locations=function_locations,
@@ -626,9 +689,25 @@ def _validate_resolved_sql(
 ) -> tuple[PlanWarning, ...]:
     """Check for unresolved refs and sources in resolved test SQL."""
 
+    patterns: tuple[re.Pattern[str], ...] = (
+        _REF_PATTERN,
+        _SOURCE_PATTERN,
+        _SEED_PATTERN,
+        _DBT_REF_PATTERN,
+    )
+    if not any(pattern.search(resolved_sql) for pattern in patterns):
+        return ()
     warnings: list[PlanWarning] = []
+    ref_matches: tuple[re.Match[str], ...]
+    source_matches: tuple[re.Match[str], ...]
+    seed_matches: tuple[re.Match[str], ...]
+    dbt_ref_matches: tuple[re.Match[str], ...]
+    ref_matches, source_matches, seed_matches, dbt_ref_matches = uncommented_matches_by_pattern(
+        patterns=patterns,
+        sql=resolved_sql,
+    )
     ref_match: re.Match[str]
-    for ref_match in _REF_PATTERN.finditer(resolved_sql):
+    for ref_match in ref_matches:
         ref_name: str = ref_match.group(1)
         warnings.append(
             PlanWarning(
@@ -642,7 +721,7 @@ def _validate_resolved_sql(
             )
         )
     source_match: re.Match[str]
-    for source_match in _SOURCE_PATTERN.finditer(resolved_sql):
+    for source_match in source_matches:
         source_name: str = source_match.group(1)
         warnings.append(
             PlanWarning(
@@ -656,7 +735,7 @@ def _validate_resolved_sql(
             )
         )
     seed_match: re.Match[str]
-    for seed_match in _SEED_PATTERN.finditer(resolved_sql):
+    for seed_match in seed_matches:
         seed_name: str = seed_match.group(1)
         warnings.append(
             PlanWarning(
@@ -670,7 +749,7 @@ def _validate_resolved_sql(
             )
         )
     dbt_ref_match: re.Match[str]
-    for dbt_ref_match in _DBT_REF_PATTERN.finditer(resolved_sql):
+    for dbt_ref_match in dbt_ref_matches:
         dbt_ref_name: str = _dbt_ref_fixture_name(
             package_name=dbt_ref_match.group(1), model_name=dbt_ref_match.group(2)
         )
@@ -688,14 +767,17 @@ def _validate_resolved_sql(
 
 
 def _has_unresolved_test_reference(sql: str) -> bool:
-    normalized_sql: str = sql.lower()
-    return (
-        _REF_PATTERN.search(normalized_sql) is not None
-        or _SOURCE_PATTERN.search(normalized_sql) is not None
-        or _SEED_PATTERN.search(normalized_sql) is not None
-        or _DBT_REF_PATTERN.search(normalized_sql) is not None
-        or SqlReferenceKind.TABLE_FUNCTION.function_name in normalized_sql
+    reference_matches: tuple[tuple[re.Match[str], ...], ...] = uncommented_matches_by_pattern(
+        patterns=(
+            _REF_PATTERN,
+            _SOURCE_PATTERN,
+            _SEED_PATTERN,
+            _DBT_REF_PATTERN,
+            _TABLE_FUNCTION_PATTERN,
+        ),
+        sql=sql,
     )
+    return any(reference_matches)
 
 
 def _wrap_mock_with_helpers(
@@ -742,12 +824,12 @@ def _topo_sort_model_chain(
         seen = seen | {node}
         model: CompiledModel | None = model_map.get(node)
         if model is not None:
-            query_sql: str = model_query_overrides.get(node, model.query_sql)
-            dependency_names: set[str] = {
-                match.group(1)
-                for match in _REF_PATTERN.finditer(query_sql)
-                if match.group(1) not in mock_ref_names and match.group(1) in model_map
-            }
+            dependency_names: set[str] = _test_model_dependency_names(
+                model=model,
+                query_override=model_query_overrides.get(node),
+                model_map=model_map,
+                mock_ref_names=mock_ref_names,
+            )
             dependency_name: str
             for dependency_name in sorted(dependency_names):
                 seen, result = _visit(node=dependency_name, seen=seen, result=result)
@@ -757,6 +839,27 @@ def _topo_sort_model_chain(
         visited, ordered = _visit(node=name, seen=visited, result=ordered)
 
     return tuple(ordered)
+
+
+def _test_model_dependency_names(
+    *,
+    model: CompiledModel,
+    query_override: str | None,
+    model_map: dict[str, CompiledModel],
+    mock_ref_names: frozenset[str],
+) -> set[str]:
+    if query_override is not None:
+        candidates: set[str] = {
+            match.group(1)
+            for match in uncommented_pattern_matches(pattern=_REF_PATTERN, sql=query_override)
+        }
+    else:
+        candidates = {
+            dependency.name
+            for dependency in model.deps
+            if dependency.resource_type == CompiledResourceType.MODEL
+        }
+    return {name for name in candidates if name not in mock_ref_names and name in model_map}
 
 
 def _extract_mock_refs(test: CompiledSqlTest) -> dict[str, str]:

--- a/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
+++ b/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
@@ -54,15 +54,22 @@ from sqlbuild.compiler.references.main.reference_call_prefix_pattern_text import
 )
 from sqlbuild.compiler.references.types import SqlReferenceKind
 
-_REF_PATTERN: re.Pattern[str] = quoted_reference_call_pattern(SqlReferenceKind.REF)
-_SOURCE_PATTERN: re.Pattern[str] = quoted_reference_call_pattern(SqlReferenceKind.SOURCE)
-_SEED_PATTERN: re.Pattern[str] = quoted_reference_call_pattern(SqlReferenceKind.SEED)
+_REF_PATTERN: re.Pattern[str] = re.compile(
+    quoted_reference_call_pattern(SqlReferenceKind.REF).pattern, re.IGNORECASE
+)
+_SOURCE_PATTERN: re.Pattern[str] = re.compile(
+    quoted_reference_call_pattern(SqlReferenceKind.SOURCE).pattern, re.IGNORECASE
+)
+_SEED_PATTERN: re.Pattern[str] = re.compile(
+    quoted_reference_call_pattern(SqlReferenceKind.SEED).pattern, re.IGNORECASE
+)
 _DBT_REF_PATTERN: re.Pattern[str] = re.compile(
     rf'{reference_call_prefix_pattern_text(SqlReferenceKind.DBT_REF)}"([^"]+)"'
-    r'(?:,\s*"([^"]+)")?\)'
+    r'(?:,\s*"([^"]+)")?\)',
+    re.IGNORECASE,
 )
 _TABLE_FUNCTION_PATTERN: re.Pattern[str] = re.compile(
-    reference_call_prefix_pattern_text(SqlReferenceKind.TABLE_FUNCTION)
+    reference_call_prefix_pattern_text(SqlReferenceKind.TABLE_FUNCTION), re.IGNORECASE
 )
 _LEADING_WITH_PATTERN: re.Pattern[str] = re.compile(r"^\s*WITH\b", re.IGNORECASE)
 

--- a/src/sqlbuild/compiler/planner/_helpers/sql_tests/comments.py
+++ b/src/sqlbuild/compiler/planner/_helpers/sql_tests/comments.py
@@ -1,0 +1,58 @@
+"""SQL comment handling for textual unit-test fallback resolution."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+_SQL_NON_CODE_PATTERN: re.Pattern[str] = re.compile(
+    r"'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"|`(?:``|[^`])*`|"
+    r"\$\$.*?\$\$|--[^\n]*|/\*.*?\*/",
+    re.DOTALL,
+)
+
+
+def uncommented_pattern_matches(*, pattern: re.Pattern[str], sql: str) -> tuple[re.Match[str], ...]:
+    """Find pattern matches outside SQL comments and quoted values."""
+
+    return uncommented_matches_by_pattern(patterns=(pattern,), sql=sql)[0]
+
+
+def uncommented_matches_by_pattern(
+    *, patterns: tuple[re.Pattern[str], ...], sql: str
+) -> tuple[tuple[re.Match[str], ...], ...]:
+    """Find matches for multiple patterns with one protected-region scan."""
+
+    protected_ranges: tuple[tuple[int, int], ...] = tuple(
+        (match.start(), match.end()) for match in _SQL_NON_CODE_PATTERN.finditer(sql)
+    )
+
+    def _matches(pattern: re.Pattern[str]) -> tuple[re.Match[str], ...]:
+        protected_index: int = 0
+        matches: list[re.Match[str]] = []
+        match: re.Match[str]
+        for match in pattern.finditer(sql):
+            while (
+                protected_index < len(protected_ranges)
+                and protected_ranges[protected_index][1] <= match.start()
+            ):
+                protected_index += 1
+            if (
+                protected_index == len(protected_ranges)
+                or match.start() < protected_ranges[protected_index][0]
+            ):
+                matches.append(match)
+        return tuple(matches)
+
+    return tuple(_matches(pattern) for pattern in patterns)
+
+
+def replace_uncommented_pattern(
+    *, pattern: re.Pattern[str], replacement: Callable[[re.Match[str]], str], sql: str
+) -> str:
+    """Replace pattern matches outside comments while preserving original comments."""
+
+    result: str = sql
+    for match in reversed(uncommented_pattern_matches(pattern=pattern, sql=sql)):
+        result = f"{result[: match.start()]}{replacement(match)}{result[match.end() :]}"
+    return result

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
@@ -37,6 +37,17 @@ class DbtShapedCompilePerformanceGuardTestCase:
 
 
 @dataclass(frozen=True)
+class SqlTestHeavyCompilePerformanceGuardTestCase:
+    description: str
+    model_count: int
+    test_count: int
+    chain_depth: int
+    fixture_row_count: int
+    expected_min_compiled_test_bytes: int
+    expected_max_seconds: float
+
+
+@dataclass(frozen=True)
 class NamespaceCompileTestCase:
     description: str
     repo_files: dict[str, str]

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/helpers.py
@@ -77,6 +77,33 @@ def run_dbt_shaped_compile_benchmark(
     return cold_seconds, warm_seconds
 
 
+def run_test_heavy_compile_benchmark(
+    *,
+    project_dir: Path,
+    model_count: int,
+    test_count: int,
+    chain_depth: int,
+    fixture_row_count: int,
+    expected_max_seconds: float,
+) -> float:
+    skip_actions: dict[bool, Callable[[], None]] = {
+        False: _continue_compile_benchmark,
+        True: _skip_compile_benchmark,
+    }
+    skip_actions[os.environ.get("SQLBUILD_SKIP_PERFORMANCE_TESTS") == "1"]()
+    write_test_heavy_compile_project(
+        project_dir=project_dir,
+        model_count=model_count,
+        test_count=test_count,
+        chain_depth=chain_depth,
+        fixture_row_count=fixture_row_count,
+    )
+    return _run_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_max_seconds,
+    )
+
+
 def _run_compile_benchmark(*, project_dir: Path, expected_max_seconds: float) -> float:
     with _fail_after_seconds(expected_max_seconds):
         start: float = time.perf_counter()
@@ -95,6 +122,11 @@ def _run_compile_benchmark(*, project_dir: Path, expected_max_seconds: float) ->
 
 def measure_model_sql_bytes(project_dir: Path) -> int:
     return sum(path.stat().st_size for path in (project_dir / "models").glob("*.sql"))
+
+
+def measure_compiled_test_sql_bytes(project_dir: Path) -> int:
+    compiled_tests_dir: Path = project_dir / "target" / "compiled" / "tests"
+    return sum(path.stat().st_size for path in compiled_tests_dir.rglob("*.sql"))
 
 
 @contextmanager
@@ -152,6 +184,41 @@ def write_dbt_shaped_compile_project(*, project_dir: Path, model_count: int) -> 
             target_bytes=_sql_size_target(model_index=index, model_count=model_count),
         )
         (models_dir / f"model_{index:05d}.sql").write_text(model_sql, encoding="utf-8")
+
+
+def write_test_heavy_compile_project(
+    *,
+    project_dir: Path,
+    model_count: int,
+    test_count: int,
+    chain_depth: int,
+    fixture_row_count: int,
+) -> None:
+    models_dir: Path = project_dir / "models"
+    tests_dir: Path = project_dir / "tests" / "unit"
+    models_dir.mkdir(parents=True)
+    tests_dir.mkdir(parents=True)
+    _write_compile_project_config(project_dir)
+    for index in range(model_count):
+        group_offset: int = index % chain_depth
+        model_sql_builder: Callable[..., str] = {
+            True: _test_heavy_base_model_sql,
+            False: _test_heavy_chain_model_sql,
+        }[group_offset == 0]
+        model_sql: str = model_sql_builder(index=index)
+        (models_dir / f"model_{index:05d}.sql").write_text(model_sql, encoding="utf-8")
+    group_count: int = model_count // chain_depth
+    for test_index in range(test_count):
+        cases_per_target: int = 5
+        group_index: int = (test_index // cases_per_target) % group_count
+        base_index: int = group_index * chain_depth
+        target_index: int = base_index + chain_depth - 1
+        test_sql: str = _test_heavy_sql(
+            base_index=base_index,
+            target_index=target_index,
+            fixture_row_count=fixture_row_count,
+        )
+        (tests_dir / f"test_{test_index:05d}.sql").write_text(test_sql, encoding="utf-8")
 
 
 def _write_compile_project_config(project_dir: Path) -> None:
@@ -326,3 +393,57 @@ SELECT
   status
 FROM joined
 '''
+
+
+def _test_heavy_base_model_sql(*, index: int) -> str:
+    return f"""MODEL (materialized view);
+
+SELECT
+  {index} AS id,
+  CAST({index} AS DOUBLE) AS amount,
+  'base' AS status
+"""
+
+
+def _test_heavy_chain_model_sql(*, index: int) -> str:
+    previous_model: str = f"model_{index - 1:05d}"
+    return f'''MODEL (materialized view);
+
+WITH transformed AS (
+  SELECT
+    id + 1 AS id,
+    amount + {index} AS amount,
+    CASE WHEN id % 2 = 0 THEN 'even' ELSE 'odd' END AS status
+  FROM __ref("{previous_model}")
+),
+windowed AS (
+  SELECT
+    id,
+    amount,
+    status,
+    ROW_NUMBER() OVER (PARTITION BY status ORDER BY id) AS row_number,
+    SUM(amount) OVER (PARTITION BY status ORDER BY id) AS running_amount
+  FROM transformed
+)
+SELECT id, amount + running_amount AS amount, status
+FROM windowed
+WHERE row_number >= 1
+'''
+
+
+def _test_heavy_sql(*, base_index: int, target_index: int, fixture_row_count: int) -> str:
+    fixture_rows: str = " UNION ALL\n".join(
+        f"  SELECT {row} AS id, CAST({row} AS DOUBLE) AS amount, 'base' AS status"
+        for row in range(fixture_row_count)
+    )
+    return f"""TEST();
+
+WITH
+__ref__model_{base_index:05d} AS (
+{fixture_rows}
+),
+__expected__model_{target_index:05d} AS (
+  SELECT 1 AS id, CAST(1 AS DOUBLE) AS amount, 'odd' AS status
+)
+SELECT 1
+"""

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_compile_performance.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_compile_performance.py
@@ -11,11 +11,14 @@ from tests.e2e.src.sqlbuild.cli.commands.main.compile._test_types import (
     CompilePerformanceGuardTestCase,
     CompileScalingGuardTestCase,
     DbtShapedCompilePerformanceGuardTestCase,
+    SqlTestHeavyCompilePerformanceGuardTestCase,
 )
 from tests.e2e.src.sqlbuild.cli.commands.main.compile.helpers import (
+    measure_compiled_test_sql_bytes,
     measure_model_sql_bytes,
     run_advanced_compile_benchmark,
     run_dbt_shaped_compile_benchmark,
+    run_test_heavy_compile_benchmark,
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -156,3 +159,43 @@ def test_given_dbt_shaped_project_when_compiling_cold_and_warm_then_finishes_wit
     assert total_sql_bytes <= test_case.expected_max_sql_bytes
     assert cold_seconds < test_case.expected_max_seconds
     assert warm_seconds < test_case.expected_warm_max_seconds
+
+
+@pytest.mark.performance
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SqlTestHeavyCompilePerformanceGuardTestCase(
+            description="1000 models and 150 chained native tests compile under seven seconds",
+            model_count=1_000,
+            test_count=150,
+            chain_depth=5,
+            fixture_row_count=120,
+            expected_min_compiled_test_bytes=2_000_000,
+            expected_max_seconds=7.0,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_test_heavy_project_when_compiling_then_finishes_within_budget(
+    tmp_path: Path,
+    test_case: SqlTestHeavyCompilePerformanceGuardTestCase,
+) -> None:
+    project_dir: Path = tmp_path / "test_heavy"
+    elapsed_seconds: float = run_test_heavy_compile_benchmark(
+        project_dir=project_dir,
+        model_count=test_case.model_count,
+        test_count=test_case.test_count,
+        chain_depth=test_case.chain_depth,
+        fixture_row_count=test_case.fixture_row_count,
+        expected_max_seconds=test_case.expected_max_seconds,
+    )
+    compiled_test_bytes: int = measure_compiled_test_sql_bytes(project_dir)
+    _LOGGER.info(
+        f"test-heavy compile models={test_case.model_count} tests={test_case.test_count} "
+        f"compiled_test_bytes={compiled_test_bytes} cold={elapsed_seconds:.3f}s "
+        f"budget={test_case.expected_max_seconds:g}s"
+    )
+
+    assert compiled_test_bytes >= test_case.expected_min_compiled_test_bytes
+    assert elapsed_seconds < test_case.expected_max_seconds

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/helpers.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from sqlbuild.compiler.compile.constants import (
@@ -24,6 +25,7 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlTestBlock,
     DiscoveredSqlTestFile,
 )
+from sqlbuild.compiler.planner._helpers.sql_tests.comments import uncommented_pattern_matches
 from tests.integration.src.sqlbuild.compiler.planner._helpers.sql_test_assembly._test_types import (
     ExecuteChainTestCase,
 )
@@ -99,13 +101,26 @@ def build_test_and_project(
     model_name: str
     query_sql: str
     for model_name, query_sql in test_case.model_queries.items():
+        dependency_names: tuple[str, ...] = tuple(
+            match.group(1)
+            for match in uncommented_pattern_matches(
+                pattern=re.compile(r'__ref\("([^"]+)"\)'), sql=query_sql
+            )
+        )
+        dependencies: tuple[CompiledObjectKey, ...] = tuple(
+            CompiledObjectKey(
+                resource_type=CompiledResourceType.MODEL,
+                name=dependency_name,
+            )
+            for dependency_name in dict.fromkeys(dependency_names)
+        )
         models.append(
             CompiledModel(
                 key=CompiledObjectKey(
                     resource_type=CompiledResourceType.MODEL,
                     name=model_name,
                 ),
-                deps=(),
+                deps=dependencies,
                 name=model_name,
                 relative_path=Path(f"models/{model_name}.sql"),
                 query_sql=query_sql,

--- a/tests/integration/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_execute_chain.py
+++ b/tests/integration/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_execute_chain.py
@@ -435,7 +435,40 @@ def test_given_macro_test_plan_when_executing_then_it_passes_direct_comparison(
                 "stg_orders": ((1, 100),),
                 "fact_orders": ((1, 101),),
             },
-        )
+        ),
+        ExecuteChainTestCase(
+            description="sql_analysis path handles a leading comment before with",
+            model_queries={
+                "orders": (
+                    "-- preserve this model comment\n"
+                    'WITH source_rows AS (SELECT id FROM __source("raw")) '
+                    "SELECT id FROM source_rows"
+                )
+            },
+            mock_ref_ctes={},
+            mock_source_ctes={"raw": "SELECT 1 AS id"},
+            helper_ctes={},
+            expected_model_names=("orders",),
+            expected_cte_bodies={"orders": "SELECT 1 AS id"},
+            expected_chain_length=1,
+            expected_results={"orders": ((1,),)},
+        ),
+        ExecuteChainTestCase(
+            description="sql_analysis path handles many leading comments before plain select",
+            model_queries={
+                "orders": (
+                    "".join(f"-- retained comment {index}\n" for index in range(30))
+                    + 'SELECT id FROM __source("raw")'
+                )
+            },
+            mock_ref_ctes={},
+            mock_source_ctes={"raw": "SELECT 1 AS id"},
+            helper_ctes={},
+            expected_model_names=("orders",),
+            expected_cte_bodies={"orders": "SELECT 1 AS id"},
+            expected_chain_length=1,
+            expected_results={"orders": ((1,),)},
+        ),
     ],
     ids=lambda case: case.description,
 )

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/_test_types.py
@@ -11,6 +11,8 @@ class TargetWriterTestCase:
     expected_files: dict[str, str] = field(default_factory=dict)
     initial_files: dict[str, str] = field(default_factory=dict)
     expected_summary_line: str = ""
+    model_count: int = 0
+    expected_max_component_bytes: int = 0
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
@@ -14,7 +14,7 @@ from sqlbuild.cli.commands._helpers.compile.target_writer import (
 )
 from sqlbuild.cli.commands.models import WrittenTarget
 from sqlbuild.compiler.compile.models import CompiledProject
-from sqlbuild.compiler.planner.models import PlanOutput, SqlTestPlanEntry
+from sqlbuild.compiler.planner.models import ChainStep, PlanOutput, SqlTestPlanEntry
 from sqlbuild.executor.testing.main.comparison_sql import build_sql_test_comparison_sql
 from tests.unit.src.sqlbuild.cli.commands.main.compile._test_types import (
     TargetWriterTestCase,
@@ -85,6 +85,46 @@ def test_given_plan_output_when_writing_target_then_expected_files_are_written(
     assert json.loads(manifest_path.read_text()) == manifest
     assert manifest_path.stat().st_mtime_ns == unchanged_mtime_ns
     assert not (tmp_path / "target" / "run").exists()
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        TargetWriterTestCase(
+            description="long chain uses a bounded deterministic artifact directory",
+            model_count=20,
+            expected_max_component_bytes=200,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_long_test_chain_when_writing_target_then_artifact_component_is_bounded(
+    test_case: TargetWriterTestCase,
+    tmp_path: Path,
+) -> None:
+    plan_output: PlanOutput = build_target_writer_plan_output()
+    template: SqlTestPlanEntry = plan_output.test_entries[0]
+    long_entry: SqlTestPlanEntry = replace(
+        template,
+        chain=tuple(
+            ChainStep(
+                model_name=f"model_{index:02d}_{'x' * 40}",
+                resolved_sql="SELECT 1 AS value",
+            )
+            for index in range(test_case.model_count)
+        ),
+    )
+
+    _ = write_compile_target(
+        target_dir=tmp_path / "target",
+        adapter=DuckDbAdapter(),
+        plan_output=replace(plan_output, test_entries=(long_entry,)),
+    )
+
+    artifact: Path = next((tmp_path / "target" / "compiled" / "tests").rglob("*.sql"))
+    assert len(artifact.parent.name.encode()) <= test_case.expected_max_component_bytes
+    assert artifact.parent.name.startswith("model_00_")
+    assert f"model_{test_case.model_count - 1:02d}_" in artifact.parent.name
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/_test_types.py
@@ -44,3 +44,10 @@ class AssertionChainCteErrorTestCase:
     assertion_sql: str
     resolved_chain: dict[str, str]
     expected_error_fragment: str
+
+
+@dataclass(frozen=True)
+class RepeatedFixturePlanTestCase:
+    description: str
+    fixture_ids: tuple[int, ...]
+    expected_sql_fragments: tuple[str, ...]

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from pathlib import Path
 from types import MappingProxyType
@@ -33,6 +34,7 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlTestBlock,
     DiscoveredSqlTestFile,
 )
+from sqlbuild.compiler.planner._helpers.sql_tests.comments import uncommented_pattern_matches
 from tests.unit.src.sqlbuild.compiler.planner._helpers.sql_test_assembly._test_types import (
     PlanTestChainTestCase,
 )
@@ -154,7 +156,15 @@ def build_test_and_project(
                     resource_type=CompiledResourceType.MODEL,
                     name=model_name,
                 ),
-                deps=(),
+                deps=tuple(
+                    CompiledObjectKey(
+                        resource_type=CompiledResourceType.MODEL,
+                        name=dependency_name,
+                    )
+                    for dependency_name in _model_dependencies(
+                        query_sql=query_sql,
+                    )
+                ),
                 name=model_name,
                 relative_path=Path(f"models/{model_name}.sql"),
                 query_sql=query_sql,
@@ -209,6 +219,17 @@ def build_test_and_project(
     )
 
     return compiled_test, project
+
+
+def _model_dependencies(*, query_sql: str) -> tuple[str, ...]:
+    return tuple(
+        dict.fromkeys(
+            match.group(1)
+            for match in uncommented_pattern_matches(
+                pattern=re.compile(r'__ref\("([^"]+)"\)'), sql=query_sql
+            )
+        )
+    )
 
 
 def _build_model_query_overrides(

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_plan_test.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_plan_test.py
@@ -36,6 +36,7 @@ from tests.unit.src.sqlbuild.compiler.planner._helpers.sql_test_assembly._test_t
     AssertionChainCteErrorTestCase,
     PlanMacroTestCase,
     PlanTestChainTestCase,
+    RepeatedFixturePlanTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.planner._helpers.sql_test_assembly.helpers import (
     build_test_and_project,
@@ -45,6 +46,25 @@ from tests.unit.src.sqlbuild.compiler.planner._helpers.sql_test_assembly.helpers
 @pytest.mark.parametrize(
     "test_case",
     [
+        PlanTestChainTestCase(
+            description="commented model ref is not added to the test chain",
+            model_queries={
+                "unused_upstream": "SELECT 1 AS id",
+                "orders": 'SELECT `value--label` AS id\n-- FROM __ref("unused_upstream")',
+            },
+            mock_ref_ctes={},
+            mock_source_ctes={},
+            helper_ctes={},
+            expected_model_names=("orders",),
+            expected_chain_length=1,
+            expected_sql_fragments={"orders": "`value--label`"},
+            expected_cte_bodies={"orders": "SELECT 1 AS id"},
+            assertion_ctes={
+                "commented_ref_is_ignored": (
+                    'SELECT 1 AS violation\n-- FROM __ref("unused_upstream")'
+                )
+            },
+        ),
         PlanTestChainTestCase(
             description="single model with mock dbt ref replaces dbt ref in sql",
             model_queries={
@@ -520,6 +540,140 @@ def test_given_test_and_project_when_planning_then_produces_expected_chain(
     expected_error_fragment: str
     for expected_error_fragment in test_case.expected_error_fragments:
         assert any(expected_error_fragment in w.message for w in warnings)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        PlanTestChainTestCase(
+            description="comment and literal refs are ignored without rewriting SQL",
+            model_queries={
+                "orders": (
+                    "SELECT `value--label` AS marker, "
+                    "'-- __ref(\"literal_model\")' AS literal_value\n"
+                    '/* optimizer hint __ref("block_model") */\n'
+                    '-- __ref("line_model")'
+                ),
+                "literal_model": "SELECT 1",
+                "block_model": "SELECT 1",
+                "line_model": "SELECT 1",
+                "literal_assertion_model": "SELECT 1",
+                "block_assertion_model": "SELECT 1",
+                "line_assertion_model": "SELECT 1",
+            },
+            mock_ref_ctes={},
+            mock_source_ctes={},
+            helper_ctes={},
+            expected_model_names=("orders",),
+            expected_chain_length=1,
+            expected_cte_bodies={"orders": "SELECT 1"},
+            assertion_ctes={
+                "comments_are_preserved": (
+                    "SELECT '-- __ref(\"literal_assertion_model\")' AS value\n"
+                    '/* assertion hint __ref("block_assertion_model") */\n'
+                    '-- __ref("line_assertion_model")'
+                )
+            },
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_refs_in_comments_and_literals_when_planning_then_preserves_sql_and_ignores_refs(
+    test_case: PlanTestChainTestCase,
+) -> None:
+    compiled_test: CompiledSqlTest
+    project: CompiledProject
+    compiled_test, project = build_test_and_project(test_case)
+
+    entry, warnings = plan_test(test=compiled_test, project=project, adapter=DuckDbAdapter())
+
+    assert not warnings
+    assert tuple(step.model_name for step in entry.chain) == test_case.expected_model_names
+    assert entry.chain[0].resolved_sql == test_case.model_queries["orders"]
+    assert len(entry.assertions) == 1
+    assert entry.assertions[0].resolved_sql == test_case.assertion_ctes["comments_are_preserved"]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        RepeatedFixturePlanTestCase(
+            description="two fixture rows stay isolated",
+            fixture_ids=(1, 2),
+            expected_sql_fragments=("SELECT 1 AS id", "SELECT 2 AS id"),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_repeated_query_with_different_fixture_rows_when_planning_then_keeps_cases_isolated(
+    test_case: RepeatedFixturePlanTestCase,
+) -> None:
+    entries: list[SqlTestPlanEntry] = []
+    fixture_id: int
+    for fixture_id in test_case.fixture_ids:
+        fixture_case: PlanTestChainTestCase = PlanTestChainTestCase(
+            description=f"fixture case {fixture_id}",
+            model_queries={"orders": 'SELECT id FROM __source("raw")'},
+            mock_ref_ctes={},
+            mock_source_ctes={"raw": f"SELECT {fixture_id} AS id"},
+            helper_ctes={},
+            expected_model_names=("orders",),
+            expected_chain_length=1,
+            expected_cte_bodies={"orders": f"SELECT {fixture_id} AS id"},
+        )
+        compiled_test: CompiledSqlTest
+        project: CompiledProject
+        compiled_test, project = build_test_and_project(fixture_case)
+        entry, warnings = plan_test(
+            test=compiled_test,
+            project=project,
+            adapter=DuckDbAdapter(),
+            sql_analysis_enabled=True,
+        )
+        assert not warnings
+        entries.append(entry)
+
+    for entry, expected_fragment in zip(entries, test_case.expected_sql_fragments, strict=True):
+        assert expected_fragment in entry.chain[0].resolved_sql
+    assert entries[0].chain[0].resolved_sql != entries[1].chain[0].resolved_sql
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        PlanTestChainTestCase(
+            description="unresolved marker inside generated mock CTE",
+            model_queries={"orders": 'SELECT id FROM __ref("raw_orders")'},
+            mock_ref_ctes={"raw_orders": 'SELECT id FROM __source("missing_source")'},
+            mock_source_ctes={},
+            helper_ctes={},
+            expected_model_names=("orders",),
+            expected_chain_length=1,
+            expected_warning_count=1,
+            expected_warning_severity=WarningSeverity.ERROR,
+            expected_error_fragments=("missing_source",),
+            expected_cte_bodies={"orders": "SELECT 1 AS id"},
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_unresolved_marker_in_mock_when_planning_with_analysis_then_reports_error(
+    test_case: PlanTestChainTestCase,
+) -> None:
+    compiled_test: CompiledSqlTest
+    project: CompiledProject
+    compiled_test, project = build_test_and_project(test_case)
+
+    _, warnings = plan_test(
+        test=compiled_test,
+        project=project,
+        adapter=DuckDbAdapter(),
+        sql_analysis_enabled=True,
+    )
+
+    assert len(warnings) == test_case.expected_warning_count
+    assert warnings[0].severity is test_case.expected_warning_severity
+    assert test_case.expected_error_fragments[0] in warnings[0].message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Real test-heavy projects could traverse commented model references, generate filesystem components beyond platform limits, and spend most compile time rebuilding identical SQL-test analysis. The Dagster Mustard project took 15.2–15.6s and failed static artifact generation with `Errno 36`.

## Changes

- traverse normal test chains through compiled dependency metadata and scan override/assertion SQL without treating comments or quoted literals as references
- preserve authored comments while resolving markers and validating unresolved generated fixture SQL
- share deterministic, bounded test artifact paths between compile and runtime writers
- cache pure CTE extraction and repeated SQL-analysis templates while keeping fixture contents isolated per case
- avoid duplicate textual assembly, AST deep copies, and repeated CTE rendering
- add a 1,000-model / 150 chained-test / 2MB+ compile performance guard with a 7s ceiling

## Verification

- `make test`: 6,226 passed
- `uv sync --all-extras && make check-ci`: passed
- compile performance guards: 6 passed, including existing 3k/10k workloads
- real Dagster core compile: 6.96s repeat, down from 15.2–15.6s full baseline
- 141 real compiled test artifacts: byte-for-byte unchanged after optimization
- real Dagster DAG compile: 976 models, 46 seeds, 23 functions, 0 errors, 0 warnings
- focused planner/writer/executable regressions passed
