### PR TITLE
fix: preserve adapter SQL in native tests

### DIFF
--- a/src/sqlbuild/compiler/planner/_helpers/sql_tests/analysis_assembly.py
+++ b/src/sqlbuild/compiler/planner/_helpers/sql_tests/analysis_assembly.py
@@ -19,6 +19,9 @@ from sqlbuild.compiler.compile.models import CompileSqlTestCte
 from sqlbuild.compiler.planner._helpers.scenario.relations import (
     _replace_relation_markers_in_polyglot_dict,
 )
+from sqlbuild.compiler.planner._helpers.sql_tests.comments import (
+    restore_sql_test_dialect_function_names,
+)
 from sqlbuild.compiler.planner.models import SqlAnalysisResolvedTestSql
 from sqlbuild.compiler.references.types import SqlReferenceKind
 from sqlbuild.compiler.sql_analysis.constants import SQL_IDENTIFIER_PREFIX
@@ -206,6 +209,7 @@ def try_resolve_test_model_sql_with_sql_analysis(
     helper_ctes: tuple[CompileSqlTestCte, ...],
     resolved_chain: dict[str, SqlAnalysisResolvedTestSql],
     file_label: str,
+    sql_analysis_dialect: str | None,
 ) -> SqlAnalysisResolvedTestSql | None:
     """Return Polyglot-backed readable test SQL or None on import/parse failure."""
 
@@ -223,6 +227,7 @@ def try_resolve_test_model_sql_with_sql_analysis(
     template: _TestSqlAnalysisTemplate | None = _analyze_test_query_template(
         query_sql=query_sql,
         marker_targets=marker_targets,
+        sql_analysis_dialect=sql_analysis_dialect,
     )
     if template is None:
         return None
@@ -292,7 +297,10 @@ def _function_marker_targets(
 
 @lru_cache(maxsize=4096)
 def _analyze_test_query_template(
-    *, query_sql: str, marker_targets: tuple[tuple[str, str, str], ...]
+    *,
+    query_sql: str,
+    marker_targets: tuple[tuple[str, str, str], ...],
+    sql_analysis_dialect: str | None,
 ) -> _TestSqlAnalysisTemplate | None:
     polyglot_module: Any | None = import_polyglot_sql()
     if polyglot_module is None:
@@ -300,6 +308,7 @@ def _analyze_test_query_template(
     parsed_dict: dict[str, Any] | None = _try_parse_test_query(
         polyglot_module=polyglot_module,
         query_sql=query_sql,
+        sql_analysis_dialect=sql_analysis_dialect,
     )
     if parsed_dict is None:
         return None
@@ -307,12 +316,13 @@ def _analyze_test_query_template(
     _replace_relation_markers_in_polyglot_dict(
         node=parsed_dict,
         polyglot_module=polyglot_module,
-        sql_analysis_dialect=None,
+        sql_analysis_dialect=sql_analysis_dialect,
         target_for_marker=target_for_marker,
     )
     cte_body_sql: str | None = _generate_one(
         polyglot_module=polyglot_module,
         expression=parsed_dict,
+        sql_analysis_dialect=sql_analysis_dialect,
     )
     if cte_body_sql is None:
         return None
@@ -323,9 +333,13 @@ def _analyze_test_query_template(
     )
 
 
-def _try_parse_test_query(*, polyglot_module: Any, query_sql: str) -> dict[str, Any] | None:
+def _try_parse_test_query(
+    *, polyglot_module: Any, query_sql: str, sql_analysis_dialect: str | None
+) -> dict[str, Any] | None:
     try:
-        parsed: Any = polyglot_module.parse_one(query_sql, dialect="generic")
+        parsed: Any = polyglot_module.parse_one(
+            query_sql, dialect=sql_analysis_dialect or "generic"
+        )
     except Exception as error:
         log_debug_event(
             logger=_DEBUG_LOGGER,
@@ -428,9 +442,13 @@ def _root_select(parsed_dict: dict[str, Any]) -> dict[str, Any] | None:
     return select_payload if isinstance(select_payload, dict) else None
 
 
-def _generate_one(*, polyglot_module: Any, expression: Any) -> str | None:
+def _generate_one(
+    *, polyglot_module: Any, expression: Any, sql_analysis_dialect: str | None
+) -> str | None:
     try:
-        generated: list[str] = polyglot_module.generate(expression, dialect="generic")
+        generated: list[str] = polyglot_module.generate(
+            expression, dialect=sql_analysis_dialect or "generic"
+        )
     except Exception as error:
         log_debug_event(
             logger=_DEBUG_LOGGER,
@@ -440,4 +458,4 @@ def _generate_one(*, polyglot_module: Any, expression: Any) -> str | None:
         return None
     if len(generated) != 1:
         return None
-    return generated[0]
+    return restore_sql_test_dialect_function_names(sql=generated[0], dialect=sql_analysis_dialect)

--- a/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
+++ b/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
@@ -228,6 +228,7 @@ def plan_test(
                     helper_ctes=helper_ctes,
                     resolved_chain=sql_analysis_resolved,
                     file_label=str(test.test_file.relative_path),
+                    sql_analysis_dialect=adapter.sql_analysis_dialect(),
                 )
             )
             if sql_analysis_sql is not None:
@@ -366,6 +367,7 @@ def _build_assertion_steps(
                     helper_ctes=helper_ctes,
                     resolved_chain=sql_analysis_resolved,
                     file_label=str(test.test_file.relative_path),
+                    sql_analysis_dialect=adapter.sql_analysis_dialect(),
                 )
             )
             if analyzed_assertion_sql is not None and not _has_unresolved_test_reference(

--- a/src/sqlbuild/compiler/planner/_helpers/sql_tests/comments.py
+++ b/src/sqlbuild/compiler/planner/_helpers/sql_tests/comments.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 
+from sqlbuild.adapter.contract.types import BuiltinAdapter
+
 _SQL_NON_CODE_PATTERN: re.Pattern[str] = re.compile(
     r"'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"|`(?:``|[^`])*`|"
     r"\$\$.*?\$\$|--[^\n]*|/\*.*?\*/",
     re.DOTALL,
+)
+_SNOWFLAKE_STARTS_WITH_PATTERN: re.Pattern[str] = re.compile(
+    r"\bSTARTS_WITH(?=\s*\()", re.IGNORECASE
 )
 
 
@@ -56,3 +61,15 @@ def replace_uncommented_pattern(
     for match in reversed(uncommented_pattern_matches(pattern=pattern, sql=sql)):
         result = f"{result[: match.start()]}{replacement(match)}{result[match.end() :]}"
     return result
+
+
+def restore_sql_test_dialect_function_names(*, sql: str, dialect: str | None) -> str:
+    """Restore warehouse-supported spellings changed by SQL analysis formatting."""
+
+    if dialect != BuiltinAdapter.SNOWFLAKE:
+        return sql
+    return replace_uncommented_pattern(
+        pattern=_SNOWFLAKE_STARTS_WITH_PATTERN,
+        replacement=lambda _match: "STARTSWITH",
+        sql=sql,
+    )

--- a/src/sqlbuild/compiler/planner/main/execution/sql_test_dialect.py
+++ b/src/sqlbuild/compiler/planner/main/execution/sql_test_dialect.py
@@ -1,0 +1,11 @@
+"""Adapter-specific SQL-test analysis output corrections."""
+
+from sqlbuild.compiler.planner._helpers.sql_tests.comments import (
+    restore_sql_test_dialect_function_names as _restore_sql_test_dialect_function_names,
+)
+
+
+def restore_sql_test_dialect_function_names(*, sql: str, dialect: str | None) -> str:
+    """Restore warehouse-supported function spellings after SQL analysis."""
+
+    return _restore_sql_test_dialect_function_names(sql=sql, dialect=dialect)

--- a/src/sqlbuild/executor/testing/_helpers/comparison_sql.py
+++ b/src/sqlbuild/executor/testing/_helpers/comparison_sql.py
@@ -9,6 +9,9 @@ from copy import deepcopy
 from typing import Any
 
 from sqlbuild.adapter.contract.types import BuiltinAdapter
+from sqlbuild.compiler.planner.main.execution.sql_test_dialect import (
+    restore_sql_test_dialect_function_names,
+)
 from sqlbuild.compiler.planner.models import ChainStep, SqlTestPlanEntry
 from sqlbuild.compiler.sql_analysis.main.import_polyglot_sql import import_polyglot_sql
 from sqlbuild.diagnostics.main.log_debug_event import log_debug_event
@@ -71,9 +74,13 @@ def format_sql(
                 dialect=sql_analysis_dialect or "generic",
             )
         )
-        return _restore_protected_identifiers(
+        restored_sql: str = _restore_protected_identifiers(
             sql=formatted_sql,
             protected_identifiers=protected_identifiers,
+        )
+        return restore_sql_test_dialect_function_names(
+            sql=restored_sql,
+            dialect=sql_analysis_dialect,
         )
     except Exception:
         return sql

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/_test_types.py
@@ -51,3 +51,12 @@ class RepeatedFixturePlanTestCase:
     description: str
     fixture_ids: tuple[int, ...]
     expected_sql_fragments: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SqlAnalysisDialectTestCase:
+    description: str
+    query_sql: str
+    dialect: str
+    expected_sql_fragment: str
+    expected_absent_sql_fragment: str

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_plan_test.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/sql_test_assembly/test_plan_test.py
@@ -37,6 +37,7 @@ from tests.unit.src.sqlbuild.compiler.planner._helpers.sql_test_assembly._test_t
     PlanMacroTestCase,
     PlanTestChainTestCase,
     RepeatedFixturePlanTestCase,
+    SqlAnalysisDialectTestCase,
 )
 from tests.unit.src.sqlbuild.compiler.planner._helpers.sql_test_assembly.helpers import (
     build_test_and_project,
@@ -1188,6 +1189,7 @@ def test_given_assertion_analysis_failure_when_planning_then_textual_chain_stays
             helper_ctes=(),
             resolved_chain={},
             file_label="tests/unit/test_chain.sql",
+            sql_analysis_dialect="duckdb",
         )
     )
     assert model_analysis_result is not None
@@ -1214,6 +1216,42 @@ def test_given_assertion_analysis_failure_when_planning_then_textual_chain_stays
     assert "SELECT 1 AS id" in resolved_assertion_sql
     assert "__REF(" not in resolved_assertion_sql.upper()
     assert "FROM (WITH" not in resolved_assertion_sql.upper()
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SqlAnalysisDialectTestCase(
+            description="Snowflake STARTSWITH spelling is preserved",
+            query_sql="SELECT STARTSWITH(name, 'A') AS matches FROM __ref(\"items\")",
+            dialect="snowflake",
+            expected_sql_fragment="STARTSWITH(name, 'A')",
+            expected_absent_sql_fragment="STARTS_WITH",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_adapter_function_when_resolving_with_analysis_then_emits_supported_spelling(
+    test_case: SqlAnalysisDialectTestCase,
+) -> None:
+    result: SqlAnalysisResolvedTestSql | None = (
+        sql_test_assembly.try_resolve_test_model_sql_with_sql_analysis(
+            query_sql=test_case.query_sql,
+            mock_refs={"items": "SELECT 'Alice' AS name"},
+            mock_sources={},
+            mock_seeds={},
+            mock_dbt_refs={},
+            function_locations={},
+            helper_ctes=(),
+            resolved_chain={},
+            file_label="tests/unit/test_dialect.sql",
+            sql_analysis_dialect=test_case.dialect,
+        )
+    )
+
+    assert result is not None
+    assert test_case.expected_sql_fragment in result.resolved_sql
+    assert test_case.expected_absent_sql_fragment not in result.resolved_sql
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/executor/testing/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/testing/main/_test_types.py
@@ -6,4 +6,5 @@ class BuildComparisonSqlTestCase:
     description: str
     adapter_name: str
     expected_fragments: tuple[str, ...]
+    expected_absent_fragments: tuple[str, ...] = ()
     sql_analysis_enabled: bool = True

--- a/tests/unit/src/sqlbuild/executor/testing/main/test_comparison_sql.py
+++ b/tests/unit/src/sqlbuild/executor/testing/main/test_comparison_sql.py
@@ -75,6 +75,37 @@ def test_given_adapter_when_building_comparison_sql_then_it_uses_expected_set_di
     expected_fragment: str
     for expected_fragment in test_case.expected_fragments:
         assert expected_fragment in comparison_sql
+    expected_absent_fragment: str
+    for expected_absent_fragment in test_case.expected_absent_fragments:
+        assert expected_absent_fragment not in comparison_sql
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        BuildComparisonSqlTestCase(
+            description="Snowflake comparison formatting preserves STARTSWITH",
+            adapter_name="snowflake",
+            expected_fragments=("STARTSWITH(name, 'A')",),
+            expected_absent_fragments=("STARTS_WITH",),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_snowflake_function_when_formatting_comparison_then_emits_supported_spelling(
+    test_case: BuildComparisonSqlTestCase,
+) -> None:
+    adapter: BaseAdapter = build_comparison_test_adapter(test_case.adapter_name)
+
+    formatted_sql: str = comparison_sql_helpers.format_sql(
+        sql="SELECT STARTSWITH(name, 'A') AS matches FROM items",
+        sql_analysis_dialect=adapter.sql_analysis_dialect(),
+    )
+
+    for expected_fragment in test_case.expected_fragments:
+        assert expected_fragment in formatted_sql
+    for expected_absent_fragment in test_case.expected_absent_fragments:
+        assert expected_absent_fragment not in formatted_sql
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Native SQL-test assembly parsed and reformatted model SQL with the generic dialect. Valid Snowflake `STARTSWITH(...)` calls became unsupported `STARTS_WITH(...)`, so execution-grade tests failed before evaluating their assertions.

## Changes

- carry the selected adapter dialect through SQL-test parsing, relation replacement, generation, and the analysis-template cache key
- restore Snowflake's supported `STARTSWITH` spelling after both analysis generation and final comparison formatting
- preserve comments and quoted literals while correcting function calls
- add planner and final-formatter regressions for Snowflake function spelling

## Verification

- `make test`: 6,228 passed
- `uv sync --all-extras && make check-ci`: passed
- focused planner, executable-chain, and comparison tests: 61 passed
- real Dagster Snowflake race-match statements execute successfully; prior unknown-function errors are gone
- independent bounded review: no blocking findings
