### PR TITLE
perf: cache unchanged compile artifacts

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/compile/sql_test_artifact_cache.py
+++ b/src/sqlbuild/cli/commands/_helpers/compile/sql_test_artifact_cache.py
@@ -1,0 +1,287 @@
+"""Persistent identities for unchanged compiled SQL test artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import cast
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.cli.commands.models import (
+    SqlTestArtifactCacheRecord,
+    SqlTestArtifactIdentityContext,
+)
+from sqlbuild.compiler.compile.models import (
+    CompiledDirectLogicSqlTestPayload,
+    CompiledModel,
+    CompiledModelSqlTestPayload,
+    CompiledProject,
+    CompiledSqlTest,
+    CompileSqlTestCte,
+)
+
+_CACHE_VERSION: int = 1
+_ALGORITHM_FINGERPRINT: str = "sql-test-artifact-v1"
+_CACHE_FILE_NAME: str = "sql-test-artifacts.json"
+_MAX_CACHE_BYTES: int = 10_000_000
+_MAX_CACHE_RECORDS: int = 100_000
+_PARENT_PATH_COMPONENT: str = ".."
+_SQL_FILE_SUFFIX: str = ".sql"
+
+
+def build_sql_test_artifact_identity_context(
+    *, project: CompiledProject, adapter: BaseAdapter
+) -> SqlTestArtifactIdentityContext:
+    """Hash adapter and model inputs once for all test artifact identities."""
+
+    common_identity: str = _payload_digest(
+        {
+            "algorithm": _ALGORITHM_FINGERPRINT,
+            "sqlbuild_version": _package_version("sqlbuild"),
+            "polyglot_version": _package_version("polyglot-sql"),
+            "python_version": platform.python_version_tuple()[:2],
+            "adapter_class": f"{type(adapter).__module__}.{type(adapter).__qualname__}",
+            "set_difference_operator": adapter.render_set_difference_operator(),
+            "sql_analysis_dialect": adapter.sql_analysis_dialect(),
+            "requires_derived_table_aliases": adapter.requires_derived_table_aliases(),
+            "sql_analysis_enabled": project.settings.sql_analysis,
+            "effective_target_name": project.effective_target_name,
+            "effective_target_database": project.effective_target_database,
+            "effective_target_schema": project.effective_target_schema,
+            "function_locations": sorted(
+                (function.name, function.destination.qualified_name)
+                for function in project.functions
+            ),
+        }
+    )
+    return SqlTestArtifactIdentityContext(
+        common_identity=common_identity,
+        model_identities={model.name: _model_identity(model=model) for model in project.models},
+    )
+
+
+def sql_test_artifact_identity(
+    *,
+    test: CompiledSqlTest,
+    model_chain_names: tuple[str, ...],
+    context: SqlTestArtifactIdentityContext,
+) -> str:
+    """Return the complete identity of one rendered comparison artifact."""
+
+    return _payload_digest(
+        {
+            "common_identity": context.common_identity,
+            "test": _test_payload(test=test),
+            "model_chain": [
+                (name, context.model_identities.get(name)) for name in model_chain_names
+            ],
+        }
+    )
+
+
+def sql_test_artifact_record_key(*, test: CompiledSqlTest) -> str:
+    """Return the stable cache slot for one source test case."""
+
+    return _payload_digest(
+        {
+            "source_path": None if test.source_path is None else test.source_path.as_posix(),
+            "block_index": test.block_index,
+            "name": test.name,
+            "parent_name": test.parent_name,
+            "case_name": test.case_name,
+            "case_index": test.case_index,
+        }
+    )
+
+
+def read_sql_test_artifact_cache(
+    *, cache_dir: Path | None
+) -> dict[str, SqlTestArtifactCacheRecord]:
+    """Read valid cache records; cache failures never fail compilation."""
+
+    if cache_dir is None:
+        return {}
+    cache_path: Path = cache_dir / _CACHE_FILE_NAME
+    try:
+        if not cache_path.is_file() or cache_path.stat().st_size > _MAX_CACHE_BYTES:
+            return {}
+        payload: object = json.loads(cache_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("version") != _CACHE_VERSION:
+            return {}
+        raw_records: object = payload.get("records")
+        if not isinstance(raw_records, dict) or len(raw_records) > _MAX_CACHE_RECORDS:
+            return {}
+        records: dict[str, SqlTestArtifactCacheRecord] = {}
+        for key, value in raw_records.items():
+            record: SqlTestArtifactCacheRecord | None = _record_from_payload(value)
+            if isinstance(key, str) and record is not None:
+                records[key] = record
+        return records
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        return {}
+
+
+def write_sql_test_artifact_cache(
+    *, cache_dir: Path | None, records: dict[str, SqlTestArtifactCacheRecord]
+) -> None:
+    """Atomically replace the cache snapshot; cache failures are non-fatal."""
+
+    if cache_dir is None:
+        return
+    payload: dict[str, object] = {
+        "version": _CACHE_VERSION,
+        "records": {
+            key: {
+                "identity": record.identity,
+                "relative_path": record.relative_path.as_posix(),
+                "size": record.size,
+                "mtime_ns": record.mtime_ns,
+            }
+            for key, record in records.items()
+        },
+    }
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_path: Path = cache_dir / _CACHE_FILE_NAME
+        temporary_path: Path = cache_dir / f".{_CACHE_FILE_NAME}.{os.getpid()}.tmp"
+        temporary_path.write_text(
+            json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True),
+            encoding="utf-8",
+        )
+        temporary_path.replace(cache_path)
+    except OSError:
+        return
+
+
+def artifact_matches_cache_record(
+    *, tests_root: Path, record: SqlTestArtifactCacheRecord, identity: str
+) -> Path | None:
+    """Return the safe existing artifact path when identity and stat metadata match."""
+
+    if record.identity != identity or not _is_safe_relative_sql_path(record.relative_path):
+        return None
+    artifact_path: Path = tests_root / record.relative_path
+    try:
+        stat: os.stat_result = artifact_path.stat()
+    except OSError:
+        return None
+    if (
+        not artifact_path.is_file()
+        or stat.st_size != record.size
+        or stat.st_mtime_ns != record.mtime_ns
+    ):
+        return None
+    return artifact_path
+
+
+def build_sql_test_artifact_cache_record(
+    *, tests_root: Path, artifact_path: Path, identity: str
+) -> SqlTestArtifactCacheRecord | None:
+    """Capture the metadata needed to reuse one newly written artifact."""
+
+    try:
+        relative_path: Path = artifact_path.relative_to(tests_root)
+        stat: os.stat_result = artifact_path.stat()
+    except (OSError, ValueError):
+        return None
+    if not _is_safe_relative_sql_path(relative_path):
+        return None
+    return SqlTestArtifactCacheRecord(
+        identity=identity,
+        relative_path=relative_path,
+        size=stat.st_size,
+        mtime_ns=stat.st_mtime_ns,
+    )
+
+
+def _model_identity(*, model: CompiledModel) -> str:
+    return _payload_digest(
+        {
+            "name": model.name,
+            "query_sql": model.query_sql,
+            "deps": sorted((str(dep.resource_type), dep.name) for dep in model.deps),
+        }
+    )
+
+
+def _test_payload(*, test: CompiledSqlTest) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "case_fingerprint": test.case_fingerprint,
+        "mode": test.mode.value,
+        "sql_body": test.sql_body,
+        "scope_deps": sorted((str(dep.resource_type), dep.name) for dep in test.scope_deps),
+    }
+    if isinstance(test.payload, CompiledModelSqlTestPayload):
+        payload["model"] = {
+            "authored_ctes": _cte_payload(test.payload.authored_ctes),
+            "macro_mocks": sorted(test.payload.macro_mocks.items()),
+            "model_query_overrides": sorted(test.payload.model_query_overrides.items()),
+            "expected_model_names": test.payload.expected_model_names,
+            "assertion_ctes": _cte_payload(test.payload.assertion_ctes),
+        }
+    elif isinstance(test.payload, CompiledDirectLogicSqlTestPayload):
+        payload["direct"] = {
+            "helper_ctes": _cte_payload(test.payload.helper_ctes),
+            "actual_cte": _cte_payload((test.payload.actual_cte,)),
+            "expected_cte": _cte_payload((test.payload.expected_cte,)),
+            "tested_resource_names": test.payload.tested_resource_names,
+        }
+    return payload
+
+
+def _cte_payload(ctes: tuple[CompileSqlTestCte, ...]) -> list[tuple[str, str]]:
+    return [(cte.name, cte.sql_body) for cte in ctes]
+
+
+def _record_from_payload(payload: object) -> SqlTestArtifactCacheRecord | None:
+    if not isinstance(payload, dict):
+        return None
+    values: dict[str, object] = cast(dict[str, object], payload)
+    identity: object = values.get("identity")
+    relative_path: object = values.get("relative_path")
+    size: object = values.get("size")
+    mtime_ns: object = values.get("mtime_ns")
+    if (
+        not isinstance(identity, str)
+        or not isinstance(relative_path, str)
+        or not isinstance(size, int)
+        or isinstance(size, bool)
+        or size < 0
+        or not isinstance(mtime_ns, int)
+        or isinstance(mtime_ns, bool)
+        or mtime_ns < 0
+    ):
+        return None
+    path: Path = Path(relative_path)
+    if not _is_safe_relative_sql_path(path):
+        return None
+    return SqlTestArtifactCacheRecord(
+        identity=identity,
+        relative_path=path,
+        size=size,
+        mtime_ns=mtime_ns,
+    )
+
+
+def _is_safe_relative_sql_path(path: Path) -> bool:
+    return (
+        not path.is_absolute()
+        and _PARENT_PATH_COMPONENT not in path.parts
+        and path.suffix == _SQL_FILE_SUFFIX
+    )
+
+
+def _payload_digest(payload: object) -> str:
+    encoded: str = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _package_version(package_name: str) -> str:
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return "unknown"

--- a/src/sqlbuild/cli/commands/_helpers/compile/target_writer.py
+++ b/src/sqlbuild/cli/commands/_helpers/compile/target_writer.py
@@ -6,11 +6,27 @@ import json
 from pathlib import Path
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
-from sqlbuild.cli.commands.models import WrittenTarget
+from sqlbuild.cli.commands._helpers.compile.sql_test_artifact_cache import (
+    artifact_matches_cache_record,
+    build_sql_test_artifact_cache_record,
+    build_sql_test_artifact_identity_context,
+    read_sql_test_artifact_cache,
+    sql_test_artifact_identity,
+    sql_test_artifact_record_key,
+    write_sql_test_artifact_cache,
+)
+from sqlbuild.cli.commands.models import (
+    SqlTestArtifactCacheRecord,
+    SqlTestArtifactIdentityContext,
+    WrittenTarget,
+)
 from sqlbuild.cli.paths.main._sql_test_output_path import sql_test_output_path
 from sqlbuild.compiler.compile.models import CompiledProject
 from sqlbuild.compiler.compile.types import FunctionLanguage
-from sqlbuild.compiler.planner.main.execution.sql_test_assembly import build_sql_test_plan_entry
+from sqlbuild.compiler.planner.main.execution.sql_test_assembly import (
+    _sql_test_model_chain_names,
+    build_sql_test_plan_entry,
+)
 from sqlbuild.compiler.planner.models import AuditPlanEntry, PlanOutput
 from sqlbuild.executor.testing.main.comparison_sql import build_sql_test_comparison_sql
 
@@ -245,14 +261,44 @@ def _write_static_tests(
     """Write offline SQL-native test SQL."""
 
     managed_paths: set[Path] = set()
+    tests_root: Path = target_dir / _COMPILED_DIR / _TESTS_DIR
+    cached_records: dict[str, SqlTestArtifactCacheRecord] = read_sql_test_artifact_cache(
+        cache_dir=project.compile_cache_dir
+    )
+    current_records: dict[str, SqlTestArtifactCacheRecord] = {}
+    identity_context: SqlTestArtifactIdentityContext | None = (
+        build_sql_test_artifact_identity_context(project=project, adapter=adapter)
+        if project.compile_cache_dir is not None
+        else None
+    )
     for test in project.sql_tests:
+        record_key: str | None = None
+        artifact_identity: str | None = None
+        if identity_context is not None:
+            record_key = sql_test_artifact_record_key(test=test)
+            artifact_identity = sql_test_artifact_identity(
+                test=test,
+                model_chain_names=_sql_test_model_chain_names(test=test, project=project),
+                context=identity_context,
+            )
+            cached_record: SqlTestArtifactCacheRecord | None = cached_records.get(record_key)
+            if cached_record is not None:
+                cached_path: Path | None = artifact_matches_cache_record(
+                    tests_root=tests_root,
+                    record=cached_record,
+                    identity=artifact_identity,
+                )
+                if cached_path is not None:
+                    managed_paths.add(cached_path)
+                    current_records[record_key] = cached_record
+                    continue
         entry, _warnings = build_sql_test_plan_entry(
             test=test,
             project=project,
             adapter=adapter,
             sql_analysis_enabled=project.settings.sql_analysis,
         )
-        test_path: Path = target_dir / _COMPILED_DIR / _TESTS_DIR / sql_test_output_path(entry)
+        test_path: Path = tests_root / sql_test_output_path(entry)
         _write_sql(
             path=test_path,
             sql=build_sql_test_comparison_sql(
@@ -262,6 +308,18 @@ def _write_static_tests(
             ),
         )
         managed_paths.add(test_path)
+        if record_key is not None and artifact_identity is not None:
+            record: SqlTestArtifactCacheRecord | None = build_sql_test_artifact_cache_record(
+                tests_root=tests_root,
+                artifact_path=test_path,
+                identity=artifact_identity,
+            )
+            if record is not None:
+                current_records[record_key] = record
+    write_sql_test_artifact_cache(
+        cache_dir=project.compile_cache_dir,
+        records=current_records,
+    )
     return managed_paths
 
 

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -546,6 +546,24 @@ class CompileWriteResult:
 
 
 @dataclass(frozen=True)
+class SqlTestArtifactCacheRecord:
+    """Validated metadata for one previously written SQL test artifact."""
+
+    identity: str
+    relative_path: Path
+    size: int
+    mtime_ns: int
+
+
+@dataclass(frozen=True)
+class SqlTestArtifactIdentityContext:
+    """Project-wide identity fragments shared by every SQL test."""
+
+    common_identity: str
+    model_identities: dict[str, str]
+
+
+@dataclass(frozen=True)
 class WrittenTarget:
     """Result of writing compiled output to target/."""
 

--- a/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
+++ b/src/sqlbuild/compiler/compile/_helpers/analysis/cache.py
@@ -1,4 +1,4 @@
-"""Versioned project-local cache for successful model SQL analysis facts."""
+"""Versioned project-local cache for deterministic model SQL analysis facts."""
 
 from __future__ import annotations
 
@@ -31,8 +31,8 @@ from sqlbuild.compiler.lineage.types import (
 )
 from sqlbuild.compiler.references.types import SqlReferenceKind
 
-_ANALYSIS_CACHE_VERSION: int = 4
-_ANALYSIS_ALGORITHM_FINGERPRINT: str = "model-sql-analysis-v4"
+_ANALYSIS_CACHE_VERSION: int = 5
+_ANALYSIS_ALGORITHM_FINGERPRINT: str = "model-sql-analysis-v5"
 _MAX_CACHE_ENTRY_BYTES: int = 10_000_000
 _SHA256_HEX_LENGTH: int = 64
 _CACHE_ENTRY_SEPARATOR: str = "\n"
@@ -229,12 +229,10 @@ def write_model_analyses(
     latest_analyses_by_model: dict[str, PolyglotAnalysisResult] | None = None,
     dependency_signatures_by_key: dict[str, dict[str, str]] | None = None,
 ) -> None:
-    """Transactionally persist successful analyses; cache failures never fail compilation."""
+    """Transactionally persist deterministic analyses; cache failures never fail compilation."""
 
     rows: list[tuple[str, str]] = []
     for cache_key, analysis in analyses_by_key.items():
-        if not analysis.analysis_succeeded:
-            continue
         contents: str = _analysis_contents(cache_key=cache_key, analysis=analysis)
         if len(contents.encode()) <= _MAX_CACHE_ENTRY_BYTES:
             rows.append((cache_key, contents))
@@ -246,12 +244,11 @@ def write_model_analyses(
             model_analysis_output_signature(analysis),
         )
         for model_name, analysis in (latest_analyses_by_model or {}).items()
-        if analysis.analysis_succeeded
     ]
     dependency_rows: list[tuple[str, str, str, str]] = []
     for cache_key, dependencies in (dependency_signatures_by_key or {}).items():
         analysis: PolyglotAnalysisResult | None = analyses_by_key.get(cache_key)
-        if analysis is None or not analysis.analysis_succeeded:
+        if analysis is None:
             continue
         dependency_rows.extend(
             (context.signature_namespace, cache_key, upstream_name, output_signature)
@@ -436,6 +433,7 @@ def _analysis_payload(*, cache_key: str, analysis: PolyglotAnalysisResult) -> di
     return {
         "v": _ANALYSIS_CACHE_VERSION,
         "k": cache_key,
+        "a": analysis.analysis_succeeded,
         "s": model_analysis_output_signature(analysis),
         "c": (
             None
@@ -476,6 +474,9 @@ def _analysis_from_payload(
         raise AnalysisCacheEntryError("analysis cache version mismatch")
     if values["k"] != expected_cache_key:
         raise AnalysisCacheEntryError("analysis cache key mismatch")
+    analysis_succeeded: object = values["a"]
+    if not isinstance(analysis_succeeded, bool):
+        raise AnalysisCacheEntryError("analysis cache success flag must be a boolean")
     output_signature: object = values["s"]
     if not (
         isinstance(output_signature, str)
@@ -497,7 +498,7 @@ def _analysis_from_payload(
         raise AnalysisCacheEntryError("analysis cache has_star must be a boolean")
     return (
         PolyglotAnalysisResult(
-            analysis_succeeded=True,
+            analysis_succeeded=analysis_succeeded,
             columns=columns,
             lineage_columns=lineage_columns,
             has_star=has_star,

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -115,7 +115,7 @@ from sqlbuild.spec.contracts.models import (
     TargetConfig,
 )
 
-_POLYGLOT_ANALYSIS_WORKERS: int = 2
+_POLYGLOT_ANALYSIS_WORKERS: int = 4
 _POLYGLOT_PARALLEL_ANALYSIS_MIN_MODELS: int = 32
 _POLYGLOT_PARALLEL_REANALYSIS_MIN_MODELS: int = 2
 
@@ -202,6 +202,7 @@ def assemble_compiled_project(
             (inputs.effective_target.schema if inputs.effective_target is not None else None)
             or _str_or_none(inputs.effective_connection.get("schema"))
         ),
+        compile_cache_dir=inputs.compile_cache_dir,
         settings=inputs.effective_settings,
         scenario=resolve_effective_scenario_config(
             project_config=inputs.project_config,
@@ -464,9 +465,16 @@ def _analyze_model_sql_in_parallel(
         if request.cache_key is None or request.cache_key not in cached_analyses
     }
     changed_signature_names: set[str] = {
-        model_name
-        for model_name, output_signature in current_signatures_by_name.items()
-        if previous_signatures.get(model_name) != output_signature
+        _model_name(request.model_input)
+        for request, analysis in zip(requests, analyses, strict=True)
+        if (
+            previous_signatures.get(_model_name(request.model_input))
+            != current_signatures_by_name[_model_name(request.model_input)]
+            or (
+                not analysis.polyglot_analysis.analysis_succeeded
+                and request.cache_key not in cached_analyses
+            )
+        )
     }
     analyses_to_record_by_name.update(
         {model_name: current_analyses_by_name[model_name] for model_name in changed_signature_names}

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/core.py
@@ -192,6 +192,9 @@ def build_model_inputs(
 ) -> tuple[CompileModelInput, ...]:
     """Attach schema metadata to discovered model files."""
 
+    legacy_schema_files: tuple[DiscoveredSchemaFile, ...] = tuple(
+        schema_file for schema_file in discovered_inputs.schema_files if schema_file.model_entries
+    )
     with cached_sql_reference_extractor(root=reference_cache_dir) as extract_references:
         return _build_model_inputs(
             discovered_inputs=discovered_inputs,
@@ -200,6 +203,7 @@ def build_model_inputs(
             defer_model_sql_validation=defer_model_sql_validation,
             external_sql_reference_resolver=external_sql_reference_resolver,
             extract_references=extract_references,
+            legacy_schema_files=legacy_schema_files,
         )
 
 
@@ -211,6 +215,7 @@ def _build_model_inputs(
     defer_model_sql_validation: bool,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None,
     extract_references: Callable[[str], tuple[CompileSqlReference, ...]],
+    legacy_schema_files: tuple[DiscoveredSchemaFile, ...],
 ) -> tuple[CompileModelInput, ...]:
 
     effective_vars: dict[str, object] = context.effective_vars
@@ -456,9 +461,7 @@ def _build_model_inputs(
                 (*declaration_expansion.usages, *generated_usages, *hook_expansion.usages)
             )
         )
-        _reject_legacy_schema_match(
-            model_file=model_file, schema_files=discovered_inputs.schema_files
-        )
+        _reject_legacy_schema_match(model_file=model_file, schema_files=legacy_schema_files)
         if header_schema_entry is None:
             model_inputs.append(
                 CompileModelInput(

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/declaration_scope.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/declaration_scope.py
@@ -21,6 +21,7 @@ from sqlbuild.compiler.scopes.exceptions import ScopeValidationError
 from sqlbuild.compiler.scopes.main._build_scope_index import build_scope_index
 from sqlbuild.compiler.scopes.main._validate_scope_index import validate_scope_index
 from sqlbuild.compiler.scopes.models import ScopeIndex
+from sqlbuild.compiler.scopes.types import ScopeKind
 
 
 def build_declaration_scope(
@@ -35,9 +36,13 @@ def build_declaration_scope(
         validate_scope_index(index=index)
     except ScopeValidationError as error:
         raise CompileInputError(str(error)) from error
+    has_scoped_declarations: bool = any(
+        declaration.scope is not ScopeKind.GLOBAL for declaration in index.declarations
+    )
     relationships: ScopeRelationshipBuild = (
         build_scope_relationship_grants(discovered_inputs=discovered_inputs, index=index)
-        if discovered_inputs.test_files or discovered_inputs.scenario_files
+        if has_scoped_declarations
+        and (discovered_inputs.test_files or discovered_inputs.scenario_files)
         else ScopeRelationshipBuild()
     )
     if relationships.faults:

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from dataclasses import replace
+from pathlib import Path
 
 from sqlbuild.compiler.compile._helpers.attachment.references import (
     build_known_function_names,
@@ -27,6 +29,7 @@ from sqlbuild.compiler.compile._helpers.render.sql_vars import (
     expand_authored_sql_result,
 )
 from sqlbuild.compiler.compile._helpers.scenarios.core import extract_sql_scenario_ctes
+from sqlbuild.compiler.compile._helpers.sql_tests.cache import cached_sql_test_cte_extractor
 from sqlbuild.compiler.compile._helpers.sql_tests.core import (
     extract_assertion_target_model_names,
     extract_sql_test_ctes,
@@ -74,6 +77,32 @@ _HOOK_CONTEXT_PARAMETER_NAMES: frozenset[str] = frozenset(
 )
 
 
+def build_test_inputs_with_cache(
+    *,
+    discovered_inputs: DiscoveredProjectInputs,
+    effective_vars: dict[str, object],
+    macro_context: MacroContext,
+    loaded_macros: dict[str, LoadedMacro],
+    declaration_expansion: DeclarationExpansionContext,
+    external_sql_reference_resolver: ExternalSqlReferenceResolver | None,
+    sql_function_inputs: tuple[CompileSqlFunctionInput, ...],
+    compile_cache_dir: Path | None,
+) -> tuple[CompileSqlTestInput, ...]:
+    """Build SQL test inputs while reusing exact expanded CTE boundaries."""
+
+    with cached_sql_test_cte_extractor(root=compile_cache_dir) as extract_test_ctes:
+        return build_test_inputs(
+            discovered_inputs=discovered_inputs,
+            effective_vars=effective_vars,
+            macro_context=macro_context,
+            loaded_macros=loaded_macros,
+            declaration_expansion=declaration_expansion,
+            external_sql_reference_resolver=external_sql_reference_resolver,
+            sql_function_inputs=sql_function_inputs,
+            sql_test_cte_extractor=extract_test_ctes,
+        )
+
+
 def build_test_inputs(
     *,
     discovered_inputs: DiscoveredProjectInputs,
@@ -83,10 +112,20 @@ def build_test_inputs(
     declaration_expansion: DeclarationExpansionContext,
     external_sql_reference_resolver: ExternalSqlReferenceResolver | None = None,
     sql_function_inputs: tuple[CompileSqlFunctionInput, ...] = (),
+    sql_test_cte_extractor: Callable[[str, str, SqlTestMode], CompileSqlTestCtes] | None = None,
 ) -> tuple[CompileSqlTestInput, ...]:
     """Build compile-time test inputs from discovered SQL-native test blocks."""
 
     vars_for_substitution: dict[str, object] = effective_vars or {}
+    extract_test_ctes: Callable[[str, str, SqlTestMode], CompileSqlTestCtes] = (
+        sql_test_cte_extractor
+        if sql_test_cte_extractor is not None
+        else lambda sql, file_label, mode: extract_sql_test_ctes(
+            sql=sql,
+            file_label=file_label,
+            mode=mode,
+        )
+    )
     known_model_names: set[str] = build_known_ref_names(discovered_inputs)
     if external_sql_reference_resolver is not None:
         known_model_names.update(
@@ -191,10 +230,10 @@ def build_test_inputs(
                     sql=expanded_sql_body,
                     context=f"SQL test '{test_block.name or test_file.file_path.stem}'",
                 )
-                test_ctes: CompileSqlTestCtes = extract_sql_test_ctes(
-                    sql=expanded_sql_body,
-                    file_label=str(test_file.relative_path),
-                    mode=test_mode,
+                test_ctes: CompileSqlTestCtes = extract_test_ctes(
+                    expanded_sql_body,
+                    str(test_file.relative_path),
+                    test_mode,
                 )
                 validate_test_ctes(
                     test_ctes=test_ctes,

--- a/src/sqlbuild/compiler/compile/_helpers/render/declarations.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/declarations.py
@@ -749,7 +749,7 @@ def _render_scalar(*, value: str | int) -> str:
 
 
 def _find_next_reference_start(*, sql: str, start: int) -> int | None:
-    if MACRO_TOKEN not in sql[start:]:
+    if sql.find("@enum", start) < 0 and sql.find("@const", start) < 0:
         return None
     index: int = start
     while index < len(sql):

--- a/src/sqlbuild/compiler/compile/_helpers/sql_tests/cache.py
+++ b/src/sqlbuild/compiler/compile/_helpers/sql_tests/cache.py
@@ -1,0 +1,210 @@
+"""Versioned project-local cache for SQL test CTE extraction."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sqlite3
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from types import TracebackType
+from typing import Any, cast
+
+from sqlbuild.compiler.compile._helpers.sql_tests.core import (
+    classify_sql_test_ctes,
+    extract_unclassified_sql_test_ctes,
+)
+from sqlbuild.compiler.compile.models import CompileSqlTestCte, CompileSqlTestCtes
+from sqlbuild.compiler.compile.types import SqlTestMode
+
+_CACHE_VERSION: int = 1
+_CACHE_DATABASE_NAME: str = "sql-test-ctes.sqlite3"
+_MAX_CACHE_ENTRY_BYTES: int = 10_000_000
+_SQLITE_TIMEOUT_SECONDS: float = 0.1
+_CACHE_CTE_ROW_FIELD_COUNT: int = 2
+_CREATE_CACHE_TABLE_SQL: str = """
+CREATE TABLE IF NOT EXISTS sql_test_cte (
+    cache_key TEXT PRIMARY KEY,
+    payload TEXT NOT NULL
+)
+"""
+
+
+class _SqlTestCteCache:
+    """Reuse exact CTE boundaries while retaining classification and validation."""
+
+    def __init__(self, *, root: Path | None) -> None:
+        self._root: Path | None = root
+        self._database_path: Path | None = None
+        self._connection: sqlite3.Connection | None = None
+        self._pending_by_key: dict[str, str] = {}
+
+    def __enter__(self) -> _SqlTestCteCache:
+        if self._root is None:
+            return self
+        self._database_path = self._root / f"sql-test-ctes-v{_CACHE_VERSION}" / _CACHE_DATABASE_NAME
+        if not self._database_path.is_file():
+            return self
+        try:
+            self._connection = sqlite3.connect(
+                self._database_path,
+                timeout=_SQLITE_TIMEOUT_SECONDS,
+            )
+        except (OSError, sqlite3.DatabaseError):
+            self._disable()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_value, traceback
+        connection: sqlite3.Connection | None = self._connection
+        self._connection = None
+        try:
+            if exc_type is None:
+                connection = self._write_pending(connection=connection)
+            elif connection is not None:
+                connection.rollback()
+        except (OSError, sqlite3.DatabaseError):
+            pass
+        finally:
+            self._pending_by_key.clear()
+            if connection is not None:
+                try:
+                    connection.close()
+                except sqlite3.DatabaseError:
+                    pass
+
+    def extract(self, *, sql: str, file_label: str, mode: SqlTestMode) -> CompileSqlTestCtes:
+        """Return cached raw CTEs or scan and record this exact expanded SQL."""
+
+        cache_key: str = hashlib.sha256(sql.encode()).hexdigest()
+        ctes: tuple[CompileSqlTestCte, ...] | None = self._pending_ctes(cache_key=cache_key)
+        if ctes is None:
+            ctes = self._read_ctes(cache_key=cache_key)
+        if ctes is None:
+            ctes = extract_unclassified_sql_test_ctes(sql=sql, file_label=file_label)
+            if self._database_path is not None:
+                contents: str = _cache_contents(cache_key=cache_key, ctes=ctes)
+                if len(contents.encode()) <= _MAX_CACHE_ENTRY_BYTES:
+                    self._pending_by_key[cache_key] = contents
+        return classify_sql_test_ctes(ctes=ctes, file_label=file_label, mode=mode)
+
+    def _pending_ctes(self, *, cache_key: str) -> tuple[CompileSqlTestCte, ...] | None:
+        contents: str | None = self._pending_by_key.get(cache_key)
+        return (
+            None
+            if contents is None
+            else _ctes_from_contents(contents=contents, cache_key=cache_key)
+        )
+
+    def _read_ctes(self, *, cache_key: str) -> tuple[CompileSqlTestCte, ...] | None:
+        connection: sqlite3.Connection | None = self._connection
+        if connection is None:
+            return None
+        try:
+            row: tuple[str] | None = connection.execute(
+                "SELECT payload FROM sql_test_cte WHERE cache_key = ?",
+                (cache_key,),
+            ).fetchone()
+        except sqlite3.DatabaseError:
+            self._disable()
+            return None
+        return None if row is None else _ctes_from_contents(contents=row[0], cache_key=cache_key)
+
+    def _write_pending(self, *, connection: sqlite3.Connection | None) -> sqlite3.Connection | None:
+        if not self._pending_by_key or self._database_path is None:
+            return connection
+        if connection is None:
+            self._database_path.parent.mkdir(parents=True, exist_ok=True)
+            connection = sqlite3.connect(self._database_path, timeout=_SQLITE_TIMEOUT_SECONDS)
+        _ = connection.execute(_CREATE_CACHE_TABLE_SQL)
+        _ = connection.executemany(
+            "INSERT OR REPLACE INTO sql_test_cte (cache_key, payload) VALUES (?, ?)",
+            self._pending_by_key.items(),
+        )
+        connection.commit()
+        return connection
+
+    def _disable(self) -> None:
+        connection: sqlite3.Connection | None = self._connection
+        self._connection = None
+        if connection is not None:
+            try:
+                connection.close()
+            except sqlite3.DatabaseError:
+                pass
+
+
+def _cache_contents(*, cache_key: str, ctes: tuple[CompileSqlTestCte, ...]) -> str:
+    serialized: str = json.dumps(
+        {
+            "v": _CACHE_VERSION,
+            "k": cache_key,
+            "c": [[cte.name, cte.sql_body] for cte in ctes],
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return f"{_cache_digest(cache_key=cache_key, serialized=serialized)}\n{serialized}"
+
+
+def _ctes_from_contents(
+    *, contents: object, cache_key: str
+) -> tuple[CompileSqlTestCte, ...] | None:
+    if not isinstance(contents, str) or len(contents.encode()) > _MAX_CACHE_ENTRY_BYTES:
+        return None
+    try:
+        digest, separator, serialized = contents.partition("\n")
+        if not separator or not hmac.compare_digest(
+            digest,
+            _cache_digest(cache_key=cache_key, serialized=serialized),
+        ):
+            return None
+        payload: object = json.loads(serialized)
+        if not isinstance(payload, dict) or payload.get("v") != _CACHE_VERSION:
+            return None
+        if payload.get("k") != cache_key or not isinstance(payload.get("c"), list):
+            return None
+        rows: list[object] = cast(list[object], payload["c"])
+        if not all(
+            isinstance(row, list)
+            and len(row) == _CACHE_CTE_ROW_FIELD_COUNT
+            and isinstance(row[0], str)
+            and isinstance(row[1], str)
+            for row in rows
+        ):
+            return None
+        return tuple(
+            CompileSqlTestCte(name=cast(list[str], row)[0], sql_body=cast(list[str], row)[1])
+            for row in rows
+        )
+    except (ValueError, TypeError, KeyError, RecursionError, json.JSONDecodeError):
+        return None
+
+
+def _cache_digest(*, cache_key: str, serialized: str) -> str:
+    digest: Any = hashlib.sha256(cache_key.encode())
+    digest.update(b"\0")
+    digest.update(serialized.encode())
+    return digest.hexdigest()
+
+
+@contextmanager
+def cached_sql_test_cte_extractor(
+    *, root: Path | None
+) -> Iterator[Callable[[str, str, SqlTestMode], CompileSqlTestCtes]]:
+    """Yield an exact cached SQL test CTE extractor for one compile invocation."""
+
+    with _SqlTestCteCache(root=root) as cache:
+        yield lambda sql, file_label, mode: cache.extract(
+            sql=sql,
+            file_label=file_label,
+            mode=mode,
+        )

--- a/src/sqlbuild/compiler/compile/_helpers/sql_tests/core.py
+++ b/src/sqlbuild/compiler/compile/_helpers/sql_tests/core.py
@@ -67,6 +67,18 @@ def extract_sql_test_ctes(
 ) -> CompileSqlTestCtes:
     """Extract top-level SQL-native test mock and expected CTEs."""
 
+    ctes: tuple[CompileSqlTestCte, ...] = extract_unclassified_sql_test_ctes(
+        sql=sql,
+        file_label=file_label,
+    )
+    return classify_sql_test_ctes(ctes=ctes, file_label=file_label, mode=mode)
+
+
+def extract_unclassified_sql_test_ctes(
+    *, sql: str, file_label: str
+) -> tuple[CompileSqlTestCte, ...]:
+    """Extract raw top-level CTEs before mode-specific classification."""
+
     try:
         ctes: tuple[CompileSqlTestCte, ...] = _extract_sql_test_ctes_with_scanner(
             sql=sql,
@@ -81,6 +93,14 @@ def extract_sql_test_ctes(
         if cte_values is None:
             raise scanner_error from None
         ctes = tuple(CompileSqlTestCte(name=name, sql_body=body) for name, body in cte_values)
+    return ctes
+
+
+def classify_sql_test_ctes(
+    *, ctes: tuple[CompileSqlTestCte, ...], file_label: str, mode: SqlTestMode
+) -> CompileSqlTestCtes:
+    """Apply mode-specific validation to extracted SQL test CTEs."""
+
     return _classify_sql_test_ctes(ctes=ctes, file_label=file_label, mode=mode)
 
 

--- a/src/sqlbuild/compiler/compile/main/_build_compile_inputs.py
+++ b/src/sqlbuild/compiler/compile/main/_build_compile_inputs.py
@@ -25,7 +25,7 @@ from sqlbuild.compiler.compile._helpers.attachment.references import (
 from sqlbuild.compiler.compile._helpers.attachment.sources import build_source_inputs
 from sqlbuild.compiler.compile._helpers.attachment.sql_tests import (
     build_scenario_inputs,
-    build_test_inputs,
+    build_test_inputs_with_cache,
 )
 from sqlbuild.compiler.compile._helpers.attachment.target import build_compile_target_context
 from sqlbuild.compiler.compile._helpers.audit_factories.core import (
@@ -161,7 +161,7 @@ def build_compile_inputs(
         declaration_expansion=model_context.declaration_expansion,
         no_sql_validation=no_sql_validation,
     )
-    test_inputs: tuple[CompileSqlTestInput, ...] = build_test_inputs(
+    test_inputs: tuple[CompileSqlTestInput, ...] = build_test_inputs_with_cache(
         discovered_inputs=discovered_inputs,
         effective_vars=effective_vars,
         macro_context=macro_context,
@@ -169,6 +169,7 @@ def build_compile_inputs(
         declaration_expansion=model_context.declaration_expansion,
         external_sql_reference_resolver=external_sql_reference_resolver,
         sql_function_inputs=sql_function_inputs,
+        compile_cache_dir=compile_cache_dir,
     )
     scenario_inputs: tuple[CompileSqlScenarioInput, ...] = build_scenario_inputs(
         discovered_inputs=discovered_inputs,

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -790,6 +790,7 @@ class CompiledProject:
     effective_vars: dict[str, object]
     effective_target_database: str | None = None
     effective_target_schema: str | None = None
+    compile_cache_dir: Path | None = None
     settings: SettingsConfig = field(default_factory=SettingsConfig)
     scenario: ScenarioConfig = field(default_factory=ScenarioConfig)
     models: tuple[CompiledModel, ...] = field(default_factory=tuple)

--- a/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
+++ b/src/sqlbuild/compiler/planner/_helpers/sql_tests/assembly.py
@@ -334,6 +334,28 @@ def plan_test(
     return entry, tuple(warnings)
 
 
+def resolve_test_model_chain_names(
+    *, test: CompiledSqlTest, project: CompiledProject
+) -> tuple[str, ...]:
+    """Return the unmocked model closure used to build one SQL test plan."""
+
+    if not isinstance(test.payload, CompiledModelSqlTestPayload):
+        return ()
+    model_map: dict[str, CompiledModel] = {model.name: model for model in project.models}
+    assertion_target_names: tuple[str, ...] = _extract_assertion_ref_targets(
+        assertion_map=_extract_assertion_ctes(test)
+    )
+    expected_names: tuple[str, ...] = tuple(
+        dict.fromkeys((*test.payload.expected_model_names, *assertion_target_names))
+    )
+    return _topo_sort_model_chain(
+        expected_names=expected_names,
+        model_map=model_map,
+        model_query_overrides=test.payload.model_query_overrides,
+        mock_ref_names=frozenset(_extract_mock_refs(test)),
+    )
+
+
 def _build_assertion_steps(
     *,
     assertion_map: dict[str, str],

--- a/src/sqlbuild/compiler/planner/main/execution/sql_test_assembly.py
+++ b/src/sqlbuild/compiler/planner/main/execution/sql_test_assembly.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.compiler.compile.models import CompiledProject, CompiledSqlTest
-from sqlbuild.compiler.planner._helpers.sql_tests.assembly import plan_test
+from sqlbuild.compiler.planner._helpers.sql_tests.assembly import (
+    plan_test,
+    resolve_test_model_chain_names,
+)
 from sqlbuild.compiler.planner.models import PlanWarning, SqlTestPlanEntry
 
 
@@ -20,3 +23,11 @@ def build_sql_test_plan_entry(
     return plan_test(
         test=test, project=project, adapter=adapter, sql_analysis_enabled=sql_analysis_enabled
     )
+
+
+def _sql_test_model_chain_names(
+    *, test: CompiledSqlTest, project: CompiledProject
+) -> tuple[str, ...]:
+    """Return the exact model closure a SQL test plan will expand."""
+
+    return resolve_test_model_chain_names(test=test, project=project)

--- a/src/sqlbuild/executor/testing/_helpers/comparison_sql.py
+++ b/src/sqlbuild/executor/testing/_helpers/comparison_sql.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import re
 from collections import OrderedDict
-from copy import deepcopy
 from typing import Any
 
 from sqlbuild.adapter.contract.types import BuiltinAdapter
@@ -210,9 +209,8 @@ def _split_top_level_with(sql: str) -> tuple[tuple[tuple[str, str], ...], str] |
             )
         )
 
-    without_with: dict[str, Any] = deepcopy(parsed_dict)
-    without_with["select"]["with"] = None
-    body_sql: str | None = _generate_one(polyglot_module=polyglot_module, expression=without_with)
+    select_dict["with"] = None
+    body_sql: str | None = _generate_one(polyglot_module=polyglot_module, expression=parsed_dict)
     if body_sql is None:
         return None
     return (

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_runtime_artifact_preservation.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_runtime_artifact_preservation.py
@@ -32,7 +32,7 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
                 "target/run/functions/python/is_completed_order_py.sql",
             ),
             expected_exit_code=0,
-            expected_compiler_cache_count=2,
+            expected_compiler_cache_count=3,
             expected_local_history=False,
             expected_compiled_paths=(
                 "target/compiled/models/marts/fact_orders.sql",

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
@@ -45,6 +45,8 @@ class SqlTestHeavyCompilePerformanceGuardTestCase:
     fixture_row_count: int
     expected_min_compiled_test_bytes: int
     expected_max_seconds: float
+    expected_warm_max_seconds: float
+    expected_edit_max_seconds: float
 
 
 @dataclass(frozen=True)

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/helpers.py
@@ -85,7 +85,9 @@ def run_test_heavy_compile_benchmark(
     chain_depth: int,
     fixture_row_count: int,
     expected_max_seconds: float,
-) -> float:
+    expected_warm_max_seconds: float,
+    expected_edit_max_seconds: float,
+) -> tuple[float, float, float, float]:
     skip_actions: dict[bool, Callable[[], None]] = {
         False: _continue_compile_benchmark,
         True: _skip_compile_benchmark,
@@ -98,9 +100,31 @@ def run_test_heavy_compile_benchmark(
         chain_depth=chain_depth,
         fixture_row_count=fixture_row_count,
     )
-    return _run_compile_benchmark(
+    cold_seconds: float = _run_compile_benchmark(
         project_dir=project_dir,
         expected_max_seconds=expected_max_seconds,
+    )
+    warm_seconds: float = _run_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_warm_max_seconds,
+    )
+    _append_benchmark_edit(project_dir / "models" / "model_00000.sql", "model")
+    model_edit_seconds: float = _run_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_edit_max_seconds,
+    )
+    _append_benchmark_edit(project_dir / "tests" / "unit" / "test_00000.sql", "test")
+    test_edit_seconds: float = _run_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_edit_max_seconds,
+    )
+    return cold_seconds, warm_seconds, model_edit_seconds, test_edit_seconds
+
+
+def _append_benchmark_edit(path: Path, label: str) -> None:
+    path.write_text(
+        path.read_text(encoding="utf-8") + f"\n-- one {label} edit\n",
+        encoding="utf-8",
     )
 
 

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_compile_performance.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_compile_performance.py
@@ -173,6 +173,8 @@ def test_given_dbt_shaped_project_when_compiling_cold_and_warm_then_finishes_wit
             fixture_row_count=120,
             expected_min_compiled_test_bytes=2_000_000,
             expected_max_seconds=7.0,
+            expected_warm_max_seconds=3.0,
+            expected_edit_max_seconds=4.0,
         )
     ],
     ids=lambda case: case.description,
@@ -182,20 +184,29 @@ def test_given_test_heavy_project_when_compiling_then_finishes_within_budget(
     test_case: SqlTestHeavyCompilePerformanceGuardTestCase,
 ) -> None:
     project_dir: Path = tmp_path / "test_heavy"
-    elapsed_seconds: float = run_test_heavy_compile_benchmark(
-        project_dir=project_dir,
-        model_count=test_case.model_count,
-        test_count=test_case.test_count,
-        chain_depth=test_case.chain_depth,
-        fixture_row_count=test_case.fixture_row_count,
-        expected_max_seconds=test_case.expected_max_seconds,
+    cold_seconds, warm_seconds, model_edit_seconds, test_edit_seconds = (
+        run_test_heavy_compile_benchmark(
+            project_dir=project_dir,
+            model_count=test_case.model_count,
+            test_count=test_case.test_count,
+            chain_depth=test_case.chain_depth,
+            fixture_row_count=test_case.fixture_row_count,
+            expected_max_seconds=test_case.expected_max_seconds,
+            expected_warm_max_seconds=test_case.expected_warm_max_seconds,
+            expected_edit_max_seconds=test_case.expected_edit_max_seconds,
+        )
     )
     compiled_test_bytes: int = measure_compiled_test_sql_bytes(project_dir)
     _LOGGER.info(
         f"test-heavy compile models={test_case.model_count} tests={test_case.test_count} "
-        f"compiled_test_bytes={compiled_test_bytes} cold={elapsed_seconds:.3f}s "
-        f"budget={test_case.expected_max_seconds:g}s"
+        f"compiled_test_bytes={compiled_test_bytes} cold={cold_seconds:.3f}s "
+        f"warm={warm_seconds:.3f}s model_edit={model_edit_seconds:.3f}s "
+        f"test_edit={test_edit_seconds:.3f}s budgets={test_case.expected_max_seconds:g}s/"
+        f"{test_case.expected_warm_max_seconds:g}s/{test_case.expected_edit_max_seconds:g}s"
     )
 
     assert compiled_test_bytes >= test_case.expected_min_compiled_test_bytes
-    assert elapsed_seconds < test_case.expected_max_seconds
+    assert cold_seconds < test_case.expected_max_seconds
+    assert warm_seconds < test_case.expected_warm_max_seconds
+    assert model_edit_seconds < test_case.expected_edit_max_seconds
+    assert test_edit_seconds < test_case.expected_edit_max_seconds

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/_test_types.py
@@ -16,6 +16,12 @@ class TargetWriterTestCase:
 
 
 @dataclass(frozen=True)
+class TargetWriterCacheTestCase:
+    description: str
+    expected_builder_calls: int
+
+
+@dataclass(frozen=True)
 class CompileCommandTestCase:
     description: str
     expected_exit_code: int

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/helpers.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +43,12 @@ from sqlbuild.executor.scheduling.types import ExecutionStatus
 from sqlbuild.spec.contracts.models import SeedCsvSettings
 from tests.unit.src.sqlbuild.cli.commands.main.dag.helpers import (
     prepare_python_dag_project,
+)
+from tests.unit.src.sqlbuild.compiler.planner._helpers.sql_test_assembly._test_types import (
+    PlanTestChainTestCase,
+)
+from tests.unit.src.sqlbuild.compiler.planner._helpers.sql_test_assembly.helpers import (
+    build_test_and_project,
 )
 
 
@@ -322,6 +329,28 @@ def build_static_target_writer_project() -> CompiledProject:
                 ),
             ),
         ),
+    )
+
+
+def build_cached_target_writer_project(*, target_dir: Path) -> CompiledProject:
+    """Build a static project containing one cacheable model SQL test."""
+
+    compiled_test, project = build_test_and_project(
+        PlanTestChainTestCase(
+            description="cached target writer project",
+            model_queries={"orders": "SELECT 2 AS order_id"},
+            mock_ref_ctes={},
+            mock_source_ctes={},
+            helper_ctes={},
+            expected_model_names=("orders",),
+            expected_chain_length=1,
+            expected_cte_bodies={"orders": "SELECT 2 AS order_id"},
+        )
+    )
+    return replace(
+        project,
+        compile_cache_dir=target_dir / "cache" / "compiler",
+        sql_tests=(compiled_test,),
     )
 
 

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py
@@ -4,22 +4,26 @@ import json
 import os
 from dataclasses import replace
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
 from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.cli.commands._helpers.compile import target_writer as target_writer_module
 from sqlbuild.cli.commands._helpers.compile.target_writer import (
     write_compile_target,
     write_static_compile_target,
 )
 from sqlbuild.cli.commands.models import WrittenTarget
-from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.compile.models import CompiledModel, CompiledProject, CompiledSqlTest
 from sqlbuild.compiler.planner.models import ChainStep, PlanOutput, SqlTestPlanEntry
 from sqlbuild.executor.testing.main.comparison_sql import build_sql_test_comparison_sql
 from tests.unit.src.sqlbuild.cli.commands.main.compile._test_types import (
+    TargetWriterCacheTestCase,
     TargetWriterTestCase,
 )
 from tests.unit.src.sqlbuild.cli.commands.main.compile.helpers import (
+    build_cached_target_writer_project,
     build_static_target_writer_project,
     build_target_writer_plan_output,
     read_target_files,
@@ -231,3 +235,238 @@ def test_given_compiled_project_when_writing_static_target_then_expected_files_a
 
     assert model_path.read_text(encoding="utf-8") == "SELECT 3 AS order_id\n"
     assert model_path.stat().st_mtime_ns != unchanged_mtime_ns
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (TargetWriterCacheTestCase(description="unchanged artifact reuse", expected_builder_calls=0),),
+    ids=lambda case: case.description,
+)
+def test_given_unchanged_test_artifact_when_writing_again_then_skips_test_plan_reconstruction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: TargetWriterCacheTestCase,
+) -> None:
+    target_dir: Path = tmp_path / "target"
+    project: CompiledProject = build_cached_target_writer_project(target_dir=target_dir)
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=project,
+    )
+    artifact_path: Path = next((target_dir / "compiled" / "tests").rglob("*.sql"))
+    original_mtime_ns: int = artifact_path.stat().st_mtime_ns
+    builder_spy: Mock = Mock(wraps=target_writer_module.build_sql_test_plan_entry)
+    monkeypatch.setattr(target_writer_module, "build_sql_test_plan_entry", builder_spy)
+
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=project,
+    )
+
+    assert artifact_path.stat().st_mtime_ns == original_mtime_ns
+    assert builder_spy.call_count == test_case.expected_builder_calls
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        TargetWriterCacheTestCase(
+            description="model closure invalidation", expected_builder_calls=1
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_changed_model_in_test_closure_when_writing_then_rebuilds_test_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: TargetWriterCacheTestCase,
+) -> None:
+    target_dir: Path = tmp_path / "target"
+    project: CompiledProject = build_cached_target_writer_project(target_dir=target_dir)
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=project,
+    )
+    builder_spy: Mock = Mock(wraps=target_writer_module.build_sql_test_plan_entry)
+    monkeypatch.setattr(target_writer_module, "build_sql_test_plan_entry", builder_spy)
+    changed_project: CompiledProject = replace(
+        project,
+        models=(replace(project.models[0], query_sql="SELECT 3 AS order_id"),),
+    )
+
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=changed_project,
+    )
+
+    assert builder_spy.call_count == test_case.expected_builder_calls
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (TargetWriterCacheTestCase(description="unrelated model reuse", expected_builder_calls=0),),
+    ids=lambda case: case.description,
+)
+def test_given_changed_unrelated_model_when_writing_then_reuses_test_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: TargetWriterCacheTestCase,
+) -> None:
+    target_dir: Path = tmp_path / "target"
+    project: CompiledProject = build_cached_target_writer_project(target_dir=target_dir)
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=project,
+    )
+    unrelated_model: CompiledModel = replace(
+        project.models[0],
+        key=replace(project.models[0].key, name="unrelated"),
+        name="unrelated",
+        relative_path=Path("models/unrelated.sql"),
+        query_sql="SELECT 9 AS unrelated_id",
+    )
+    changed_project: CompiledProject = replace(
+        project,
+        models=(*project.models, unrelated_model),
+    )
+    builder_spy: Mock = Mock(wraps=target_writer_module.build_sql_test_plan_entry)
+    monkeypatch.setattr(target_writer_module, "build_sql_test_plan_entry", builder_spy)
+
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=changed_project,
+    )
+    assert builder_spy.call_count == test_case.expected_builder_calls
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (TargetWriterCacheTestCase(description="test SQL invalidation", expected_builder_calls=1),),
+    ids=lambda case: case.description,
+)
+def test_given_changed_test_sql_when_writing_then_rebuilds_test_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: TargetWriterCacheTestCase,
+) -> None:
+    target_dir: Path = tmp_path / "target"
+    project: CompiledProject = build_cached_target_writer_project(target_dir=target_dir)
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=project,
+    )
+    builder_spy: Mock = Mock(wraps=target_writer_module.build_sql_test_plan_entry)
+    monkeypatch.setattr(target_writer_module, "build_sql_test_plan_entry", builder_spy)
+    changed_test: CompiledSqlTest = replace(
+        project.sql_tests[0], sql_body=project.sql_tests[0].sql_body + "\n-- edit"
+    )
+
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=replace(project, sql_tests=(changed_test,)),
+    )
+
+    assert builder_spy.call_count == test_case.expected_builder_calls
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        TargetWriterCacheTestCase(
+            description="compile target invalidation", expected_builder_calls=1
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_changed_compile_target_when_writing_then_rebuilds_test_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: TargetWriterCacheTestCase,
+) -> None:
+    target_dir: Path = tmp_path / "target"
+    project: CompiledProject = build_cached_target_writer_project(target_dir=target_dir)
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=project,
+    )
+    builder_spy: Mock = Mock(wraps=target_writer_module.build_sql_test_plan_entry)
+    monkeypatch.setattr(target_writer_module, "build_sql_test_plan_entry", builder_spy)
+
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=replace(project, effective_target_schema="changed_schema"),
+    )
+
+    assert builder_spy.call_count == test_case.expected_builder_calls
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (TargetWriterCacheTestCase(description="disabled cache rebuild", expected_builder_calls=2),),
+    ids=lambda case: case.description,
+)
+def test_given_compile_cache_disabled_when_writing_twice_then_rebuilds_test_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: TargetWriterCacheTestCase,
+) -> None:
+    target_dir: Path = tmp_path / "target"
+    project: CompiledProject = replace(
+        build_cached_target_writer_project(target_dir=target_dir),
+        compile_cache_dir=None,
+    )
+    builder_spy: Mock = Mock(wraps=target_writer_module.build_sql_test_plan_entry)
+    monkeypatch.setattr(target_writer_module, "build_sql_test_plan_entry", builder_spy)
+
+    for _ in range(2):
+        _ = write_static_compile_target(
+            target_dir=target_dir,
+            adapter=DuckDbAdapter(),
+            project=project,
+        )
+
+    assert builder_spy.call_count == test_case.expected_builder_calls
+    assert not (target_dir / "cache" / "compiler" / "sql-test-artifacts.json").exists()
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (TargetWriterCacheTestCase(description="tampered artifact repair", expected_builder_calls=1),),
+    ids=lambda case: case.description,
+)
+def test_given_modified_test_artifact_when_writing_then_rebuilds_expected_sql(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: TargetWriterCacheTestCase,
+) -> None:
+    target_dir: Path = tmp_path / "target"
+    project: CompiledProject = build_cached_target_writer_project(target_dir=target_dir)
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=project,
+    )
+    artifact_path: Path = next((target_dir / "compiled" / "tests").rglob("*.sql"))
+    expected_sql: str = artifact_path.read_text(encoding="utf-8")
+    artifact_path.write_text("SELECT 'tampered'\n", encoding="utf-8")
+    builder_spy: Mock = Mock(wraps=target_writer_module.build_sql_test_plan_entry)
+    monkeypatch.setattr(target_writer_module, "build_sql_test_plan_entry", builder_spy)
+
+    _ = write_static_compile_target(
+        target_dir=target_dir,
+        adapter=DuckDbAdapter(),
+        project=project,
+    )
+
+    assert builder_spy.call_count == test_case.expected_builder_calls
+    assert artifact_path.read_text(encoding="utf-8") == expected_sql

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/_test_types.py
@@ -35,6 +35,12 @@ class AnalysisCacheTestCase:
 
 
 @dataclass(frozen=True)
+class SqlTestCteCacheTestCase:
+    description: str
+    expected_scanner_calls: int
+
+
+@dataclass(frozen=True)
 class WatermarkLimitValidationTestCase:
     description: str
     incremental_strategy: str

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_analysis_cache.py
@@ -13,6 +13,7 @@ from sqlbuild.adapter.contract.models import ExpressionInferenceProfile
 from sqlbuild.compiler.compile._helpers.analysis.cache import (
     build_analysis_cache_context,
     model_analysis_cache_key,
+    read_model_analyses,
     write_model_analyses,
 )
 from sqlbuild.compiler.compile._helpers.assembly import project as assembly_project
@@ -139,7 +140,7 @@ def test_given_corrupt_analysis_when_compiling_then_reanalyzes_and_repairs_the_e
 ) -> None:
     write_repo_files(tmp_path, _CACHE_REPO_FILES)
     cold_project: CompiledProject = compile_project_with_cache(project_dir=tmp_path)
-    cache_path: Path = tmp_path / "target" / "cache" / "compiler" / "v4" / "model-analysis.sqlite3"
+    cache_path: Path = tmp_path / "target" / "cache" / "compiler" / "v5" / "model-analysis.sqlite3"
     with sqlite3.connect(cache_path) as connection:
         persisted_contents: str = connection.execute(
             "SELECT payload FROM model_analysis"
@@ -162,7 +163,7 @@ def test_given_corrupt_analysis_when_compiling_then_reanalyzes_and_repairs_the_e
     _digest, _separator, serialized_payload = repaired_contents.partition("\n")
     repaired_payload: dict[str, object] = json.loads(serialized_payload)
     assert repaired_project.models == cold_project.models
-    assert repaired_payload["v"] == 4
+    assert repaired_payload["v"] == 5
     assert isinstance(repaired_payload["s"], str)
     assert analyzer.call_count == test_case.expected_count
 
@@ -180,7 +181,7 @@ def test_given_non_text_analysis_cache_when_compiling_then_reanalyzes_safely(
 ) -> None:
     write_repo_files(tmp_path, _CACHE_REPO_FILES)
     _ = compile_project_with_cache(project_dir=tmp_path)
-    cache_path: Path = tmp_path / "target" / "cache" / "compiler" / "v4" / "model-analysis.sqlite3"
+    cache_path: Path = tmp_path / "target" / "cache" / "compiler" / "v5" / "model-analysis.sqlite3"
     with sqlite3.connect(cache_path) as connection:
         _ = connection.execute(
             "UPDATE model_analysis SET payload = ?",
@@ -265,21 +266,36 @@ def test_given_non_text_reference_cache_when_compiling_then_rescans_safely(
 
 @pytest.mark.parametrize(
     "test_case",
-    (AnalysisCacheTestCase(description="unsuccessful result exclusion", expected_count=0),),
+    (AnalysisCacheTestCase(description="deterministic unsuccessful result", expected_count=1),),
     ids=lambda case: case.description,
 )
-def test_given_unsuccessful_analysis_when_writing_then_does_not_persist_it(
+def test_given_unsuccessful_analysis_when_writing_then_reuses_deterministic_result(
     test_case: AnalysisCacheTestCase,
     tmp_path: Path,
 ) -> None:
+    cache_key: str = "a" * 64
+    context: AnalysisCacheContext = AnalysisCacheContext(
+        root=tmp_path,
+        shared_fingerprint="shared",
+    )
     write_model_analyses(
-        context=AnalysisCacheContext(root=tmp_path, shared_fingerprint="shared"),
+        context=context,
         analyses_by_key={
-            "a" * 64: PolyglotAnalysisResult(analysis_succeeded=False),
+            cache_key: PolyglotAnalysisResult(analysis_succeeded=False),
+        },
+        latest_analyses_by_model={
+            "orders": PolyglotAnalysisResult(analysis_succeeded=False),
         },
     )
+    analyses, _, _ = read_model_analyses(
+        context=context,
+        cache_keys=(cache_key,),
+        model_names=("orders",),
+        upstream_model_names_by_key={cache_key: ()},
+    )
 
-    assert len(tuple(tmp_path.rglob("*.sqlite3"))) == test_case.expected_count
+    assert len(analyses) == test_case.expected_count
+    assert analyses[cache_key].analysis_succeeded is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_sql_test_cte_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_sql_test_cte_cache.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from sqlbuild.compiler.compile._helpers.sql_tests import cache as cte_cache
+from sqlbuild.compiler.compile._helpers.sql_tests.cache import cached_sql_test_cte_extractor
+from sqlbuild.compiler.compile.models import CompileSqlTestCtes
+from sqlbuild.compiler.compile.types import SqlTestMode
+from tests.unit.src.sqlbuild.compiler.compile._helpers._test_types import (
+    SqlTestCteCacheTestCase,
+)
+
+_TEST_SQL: str = (
+    "WITH __ref__raw_orders AS (SELECT 1 AS order_id), "
+    "__expected__orders AS (SELECT 1 AS order_id) SELECT 1"
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (SqlTestCteCacheTestCase(description="unchanged SQL reuses CTEs", expected_scanner_calls=0),),
+    ids=lambda case: case.description,
+)
+def test_given_cached_test_ctes_when_extracting_again_then_skips_scanner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: SqlTestCteCacheTestCase,
+) -> None:
+    with cached_sql_test_cte_extractor(root=tmp_path) as extract:
+        expected: CompileSqlTestCtes = extract(_TEST_SQL, "test_orders.sql", SqlTestMode.MODEL)
+    scanner: Mock = Mock(wraps=cte_cache.extract_unclassified_sql_test_ctes)
+    monkeypatch.setattr(cte_cache, "extract_unclassified_sql_test_ctes", scanner)
+
+    with cached_sql_test_cte_extractor(root=tmp_path) as extract:
+        actual: CompileSqlTestCtes = extract(_TEST_SQL, "test_orders.sql", SqlTestMode.MODEL)
+
+    assert scanner.call_count == test_case.expected_scanner_calls
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (SqlTestCteCacheTestCase(description="changed SQL scans CTEs", expected_scanner_calls=1),),
+    ids=lambda case: case.description,
+)
+def test_given_changed_test_sql_when_extracting_then_scans_new_ctes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: SqlTestCteCacheTestCase,
+) -> None:
+    with cached_sql_test_cte_extractor(root=tmp_path) as extract:
+        _ = extract(_TEST_SQL, "test_orders.sql", SqlTestMode.MODEL)
+    scanner: Mock = Mock(wraps=cte_cache.extract_unclassified_sql_test_ctes)
+    monkeypatch.setattr(cte_cache, "extract_unclassified_sql_test_ctes", scanner)
+    changed_sql: str = _TEST_SQL.replace("SELECT 1 AS order_id", "SELECT 2 AS order_id")
+
+    with cached_sql_test_cte_extractor(root=tmp_path) as extract:
+        _ = extract(changed_sql, "test_orders.sql", SqlTestMode.MODEL)
+
+    assert scanner.call_count == test_case.expected_scanner_calls
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (SqlTestCteCacheTestCase(description="corrupt cache rescans", expected_scanner_calls=1),),
+    ids=lambda case: case.description,
+)
+def test_given_corrupt_test_cte_cache_when_extracting_then_rescans_safely(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    test_case: SqlTestCteCacheTestCase,
+) -> None:
+    with cached_sql_test_cte_extractor(root=tmp_path) as extract:
+        _ = extract(_TEST_SQL, "test_orders.sql", SqlTestMode.MODEL)
+    cache_path: Path = next(tmp_path.rglob("sql-test-ctes.sqlite3"))
+    with sqlite3.connect(cache_path) as connection:
+        _ = connection.execute("UPDATE sql_test_cte SET payload = 'broken'")
+    scanner: Mock = Mock(wraps=cte_cache.extract_unclassified_sql_test_ctes)
+    monkeypatch.setattr(cte_cache, "extract_unclassified_sql_test_ctes", scanner)
+
+    with cached_sql_test_cte_extractor(root=tmp_path) as extract:
+        _ = extract(_TEST_SQL, "test_orders.sql", SqlTestMode.MODEL)
+
+    assert scanner.call_count == test_case.expected_scanner_calls


### PR DESCRIPTION
## Why

Real-world test-heavy projects rebuilt execution-grade SQL test plans and multi-megabyte comparison artifacts on every compile. The Dagster representative project met its cold budget but missed the <=3s unchanged and <=4s single-edit goals. CHI-253 tracks closing that gap while preserving compiled SQL and diagnostics.

## Changes

- cache compiled SQL test artifacts by adapter, target, complete test identity, and exact model closure
- cache expanded SQL test CTE boundaries and deterministic unsuccessful model-analysis outcomes
- invalidate only affected test artifacts for model, test, target, adapter, or artifact changes
- avoid deep-copying Polyglot trees during comparison generation and use four existing analysis workers
- skip unnecessary scoped-declaration work for all-global projects and prefilter legacy schema files once
- extend the model/test-heavy E2E guard with unchanged, one-model-edit, and one-test-edit budgets

## Verification

- `make test` (6,355 passed)
- `uv sync --all-extras && make check-ci`
- compile performance guards (6 passed)
- focused cache/planner/comparison tests (166 passed)
- Dagster representative project: 976 models, 731 audits, 130 tests; cold 6.19s, unchanged 2.97-3.00s, model edit 3.12s, test edit 3.05s
- all 130 Dagster compiled test artifacts matched the SQLBuild 0.82.6 baseline byte-for-byte
