### PR TITLE
fix: reject Python outside supported project roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ SELECT 1
 
 See the [documentation](https://docs.sqlbuild.com) for incremental models, scenarios, loaders, and more.
 
+### Python project layout
+
+Project-owned Python must live in a supported extension location such as `factories/`, `libs/`,
+`macros/`, `providers/`, or another documented Python resource root. Factory locations contain
+normal Python: constants, classes, undecorated helper functions, and modules such as `_helpers.py`
+are allowed, while decorators determine which functions become SQLBuild resources. Compilation
+rejects Python under invented project roots so indirectly importable modules cannot create an
+unofficial project structure. Keep repository pytest tests outside the SQLBuild project's `tests/`
+directory, which is reserved for SQLBuild SQL tests and scenarios. Documented integration paths
+such as `dagster/`, `rivers_pipeline/`, and their `definitions.py` modules are also supported.
+
 ## Kata SQL architecture checks
 
 Kata is SQLBuild's opt-in, error-only SQL model shape checker. It runs offline over the compiled

--- a/src/sqlbuild/compiler/discovery/_helpers/filesystem/python_paths.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/filesystem/python_paths.py
@@ -1,0 +1,112 @@
+"""Validation for the supported SQLBuild project Python layout."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from sqlbuild.compiler.discovery.constants import (
+    CANONICAL_AUTHORED_ROOTS,
+    LANGUAGE_PYTHON_ROOT_PART_COUNT,
+    PYTHON_CACHE_DIRECTORY_NAME,
+)
+from sqlbuild.compiler.discovery.exceptions import ProjectPythonPathError
+from sqlbuild.compiler.scopes.constants import (
+    GLOBAL_DECLARATION_DIRECTORIES,
+    INHERITED_DECLARATION_DIRECTORIES,
+    LOCAL_DECLARATION_DIRECTORIES,
+)
+
+_DIRECT_PYTHON_ROOTS: frozenset[str] = frozenset(
+    {
+        "adapters",
+        "assets",
+        "checks",
+        "dagster",
+        "factories",
+        "kata",
+        "loaders",
+        "libs",
+        "materializations",
+        "providers",
+        "rivers_pipeline",
+        "sinks",
+        "tasks",
+    }
+)
+_LANGUAGE_PYTHON_ROOTS: frozenset[tuple[str, str]] = frozenset(
+    {("functions", "python"), ("hooks", "python")}
+)
+_IGNORED_ROOTS: frozenset[str] = frozenset({"logs", "target", "venv"})
+_LEGACY_DIAGNOSTIC_ROOTS: frozenset[str] = frozenset({"event_exporters"})
+_SUPPORTED_ROOT_FILES: frozenset[Path] = frozenset({Path("adapter.py"), Path("definitions.py")})
+_SCOPED_DECLARATION_DIRECTORIES: frozenset[str] = (
+    INHERITED_DECLARATION_DIRECTORIES | LOCAL_DECLARATION_DIRECTORIES
+)
+
+
+def validate_project_python_paths(*, project_dir: Path) -> None:
+    """Reject project Python outside documented executable roots."""
+
+    unsupported: tuple[Path, ...] = _unsupported_python_paths(project_dir=project_dir)
+    if not unsupported:
+        return
+    rendered_paths: str = ", ".join(str(path) for path in unsupported)
+    raise ProjectPythonPathError(
+        f"Unsupported project Python path(s): {rendered_paths}",
+        help=(
+            "Move project Python under a documented resource, library, or integration path. "
+            "Factory support modules, including factories/**/_helpers.py, are allowed."
+        ),
+    )
+
+
+def _unsupported_python_paths(*, project_dir: Path) -> tuple[Path, ...]:
+    unsupported: list[Path] = []
+    for file_path in _project_python_files(project_dir=project_dir):
+        if _is_supported(file_path=file_path, project_dir=project_dir):
+            continue
+        unsupported.append(file_path.relative_to(project_dir))
+    return tuple(unsupported)
+
+
+def _project_python_files(*, project_dir: Path) -> tuple[Path, ...]:
+    files: list[Path] = []
+    for root, directories, filenames in os.walk(project_dir):
+        root_path: Path = Path(root)
+        directories[:] = [
+            name
+            for name in directories
+            if not name.startswith(".")
+            and name != PYTHON_CACHE_DIRECTORY_NAME
+            and not (root_path == project_dir and name in _IGNORED_ROOTS)
+        ]
+        files.extend(root_path / name for name in filenames if name.endswith(".py"))
+    return tuple(sorted(files))
+
+
+def _is_supported(*, file_path: Path, project_dir: Path) -> bool:
+    relative_path: Path = file_path.relative_to(project_dir)
+    parts: tuple[str, ...] = relative_path.parts
+    if relative_path in _SUPPORTED_ROOT_FILES:
+        return True
+    if (
+        parts[0] in _DIRECT_PYTHON_ROOTS
+        or parts[0] in GLOBAL_DECLARATION_DIRECTORIES
+        or parts[0] in _LEGACY_DIAGNOSTIC_ROOTS
+    ):
+        return True
+    if (
+        len(parts) >= LANGUAGE_PYTHON_ROOT_PART_COUNT
+        and parts[:LANGUAGE_PYTHON_ROOT_PART_COUNT] in _LANGUAGE_PYTHON_ROOTS
+    ):
+        return True
+    return _is_scoped_declaration_path(parts)
+
+
+def _is_scoped_declaration_path(parts: tuple[str, ...]) -> bool:
+    for root_parts in CANONICAL_AUTHORED_ROOTS:
+        if parts[: len(root_parts)] != root_parts:
+            continue
+        return any(part in _SCOPED_DECLARATION_DIRECTORIES for part in parts[len(root_parts) : -1])
+    return False

--- a/src/sqlbuild/compiler/discovery/constants.py
+++ b/src/sqlbuild/compiler/discovery/constants.py
@@ -13,6 +13,8 @@ YAML_FILE_SUFFIXES: frozenset[str] = frozenset({".yml", ".yaml"})
 RESERVED_MODEL_NAMES: frozenset[str] = frozenset({"_chain_"})
 
 PYTHON_INIT_MODULE_STEM: str = "__init__"
+PYTHON_CACHE_DIRECTORY_NAME: str = "__pycache__"
+LANGUAGE_PYTHON_ROOT_PART_COUNT: int = 2
 PYTHON_LOADER_FOLDER: str = "loaders"
 PYTHON_FACTORY_FOLDER: str = "factories"
 PYTHON_NODE_KIND_VOWELS: frozenset[str] = frozenset({"a", "e", "i", "o", "u"})

--- a/src/sqlbuild/compiler/discovery/exceptions.py
+++ b/src/sqlbuild/compiler/discovery/exceptions.py
@@ -109,3 +109,9 @@ class EventExporterDiscoveryError(DiscoveryError):
     """Raised when project lifecycle event exporters are invalid."""
 
     code: str = "D015"
+
+
+class ProjectPythonPathError(DiscoveryError):
+    """Raised when project-owned Python lives outside a supported extension root."""
+
+    code: str = "D016"

--- a/src/sqlbuild/compiler/discovery/main/discover.py
+++ b/src/sqlbuild/compiler/discovery/main/discover.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from sqlbuild.compiler.discovery._helpers.filesystem.aggregation import (
     build_discovered_project_inputs,
 )
+from sqlbuild.compiler.discovery._helpers.filesystem.python_paths import (
+    validate_project_python_paths,
+)
 from sqlbuild.compiler.discovery._helpers.validation.discovery import validate_discovered_inputs
 from sqlbuild.compiler.discovery._helpers.yml.project import (
     load_local_config,
@@ -56,6 +59,7 @@ def _assemble_discovered_project_inputs(
 ) -> DiscoveredProjectInputs:
     project_config: ProjectConfig = load_project_config(project_dir=project_dir)
     local_config: LocalConfig = load_local_config(project_dir=project_dir)
+    validate_project_python_paths(project_dir=project_dir)
     sql_analysis_enabled: bool = (
         sql_analysis_enabled_override
         if sql_analysis_enabled_override is not None

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
@@ -63,3 +63,11 @@ class PathDefaultCompileTestCase:
     repo_files: dict[str, str]
     expected_exit_code: int
     expected_stderr_fragment: str
+
+
+@dataclass(frozen=True)
+class PythonProjectLayoutCompileTestCase:
+    description: str
+    repo_files: dict[str, str]
+    expected_exit_code: int
+    expected_stderr_fragments: tuple[str, ...]

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_python_project_layout.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_python_project_layout.py
@@ -1,0 +1,54 @@
+"""E2E coverage for fail-closed Python project layout validation."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.src.sqlbuild.cli.commands.main.compile._test_types import (
+    PythonProjectLayoutCompileTestCase,
+)
+from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import prepare_inline_project, run_sqb
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        PythonProjectLayoutCompileTestCase(
+            description="unsupported project Python root",
+            repo_files={
+                "sqlbuild_project.toml": 'name = "python_layout"\nadapter = "duckdb"\n',
+                "audit_helpers/measurements.py": "def build_cases(): return []\n",
+            },
+            expected_exit_code=1,
+            expected_stderr_fragments=(
+                "Unsupported project Python path(s): audit_helpers/measurements.py",
+                "Factory support modules, including factories/**/_helpers.py, are allowed",
+            ),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_python_under_unsupported_root_when_compiling_then_command_fails_with_path_guidance(
+    test_case: PythonProjectLayoutCompileTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_inline_project(
+        tmp_path=tmp_path,
+        project_name="python_layout",
+        repo_files=test_case.repo_files,
+    )
+
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", "compile"),
+        project_dir=project_dir,
+    )
+
+    assert result.returncode == test_case.expected_exit_code, result.stdout + result.stderr
+    assert all(fragment in result.stderr for fragment in test_case.expected_stderr_fragments)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vv"])

--- a/tests/unit/src/sqlbuild/compiler/discovery/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_test_types.py
@@ -72,6 +72,13 @@ class DiscoverFactoryValidationTestCase:
 
 
 @dataclass(frozen=True)
+class ProjectPythonPathAcceptanceTestCase:
+    description: str
+    repo_files: dict[str, str]
+    expected_project_name: str
+
+
+@dataclass(frozen=True)
 class DiscoveryLifecycleTestCase:
     description: str
     expected_event_types: tuple[str, ...]

--- a/tests/unit/src/sqlbuild/compiler/discovery/test_main.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/test_main.py
@@ -18,6 +18,7 @@ from tests.unit.src.sqlbuild.compiler.discovery._test_types import (
     DiscoverProjectInputsTestCase,
     DiscoveryLifecycleTestCase,
     DiscoveryRelevantCountTestCase,
+    ProjectPythonPathAcceptanceTestCase,
 )
 
 
@@ -464,6 +465,28 @@ def generated_tasks():
             },
             expected_task_names=("prepare_orders",),
         ),
+        DiscoverFactoryValidationTestCase(
+            description="factory can import ordinary private helper module",
+            repo_files=base_repo_files()
+            | {
+                "factories/orders/_helpers.py": "TASK_NAME = 'prepare_orders'\n",
+                "factories/orders/generated.py": """
+from factories.orders._helpers import TASK_NAME
+from sqlbuild.factories import factory
+from sqlbuild.tasks import task
+
+
+@factory
+def generated_tasks():
+    @task(name=TASK_NAME)
+    def prepare(ctx):
+        return None
+
+    return prepare
+""",
+            },
+            expected_task_names=("prepare_orders",),
+        ),
     ),
     ids=lambda case: case.description,
 )
@@ -482,6 +505,55 @@ def test_given_generated_factory_nodes_when_discovering_inputs_then_validates_ex
     assert tuple(task.name for task in result.task_functions) == test_case.expected_task_names
     assert tuple(asset.name for asset in result.asset_functions) == test_case.expected_asset_names
     assert tuple(check.name for check in result.check_functions) == test_case.expected_check_names
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        ProjectPythonPathAcceptanceTestCase(
+            description="documented integration Python paths",
+            repo_files={
+                "definitions.py": "ROOT_DEFINITIONS = True\n",
+                "dagster/definitions.py": "DAGSTER_DEFINITIONS = True\n",
+                "rivers_pipeline/definitions.py": "RIVERS_DEFINITIONS = True\n",
+            },
+            expected_project_name="demo",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_documented_integration_python_when_discovering_inputs_then_paths_are_accepted(
+    test_case: ProjectPythonPathAcceptanceTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, base_repo_files() | test_case.repo_files)
+
+    result: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
+
+    assert result.project_config.name == test_case.expected_project_name
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        DiscoverProjectInputsErrorTestCase(
+            description="non-project directory containing Python",
+            repo_files={"application/main.py": "print('hello')\n"},
+            expected_error_fragment="Project config not found",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_non_project_with_python_when_discovering_then_missing_config_error_takes_precedence(
+    test_case: DiscoverProjectInputsErrorTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, test_case.repo_files)
+
+    with pytest.raises(ValueError, match=test_case.expected_error_fragment):
+        discover_project_inputs(project_dir=tmp_path)
 
 
 @pytest.mark.parametrize(
@@ -660,6 +732,14 @@ def test_given_invalid_generated_factory_nodes_when_discovering_inputs_then_rais
 @pytest.mark.parametrize(
     "test_case",
     [
+        DiscoverProjectInputsErrorTestCase(
+            description="raises when Python lives outside a supported project root",
+            repo_files=base_repo_files()
+            | {"audit_helpers/measurements.py": "def build_cases(): return []\n"},
+            expected_error_fragment=(
+                "Unsupported project Python path\\(s\\): audit_helpers/measurements.py"
+            ),
+        ),
         DiscoverProjectInputsErrorTestCase(
             description="raises on duplicate source names across files",
             repo_files=base_repo_files()


### PR DESCRIPTION
## Why

SQLBuild added the project root to `sys.path` while importing factories, so Python under an invented directory such as `audit_helpers/` could be executed indirectly even though discovery did not recognize that directory. This allowed unofficial project structures to compile silently.

Closes CHI-259 and unblocks the CHI-254 Bias measurement-audit layout.

## Changes

- Validate project-owned Python paths after project configuration is loaded and before resource imports.
- Reject Python outside documented resource, library, scoped-declaration, and integration roots with `D016` guidance.
- Keep normal factory support code, including `factories/**/_helpers.py`, valid; decorators still determine resource registration.
- Preserve supported `libs/`, project adapters, Kata rules, Dagster/Rivers definitions, generated/hidden directories, and the targeted `event_exporters/` migration diagnostic.
- Document the Python project boundary and add focused discovery plus real CLI compile coverage.

## Verification

- Focused discovery, event-exporter, Kata, and CLI compile tests: 76 passed.
- `make test`: 6,359 passed.
- `uv sync --all-extras` and `make check-ci`: passed.
- Independent review completed; all three findings were fixed and verified in one bounded follow-up.
