### PR TITLE
perf: add Dagster-shaped compile guard

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/compile/target_writer.py
+++ b/src/sqlbuild/cli/commands/_helpers/compile/target_writer.py
@@ -28,6 +28,7 @@ from sqlbuild.compiler.planner.main.execution.sql_test_assembly import (
     build_sql_test_plan_entry,
 )
 from sqlbuild.compiler.planner.models import AuditPlanEntry, PlanOutput
+from sqlbuild.compiler.profiling.main.record import record_compile_timing
 from sqlbuild.executor.testing.main.comparison_sql import build_sql_test_comparison_sql
 
 _COMPILED_DIR: str = "compiled"
@@ -59,7 +60,8 @@ def write_compile_target(
         _write_audits(target_dir=target_dir, plan_output=plan_output),
         _write_tests(target_dir=target_dir, adapter=adapter, plan_output=plan_output),
     )
-    _remove_stale_compiled_files(target_dir=target_dir, managed_paths=managed_paths)
+    with record_compile_timing("stale_traversal_ms"):
+        _remove_stale_compiled_files(target_dir=target_dir, managed_paths=managed_paths)
     if manifest is not None:
         _write_manifest(target_dir=target_dir, manifest=manifest)
 
@@ -89,7 +91,8 @@ def write_static_compile_target(
         _write_static_audits(target_dir=target_dir, project=project),
         _write_static_tests(target_dir=target_dir, adapter=adapter, project=project),
     )
-    _remove_stale_compiled_files(target_dir=target_dir, managed_paths=managed_paths)
+    with record_compile_timing("stale_traversal_ms"):
+        _remove_stale_compiled_files(target_dir=target_dir, managed_paths=managed_paths)
     if manifest is not None:
         _write_manifest(target_dir=target_dir, manifest=manifest)
 
@@ -240,14 +243,13 @@ def _write_tests(
     managed_paths: set[Path] = set()
     for entry in plan_output.test_entries:
         test_path: Path = target_dir / _COMPILED_DIR / _TESTS_DIR / sql_test_output_path(entry)
-        _write_sql(
-            path=test_path,
-            sql=build_sql_test_comparison_sql(
+        with record_compile_timing("comparison_render_ms"):
+            comparison_sql: str = build_sql_test_comparison_sql(
                 test_entry=entry,
                 set_difference_operator=adapter.render_set_difference_operator(),
                 sql_analysis_dialect=adapter.sql_analysis_dialect(),
-            ),
-        )
+            )
+        _write_sql(path=test_path, sql=comparison_sql)
         managed_paths.add(test_path)
     return managed_paths
 
@@ -292,21 +294,21 @@ def _write_static_tests(
                     managed_paths.add(cached_path)
                     current_records[record_key] = cached_record
                     continue
-        entry, _warnings = build_sql_test_plan_entry(
-            test=test,
-            project=project,
-            adapter=adapter,
-            sql_analysis_enabled=project.settings.sql_analysis,
-        )
+        with record_compile_timing("test_planning_ms"):
+            entry, _warnings = build_sql_test_plan_entry(
+                test=test,
+                project=project,
+                adapter=adapter,
+                sql_analysis_enabled=project.settings.sql_analysis,
+            )
         test_path: Path = tests_root / sql_test_output_path(entry)
-        _write_sql(
-            path=test_path,
-            sql=build_sql_test_comparison_sql(
+        with record_compile_timing("comparison_render_ms"):
+            comparison_sql: str = build_sql_test_comparison_sql(
                 test_entry=entry,
                 set_difference_operator=adapter.render_set_difference_operator(),
                 sql_analysis_dialect=adapter.sql_analysis_dialect(),
-            ),
-        )
+            )
+        _write_sql(path=test_path, sql=comparison_sql)
         managed_paths.add(test_path)
         if record_key is not None and artifact_identity is not None:
             record: SqlTestArtifactCacheRecord | None = build_sql_test_artifact_cache_record(
@@ -316,10 +318,11 @@ def _write_static_tests(
             )
             if record is not None:
                 current_records[record_key] = record
-    write_sql_test_artifact_cache(
-        cache_dir=project.compile_cache_dir,
-        records=current_records,
-    )
+    with record_compile_timing("cache_publication_ms"):
+        write_sql_test_artifact_cache(
+            cache_dir=project.compile_cache_dir,
+            records=current_records,
+        )
     return managed_paths
 
 
@@ -337,10 +340,11 @@ def _write_sql(*, path: Path, sql: str) -> None:
 
 
 def _write_text_if_changed(*, path: Path, contents: str) -> None:
-    if path.is_file() and path.read_text(encoding="utf-8") == contents:
-        return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(contents, encoding="utf-8")
+    with record_compile_timing("physical_write_ms"):
+        if path.is_file() and path.read_text(encoding="utf-8") == contents:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
 
 
 def _remove_stale_compiled_files(*, target_dir: Path, managed_paths: set[Path]) -> None:

--- a/src/sqlbuild/cli/commands/main/project/_compile.py
+++ b/src/sqlbuild/cli/commands/main/project/_compile.py
@@ -23,6 +23,8 @@ from sqlbuild.cli.commands.models import (
     CompileWriteResult,
 )
 from sqlbuild.cli.commands.types import CompileLineageMode
+from sqlbuild.compiler.profiling.main.collect import collect_compile_timings
+from sqlbuild.compiler.profiling.models import CompileTimingCollector
 from sqlbuild.presentation.classes.transient_status_reporter import TransientStatusReporter
 from sqlbuild.presentation.main.supports_color import supports_color
 
@@ -39,11 +41,13 @@ def run_compile(request: CompileCommandRequest) -> int:
         no_color=request.no_color,
     )
     try:
-        return _run_compile_with_status(
-            request=effective_request,
-            total_start=total_start,
-            status=status,
-        )
+        with collect_compile_timings() as detailed_timings:
+            return _run_compile_with_status(
+                request=effective_request,
+                total_start=total_start,
+                status=status,
+                detailed_timings=detailed_timings,
+            )
     finally:
         if status is not None:
             status.close()
@@ -54,6 +58,7 @@ def _run_compile_with_status(
     request: CompileCommandRequest,
     total_start: float,
     status: TransientStatusReporter | None,
+    detailed_timings: CompileTimingCollector,
 ) -> int:
     """Execute compile after the optional interactive status reporter is initialized."""
 
@@ -96,6 +101,7 @@ def _run_compile_with_status(
         "lineage_ms": analysis.lineage_ms,
         "contracts_ms": analysis.contract_ms,
         "write_ms": write_result.write_ms,
+        **detailed_timings.as_milliseconds(),
         "total_ms": elapsed_ms(total_start),
     }
     exit_code: int = 1 if any(diagnostic.is_error for diagnostic in analysis.diagnostics) else 0

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -94,6 +94,7 @@ from sqlbuild.compiler.discovery.main._model_output_column_locations import (
     extract_model_output_column_locations,
 )
 from sqlbuild.compiler.lineage.types import ColumnLineageMode, InferredNullability
+from sqlbuild.compiler.profiling.main.record import record_compile_timing
 from sqlbuild.compiler.references.types import SqlReferenceKind
 from sqlbuild.compiler.scopes.exceptions import ScopeValidationError
 from sqlbuild.compiler.scopes.main._validate_scope_index import validate_scope_index
@@ -172,18 +173,20 @@ def assemble_compiled_project(
     )
     model_sql_analysis_by_name: dict[str, _ModelSqlAnalysis] = {}
     if sql_analysis_enabled:
-        model_sql_analysis_by_name = _analyze_model_sql_in_parallel(
-            model_inputs=tuple(
-                model_input
-                for model_input in inputs.model_inputs
-                if analysis_model_names is None or _model_name(model_input) in analysis_model_names
-            ),
-            column_nullability_by_table=column_nullability_by_table,
-            column_types_by_table=column_types_by_table,
-            inference_profile=profile,
-            allow_compact_analysis=allow_compact_analysis,
-            analysis_cache=analysis_cache,
-        )
+        with record_compile_timing("model_analysis_ms"):
+            model_sql_analysis_by_name = _analyze_model_sql_in_parallel(
+                model_inputs=tuple(
+                    model_input
+                    for model_input in inputs.model_inputs
+                    if analysis_model_names is None
+                    or _model_name(model_input) in analysis_model_names
+                ),
+                column_nullability_by_table=column_nullability_by_table,
+                column_types_by_table=column_types_by_table,
+                inference_profile=profile,
+                allow_compact_analysis=allow_compact_analysis,
+                analysis_cache=analysis_cache,
+            )
     scope_index: ScopeIndex = scope_index_with_compile_usages(inputs=inputs)
     try:
         validate_scope_index(index=scope_index)
@@ -531,25 +534,26 @@ def _analyze_model_sql_in_parallel(
             }
         )
     if analysis_cache is not None:
-        write_model_analyses(
-            context=analysis_cache,
-            analyses_by_key={
-                request.cache_key: analysis.polyglot_analysis
-                for request, analysis in zip(requests, analyses, strict=True)
-                if request.cache_key is not None
-                and (
-                    request.cache_key not in cached_analyses
-                    or _model_name(request.model_input) in invalidated_names
-                )
-            },
-            latest_analyses_by_model=analyses_to_record_by_name,
-            dependency_signatures_by_key=_dependency_signatures_by_key(
-                requests=requests,
-                cached_analyses=cached_analyses,
-                invalidated_names=invalidated_names,
-                current_signatures_by_name=current_signatures_by_name,
-            ),
-        )
+        with record_compile_timing("cache_publication_ms"):
+            write_model_analyses(
+                context=analysis_cache,
+                analyses_by_key={
+                    request.cache_key: analysis.polyglot_analysis
+                    for request, analysis in zip(requests, analyses, strict=True)
+                    if request.cache_key is not None
+                    and (
+                        request.cache_key not in cached_analyses
+                        or _model_name(request.model_input) in invalidated_names
+                    )
+                },
+                latest_analyses_by_model=analyses_to_record_by_name,
+                dependency_signatures_by_key=_dependency_signatures_by_key(
+                    requests=requests,
+                    cached_analyses=cached_analyses,
+                    invalidated_names=invalidated_names,
+                    current_signatures_by_name=current_signatures_by_name,
+                ),
+            )
     return {
         _model_name(model_input): analysis
         for model_input, analysis in zip(model_inputs, analyses, strict=True)

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
@@ -65,6 +65,7 @@ from sqlbuild.compiler.discovery.models import (
     DiscoveredSqlTestFile,
     EnumDeclaration,
 )
+from sqlbuild.compiler.profiling.main.record import record_compile_timing
 from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver, SqlReferenceKind
 from sqlbuild.compiler.scopes.models import ResourceIdentity, UsageRecord
 from sqlbuild.compiler.scopes.types import ResourceKind, UsageKind
@@ -90,17 +91,18 @@ def build_test_inputs_with_cache(
 ) -> tuple[CompileSqlTestInput, ...]:
     """Build SQL test inputs while reusing exact expanded CTE boundaries."""
 
-    with cached_sql_test_cte_extractor(root=compile_cache_dir) as extract_test_ctes:
-        return build_test_inputs(
-            discovered_inputs=discovered_inputs,
-            effective_vars=effective_vars,
-            macro_context=macro_context,
-            loaded_macros=loaded_macros,
-            declaration_expansion=declaration_expansion,
-            external_sql_reference_resolver=external_sql_reference_resolver,
-            sql_function_inputs=sql_function_inputs,
-            sql_test_cte_extractor=extract_test_ctes,
-        )
+    with record_compile_timing("test_input_compile_ms"):
+        with cached_sql_test_cte_extractor(root=compile_cache_dir) as extract_test_ctes:
+            return build_test_inputs(
+                discovered_inputs=discovered_inputs,
+                effective_vars=effective_vars,
+                macro_context=macro_context,
+                loaded_macros=loaded_macros,
+                declaration_expansion=declaration_expansion,
+                external_sql_reference_resolver=external_sql_reference_resolver,
+                sql_function_inputs=sql_function_inputs,
+                sql_test_cte_extractor=extract_test_ctes,
+            )
 
 
 def build_test_inputs(

--- a/src/sqlbuild/compiler/compile/_helpers/sql_tests/cache.py
+++ b/src/sqlbuild/compiler/compile/_helpers/sql_tests/cache.py
@@ -18,6 +18,7 @@ from sqlbuild.compiler.compile._helpers.sql_tests.core import (
 )
 from sqlbuild.compiler.compile.models import CompileSqlTestCte, CompileSqlTestCtes
 from sqlbuild.compiler.compile.types import SqlTestMode
+from sqlbuild.compiler.profiling.main.record import record_compile_timing
 
 _CACHE_VERSION: int = 1
 _CACHE_DATABASE_NAME: str = "sql-test-ctes.sqlite3"
@@ -67,7 +68,8 @@ class _SqlTestCteCache:
         self._connection = None
         try:
             if exc_type is None:
-                connection = self._write_pending(connection=connection)
+                with record_compile_timing("cache_publication_ms"):
+                    connection = self._write_pending(connection=connection)
             elif connection is not None:
                 connection.rollback()
         except (OSError, sqlite3.DatabaseError):

--- a/src/sqlbuild/compiler/pipeline/main/compiled_project.py
+++ b/src/sqlbuild/compiler/pipeline/main/compiled_project.py
@@ -29,6 +29,7 @@ from sqlbuild.compiler.planner.models import (
     PlannerScopeResolution,
     PlannerSelection,
 )
+from sqlbuild.compiler.profiling.main.record import record_compile_timing
 from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver
 from sqlbuild.spec.contracts.main.resolve_effective_adapter_name import (
     resolve_effective_adapter_name,
@@ -64,26 +65,27 @@ def build_compiled_project(
         resolved_connection=resolved_connection,
     )
     no_cache: bool = analysis_selection is not None and analysis_selection.no_cache
-    compile_inputs: CompileProjectInputs = build_compile_inputs(
-        discovered_inputs=discovered_inputs,
-        adapter_context=CompileAdapterContext(
-            value_renderer=adapter,
-            collection_rendering=resolve_effective_collection_rendering(
-                project_config=discovered_inputs.project_config,
-                declaration_override=None,
+    with record_compile_timing("attachment_ms"):
+        compile_inputs: CompileProjectInputs = build_compile_inputs(
+            discovered_inputs=discovered_inputs,
+            adapter_context=CompileAdapterContext(
+                value_renderer=adapter,
+                collection_rendering=resolve_effective_collection_rendering(
+                    project_config=discovered_inputs.project_config,
+                    declaration_override=None,
+                ),
+                python_functions_inherit_default_namespace=(
+                    adapter.python_functions_inherit_default_namespace()
+                ),
             ),
-            python_functions_inherit_default_namespace=(
-                adapter.python_functions_inherit_default_namespace()
-            ),
-        ),
-        selected_target=selected_target,
-        no_sql_validation=no_sql_validation,
-        defer_model_sql_validation=True,
-        cli_vars=cli_vars,
-        resolved_connection=resolved_connection,
-        external_sql_reference_resolver=external_sql_reference_resolver,
-        no_cache=no_cache,
-    )
+            selected_target=selected_target,
+            no_sql_validation=no_sql_validation,
+            defer_model_sql_validation=True,
+            cli_vars=cli_vars,
+            resolved_connection=resolved_connection,
+            external_sql_reference_resolver=external_sql_reference_resolver,
+            no_cache=no_cache,
+        )
     inference_profile: ExpressionInferenceProfile = adapter.expression_inference_profile()
     analysis_model_names: frozenset[str] | None = _resolve_analysis_model_names(
         compile_inputs=compile_inputs,

--- a/src/sqlbuild/compiler/profiling/__init__.py
+++ b/src/sqlbuild/compiler/profiling/__init__.py
@@ -1,0 +1,1 @@
+"""Compile profiling support."""

--- a/src/sqlbuild/compiler/profiling/classes/__init__.py
+++ b/src/sqlbuild/compiler/profiling/classes/__init__.py
@@ -1,0 +1,1 @@
+"""Compile profiling runtime classes."""

--- a/src/sqlbuild/compiler/profiling/classes/context.py
+++ b/src/sqlbuild/compiler/profiling/classes/context.py
@@ -1,0 +1,14 @@
+"""Active compile timing context."""
+
+from contextvars import ContextVar
+from typing import ClassVar
+
+from sqlbuild.compiler.profiling.models import CompileTimingCollector
+
+
+class CompileTimingContext:
+    """Own the invocation-local active compile timing collector."""
+
+    active: ClassVar[ContextVar[CompileTimingCollector | None]] = ContextVar(
+        "active_compile_timings", default=None
+    )

--- a/src/sqlbuild/compiler/profiling/constants.py
+++ b/src/sqlbuild/compiler/profiling/constants.py
@@ -1,0 +1,14 @@
+"""Compile profiling constants."""
+
+from sqlbuild.compiler.profiling.types import CompileTimingPhase
+
+COMPILE_TIMING_PHASES: tuple[CompileTimingPhase, ...] = (
+    "attachment_ms",
+    "model_analysis_ms",
+    "test_input_compile_ms",
+    "test_planning_ms",
+    "comparison_render_ms",
+    "cache_publication_ms",
+    "physical_write_ms",
+    "stale_traversal_ms",
+)

--- a/src/sqlbuild/compiler/profiling/main/__init__.py
+++ b/src/sqlbuild/compiler/profiling/main/__init__.py
@@ -1,0 +1,1 @@
+"""Public compile profiling entry points."""

--- a/src/sqlbuild/compiler/profiling/main/collect.py
+++ b/src/sqlbuild/compiler/profiling/main/collect.py
@@ -1,0 +1,20 @@
+"""Compile timing collection entry point."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import Token
+
+from sqlbuild.compiler.profiling.classes.context import CompileTimingContext
+from sqlbuild.compiler.profiling.models import CompileTimingCollector
+
+
+@contextmanager
+def collect_compile_timings() -> Iterator[CompileTimingCollector]:
+    """Collect detailed timings for one compile command invocation."""
+
+    collector: CompileTimingCollector = CompileTimingCollector()
+    token: Token[CompileTimingCollector | None] = CompileTimingContext.active.set(collector)
+    try:
+        yield collector
+    finally:
+        CompileTimingContext.active.reset(token)

--- a/src/sqlbuild/compiler/profiling/main/record.py
+++ b/src/sqlbuild/compiler/profiling/main/record.py
@@ -1,0 +1,24 @@
+"""Compile phase recording entry point."""
+
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from sqlbuild.compiler.profiling.classes.context import CompileTimingContext
+from sqlbuild.compiler.profiling.models import CompileTimingCollector
+from sqlbuild.compiler.profiling.types import CompileTimingPhase
+
+
+@contextmanager
+def record_compile_timing(phase: CompileTimingPhase) -> Iterator[None]:
+    """Record an operation when a compile timing collector is active."""
+
+    collector: CompileTimingCollector | None = CompileTimingContext.active.get()
+    if collector is None:
+        yield
+        return
+    start_ns: int = time.perf_counter_ns()
+    try:
+        yield
+    finally:
+        collector.add(phase=phase, elapsed_ns=time.perf_counter_ns() - start_ns)

--- a/src/sqlbuild/compiler/profiling/models.py
+++ b/src/sqlbuild/compiler/profiling/models.py
@@ -1,0 +1,25 @@
+"""Compile profiling models."""
+
+from dataclasses import dataclass, field
+
+from sqlbuild.compiler.profiling.constants import COMPILE_TIMING_PHASES
+from sqlbuild.compiler.profiling.types import CompileTimingPhase
+
+
+@dataclass(frozen=True)
+class CompileTimingCollector:
+    """Accumulate elapsed nanoseconds for nested compile operations."""
+
+    elapsed_ns: dict[CompileTimingPhase, int] = field(default_factory=dict)
+
+    def add(self, *, phase: CompileTimingPhase, elapsed_ns: int) -> None:
+        """Add one measured operation to a compile phase."""
+
+        self.elapsed_ns[phase] = self.elapsed_ns.get(phase, 0) + elapsed_ns
+
+    def as_milliseconds(self) -> dict[str, int]:
+        """Return every supported phase in stable presentation order."""
+
+        return {
+            phase: self.elapsed_ns.get(phase, 0) // 1_000_000 for phase in COMPILE_TIMING_PHASES
+        }

--- a/src/sqlbuild/compiler/profiling/types.py
+++ b/src/sqlbuild/compiler/profiling/types.py
@@ -1,0 +1,14 @@
+"""Compile profiling type aliases."""
+
+from typing import Literal
+
+type CompileTimingPhase = Literal[
+    "attachment_ms",
+    "model_analysis_ms",
+    "test_input_compile_ms",
+    "test_planning_ms",
+    "comparison_render_ms",
+    "cache_publication_ms",
+    "physical_write_ms",
+    "stale_traversal_ms",
+]

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_compile_json_behavior.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_compile_json_behavior.py
@@ -60,7 +60,23 @@ def test_given_waffle_shop_when_running_compile_json_then_it_reports_offline_que
         test_case.expected_diagnostic_codes
     )
     timings: dict[str, object] = payload["compile_timings"]
-    assert "total_ms" in timings
+    assert set(timings) == {
+        "discover_ms",
+        "graph_ms",
+        "lineage_ms",
+        "contracts_ms",
+        "write_ms",
+        "attachment_ms",
+        "model_analysis_ms",
+        "test_input_compile_ms",
+        "test_planning_ms",
+        "comparison_render_ms",
+        "cache_publication_ms",
+        "physical_write_ms",
+        "stale_traversal_ms",
+        "total_ms",
+    }
+    assert all(isinstance(value, int) and value >= 0 for value in timings.values())
     artifacts: dict[str, object] = payload["artifacts"]
     assert artifacts["compiled_sql_dir"] == "target/compiled/"
     assert artifacts["manifest"] is None

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/DAGSTER_SHAPED_BENCHMARK.md
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/DAGSTER_SHAPED_BENCHMARK.md
@@ -1,0 +1,44 @@
+# Dagster-shaped compile benchmark
+
+This generated project protects SQLBuild against regressions that only appear when model,
+declaration, native-test, and artifact-writing workloads occur together. It contains no Dagster
+SQL, names, or fixture data.
+
+The profile was sampled from the September 2026 Dagster SQLBuild project. Counts and model SQL
+sizes are intentionally close, while generated names and logic are generic:
+
+| Characteristic | Dagster profile | Generated guard |
+| --- | ---: | ---: |
+| Models | 976 | 976 |
+| Sources | 232 | 232 |
+| Seeds | 46 | 46 |
+| SQL functions | 23 | 23 |
+| Attached audits | 731 | 700 |
+| Native test cases | 130 | 130 |
+| Hooks | 2 | 2 |
+| Execution layers | 54 | 54 |
+| Model SQL bytes | 6.05 MB | about 6.4 MB |
+| Model SQL p50 / p75 | 1.9 / 4.5 KB | 1.9 / 4.5 KB |
+| Model SQL p90 / p95 | 10.9 / 15.2 KB | 11.0 / 15.2 KB |
+| Model SQL p99 / max | 48.2 / 519 KB | 48.0 / 520 KB |
+
+The graph combines one 54-layer spine with bounded eight-model test chains. SQL shapes include
+roughly 49 top-level CTE models, 49 derived-table models, and direct selects for the remainder.
+It also includes path defaults, a reusable schema, an enforced contract, attached audits, two SQL
+hooks, SQL functions, seed and source references, macros (including a composed macro), assertions,
+26 repeated test targets, and fixtures ranging from 40 to 200 rows. Generated comments reproduce
+the source-size distribution without manufacturing thousands of expensive CASE branches that do
+not represent the real project's SQL analysis cost.
+
+The guard measures cold, unchanged, leaf-model edit, central-model edit, test edit, macro edit, and
+project-config edit paths. JSON output reports discovery, attachment, model analysis, test input
+compilation, test planning, comparison rendering, cache publication, physical writes, and stale
+artifact traversal so a failure identifies the regressed phase rather than only the total runtime.
+The detailed timings are attribution spans, not additive buckets: attachment includes test-input
+compilation and its CTE-cache publication, model analysis includes its cache publication, and the
+legacy write span contains test planning, comparison rendering, cache publication, physical writes,
+and stale traversal.
+
+The process-local SQL runtime is initialized with an unrelated 32-model project before measuring.
+“Cold” therefore means no compiler cache or target artifacts exist for the representative project;
+it does not include one-time lazy initialization noise from the Python test worker.

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/_test_types.py
@@ -50,6 +50,27 @@ class SqlTestHeavyCompilePerformanceGuardTestCase:
 
 
 @dataclass(frozen=True)
+class DagsterShapedCompilePerformanceGuardTestCase:
+    description: str
+    model_count: int
+    source_count: int
+    seed_count: int
+    function_count: int
+    macro_count: int
+    test_count: int
+    expected_audit_count: int
+    expected_hook_count: int
+    expected_min_model_sql_bytes: int
+    expected_max_model_sql_bytes: int
+    expected_min_compiled_test_bytes: int
+    expected_max_compiled_test_bytes: int
+    expected_cold_max_seconds: float
+    expected_warm_max_seconds: float
+    expected_edit_max_seconds: float
+    expected_config_edit_max_seconds: float
+
+
+@dataclass(frozen=True)
 class NamespaceCompileTestCase:
     description: str
     repo_files: dict[str, str]

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/helpers.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import os
 import signal
 import time
 from bisect import bisect_left
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
+from io import StringIO
 from pathlib import Path
 from types import FrameType
-from typing import Any
+from typing import Any, NamedTuple
 
 import pytest
 
@@ -27,6 +29,22 @@ _DBT_SHAPED_SQL_SIZE_PROFILE: tuple[tuple[float, int], ...] = (
     (0.999, 265_000),
     (1.0, 522_000),
 )
+
+
+class CompileBenchmarkMeasurement(NamedTuple):
+    elapsed_seconds: float
+    timings_ms: dict[str, int]
+    summary: dict[str, int]
+
+
+class DagsterShapedCompileBenchmarkResult(NamedTuple):
+    cold: CompileBenchmarkMeasurement
+    warm: CompileBenchmarkMeasurement
+    leaf_model_edit: CompileBenchmarkMeasurement
+    central_model_edit: CompileBenchmarkMeasurement
+    test_edit: CompileBenchmarkMeasurement
+    macro_edit: CompileBenchmarkMeasurement
+    project_config_edit: CompileBenchmarkMeasurement
 
 
 def run_advanced_compile_benchmark(
@@ -121,11 +139,107 @@ def run_test_heavy_compile_benchmark(
     return cold_seconds, warm_seconds, model_edit_seconds, test_edit_seconds
 
 
+def run_dagster_shaped_compile_benchmark(
+    *,
+    project_dir: Path,
+    model_count: int,
+    source_count: int,
+    seed_count: int,
+    function_count: int,
+    macro_count: int,
+    test_count: int,
+    expected_cold_max_seconds: float,
+    expected_warm_max_seconds: float,
+    expected_edit_max_seconds: float,
+    expected_config_edit_max_seconds: float,
+) -> DagsterShapedCompileBenchmarkResult:
+    """Measure the production-shaped cold, warm, and representative edit paths."""
+
+    skip_actions: dict[bool, Callable[[], None]] = {
+        False: _continue_compile_benchmark,
+        True: _skip_compile_benchmark,
+    }
+    skip_actions[os.environ.get("SQLBUILD_SKIP_PERFORMANCE_TESTS") == "1"]()
+    warmup_dir: Path = project_dir.parent / "compile_runtime_warmup"
+    write_advanced_compile_project(project_dir=warmup_dir, model_count=32)
+    _ = _run_compile_benchmark(project_dir=warmup_dir, expected_max_seconds=5.0)
+    write_dagster_shaped_compile_project(
+        project_dir=project_dir,
+        model_count=model_count,
+        source_count=source_count,
+        seed_count=seed_count,
+        function_count=function_count,
+        macro_count=macro_count,
+        test_count=test_count,
+    )
+    cold: CompileBenchmarkMeasurement = _run_profiled_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_cold_max_seconds,
+    )
+    warm: CompileBenchmarkMeasurement = _run_profiled_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_warm_max_seconds,
+    )
+    _append_benchmark_edit(_generated_model_path(project_dir, model_count - 1), "leaf model")
+    leaf_model_edit: CompileBenchmarkMeasurement = _run_profiled_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_edit_max_seconds,
+    )
+    _append_benchmark_edit(_generated_model_path(project_dir, 0), "central model")
+    central_model_edit: CompileBenchmarkMeasurement = _run_profiled_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_edit_max_seconds,
+    )
+    _append_benchmark_edit(
+        project_dir / "tests" / "unit" / "test_group_00000.sql",
+        "test",
+    )
+    test_edit: CompileBenchmarkMeasurement = _run_profiled_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_edit_max_seconds,
+    )
+    macro_path: Path = project_dir / "models" / "macros" / "macro_00000.py"
+    _replace_benchmark_text(
+        path=macro_path,
+        old='return f"({expression} + 0)"',
+        new='return f"({expression} + 1000)"',
+    )
+    macro_edit: CompileBenchmarkMeasurement = _run_profiled_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_edit_max_seconds,
+    )
+    config_path: Path = project_dir / "sqlbuild_project.toml"
+    _replace_benchmark_text(
+        path=config_path,
+        old='benchmark_revision = "0"',
+        new='benchmark_revision = "1"',
+    )
+    project_config_edit: CompileBenchmarkMeasurement = _run_profiled_compile_benchmark(
+        project_dir=project_dir,
+        expected_max_seconds=expected_config_edit_max_seconds,
+    )
+    return DagsterShapedCompileBenchmarkResult(
+        cold=cold,
+        warm=warm,
+        leaf_model_edit=leaf_model_edit,
+        central_model_edit=central_model_edit,
+        test_edit=test_edit,
+        macro_edit=macro_edit,
+        project_config_edit=project_config_edit,
+    )
+
+
 def _append_benchmark_edit(path: Path, label: str) -> None:
     path.write_text(
         path.read_text(encoding="utf-8") + f"\n-- one {label} edit\n",
         encoding="utf-8",
     )
+
+
+def _replace_benchmark_text(*, path: Path, old: str, new: str) -> None:
+    contents: str = path.read_text(encoding="utf-8")
+    _ = contents.index(old)
+    path.write_text(contents.replace(old, new, 1), encoding="utf-8")
 
 
 def _run_compile_benchmark(*, project_dir: Path, expected_max_seconds: float) -> float:
@@ -144,8 +258,51 @@ def _run_compile_benchmark(*, project_dir: Path, expected_max_seconds: float) ->
     return elapsed_seconds
 
 
+def _run_profiled_compile_benchmark(
+    *, project_dir: Path, expected_max_seconds: float
+) -> CompileBenchmarkMeasurement:
+    output: StringIO = StringIO()
+    diagnostic_grace_seconds: float = 5.0
+    with (
+        _fail_after_seconds(expected_max_seconds + diagnostic_grace_seconds),
+        redirect_stdout(output),
+    ):
+        start: float = time.perf_counter()
+        exit_code: int = main(
+            [
+                "--project-dir",
+                str(project_dir),
+                "--no-color",
+                "compile",
+                "--json",
+            ]
+        )
+        elapsed_seconds: float = time.perf_counter() - start
+    assert exit_code == 0
+    payload: dict[str, object] = json.loads(output.getvalue())
+    timings: object = payload["compile_timings"]
+    summary: object = payload["summary"]
+    assert isinstance(timings, dict)
+    assert isinstance(summary, dict)
+    return CompileBenchmarkMeasurement(
+        elapsed_seconds=elapsed_seconds,
+        timings_ms={str(key): int(value) for key, value in timings.items()},
+        summary={str(key): int(value) for key, value in summary.items()},
+    )
+
+
+def _generated_model_path(project_dir: Path, index: int) -> Path:
+    layer_index: int = index % 10
+    folder: str = {
+        (True, True): "staging",
+        (False, True): "intermediate",
+        (False, False): "mart",
+    }[(layer_index < 4, layer_index < 8)]
+    return project_dir / "models" / folder / f"model_{index:05d}.sql"
+
+
 def measure_model_sql_bytes(project_dir: Path) -> int:
-    return sum(path.stat().st_size for path in (project_dir / "models").glob("*.sql"))
+    return sum(path.stat().st_size for path in (project_dir / "models").rglob("*.sql"))
 
 
 def measure_compiled_test_sql_bytes(project_dir: Path) -> int:
@@ -471,3 +628,489 @@ __expected__model_{target_index:05d} AS (
 )
 SELECT 1
 """
+
+
+_SPINE_DEPTH: int = 54
+_TEST_CHAIN_DEPTH: int = 8
+_ATTACHED_AUDIT_COUNT: int = 700
+_TOP_LEVEL_WITH_INTERVAL: int = 20
+_NESTED_QUERY_INTERVAL: int = 15
+_MACRO_INTERVAL: int = 13
+_FUNCTION_INTERVAL: int = 43
+_SEED_INTERVAL: int = 67
+_SEED_REFERENCE_START_INDEX: int = 300
+_SQL_SIZE_PROFILE: tuple[tuple[float, int], ...] = (
+    (0.0, 400),
+    (0.50, 1_900),
+    (0.75, 4_500),
+    (0.90, 11_000),
+    (0.95, 15_200),
+    (0.99, 48_200),
+    (0.995, 120_000),
+    (0.999, 260_000),
+    (1.0, 520_000),
+)
+
+
+def write_dagster_shaped_compile_project(
+    *,
+    project_dir: Path,
+    model_count: int,
+    source_count: int,
+    seed_count: int,
+    function_count: int,
+    macro_count: int,
+    test_count: int,
+) -> None:
+    """Write a deterministic generated project matching real resource ratios."""
+
+    _dagster_write_project_config(project_dir=project_dir)
+    _dagster_write_sources(project_dir=project_dir, source_count=source_count)
+    _dagster_write_seeds(project_dir=project_dir, seed_count=seed_count)
+    _dagster_write_functions(project_dir=project_dir, function_count=function_count)
+    _dagster_write_macros(project_dir=project_dir, macro_count=macro_count)
+    _dagster_write_schemas(project_dir=project_dir)
+    _dagster_write_hooks(project_dir=project_dir)
+    _dagster_write_models(
+        project_dir=project_dir,
+        model_count=model_count,
+        source_count=source_count,
+        seed_count=seed_count,
+        function_count=function_count,
+        macro_count=macro_count,
+    )
+    _dagster_write_tests(
+        project_dir=project_dir,
+        model_count=model_count,
+        test_count=test_count,
+        source_count=source_count,
+    )
+
+
+def _dagster_write_project_config(*, project_dir: Path) -> None:
+    project_dir.mkdir(parents=True)
+    (project_dir / "sqlbuild_project.toml").write_text(
+        """name = "dagster_shaped_performance_guard"
+adapter = "duckdb"
+default_target = "dev"
+
+[settings]
+column_contract_mode = "explicit"
+
+[vars]
+benchmark_revision = "0"
+
+[targets.dev]
+schema = "main"
+
+[path_defaults."staging"]
+materialized = "view"
+
+[path_defaults."intermediate"]
+materialized = "table"
+
+[path_defaults."mart"]
+materialized = "table"
+""",
+        encoding="utf-8",
+    )
+
+
+def _dagster_write_sources(*, project_dir: Path, source_count: int) -> None:
+    sources_dir: Path = project_dir / "sources"
+    sources_dir.mkdir()
+    entries: str = "\n".join(
+        f"""  - name: source_{index:05d}
+    expression: "(SELECT {index} AS id, CAST({index} AS DOUBLE) AS amount, 'source' AS status)"
+    columns:
+      - name: id
+        type: INTEGER
+      - name: amount
+        type: DOUBLE
+      - name: status
+        type: VARCHAR"""
+        for index in range(source_count)
+    )
+    (sources_dir / "generated.yml").write_text(f"sources:\n{entries}\n", encoding="utf-8")
+
+
+def _dagster_write_seeds(*, project_dir: Path, seed_count: int) -> None:
+    seeds_dir: Path = project_dir / "seeds"
+    seeds_dir.mkdir()
+    schema_entries: str = "\n".join(
+        f"""  - name: seed_{index:05d}
+    columns:
+      - name: id
+        type: INTEGER
+      - name: label
+        type: VARCHAR"""
+        for index in range(seed_count)
+    )
+    (seeds_dir / "generated.yml").write_text(f"seeds:\n{schema_entries}\n", encoding="utf-8")
+    for index in range(seed_count):
+        (seeds_dir / f"seed_{index:05d}.csv").write_text(
+            f"id,label\n{index},seed_{index:05d}\n",
+            encoding="utf-8",
+        )
+
+
+def _dagster_write_functions(*, project_dir: Path, function_count: int) -> None:
+    functions_dir: Path = project_dir / "functions" / "sql"
+    functions_dir.mkdir(parents=True)
+    for index in range(function_count):
+        (functions_dir / f"fn_{index:05d}.sql").write_text(
+            """FUNCTION (
+  arguments (input_value DOUBLE),
+  returns DOUBLE,
+);
+
+input_value + 1
+""",
+            encoding="utf-8",
+        )
+
+
+def _dagster_write_macros(*, project_dir: Path, macro_count: int) -> None:
+    macros_dir: Path = project_dir / "models" / "macros"
+    macros_dir.mkdir(parents=True)
+    for index in range(macro_count):
+        composed_dependency: str = {
+            True: (
+                '\n\ndef base_offset(expression: str) -> str:\n    return f"({expression} + 1)"\n'
+            ),
+            False: "",
+        }[index == 0]
+        macro_body: str = {
+            True: "    return base_offset(_offset(expression))",
+            False: "    return _offset(expression)",
+        }[index == 0]
+        (macros_dir / f"macro_{index:05d}.py").write_text(
+            f"""def _offset(expression: str) -> str:
+    return f"({{expression}} + {index})"
+{composed_dependency}
+
+
+def macro_{index:05d}(expression: str) -> str:
+{macro_body}
+""",
+            encoding="utf-8",
+        )
+
+
+def _dagster_write_schemas(*, project_dir: Path) -> None:
+    schemas_dir: Path = project_dir / "schemas"
+    schemas_dir.mkdir()
+    (schemas_dir / "benchmark_row.sql").write_text(
+        """SCHEMA (
+  name benchmark_row,
+  columns (
+    id (type INTEGER, nullable false),
+    amount (type DOUBLE),
+    status (type VARCHAR),
+  ),
+);
+""",
+        encoding="utf-8",
+    )
+
+
+def _dagster_write_hooks(*, project_dir: Path) -> None:
+    hooks_dir: Path = project_dir / "hooks" / "sql"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "before_build.sql").write_text(
+        'HOOK (description "Generated pre-build hook");\n\nSELECT 1\n',
+        encoding="utf-8",
+    )
+    (hooks_dir / "after_build.sql").write_text(
+        'HOOK (description "Generated post-build hook");\n\nSELECT 2\n',
+        encoding="utf-8",
+    )
+
+
+def _dagster_write_models(
+    *,
+    project_dir: Path,
+    model_count: int,
+    source_count: int,
+    seed_count: int,
+    function_count: int,
+    macro_count: int,
+) -> None:
+    for index in range(model_count):
+        folder: str = _dagster_model_folder(index=index)
+        model_dir: Path = project_dir / "models" / folder
+        model_dir.mkdir(parents=True, exist_ok=True)
+        sql: str = _dagster_model_sql(
+            index=index,
+            model_count=model_count,
+            source_count=source_count,
+            seed_count=seed_count,
+            function_count=function_count,
+            macro_count=macro_count,
+        )
+        (model_dir / f"model_{index:05d}.sql").write_text(sql, encoding="utf-8")
+
+
+def _dagster_model_folder(*, index: int) -> str:
+    layer_index: int = index % 10
+    return {
+        (True, True): "staging",
+        (False, True): "intermediate",
+        (False, False): "mart",
+    }[(layer_index < 4, layer_index < 8)]
+
+
+def _dagster_is_base_model(*, index: int) -> bool:
+    return index == 0 or (index >= _SPINE_DEPTH and (index - _SPINE_DEPTH) % _TEST_CHAIN_DEPTH == 0)
+
+
+def _dagster_model_header(*, index: int) -> str:
+    contract_header: str = """MODEL (
+  model_schema benchmark_row,
+  contract enforced,
+  columns (
+    id (audits [not_null]),
+  ),
+);"""
+    audit_header: str = """MODEL (
+  columns (
+    id (nullable false, audits [not_null]),
+  ),
+);"""
+    return {
+        (True, False): contract_header,
+        (False, True): "MODEL ();",
+        (False, False): audit_header,
+    }[(index == 0, index >= _ATTACHED_AUDIT_COUNT)]
+
+
+def _dagster_model_sql(
+    *,
+    index: int,
+    model_count: int,
+    source_count: int,
+    seed_count: int,
+    function_count: int,
+    macro_count: int,
+) -> str:
+    builders: dict[bool, Callable[[], str]] = {
+        True: lambda: _dagster_base_model_sql(
+            index=index,
+            model_count=model_count,
+            source_count=source_count,
+        ),
+        False: lambda: _dagster_dependent_model_sql(
+            index=index,
+            model_count=model_count,
+            seed_count=seed_count,
+            function_count=function_count,
+            macro_count=macro_count,
+        ),
+    }
+    return builders[_dagster_is_base_model(index=index)]()
+
+
+def _dagster_base_model_sql(*, index: int, model_count: int, source_count: int) -> str:
+    source_index: int = _dagster_base_source_index(index=index, source_count=source_count)
+    contract_query_sql: str = f"""{_dagster_model_header(index=index)}
+
+SELECT
+  CAST(id AS INTEGER) AS id,
+  CAST(amount + CAST(@@benchmark_revision AS INTEGER) AS DOUBLE) AS amount,
+  CAST(status AS VARCHAR) AS status
+FROM __source("source_{source_index:05d}")
+"""
+    regular_query_sql: str = f"""{_dagster_model_header(index=index)}
+
+SELECT
+  id,
+  amount + {_dagster_generated_mapping_expression()}
+    + CAST(@@benchmark_revision AS INTEGER) AS amount,
+  status
+FROM __source("source_{source_index:05d}")
+"""
+    query_sql: str = {True: contract_query_sql, False: regular_query_sql}[index == 0]
+    return _dagster_pad_model_sql(
+        sql=query_sql,
+        target_bytes=_dagster_model_sql_size_target(index=index, model_count=model_count),
+        index=index,
+    )
+
+
+def _dagster_dependent_model_sql(
+    *,
+    index: int,
+    model_count: int,
+    seed_count: int,
+    function_count: int,
+    macro_count: int,
+) -> str:
+    previous_name: str = f"model_{index - 1:05d}"
+    macro_index: int = (index // _MACRO_INTERVAL) % macro_count
+    id_expression: str = {
+        True: f'@macro_{macro_index:05d}("id")',
+        False: f"id + {index % 7}",
+    }[index % _MACRO_INTERVAL == 0]
+    generated_amount_expression: str = (
+        f"amount + {index % 11} + {_dagster_generated_mapping_expression()} "
+        "+ CAST(@@benchmark_revision AS INTEGER)"
+    )
+    function_index: int = index % function_count
+    amount_expression: str = {
+        True: f'__udf("fn_{function_index:05d}")(amount)',
+        False: generated_amount_expression,
+    }[index % _FUNCTION_INTERVAL == 0]
+    seed_index: int = index % seed_count
+    join_sql: str = {
+        True: f'\nLEFT JOIN __seed("seed_{seed_index:05d}") AS seed ON seed.id = previous.id',
+        False: "",
+    }[index >= _SEED_REFERENCE_START_INDEX and index % _SEED_INTERVAL == 0]
+    query: str = f'''SELECT
+  {id_expression} AS id,
+  {amount_expression} AS amount,
+  CASE WHEN id % 2 = 0 THEN 'even' ELSE 'odd' END AS status
+FROM __ref("{previous_name}") AS previous{join_sql}
+'''
+    direct_sql: str = f"{_dagster_model_header(index=index)}\n\n{query}"
+    with_sql: str = f"""{_dagster_model_header(index=index)}
+
+WITH transformed AS (
+{query.rstrip()}
+)
+SELECT id, amount, status FROM transformed
+"""
+    nested_sql: str = f"""{_dagster_model_header(index=index)}
+
+SELECT id, amount, status
+FROM (
+{query.rstrip()}
+) AS nested_query
+"""
+    model_sql: str = {
+        (True, True): with_sql,
+        (True, False): with_sql,
+        (False, True): nested_sql,
+        (False, False): direct_sql,
+    }[
+        (
+            index % _TOP_LEVEL_WITH_INTERVAL == 0,
+            index % _NESTED_QUERY_INTERVAL == 0,
+        )
+    ]
+    return _dagster_pad_model_sql(
+        sql=model_sql,
+        target_bytes=_dagster_model_sql_size_target(index=index, model_count=model_count),
+        index=index,
+    )
+
+
+def _dagster_write_tests(
+    *, project_dir: Path, model_count: int, test_count: int, source_count: int
+) -> None:
+    tests_dir: Path = project_dir / "tests" / "unit"
+    tests_dir.mkdir(parents=True)
+    tests_per_file: int = 4
+    cases_per_target: int = 5
+    repeated_target_count: int = (test_count + cases_per_target - 1) // cases_per_target
+    for file_index in range((test_count + tests_per_file - 1) // tests_per_file):
+        first_test_index: int = file_index * tests_per_file
+        blocks: str = "\n".join(
+            _dagster_test_block(
+                test_index=test_index,
+                model_count=model_count,
+                source_count=source_count,
+                repeated_target_count=repeated_target_count,
+            )
+            for test_index in range(
+                first_test_index,
+                min(test_count, first_test_index + tests_per_file),
+            )
+        )
+        (tests_dir / f"test_group_{file_index:05d}.sql").write_text(blocks, encoding="utf-8")
+
+
+def _dagster_test_block(
+    *,
+    test_index: int,
+    model_count: int,
+    source_count: int,
+    repeated_target_count: int,
+) -> str:
+    group_count: int = (model_count - _SPINE_DEPTH) // _TEST_CHAIN_DEPTH
+    representative_group_count: int = (group_count * 2) // 3
+    group_index: int = ((test_index // 5) * representative_group_count) // repeated_target_count
+    base_index: int = _SPINE_DEPTH + group_index * _TEST_CHAIN_DEPTH
+    target_index: int = base_index + _TEST_CHAIN_DEPTH - 1
+    source_index: int = _dagster_base_source_index(index=base_index, source_count=source_count)
+    fixture_row_count: int = 40 + (test_index % 5) * 40
+    return _dagster_test_sql(
+        test_index=test_index,
+        source_index=source_index,
+        target_index=target_index,
+        fixture_row_count=fixture_row_count,
+        include_assertion=test_index % 7 == 0,
+    )
+
+
+def _dagster_test_sql(
+    *,
+    test_index: int,
+    source_index: int,
+    target_index: int,
+    fixture_row_count: int,
+    include_assertion: bool,
+) -> str:
+    fixture_rows: str = " UNION ALL\n".join(
+        f"  SELECT {row} AS id, CAST({row} AS DOUBLE) AS amount, 'source' AS status"
+        for row in range(fixture_row_count)
+    )
+    assertion_sql: str = f""",
+__assert__non_negative_{target_index:05d} AS (
+  SELECT * FROM __ref("model_{target_index:05d}") WHERE amount < 0
+)"""
+    assertion: str = {True: assertion_sql, False: ""}[include_assertion]
+    return f"""TEST (name "dagster_shaped_case_{test_index:05d}");
+
+WITH
+__source__source_{source_index:05d} AS (
+{fixture_rows}
+),
+__expected__model_{target_index:05d} AS (
+  SELECT 1 AS id, CAST(1 AS DOUBLE) AS amount, 'odd' AS status
+){assertion}
+SELECT 1
+"""
+
+
+def _dagster_base_source_index(*, index: int, source_count: int) -> int:
+    base_ordinal: int = {
+        True: 0,
+        False: 1 + (index - _SPINE_DEPTH) // _TEST_CHAIN_DEPTH,
+    }[index == 0]
+    return base_ordinal % source_count
+
+
+def _dagster_model_sql_size_target(*, index: int, model_count: int) -> int:
+    quantile: float = (index + 1) / model_count
+    upper_quantiles: tuple[float, ...] = tuple(item[0] for item in _SQL_SIZE_PROFILE)
+    upper_index: int = bisect_left(upper_quantiles, quantile)
+    lower_quantile, lower_size = _SQL_SIZE_PROFILE[upper_index - 1]
+    upper_quantile, upper_size = _SQL_SIZE_PROFILE[upper_index]
+    position: float = (quantile - lower_quantile) / (upper_quantile - lower_quantile)
+    return round(lower_size + position * (upper_size - lower_size))
+
+
+def _dagster_generated_mapping_expression() -> str:
+    clauses: str = "".join(f"WHEN id = {value:05d} THEN {value % 13:02d} " for value in range(45))
+    return f"CASE {clauses} ELSE 0 END"
+
+
+def _dagster_pad_model_sql(*, sql: str, target_bytes: int, index: int) -> str:
+    missing_bytes: int = max(0, target_bytes - len(sql.encode()))
+    line_template: str = "-- generated field 00000 maps source_metric to output_metric_00000\n"
+    line_count: int = (missing_bytes + len(line_template) - 1) // len(line_template)
+    comments: str = "".join(
+        f"-- generated field {line:05d} maps source_metric to output_metric_{index:05d}\n"
+        for line in range(line_count)
+    )
+    return f"{sql.rstrip()}\n{comments}"

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_compile_performance.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/test_compile_performance.py
@@ -10,13 +10,17 @@ import pytest
 from tests.e2e.src.sqlbuild.cli.commands.main.compile._test_types import (
     CompilePerformanceGuardTestCase,
     CompileScalingGuardTestCase,
+    DagsterShapedCompilePerformanceGuardTestCase,
     DbtShapedCompilePerformanceGuardTestCase,
     SqlTestHeavyCompilePerformanceGuardTestCase,
 )
 from tests.e2e.src.sqlbuild.cli.commands.main.compile.helpers import (
+    CompileBenchmarkMeasurement,
+    DagsterShapedCompileBenchmarkResult,
     measure_compiled_test_sql_bytes,
     measure_model_sql_bytes,
     run_advanced_compile_benchmark,
+    run_dagster_shaped_compile_benchmark,
     run_dbt_shaped_compile_benchmark,
     run_test_heavy_compile_benchmark,
 )
@@ -210,3 +214,93 @@ def test_given_test_heavy_project_when_compiling_then_finishes_within_budget(
     assert warm_seconds < test_case.expected_warm_max_seconds
     assert model_edit_seconds < test_case.expected_edit_max_seconds
     assert test_edit_seconds < test_case.expected_edit_max_seconds
+
+
+@pytest.mark.performance
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DagsterShapedCompilePerformanceGuardTestCase(
+            description="Dagster-shaped compile paths stay within production budgets",
+            model_count=976,
+            source_count=232,
+            seed_count=46,
+            function_count=23,
+            macro_count=12,
+            test_count=130,
+            expected_audit_count=700,
+            expected_hook_count=2,
+            expected_min_model_sql_bytes=5_500_000,
+            expected_max_model_sql_bytes=7_000_000,
+            expected_min_compiled_test_bytes=3_300_000,
+            expected_max_compiled_test_bytes=6_500_000,
+            expected_cold_max_seconds=7.0,
+            expected_warm_max_seconds=3.0,
+            expected_edit_max_seconds=4.0,
+            expected_config_edit_max_seconds=8.0,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_dagster_shaped_project_when_compiling_and_editing_then_reports_phased_budgets(
+    tmp_path: Path,
+    test_case: DagsterShapedCompilePerformanceGuardTestCase,
+) -> None:
+    project_dir: Path = tmp_path / "dagster_shaped"
+    result: DagsterShapedCompileBenchmarkResult = run_dagster_shaped_compile_benchmark(
+        project_dir=project_dir,
+        model_count=test_case.model_count,
+        source_count=test_case.source_count,
+        seed_count=test_case.seed_count,
+        function_count=test_case.function_count,
+        macro_count=test_case.macro_count,
+        test_count=test_case.test_count,
+        expected_cold_max_seconds=test_case.expected_cold_max_seconds,
+        expected_warm_max_seconds=test_case.expected_warm_max_seconds,
+        expected_edit_max_seconds=test_case.expected_edit_max_seconds,
+        expected_config_edit_max_seconds=test_case.expected_config_edit_max_seconds,
+    )
+    measurements: dict[str, CompileBenchmarkMeasurement] = {
+        "cold": result.cold,
+        "warm": result.warm,
+        "leaf_model_edit": result.leaf_model_edit,
+        "central_model_edit": result.central_model_edit,
+        "test_edit": result.test_edit,
+        "macro_edit": result.macro_edit,
+        "project_config_edit": result.project_config_edit,
+    }
+    for label, measurement in measurements.items():
+        phase_text: str = " ".join(
+            f"{phase}={milliseconds}ms" for phase, milliseconds in measurement.timings_ms.items()
+        )
+        _LOGGER.info(
+            f"dagster-shaped compile path={label} total={measurement.elapsed_seconds:.3f}s "
+            f"{phase_text}"
+        )
+
+    assert result.cold.summary == {
+        "models": test_case.model_count,
+        "selected_models": test_case.model_count,
+        "sources": test_case.source_count,
+        "seeds": test_case.seed_count,
+        "functions": test_case.function_count,
+        "audits": test_case.expected_audit_count,
+        "tests": test_case.test_count,
+        "hooks": test_case.expected_hook_count,
+        "execution_layers": 54,
+        "errors": 0,
+        "warnings": 0,
+    }
+    model_sql_bytes: int = measure_model_sql_bytes(project_dir)
+    compiled_test_bytes: int = measure_compiled_test_sql_bytes(project_dir)
+    assert test_case.expected_min_model_sql_bytes <= model_sql_bytes
+    assert model_sql_bytes <= test_case.expected_max_model_sql_bytes
+    assert test_case.expected_min_compiled_test_bytes <= compiled_test_bytes
+    assert compiled_test_bytes <= test_case.expected_max_compiled_test_bytes
+    assert result.cold.elapsed_seconds < test_case.expected_cold_max_seconds
+    assert result.warm.elapsed_seconds < test_case.expected_warm_max_seconds
+    assert result.leaf_model_edit.elapsed_seconds < test_case.expected_edit_max_seconds
+    assert result.central_model_edit.elapsed_seconds < test_case.expected_edit_max_seconds
+    assert result.test_edit.elapsed_seconds < test_case.expected_edit_max_seconds
+    assert result.macro_edit.elapsed_seconds < test_case.expected_edit_max_seconds
+    assert result.project_config_edit.elapsed_seconds < test_case.expected_config_edit_max_seconds


### PR DESCRIPTION
## Why

The existing model-heavy and native-test-heavy guards isolate useful scaling contracts, but neither reproduces the combined shape of the production Dagster project. That made synthetic SQL shapes capable of producing misleading optimization priorities. Compile JSON also exposed only coarse graph/write totals, so regressions could not be attributed to the responsible phase.

## Changes

- add a non-proprietary 976-model benchmark with 232 sources, 46 seeds, 23 functions, 700 audits, 130 native tests, 2 hooks, and 54 execution layers
- reproduce the sampled model SQL size distribution, mixed query shapes, repeated test targets, large fixtures, macros, schemas, contracts, path defaults, and assertions
- measure cold, unchanged, leaf-model, central-model, test, macro, and project-config edit paths
- add additive JSON timings for attachment, model analysis, test input compilation, test planning, comparison rendering, cache publication, physical writes, and stale traversal
- document the generated profile and nested timing semantics

## Verification

- `uv run pytest tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_target_writer.py tests/e2e/src/sqlbuild/cli/commands/main/build/test_compile_json_behavior.py -n auto --dist loadfile` (13 passed)
- focused Dagster-shaped performance guard (passed; cold <7s, warm <3s, model/test edits <4s)
- `uv sync --all-extras && make check-ci`
- bounded independent review and focused follow-up completed
