### PR TITLE
fix: report measurement warnings correctly in Dagster

### DIFF
--- a/src/sqlbuild/executor/auditing/_helpers/execution.py
+++ b/src/sqlbuild/executor/auditing/_helpers/execution.py
@@ -128,9 +128,29 @@ def _measurement_result(  # noqa: PLR0913
         error = "measurement audit is missing its compiled value column or thresholds"
     else:
         row: dict[str, object] = _row_mapping(cursor=cursor, row=rows[0])
-        measured_value, error = _measurement_value(row=row, column=audit.value_column)
-        if error is None and audit.sample_count_column is not None:
+        if audit.sample_count_column is not None:
             sample_count, error = _sample_count(row=row, column=audit.sample_count_column)
+        if error is None:
+            raw_value, value_found = _case_insensitive_value(row=row, column=audit.value_column)
+            if not value_found:
+                error = f"measurement audit result is missing value column '{audit.value_column}'"
+            elif (
+                raw_value is None
+                and audit.minimum_samples is not None
+                and (sample_count is None or sample_count < audit.minimum_samples)
+            ):
+                return replace(
+                    _base_result(
+                        audit=audit,
+                        outcome=AuditOutcome.INSUFFICIENT,
+                        row_count=0,
+                        executed_sql=executed_sql,
+                        run_scope_phase=context.run_scope_phase,
+                    ),
+                    sample_count=sample_count,
+                )
+            else:
+                measured_value, error = _measurement_value(row=row, column=audit.value_column)
 
     if error is not None:
         return replace(

--- a/src/sqlbuild/integrations/dagster/_helpers/invocation.py
+++ b/src/sqlbuild/integrations/dagster/_helpers/invocation.py
@@ -862,7 +862,7 @@ def _metadata_from_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
 
 def _dagster_check_severity(*, dg: Any, check: Mapping[str, Any]) -> Any:
     if (
-        str(check.get("status")) == INSUFFICIENT_CHECK_STATUS
+        str(check.get("status")) in {INSUFFICIENT_CHECK_STATUS, WARNING_CHECK_SEVERITY}
         or str(check.get("severity")) == WARNING_CHECK_SEVERITY
     ):
         return dg.AssetCheckSeverity.WARN

--- a/tests/e2e/src/sqlbuild/integrations/dagster/helpers.py
+++ b/tests/e2e/src/sqlbuild/integrations/dagster/helpers.py
@@ -204,7 +204,7 @@ _STDOUT_POLL_OUTCOMES: MappingProxyType[bool, Callable[[str, Event], None]] = Ma
 
 
 def add_failing_daily_revenue_audits(*, project_dir: Path) -> None:
-    """Add one failing WARN audit and one failing ERROR audit to the copied project."""
+    """Add violation and measurement failures to the copied project."""
 
     audits_dir: Path = project_dir / "audits" / "generic"
     audits_dir.mkdir(parents=True, exist_ok=True)
@@ -215,6 +215,22 @@ def add_failing_daily_revenue_audits(*, project_dir: Path) -> None:
     )
     (audits_dir / "forced_error_failure.sql").write_text(
         failing_audit_sql,
+        encoding="utf-8",
+    )
+    (audits_dir / "forced_measurement_warning.sql").write_text(
+        """AUDIT (
+  evaluation measurement,
+  value measured_value,
+  sample_count sample_count,
+  sample_unit rows,
+);
+
+MEASURE (
+  SELECT 95.0 AS measured_value, 100 AS sample_count
+  FROM @relation
+  LIMIT 1
+);
+""",
         encoding="utf-8",
     )
     model_path: Path = project_dir / "models" / "marts" / "daily_revenue.sql"
@@ -233,6 +249,10 @@ def add_failing_daily_revenue_audits(*, project_dir: Path) -> None:
     ),
     forced_error_failure (
       severity "error",
+    ),
+    forced_measurement_warning (
+      minimum_samples 100,
+      thresholds (warn (below 100), error (below 90)),
     ),""",
     )
     model_path.write_text(contents, encoding="utf-8")

--- a/tests/e2e/src/sqlbuild/integrations/dagster/test_sqlbuild_assets.py
+++ b/tests/e2e/src/sqlbuild/integrations/dagster/test_sqlbuild_assets.py
@@ -747,6 +747,7 @@ def test_given_sqlbuild_process_is_still_running_when_emitting_stdout_then_dagst
             expected_check_names=(
                 "audit__forced_warning_failure__daily_revenue",
                 "audit__forced_error_failure__daily_revenue",
+                "audit__forced_measurement_warning__daily_revenue",
             ),
         )
     ],
@@ -794,6 +795,7 @@ def test_given_failing_sqlbuild_audits_when_executing_dagster_then_links_checks_
     assert set(test_case.expected_check_names) <= set(severities)
     assert severities["audit__forced_warning_failure__daily_revenue"] == AssetCheckSeverity.WARN
     assert severities["audit__forced_error_failure__daily_revenue"] == AssetCheckSeverity.ERROR
+    assert severities["audit__forced_measurement_warning__daily_revenue"] == AssetCheckSeverity.WARN
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/src/sqlbuild/executor/build/test_measurement_audit_execution.py
+++ b/tests/integration/src/sqlbuild/executor/build/test_measurement_audit_execution.py
@@ -55,11 +55,16 @@ def test_given_measurement_outcomes_when_building_then_gates_and_persists_canoni
               minimum_samples 5,
               thresholds (warn (below 99), error (below 90))
             ),
-            configured_rate (
-              name insufficient_rate, measured_value 80, sample_count 1,
-              minimum_samples 5,
-              thresholds (warn (below 99), error (below 90))
-            )
+             configured_rate (
+               name insufficient_rate, measured_value 80, sample_count 1,
+               minimum_samples 5,
+               thresholds (warn (below 99), error (below 90))
+             ),
+             empty_rate (
+               name empty_rate,
+               minimum_samples 5,
+               thresholds (warn (below 99), error (below 90))
+             )
           ]
         );
         SELECT * FROM (VALUES (1), (2), (3)) AS orders(order_id)
@@ -88,6 +93,19 @@ def test_given_measurement_outcomes_when_building_then_gates_and_persists_canoni
             "sqlbuild_project.toml": 'name = "measurement_build"\nadapter = "duckdb"\n',
             "models/orders.sql": model_sql,
             "audits/generic/configured_rate.sql": audit_sql,
+            "audits/generic/empty_rate.sql": """
+            AUDIT (
+              evaluation measurement,
+              value measured_value,
+              sample_count samples,
+              sample_unit rows
+            );
+            MEASURE (
+              SELECT CAST(NULL AS DOUBLE) AS measured_value, 0 AS samples
+              FROM @relation
+              LIMIT 1
+            );
+        """,
         },
     )
     with identity_scope(ExecutionIdentity(invocation_id="integration", run_id="test_run")):
@@ -107,6 +125,7 @@ def test_given_measurement_outcomes_when_building_then_gates_and_persists_canoni
         "warn_rate": AuditOutcome.WARN,
         "error_rate": AuditOutcome.ERROR,
         "insufficient_rate": AuditOutcome.INSUFFICIENT,
+        "empty_rate": AuditOutcome.INSUFFICIENT,
     }
     assert connection.execute(
         "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'orders'"
@@ -119,11 +138,12 @@ def test_given_measurement_outcomes_when_building_then_gates_and_persists_canoni
         ORDER BY audit_name
         """
     ).fetchall()
-    assert len(history) == 4
+    assert len(history) == 5
     by_name: dict[str, tuple[Any, ...]] = {row[0]: row for row in history}
     assert by_name["pass_rate"][1:5] == ("pass", "100.0", 10, None)
     assert by_name["warn_rate"][1] == "warn"
     assert by_name["warn_rate"][6] == 3
     assert by_name["error_rate"][1] == "error"
     assert by_name["insufficient_rate"][1] == "insufficient"
+    assert by_name["empty_rate"][1:5] == ("insufficient", None, 0, None)
     assert '"operator":"below"' in by_name["error_rate"][5]

--- a/tests/unit/src/sqlbuild/executor/auditing/main/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/auditing/main/_test_types.py
@@ -29,6 +29,13 @@ class MeasurementOutcomeCase:
 
 
 @dataclass(frozen=True)
+class NullMeasurementOutcomeCase:
+    description: str
+    sample_count: int
+    expected_outcome: AuditOutcome
+
+
+@dataclass(frozen=True)
 class AuditExecutionCase:
     description: str
     expected_outcome: AuditOutcome

--- a/tests/unit/src/sqlbuild/executor/auditing/main/test_execute.py
+++ b/tests/unit/src/sqlbuild/executor/auditing/main/test_execute.py
@@ -12,6 +12,7 @@ from tests.unit.src.sqlbuild.executor.auditing.main._test_types import (
     InvalidMeasurementCase,
     MeasurementOutcomeCase,
     MeasurementRowCountCase,
+    NullMeasurementOutcomeCase,
 )
 from tests.unit.src.sqlbuild.executor.auditing.main.helpers import (
     Adapter,
@@ -108,6 +109,27 @@ def test_given_valid_measurement_when_executed_then_maps_outcome(
     assert result.measured_value == float(test_case.value)
     assert result.sample_count == test_case.sample_count
     assert result.row_count == 0
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [NullMeasurementOutcomeCase("zero samples", 0, AuditOutcome.INSUFFICIENT)],
+    ids=lambda case: case.description,
+)
+def test_given_null_measurement_with_too_few_samples_when_executed_then_is_insufficient(
+    test_case: NullMeasurementOutcomeCase,
+) -> None:
+    result: AuditExecutionResult = execute_entry(
+        entry=build_entry(),
+        adapter=Adapter(
+            [Cursor(columns=("VALID_RATE", "TOTAL_ROWS"), rows=[(None, test_case.sample_count)])]
+        ),
+    )
+
+    assert result.outcome == test_case.expected_outcome
+    assert result.measured_value is None
+    assert result.sample_count == test_case.sample_count
+    assert result.execution_error is None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/_test_types.py
@@ -20,6 +20,7 @@ class DagsterInsufficientStatusTestCase:
 class DagsterMeasurementMetadataTestCase:
     description: str
     expected_status: str
+    expected_passed: bool
     expected_metadata: dict[str, object]
 
 

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
@@ -281,6 +281,7 @@ def test_given_two_audit_envelopes_when_projecting_then_each_check_keeps_own_can
         DagsterMeasurementMetadataTestCase(
             "insufficient measurement metadata",
             "insufficient",
+            True,
             {
                 "evaluation_mode": "measurement",
                 "measured_value": 99.5,
@@ -290,6 +291,19 @@ def test_given_two_audit_envelopes_when_projecting_then_each_check_keeps_own_can
                 "thresholds": {"warn": {"operator": "below", "limit": 100.0}},
                 "evidence_count": 2,
                 "evidence_truncated": True,
+            },
+        ),
+        DagsterMeasurementMetadataTestCase(
+            "warning measurement metadata",
+            "warn",
+            False,
+            {
+                "evaluation_mode": "measurement",
+                "measured_value": 99.5,
+                "sample_count": 100,
+                "sample_unit": "rows",
+                "minimum_samples": 100,
+                "thresholds": {"warn": {"operator": "below", "limit": 100.0}},
             },
         ),
     ),
@@ -308,6 +322,7 @@ def test_given_measurement_check_when_projecting_then_dagster_metadata_and_warni
     check: IntegrationCheckResult = replace(
         envelope.checks[0],
         status=test_case.expected_status,
+        passed=test_case.expected_passed,
         **test_case.expected_metadata,
     )
     envelope = replace(envelope, checks=(check,))
@@ -323,7 +338,7 @@ def test_given_measurement_check_when_projecting_then_dagster_metadata_and_warni
 
     assert len(results) == 1
     result: Any = results[0]
-    assert result.passed is True
+    assert result.passed is test_case.expected_passed
     assert result.severity == dg.AssetCheckSeverity.WARN
     assert result.metadata["status"].value == test_case.expected_status
     for key, expected_value in test_case.expected_metadata.items():


### PR DESCRIPTION
## Why

Measurement audits with no qualifying rows return a single aggregate row containing `sample_count = 0` and `measured_value = NULL`. SQLBuild treated the null value as an execution error before applying `minimum_samples`, failing otherwise healthy jobs. Measurement outcomes that crossed only a warning threshold were also projected to Dagster using the audit's configured severity, so they appeared as ERROR checks rather than WARN checks.

## Changes

- Classify a present null measurement as `INSUFFICIENT` when its valid sample count is below `minimum_samples`.
- Preserve strict errors for missing value columns, malformed counts, null values with enough samples, and null values without a minimum-sample policy.
- Map check status `warn` to `AssetCheckSeverity.WARN` while preserving error-threshold failures as ERROR.
- Add unit, real DuckDB integration, and Dagster E2E regressions for both paths.

## Verification

- `uv run pytest tests/unit/src/sqlbuild/executor/auditing/main/test_execute.py tests/unit/src/sqlbuild/integrations/dagster/test_resource.py tests/integration/src/sqlbuild/executor/build/test_measurement_audit_execution.py tests/e2e/src/sqlbuild/integrations/dagster/test_sqlbuild_assets.py::test_given_failing_sqlbuild_audits_when_executing_dagster_then_links_checks_with_severity -n auto --dist loadfile` (73 passed)
- `make check-ci`
- Independent bounded review: no blockers
