### PR TITLE
feat: add sqb --version flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sqlbuild-kata-native"
-version = "0.87.1"
+version = "0.87.3"
 dependencies = [
  "fensu-policy",
  "globset",

--- a/src/sqlbuild/cli/commands/_helpers/entry/parser.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 from sqlbuild.cli.commands._helpers.entry.errors import build_argument_parser_class
@@ -27,11 +28,26 @@ from sqlbuild.compiler.lineage.types import ColumnLineageMode
 from sqlbuild.virtual.state.types import StateCommand
 
 
+def _installed_version() -> str:
+    """Return the installed sqlbuild distribution version."""
+
+    try:
+        return version("sqlbuild")
+    except PackageNotFoundError:
+        return "unknown"
+
+
 def build_cli_parser(*, use_color: bool = False) -> argparse.ArgumentParser:
     """Build the root CLI parser."""
 
     parser_class: type[SqlbuildArgumentParser] = build_argument_parser_class(use_color=use_color)
     parser: argparse.ArgumentParser = parser_class(prog="sqb")
+    parser.add_argument(
+        "--version",
+        "-V",
+        action="version",
+        version=f"sqb {_installed_version()}",
+    )
     parser.add_argument("--project-dir", "--sqb-project-dir", dest="project_dir", default=None)
     parser.add_argument("--no-color", action="store_true", default=False)
     parser.add_argument(

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/_test_types.py
@@ -16,3 +16,12 @@ class AuditConcurrencyParsingTestCase:
     environment_value: str | None
     expected_concurrency: int | None
     expected_exit_code: int | None
+
+
+@dataclass(frozen=True)
+class VersionFlagTestCase:
+    """One --version invocation shape."""
+
+    description: str
+    argv: tuple[str, ...]
+    expected_exit_code: int

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/test_parsing.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/entry/test_parsing.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from importlib.metadata import version as installed_version
+
 import pytest
 
 from sqlbuild.cli.commands._helpers.entry.parser import build_cli_parser
@@ -10,6 +12,7 @@ from sqlbuild.cli.commands.models import ParsedCliInvocation
 from tests.unit.src.sqlbuild.cli.commands._helpers.entry._test_types import (
     AuditConcurrencyParsingTestCase,
     VerboseCommandTestCase,
+    VersionFlagTestCase,
 )
 
 
@@ -118,3 +121,33 @@ def test_given_audit_concurrency_sources_when_parsing_then_precedence_and_valida
 
     assert parsed.exit_code == test_case.expected_exit_code
     assert getattr(parsed.args, "concurrency", None) == test_case.expected_concurrency
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        VersionFlagTestCase(
+            description="long flag exits zero without a project",
+            argv=("--version",),
+            expected_exit_code=0,
+        ),
+        VersionFlagTestCase(
+            description="short flag exits zero without a project",
+            argv=("-V",),
+            expected_exit_code=0,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_version_flag_when_parsing_then_prints_version_and_exits_zero(
+    test_case: VersionFlagTestCase,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    invocation: ParsedCliInvocation = parse_cli_invocation(
+        argv=test_case.argv,
+        parser=build_cli_parser(),
+    )
+
+    assert invocation.args is None
+    assert invocation.exit_code == test_case.expected_exit_code
+    assert f"sqb {installed_version('sqlbuild')}" in capsys.readouterr().out


### PR DESCRIPTION
## Why

`sqb --version` did not exist; the CLI errored with usage text. Diagnosing a colleague's stale-install D001 (`unknown key(s): column_contract_mode`) required Python introspection because the CLI could not report its own version. Linear: CHI-275.

## Changes

- Add `--version` / `-V` to the root parser via argparse `action="version"`, printing `sqb <installed version>` and exiting 0.
- Resolve the version from `importlib.metadata` with a `PackageNotFoundError` fallback to `unknown`.
- Works with no project directory: version action fires during parsing, before discovery, config load, or providers.
- Parametrized unit tests for both flags asserting exit code 0 and version output.

## Verification

- `uv run sqb --version` / `-V` print `sqb 0.87.3`, exit 0, including from a directory with no sqlbuild project.
- Focused suite: tests/unit/.../entry/test_parsing.py — 14 passed.
- `uv sync --all-extras` + `make check-ci`: passed; `fensu check`: 0 faults.
- Independent review: no blocking findings; SystemExit(0) path verified through parse_cli_invocation and entrypoint (0 preserved, not coerced to 1); no `-V` collision (subcommand `-v` verbose flags live on separate subparsers).
