### PR TITLE
fix: retain shared source contract edits

### DIFF
--- a/src/sqlbuild/compiler/contract_adoption/_helpers/repository_edits.py
+++ b/src/sqlbuild/compiler/contract_adoption/_helpers/repository_edits.py
@@ -124,10 +124,14 @@ def _declared_type_span(
 
 
 def edit_source(
-    *, source: CompiledSource, physical_columns: tuple[ColumnInfo, ...], overwrite: bool
+    *,
+    source: CompiledSource,
+    physical_columns: tuple[ColumnInfo, ...],
+    overwrite: bool,
+    contents: str | None = None,
 ) -> tuple[str | None, str | None]:
-    contents: str = source.source_file.contents
-    if _GENERATED_MARKER in "\n".join(contents.splitlines()[:5]).casefold():
+    contents = source.source_file.contents if contents is None else contents
+    if _GENERATED_MARKER in "\n".join(source.source_file.contents.splitlines()[:5]).casefold():
         return None, "source file is marked as generated"
     lines: list[str] = contents.splitlines(keepends=True)
     source_range: tuple[int, int, int] | None = _yaml_named_block(

--- a/src/sqlbuild/compiler/contract_adoption/main/write.py
+++ b/src/sqlbuild/compiler/contract_adoption/main/write.py
@@ -52,12 +52,13 @@ def write_contracts(
             )
             path: Path = project_dir / models[evidence.resource_name].relative_path
         else:
+            path = sources[evidence.resource_name].source_file.file_path
             contents, conflict = edit_source(
                 source=sources[evidence.resource_name],
                 physical_columns=evidence.physical_columns,
                 overwrite=overwrite,
+                contents=updates.get(path),
             )
-            path = sources[evidence.resource_name].source_file.file_path
         if contents is not None and contents != path.read_text(encoding="utf-8"):
             updates[path] = contents
         remaining: tuple[ContractFinding, ...] = remaining_findings(

--- a/tests/integration/src/sqlbuild/cli/commands/main/helpers.py
+++ b/tests/integration/src/sqlbuild/cli/commands/main/helpers.py
@@ -53,3 +53,21 @@ SELECT CAST(1 AS INTEGER) AS id, CAST('a' AS VARCHAR) AS name
         connection.execute("CREATE TABLE prod.orders(id INTEGER, name VARCHAR)")
         connection.execute("CREATE TABLE raw.orders(id BIGINT, status VARCHAR)")
     return database
+
+
+def add_second_contract_source(*, project_dir: Path, database: Path) -> None:
+    """Add another physical source declared in the existing source YAML file."""
+
+    source_path: Path = project_dir / "sources" / "raw.yml"
+    _ = source_path.write_text(
+        source_path.read_text(encoding="utf-8")
+        + """  - name: raw_customers
+    schema: raw
+    table: customers
+    description: keep second source
+""",
+        encoding="utf-8",
+    )
+    with duckdb.connect(str(database)) as connection:
+        connection.execute("ALTER TABLE raw.orders ADD COLUMN generated_at TIMESTAMP")
+        connection.execute("CREATE TABLE raw.customers(customer_id BIGINT, email VARCHAR)")

--- a/tests/integration/src/sqlbuild/cli/commands/main/test_contract_command.py
+++ b/tests/integration/src/sqlbuild/cli/commands/main/test_contract_command.py
@@ -11,7 +11,10 @@ from sqlbuild.cli.commands.main.entrypoint.entry import main
 from tests.integration.src.sqlbuild.cli.commands.main._test_types import (
     ContractCommandIntegrationTestCase,
 )
-from tests.integration.src.sqlbuild.cli.commands.main.helpers import prepare_contract_project
+from tests.integration.src.sqlbuild.cli.commands.main.helpers import (
+    add_second_contract_source,
+    prepare_contract_project,
+)
 
 
 @pytest.mark.parametrize(
@@ -101,6 +104,50 @@ def test_given_missing_declarations_when_generating_additively_then_preserves_me
     assert "type: 'BIGINT'" in source_yaml
     assert "- name: status" in source_yaml
     assert "type: 'VARCHAR'" in source_yaml
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ContractCommandIntegrationTestCase(
+            description="multiple sources sharing one YAML file retain every generated edit",
+            expected_exit_code=0,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_multiple_sources_in_one_file_when_generating_then_all_edits_are_retained(
+    test_case: ContractCommandIntegrationTestCase,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database: Path = prepare_contract_project(tmp_path)
+    add_second_contract_source(project_dir=tmp_path, database=database)
+
+    exit_code: int = main(
+        [
+            "--no-color",
+            "--project-dir",
+            str(tmp_path),
+            "contract",
+            "generate",
+            "--from",
+            "prod",
+            "--select",
+            "source:raw_orders",
+            "source:raw_customers",
+            "--write",
+        ]
+    )
+
+    source_yaml: str = (tmp_path / "sources" / "raw.yml").read_text(encoding="utf-8")
+    assert exit_code == test_case.expected_exit_code
+    assert "0 contract difference(s)" in capsys.readouterr().out
+    assert "type: 'BIGINT'" in source_yaml
+    assert "- name: generated_at" in source_yaml
+    assert "- name: status" in source_yaml
+    assert "- name: customer_id" in source_yaml
+    assert "- name: email" in source_yaml
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

`contract generate --write` lost earlier edits when multiple selected sources shared one YAML file: every resource started from the original contents and the final resource overwrote the accumulated result. Real CHI-262 adoption reproduced this across 67 sources.

## Changes

- Feed each source edit the latest in-memory contents already accumulated for its file.
- Keep generated-file ownership checks anchored to the original authored contents.
- Add real CLI/DuckDB integration coverage proving columns from two sources in one YAML file are all retained, including a `generated_at` column that must not trip ownership detection.

## Verification

- `uv run pytest tests/integration/src/sqlbuild/cli/commands/main/test_contract_command.py -n auto --dist loadfile` (9 passed)
- Focused Ruff and ty checks passed.
- Fensu: 0 faults.
- `uv sync --all-extras`
- `make check-ci`
- One bounded independent review and focused follow-up completed; the reported marker-boundary finding is resolved.
