### PR TITLE
fix: honor model SQL analysis opt-outs

### DIFF
--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -194,8 +194,11 @@ def assemble_compiled_project(
                 model_inputs=tuple(
                     model_input
                     for model_input in inputs.model_inputs
-                    if analysis_model_names is None
-                    or _model_name(model_input) in analysis_model_names
+                    if model_input.sql_validation_enabled
+                    and (
+                        analysis_model_names is None
+                        or _model_name(model_input) in analysis_model_names
+                    )
                 ),
                 column_nullability_by_table=column_nullability_by_table,
                 column_types_by_table=column_types_by_table,
@@ -233,6 +236,7 @@ def assemble_compiled_project(
                 model_input=model_input,
                 sql_analysis_enabled=(
                     sql_analysis_enabled
+                    and model_input.sql_validation_enabled
                     and (
                         analysis_model_names is None
                         or _model_name(model_input) in analysis_model_names
@@ -443,6 +447,9 @@ def _analyze_model_sql_in_parallel(
 ) -> dict[str, _ModelSqlAnalysis]:
     if not model_inputs:
         return {}
+    analyzed_model_names: frozenset[str] = frozenset(
+        _model_name(model_input) for model_input in model_inputs
+    )
     requests: tuple[_ModelSqlAnalysisRequest, ...] = tuple(
         _model_sql_analysis_request(
             model_input=model_input,
@@ -464,7 +471,10 @@ def _analyze_model_sql_in_parallel(
             ),
             model_names=tuple(_model_name(request.model_input) for request in requests),
             upstream_model_names_by_key={
-                request.cache_key: _referenced_model_names(request.model_input)
+                request.cache_key: _referenced_model_names(
+                    model_input=request.model_input,
+                    available_names=analyzed_model_names,
+                )
                 for request in requests
                 if request.cache_key is not None
             },
@@ -599,6 +609,7 @@ def _analyze_model_sql_in_parallel(
                     cached_analyses=cached_analyses,
                     invalidated_names=invalidated_names,
                     current_signatures_by_name=current_signatures_by_name,
+                    analyzed_model_names=analyzed_model_names,
                 ),
             )
     return {
@@ -763,13 +774,18 @@ def _downstream_model_names(
     return downstream_names
 
 
-def _referenced_model_names(model_input: CompileModelInput) -> tuple[str, ...]:
+def _referenced_model_names(
+    *,
+    model_input: CompileModelInput,
+    available_names: frozenset[str] | None = None,
+) -> tuple[str, ...]:
     return tuple(
         sorted(
             {
                 reference.ref_name
                 for reference in model_input.references
                 if reference.ref_kind == SqlReferenceKind.REF
+                and (available_names is None or reference.ref_name in available_names)
             }
         )
     )
@@ -781,6 +797,7 @@ def _dependency_signatures_by_key(
     cached_analyses: dict[str, PolyglotAnalysisResult],
     invalidated_names: set[str],
     current_signatures_by_name: dict[str, str],
+    analyzed_model_names: frozenset[str],
 ) -> dict[str, dict[str, str]]:
     dependencies_by_key: dict[str, dict[str, str]] = {}
     for request in requests:
@@ -792,7 +809,10 @@ def _dependency_signatures_by_key(
             continue
         dependencies_by_key[cache_key] = {
             upstream_name: current_signatures_by_name[upstream_name]
-            for upstream_name in _referenced_model_names(request.model_input)
+            for upstream_name in _referenced_model_names(
+                model_input=request.model_input,
+                available_names=analyzed_model_names,
+            )
             if upstream_name in current_signatures_by_name
         }
     return dependencies_by_key

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_semantic_binding.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_semantic_binding.py
@@ -294,7 +294,15 @@ def test_given_model_analysis_disabled_when_column_is_missing_then_binding_is_sk
         project_dir=tmp_path,
         upstream_sql=_AUTHORITATIVE_MODEL,
         downstream_sql=(
-            "MODEL (materialized view, sql_analysis false);\n"
+            "MODEL (\n"
+            "  materialized view\n"
+            "  sql_analysis false\n"
+            "  contract enforced\n"
+            "  columns (\n"
+            "    missing_vendor_column (type VARCHAR)\n"
+            "    runtime_only_column (type VARCHAR)\n"
+            "  )\n"
+            ");\n"
             'SELECT missing_vendor_column FROM __ref("upstream")\n'
         ),
     )
@@ -304,6 +312,57 @@ def test_given_model_analysis_disabled_when_column_is_missing_then_binding_is_sk
     output: str = capsys.readouterr().out
     assert exit_code == test_case.expected_exit_code
     assert "error[B" not in output
+    assert "error[K" not in output
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        SemanticBindingIntegrationTestCase(
+            description="given cached dependent error when upstream analysis is disabled then stale error clears",
+            expected_exit_code=0,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_cached_dependent_error_when_upstream_analysis_disabled_then_stale_error_clears(
+    test_case: SemanticBindingIntegrationTestCase,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    write_semantic_binding_project(
+        project_dir=tmp_path,
+        upstream_sql=_AUTHORITATIVE_MODEL,
+        downstream_sql=(
+            'MODEL (materialized view);\nSELECT runtime_column FROM __ref("intermediate")\n'
+        ),
+    )
+    intermediate_path: Path = tmp_path / "models" / "intermediate.sql"
+    _ = intermediate_path.write_text(
+        'MODEL (materialized view);\nSELECT id FROM __ref("upstream")\n',
+        encoding="utf-8",
+    )
+
+    initial_exit_code: int = main(["--no-color", "--project-dir", str(tmp_path), "compile"])
+    initial_output: str = capsys.readouterr().out
+    assert initial_exit_code == 1
+    assert "error[B002]: Unknown column 'runtime_column'" in initial_output
+
+    _ = intermediate_path.write_text(
+        "MODEL (materialized view, sql_analysis false);\n"
+        'SELECT runtime_column FROM __ref("upstream")\n',
+        encoding="utf-8",
+    )
+    exit_code: int = main(["--no-color", "--project-dir", str(tmp_path), "compile"])
+    output: str = capsys.readouterr().out
+
+    assert exit_code == test_case.expected_exit_code
+    assert "error[B002]" not in output
+
+    cached_exit_code: int = main(["--no-color", "--project-dir", str(tmp_path), "compile"])
+    cached_output: str = capsys.readouterr().out
+    assert cached_exit_code == test_case.expected_exit_code
+    assert "error[B002]" not in cached_output
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_command.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/compile/test_compile_command.py
@@ -58,9 +58,7 @@ def test_given_local_project_when_running_compile_then_it_does_not_connect(
         lambda *args, **kwargs: NoConnectDuckDbAdapter(),
     )
 
-    exit_code: int = run_compile(
-        CompileCommandRequest(project_dir=project_dir, no_sql_validation=True)
-    )
+    exit_code: int = run_compile(CompileCommandRequest(project_dir=project_dir))
     rendered_stdout: str = capsys.readouterr().out
 
     assert exit_code == test_case.expected_exit_code
@@ -353,9 +351,7 @@ def test_given_contract_errors_when_running_compile_then_reports_diagnostics(
         lambda *args, **kwargs: NoConnectDuckDbAdapter(),
     )
 
-    exit_code: int = run_compile(
-        CompileCommandRequest(project_dir=project_dir, no_sql_validation=True)
-    )
+    exit_code: int = run_compile(CompileCommandRequest(project_dir=project_dir))
     rendered_stdout: str = capsys.readouterr().out
 
     assert exit_code == test_case.expected_exit_code
@@ -413,7 +409,6 @@ def test_given_contract_errors_when_running_compile_json_then_serializes_diagnos
     exit_code: int = run_compile(
         CompileCommandRequest(
             project_dir=project_dir,
-            no_sql_validation=True,
             json_output=True,
         )
     )


### PR DESCRIPTION
## Why

A model-level `sql_analysis false` override suppressed binding diagnostics but still ran batched column/type inference. Enforced contracts could therefore fail on analysis results the user explicitly disabled. Simply excluding those models also exposed asymmetric cache dependencies that could retain stale downstream diagnostics or permanently miss the cache.

## Changes

- Exclude analysis-disabled models from batched Polyglot analysis and assembly inference.
- Filter disabled models symmetrically from analysis-cache dependency reads and writes.
- Reject old cache entries once when analysis state changes, then allow steady-state cache hits.
- Cover contract behavior and enabled → disabled → cached compilation transitions through the real CLI.

## Verification

- `uv run pytest tests/integration/src/sqlbuild/compiler/pipeline/test_semantic_binding.py -n auto --dist loadfile` (20 passed)
- Dagster Bias: 46 enforced models compile cleanly and production contract diff is zero with bounded model opt-outs.
- `make check-ci`
- Bounded complete-diff review found two cache issues; both were fixed and the focused follow-up verified enabled/disabled/re-enabled cache transitions.
