### PR TITLE
feat: correlate lifecycle events with orchestrators

### DIFF
--- a/src/sqlbuild/cli/commands/main/entrypoint/entry.py
+++ b/src/sqlbuild/cli/commands/main/entrypoint/entry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from sqlbuild.cli.commands._helpers.entry.dispatch_errors import dispatch_and_handle_errors
 from sqlbuild.cli.commands._helpers.entry.errors import cli_error_use_color
@@ -19,8 +19,12 @@ from sqlbuild.cli.commands.models import (
     ParsedCliInvocation,
 )
 from sqlbuild.diagnostics.main.diagnostics_context import diagnostics_context
-from sqlbuild.observability import invocation_scope
+from sqlbuild.observability import invocation_external_context_scope, invocation_scope
 from sqlbuild.presentation.main.supports_color import supports_color
+from sqlbuild.runtime.output_capture.exceptions import OutputCaptureInputError
+from sqlbuild.runtime.output_capture.main.invocation_context import (
+    invocation_context_from_environment,
+)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -36,7 +40,14 @@ def _main_with_dependencies(
 ) -> int:
     """Run the CLI entrypoint with injected handlers for testing."""
 
-    with invocation_scope() as identity:
+    try:
+        external_context: Mapping[str, object] = invocation_context_from_environment()
+    except OutputCaptureInputError:
+        external_context = {}
+    with (
+        invocation_scope() as identity,
+        invocation_external_context_scope(external_context=external_context),
+    ):
         with diagnostics_context(sqlbuild_invocation_id=identity.invocation_id):
             use_color: bool = cli_error_use_color(argv=argv, supports_color=supports_color)
             parser: argparse.ArgumentParser = build_cli_parser(use_color=use_color)

--- a/src/sqlbuild/integrations/dagster/_helpers/invocation_context.py
+++ b/src/sqlbuild/integrations/dagster/_helpers/invocation_context.py
@@ -13,13 +13,13 @@ def dagster_invocation_context(context: Any) -> dict[str, object]:
     """Return bounded, non-sensitive identifiers for subprocess correlation."""
 
     integration: dict[str, object] = {"name": "dagster"}
-    run_id: str | None = _string_attribute(source=context, name="run_id")
+    run_id: str | None = _run_id(context=context)
     if run_id is not None:
         integration["run_id"] = run_id
     job_name: str | None = _string_attribute(source=context, name="job_name")
     if job_name is not None:
         integration["job_name"] = job_name
-    retry_number: int | None = _integer_attribute(source=context, name="retry_number")
+    retry_number: int | None = _retry_number(context=context)
     if retry_number is not None:
         integration["retry_number"] = retry_number
     step_key: str | None = _step_key(context=context)
@@ -37,12 +37,27 @@ def _step_key(*, context: Any) -> str | None:
     bounded_direct: str | None = _bounded_identifier(direct)
     if bounded_direct is not None:
         return bounded_direct
-    handle: object | None = _attribute(source=context, name="op_handle")
+    operation_context: object | None = _attribute(source=context, name="op_execution_context")
+    handle: object | None = _attribute(source=operation_context, name="op_handle")
+    if handle is None:
+        handle = _attribute(source=context, name="op_handle")
     formatter: object | None = _attribute(source=handle, name="to_string")
     if callable(formatter):
         value: object = cast(Callable[[], object], formatter)()
         return _bounded_identifier(value)
     return None
+
+
+def _run_id(*, context: Any) -> str | None:
+    run: object | None = _attribute(source=context, name="run")
+    nested: str | None = _string_attribute(source=run, name="run_id")
+    return nested if nested is not None else _string_attribute(source=context, name="run_id")
+
+
+def _retry_number(*, context: Any) -> int | None:
+    operation_context: object | None = _attribute(source=context, name="op_execution_context")
+    nested: int | None = _integer_attribute(source=operation_context, name="retry_number")
+    return nested if nested is not None else _integer_attribute(source=context, name="retry_number")
 
 
 def _string_attribute(*, source: Any, name: str) -> str | None:

--- a/src/sqlbuild/observability.py
+++ b/src/sqlbuild/observability.py
@@ -37,6 +37,9 @@ from sqlbuild.runtime.observability.main.execution_identity_to_dict import (
     execution_identity_to_dict as _execution_identity_to_dict,
 )
 from sqlbuild.runtime.observability.main.identity_scope import identity_scope as _identity_scope
+from sqlbuild.runtime.observability.main.invocation_external_context_scope import (
+    invocation_external_context_scope as _invocation_external_context_scope,
+)
 from sqlbuild.runtime.observability.main.invocation_scope import (
     invocation_scope as _invocation_scope,
 )
@@ -103,6 +106,7 @@ __all__ = (
     "current_execution_identity",
     "execution_identity_to_dict",
     "identity_scope",
+    "invocation_external_context_scope",
     "invocation_scope",
     "is_terminal_event",
     "lifecycle_event_from_json",
@@ -177,6 +181,16 @@ def invocation_scope(invocation_id: str | None = None) -> Iterator[ExecutionIden
 
     with _invocation_scope(invocation_id) as identity:
         yield identity
+
+
+@contextmanager
+def invocation_external_context_scope(
+    *, external_context: Mapping[str, object]
+) -> Iterator[Mapping[str, JSONValue]]:
+    """Attach validated integration context to lifecycle facts in the current invocation."""
+
+    with _invocation_external_context_scope(external_context=external_context) as installed:
+        yield installed
 
 
 @contextmanager

--- a/src/sqlbuild/runtime/observability/_helpers/factory.py
+++ b/src/sqlbuild/runtime/observability/_helpers/factory.py
@@ -6,7 +6,10 @@ from importlib.metadata import version
 from types import MappingProxyType
 from uuid import uuid4
 
-from sqlbuild.runtime.observability._helpers.identity import current_execution_identity
+from sqlbuild.runtime.observability._helpers.identity import (
+    current_execution_identity,
+    current_invocation_external_context,
+)
 from sqlbuild.runtime.observability.constants import CURRENT_LIFECYCLE_EVENT_SCHEMA_VERSION
 from sqlbuild.runtime.observability.exceptions import ObservabilityValidationError
 from sqlbuild.runtime.observability.models import ExecutionIdentity, LifecycleEvent
@@ -43,10 +46,12 @@ def create_lifecycle_event(
         ),
         occurred_at=datetime.now(UTC) if occurred_at is None else occurred_at,
         invocation_id=identity.invocation_id,
+        invocation_sequence=0,
         run_id=identity.run_id,
         resource_id=identity.resource_id,
         resource_attempt_id=identity.resource_attempt_id,
         operation_id=identity.operation_id,
         statement_id=identity.statement_id,
+        external_context=current_invocation_external_context(),
         payload=payload,
     )

--- a/src/sqlbuild/runtime/observability/_helpers/identity.py
+++ b/src/sqlbuild/runtime/observability/_helpers/identity.py
@@ -2,17 +2,26 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import asdict, replace
+from types import MappingProxyType
+from typing import cast
 from uuid import uuid4
 
+from sqlbuild.runtime.observability._helpers.validation import freeze_json
 from sqlbuild.runtime.observability.exceptions import ObservabilityValidationError
 from sqlbuild.runtime.observability.models import ExecutionIdentity
+from sqlbuild.runtime.observability.types import JSONValue
 
 _CURRENT_EXECUTION_IDENTITY: ContextVar[ExecutionIdentity | None] = ContextVar(
     "sqlbuild_execution_identity", default=None
+)
+
+
+_CURRENT_INVOCATION_EXTERNAL_CONTEXT: ContextVar[Mapping[str, JSONValue]] = ContextVar(
+    "sqlbuild_invocation_external_context", default=MappingProxyType({})
 )
 
 
@@ -22,11 +31,11 @@ def current_execution_identity() -> ExecutionIdentity | None:
 
 @contextmanager
 def identity_scope(identity: ExecutionIdentity) -> Iterator[ExecutionIdentity]:
-    token: Token[ExecutionIdentity | None] = _CURRENT_EXECUTION_IDENTITY.set(identity)
+    identity_token: Token[ExecutionIdentity | None] = _CURRENT_EXECUTION_IDENTITY.set(identity)
     try:
         yield identity
     finally:
-        _CURRENT_EXECUTION_IDENTITY.reset(token)
+        _CURRENT_EXECUTION_IDENTITY.reset(identity_token)
 
 
 def execution_identity_to_dict(identity: ExecutionIdentity) -> dict[str, str | None]:
@@ -47,6 +56,29 @@ def invocation_scope(invocation_id: str | None = None) -> Iterator[ExecutionIden
     )
     with identity_scope(identity) as installed:
         yield installed
+
+
+def current_invocation_external_context() -> Mapping[str, JSONValue]:
+    """Return validated external context for the active invocation."""
+
+    return _CURRENT_INVOCATION_EXTERNAL_CONTEXT.get()
+
+
+@contextmanager
+def invocation_external_context_scope(
+    *, external_context: Mapping[str, object]
+) -> Iterator[Mapping[str, JSONValue]]:
+    """Install validated integration context for lifecycle facts in one command."""
+
+    frozen: JSONValue = freeze_json(value=external_context, path="external_context")
+    if not isinstance(frozen, Mapping):
+        raise ObservabilityValidationError("external_context must be a JSON object")
+    context: Mapping[str, JSONValue] = cast(Mapping[str, JSONValue], frozen)
+    token: Token[Mapping[str, JSONValue]] = _CURRENT_INVOCATION_EXTERNAL_CONTEXT.set(context)
+    try:
+        yield context
+    finally:
+        _CURRENT_INVOCATION_EXTERNAL_CONTEXT.reset(token)
 
 
 @contextmanager

--- a/src/sqlbuild/runtime/observability/_helpers/observability.py
+++ b/src/sqlbuild/runtime/observability/_helpers/observability.py
@@ -11,8 +11,9 @@ from sqlbuild.runtime.observability._helpers.validation import validate_schema_v
 from sqlbuild.runtime.observability.constants import (
     CURRENT_DIAGNOSTIC_LOG_SCHEMA_VERSION,
     DIAGNOSTIC_ENVELOPE_FIELDS,
-    LIFECYCLE_ENVELOPE_FIELDS,
+    LIFECYCLE_ENVELOPE_FIELDS_BY_VERSION,
     LIFECYCLE_EVENT_CATALOGS,
+    LIFECYCLE_INVOCATION_METADATA_SCHEMA_VERSION,
 )
 from sqlbuild.runtime.observability.exceptions import ObservabilityValidationError
 from sqlbuild.runtime.observability.models import (
@@ -68,27 +69,29 @@ def lifecycle_event_to_json(event: LifecycleEvent | OpaqueLifecycleEvent) -> str
 
     if isinstance(event, OpaqueLifecycleEvent):
         return _dumps(_json_data(event.raw))
-    return _dumps(
-        {
-            "event_id": event.event_id,
-            "event_type": event.event_type,
-            "schema_version": event.schema_version,
-            "producer": event.producer,
-            "producer_version": event.producer_version,
-            "occurred_at": _timestamp(event.occurred_at),
-            "invocation_id": event.invocation_id,
-            "run_id": event.run_id,
-            "resource_id": event.resource_id,
-            "resource_attempt_id": event.resource_attempt_id,
-            "operation_id": event.operation_id,
-            "statement_id": event.statement_id,
-            "payload": _json_data(event.payload),
-        }
-    )
+    data: dict[str, object] = {
+        "event_id": event.event_id,
+        "event_type": event.event_type,
+        "schema_version": event.schema_version,
+        "producer": event.producer,
+        "producer_version": event.producer_version,
+        "occurred_at": _timestamp(event.occurred_at),
+        "invocation_id": event.invocation_id,
+        "run_id": event.run_id,
+        "resource_id": event.resource_id,
+        "resource_attempt_id": event.resource_attempt_id,
+        "operation_id": event.operation_id,
+        "statement_id": event.statement_id,
+        "payload": _json_data(event.payload),
+    }
+    if event.schema_version >= LIFECYCLE_INVOCATION_METADATA_SCHEMA_VERSION:
+        data["invocation_sequence"] = event.invocation_sequence
+        data["external_context"] = _json_data(event.external_context)
+    return _dumps(data)
 
 
 def lifecycle_event_from_json(raw_json: str) -> LifecycleEvent | OpaqueLifecycleEvent:
-    """Decode known v1 events strictly and retain unknown envelopes opaquely."""
+    """Decode known events strictly and retain unknown envelopes opaquely."""
 
     data: dict[str, Any] = _loads_object(raw_json=raw_json, envelope_name="lifecycle event")
     event_type: object = data.get("event_type")
@@ -106,7 +109,7 @@ def lifecycle_event_from_json(raw_json: str) -> LifecycleEvent | OpaqueLifecycle
         return OpaqueLifecycleEvent(raw=data)
     _reject_unknown_fields(
         data=data,
-        allowed=LIFECYCLE_ENVELOPE_FIELDS,
+        allowed=LIFECYCLE_ENVELOPE_FIELDS_BY_VERSION[schema_version],
         envelope_name=f"v{schema_version} lifecycle event",
     )
     try:
@@ -122,11 +125,13 @@ def lifecycle_event_from_json(raw_json: str) -> LifecycleEvent | OpaqueLifecycle
             producer_version=data["producer_version"],
             occurred_at=occurred_at,
             invocation_id=data["invocation_id"],
+            invocation_sequence=data.get("invocation_sequence"),
             run_id=data.get("run_id"),
             resource_id=data.get("resource_id"),
             resource_attempt_id=data.get("resource_attempt_id"),
             operation_id=data.get("operation_id"),
             statement_id=data.get("statement_id"),
+            external_context=data.get("external_context", {}),
             payload=data.get("payload", {}),
         )
     except KeyError as error:

--- a/src/sqlbuild/runtime/observability/classes/event_dispatcher.py
+++ b/src/sqlbuild/runtime/observability/classes/event_dispatcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import deque
 from contextvars import ContextVar, Token
+from dataclasses import replace
 from functools import partial
 from threading import RLock
 from typing import Literal, cast, overload
@@ -14,6 +15,9 @@ from sqlbuild.runtime.observability._helpers.failure_formatting import (
     _safe_subscriber_name,
 )
 from sqlbuild.runtime.observability._helpers.validation import validate_known_lifecycle_event
+from sqlbuild.runtime.observability.constants import (
+    LIFECYCLE_INVOCATION_METADATA_SCHEMA_VERSION,
+)
 from sqlbuild.runtime.observability.exceptions import ObservabilityValidationError
 from sqlbuild.runtime.observability.models import (
     DiagnosticLog,
@@ -47,6 +51,7 @@ class EventDispatcher:
         self._publication_lock: RLock = RLock()
         self._lifecycle: tuple[LifecycleRegistration, ...] = ()
         self._diagnostics: tuple[DiagnosticRegistration, ...] = ()
+        self._lifecycle_sequences: dict[str, int] = {}
         self._pending_publications: deque[
             tuple[Literal["lifecycle"], LifecycleEvent | OpaqueLifecycleEvent, bool]
             | tuple[Literal["diagnostic"], DiagnosticLog, bool]
@@ -118,6 +123,14 @@ class EventDispatcher:
                 lifecycle_value: LifecycleEvent | OpaqueLifecycleEvent = cast(
                     LifecycleEvent | OpaqueLifecycleEvent, value
                 )
+                if (
+                    isinstance(lifecycle_value, LifecycleEvent)
+                    and lifecycle_value.schema_version
+                    >= LIFECYCLE_INVOCATION_METADATA_SCHEMA_VERSION
+                ):
+                    sequence: int = self._lifecycle_sequences.get(lifecycle_value.invocation_id, 0)
+                    self._lifecycle_sequences[lifecycle_value.invocation_id] = sequence + 1
+                    lifecycle_value = replace(lifecycle_value, invocation_sequence=sequence)
                 self._pending_publications.append((channel, lifecycle_value, suppress_health))
             else:
                 diagnostic_value: DiagnosticLog = cast(DiagnosticLog, value)

--- a/src/sqlbuild/runtime/observability/constants.py
+++ b/src/sqlbuild/runtime/observability/constants.py
@@ -5,7 +5,8 @@ from types import MappingProxyType
 
 from sqlbuild.runtime.observability.models import LifecycleEventDefinition
 
-CURRENT_LIFECYCLE_EVENT_SCHEMA_VERSION: int = 1
+CURRENT_LIFECYCLE_EVENT_SCHEMA_VERSION: int = 2
+LIFECYCLE_INVOCATION_METADATA_SCHEMA_VERSION: int = 2
 CURRENT_DIAGNOSTIC_LOG_SCHEMA_VERSION: int = 1
 DURATION_MS_FIELD: str = "duration_ms"
 EXIT_CODE_FIELD: str = "exit_code"
@@ -296,7 +297,7 @@ FORBIDDEN_STATEMENT_PAYLOAD_FIELDS: frozenset[str] = frozenset(
         "statement_sql",
     }
 )
-LIFECYCLE_ENVELOPE_FIELDS: frozenset[str] = frozenset(
+LIFECYCLE_ENVELOPE_FIELDS_V1: frozenset[str] = frozenset(
     {
         "event_id",
         "event_type",
@@ -312,6 +313,12 @@ LIFECYCLE_ENVELOPE_FIELDS: frozenset[str] = frozenset(
         "statement_id",
         "payload",
     }
+)
+LIFECYCLE_ENVELOPE_FIELDS_V2: frozenset[str] = LIFECYCLE_ENVELOPE_FIELDS_V1 | frozenset(
+    {"invocation_sequence", "external_context"}
+)
+LIFECYCLE_ENVELOPE_FIELDS_BY_VERSION: Mapping[int, frozenset[str]] = MappingProxyType(
+    {1: LIFECYCLE_ENVELOPE_FIELDS_V1, 2: LIFECYCLE_ENVELOPE_FIELDS_V2}
 )
 DIAGNOSTIC_ENVELOPE_FIELDS: frozenset[str] = frozenset(
     {
@@ -517,6 +524,6 @@ LIFECYCLE_EVENT_CATALOG_V1: Mapping[str, LifecycleEventDefinition] = MappingProx
     }
 )
 LIFECYCLE_EVENT_CATALOGS: Mapping[int, Mapping[str, LifecycleEventDefinition]] = MappingProxyType(
-    {CURRENT_LIFECYCLE_EVENT_SCHEMA_VERSION: LIFECYCLE_EVENT_CATALOG_V1}
+    {1: LIFECYCLE_EVENT_CATALOG_V1, 2: LIFECYCLE_EVENT_CATALOG_V1}
 )
 LIFECYCLE_EVENT_CATALOG: Mapping[str, LifecycleEventDefinition] = LIFECYCLE_EVENT_CATALOG_V1

--- a/src/sqlbuild/runtime/observability/main/invocation_external_context_scope.py
+++ b/src/sqlbuild/runtime/observability/main/invocation_external_context_scope.py
@@ -1,0 +1,19 @@
+"""Invocation lifecycle metadata scope entrypoint."""
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+
+from sqlbuild.runtime.observability._helpers.identity import (
+    invocation_external_context_scope as _invocation_external_context_scope,
+)
+from sqlbuild.runtime.observability.types import JSONValue
+
+
+@contextmanager
+def invocation_external_context_scope(
+    *, external_context: Mapping[str, object]
+) -> Iterator[Mapping[str, JSONValue]]:
+    """Install validated integration context for lifecycle event creation."""
+
+    with _invocation_external_context_scope(external_context=external_context) as installed:
+        yield installed

--- a/src/sqlbuild/runtime/observability/models.py
+++ b/src/sqlbuild/runtime/observability/models.py
@@ -86,11 +86,13 @@ class LifecycleEvent:
     producer_version: str
     occurred_at: datetime
     invocation_id: str
+    invocation_sequence: int | None = None
     run_id: str | None = None
     resource_id: str | None = None
     resource_attempt_id: str | None = None
     operation_id: str | None = None
     statement_id: str | None = None
+    external_context: Mapping[str, JSONValue] = field(default_factory=dict)
     payload: Mapping[str, JSONValue] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -102,7 +104,10 @@ class LifecycleEvent:
             validate_schema_version,
             validate_timestamp,
         )
-        from sqlbuild.runtime.observability.constants import CURRENT_LIFECYCLE_EVENT_SCHEMA_VERSION
+        from sqlbuild.runtime.observability.constants import (
+            CURRENT_LIFECYCLE_EVENT_SCHEMA_VERSION,
+            LIFECYCLE_EVENT_CATALOGS,
+        )
 
         for field_name in (
             "event_id",
@@ -113,11 +118,24 @@ class LifecycleEvent:
         ):
             validate_required_text(value=getattr(self, field_name), field_name=field_name)
         validate_schema_version(value=self.schema_version)
-        if self.schema_version != CURRENT_LIFECYCLE_EVENT_SCHEMA_VERSION:
+        if self.schema_version not in LIFECYCLE_EVENT_CATALOGS:
             raise ObservabilityValidationError(
-                "LifecycleEvent only represents known schema version "
-                f"{CURRENT_LIFECYCLE_EVENT_SCHEMA_VERSION}; "
-                "decode other versions as OpaqueLifecycleEvent"
+                "LifecycleEvent only represents known schema versions through "
+                f"{CURRENT_LIFECYCLE_EVENT_SCHEMA_VERSION}; decode other versions as "
+                "OpaqueLifecycleEvent"
+            )
+        if self.schema_version == 1:
+            if self.invocation_sequence is not None or self.external_context:
+                raise ObservabilityValidationError(
+                    "schema version 1 lifecycle events cannot contain invocation metadata"
+                )
+        elif (
+            isinstance(self.invocation_sequence, bool)
+            or not isinstance(self.invocation_sequence, int)
+            or self.invocation_sequence < 0
+        ):
+            raise ObservabilityValidationError(
+                "invocation_sequence must be a non-negative integer excluding bool"
             )
         validate_timestamp(value=self.occurred_at)
         for field_name in (
@@ -128,6 +146,12 @@ class LifecycleEvent:
             "statement_id",
         ):
             validate_optional_text(value=getattr(self, field_name), field_name=field_name)
+        frozen_context: JSONValue = freeze_json(
+            value=self.external_context, path="external_context"
+        )
+        if not isinstance(frozen_context, Mapping):
+            raise ObservabilityValidationError("external_context must be a JSON object")
+        object.__setattr__(self, "external_context", frozen_context)
         frozen_payload: JSONValue = freeze_json(value=self.payload, path="payload")
         if not isinstance(frozen_payload, Mapping):
             raise ObservabilityValidationError("payload must be a JSON object")

--- a/tests/e2e/src/sqlbuild/cli/commands/main/providers/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/providers/_test_types.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 class EventExporterE2ETestCase:
     description: str
     expected_first_event: str
+    expected_context: dict[str, object]
 
 
 @dataclass(frozen=True)

--- a/tests/e2e/src/sqlbuild/cli/commands/main/providers/test_event_exporters.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/providers/test_event_exporters.py
@@ -19,7 +19,13 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import prepare_inline_pr
 
 @pytest.mark.parametrize(
     "test_case",
-    (EventExporterE2ETestCase("redacted provider export", "invocation_started"),),
+    (
+        EventExporterE2ETestCase(
+            "redacted provider export",
+            "invocation_started",
+            {"integration": {"name": "test_orchestrator", "run_id": "external-run-1"}},
+        ),
+    ),
     ids=lambda case: case.description,
 )
 def test_given_provider_exporter_when_building_then_receives_redacted_events_before_teardown(
@@ -31,6 +37,7 @@ def test_given_provider_exporter_when_building_then_receives_redacted_events_bef
     import_path: Path = tmp_path / "exporter-imports"
     monkeypatch.setenv("EVENT_EXPORT_PATH", str(output_path))
     monkeypatch.setenv("EXPORTER_IMPORT_PATH", str(import_path))
+    monkeypatch.setenv("SQLBUILD_INVOCATION_CONTEXT_JSON", json.dumps(test_case.expected_context))
     project_dir: Path = prepare_inline_project(
         tmp_path=tmp_path,
         project_name="lifecycle_event_sink_project",
@@ -121,6 +128,8 @@ def test_given_provider_exporter_when_building_then_receives_redacted_events_bef
     assert event_types[0] == test_case.expected_first_event
     assert event_types[-1] == "invocation_completed"
     assert "statement_completed" in event_types
+    assert sorted(event["invocation_sequence"] for event in events) == list(range(len(events)))
+    assert all(event["external_context"] == test_case.expected_context for event in events)
     assert "do-not-export-this-sql" not in "\n".join(lines)
     assert import_path.read_text(encoding="utf-8").splitlines() == ["imported"]
 

--- a/tests/integration/src/sqlbuild/runtime/execution_history/test_postgres_execution_history.py
+++ b/tests/integration/src/sqlbuild/runtime/execution_history/test_postgres_execution_history.py
@@ -134,7 +134,7 @@ def test_given_first_plain_append_allocated_but_uncommitted_when_second_appends_
     first, second, allocated, release = paused_plain_append
     known: LifecycleEvent = lifecycle_event("known-first", run_id="cursor-run")
     opaque: OpaqueLifecycleEvent = OpaqueLifecycleEvent(
-        raw={"event_id": "opaque-second", "schema_version": 2, "nested": {"kind": "opaque"}}
+        raw={"event_id": "opaque-second", "schema_version": 3, "nested": {"kind": "opaque"}}
     )
 
     with ThreadPoolExecutor(max_workers=2) as executor:
@@ -252,7 +252,7 @@ def test_given_opaque_nested_nul_and_jsonb_oversized_number_when_roundtripping_t
     event: OpaqueLifecycleEvent = OpaqueLifecycleEvent(
         raw={
             "event_id": "opaque-text-only",
-            "schema_version": 2,
+            "schema_version": 3,
             "nested": {"nul": "before\u0000after", "huge": huge_number},
         }
     )

--- a/tests/integration/src/sqlbuild/runtime/execution_history/test_sqlite_execution_history.py
+++ b/tests/integration/src/sqlbuild/runtime/execution_history/test_sqlite_execution_history.py
@@ -524,7 +524,7 @@ def test_given_opaque_nested_extra_fields_when_reopening_and_retrying_then_canon
     event: OpaqueLifecycleEvent = OpaqueLifecycleEvent(
         raw={
             "event_id": "opaque-nested",
-            "schema_version": 2,
+            "schema_version": 3,
             "event_type": "future_event",
             "occurred_at": "2026-01-01T00:00:00.123456Z",
             "nested": {"items": [1, {"extra": True}]},

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
@@ -779,10 +779,18 @@ def test_given_dagster_context_when_starting_cli_then_generic_context_crosses_su
         "InvocationContext",
         (),
         {
-            "run_id": "dagster-run-1",
+            "run": type("DagsterRun", (), {"run_id": "dagster-run-1"})(),
             "job_name": "prices_job",
-            "op_handle": type("OpHandle", (), {"to_string": lambda self: "all_sqlbuild_assets"})(),
-            "retry_number": 1,
+            "op_execution_context": type(
+                "OpExecutionContext",
+                (),
+                {
+                    "op_handle": type(
+                        "OpHandle", (), {"to_string": lambda self: "all_sqlbuild_assets"}
+                    )(),
+                    "retry_number": 1,
+                },
+            )(),
             "has_partition_key": False,
         },
     )()

--- a/tests/unit/src/sqlbuild/runtime/execution_history/conformance/conftest.py
+++ b/tests/unit/src/sqlbuild/runtime/execution_history/conformance/conftest.py
@@ -511,7 +511,7 @@ def run_cursor_key(
 def opaque_event(event_id: str) -> OpaqueLifecycleEvent:
     """Build an opaque canonical lifecycle envelope for storage tests."""
 
-    return OpaqueLifecycleEvent(raw={"event_id": event_id, "schema_version": 2})
+    return OpaqueLifecycleEvent(raw={"event_id": event_id, "schema_version": 3})
 
 
 def append_failing_event_log_factory() -> LifecycleEventLogStorage:

--- a/tests/unit/src/sqlbuild/runtime/execution_history/conformance/helpers.py
+++ b/tests/unit/src/sqlbuild/runtime/execution_history/conformance/helpers.py
@@ -64,7 +64,7 @@ def opaque_event(
         raw={
             "event_id": event_id,
             "event_type": event_type,
-            "schema_version": 2,
+            "schema_version": 3,
             "producer": producer,
             "occurred_at": occurred_at,
             "invocation_id": invocation_id,

--- a/tests/unit/src/sqlbuild/runtime/execution_history/conformance/test_event_log_contract.py
+++ b/tests/unit/src/sqlbuild/runtime/execution_history/conformance/test_event_log_contract.py
@@ -246,7 +246,7 @@ def test_given_opaque_envelope_missing_filter_fields_when_querying_without_filte
     event_log: LifecycleEventLogStorage, test_case: ContractCase
 ) -> None:
     opaque: OpaqueLifecycleEvent = OpaqueLifecycleEvent(
-        raw={"event_id": "minimal-opaque", "schema_version": 2}
+        raw={"event_id": "minimal-opaque", "schema_version": 3}
     )
     _ = event_log.append_event(opaque)
 
@@ -456,7 +456,7 @@ def test_given_opaque_envelope_without_valid_event_id_when_appending_then_event_
     event_log: LifecycleEventLogStorage, test_case: OpaqueIdCase
 ) -> None:
     malformed: OpaqueLifecycleEvent = OpaqueLifecycleEvent(
-        raw={"schema_version": 2, "event_id": test_case.event_id}
+        raw={"schema_version": 3, "event_id": test_case.event_id}
     )
 
     with pytest.raises(InvalidEventError, match=test_case.expected_error):

--- a/tests/unit/src/sqlbuild/runtime/observability/_test_types.py
+++ b/tests/unit/src/sqlbuild/runtime/observability/_test_types.py
@@ -238,6 +238,20 @@ class ProducerVersionCase:
 
 
 @dataclass(frozen=True)
+class InvocationMetadataCase:
+    description: str
+    event_count: int
+    expected_external_context: Mapping[str, JSONValue]
+    expected_first_sequence: int
+
+
+@dataclass(frozen=True)
+class PublicScopeSequenceCase:
+    description: str
+    expected_sequence: int
+
+
+@dataclass(frozen=True)
 class BlockingDispatchCase:
     description: str
     expected_before_release: tuple[str, ...]

--- a/tests/unit/src/sqlbuild/runtime/observability/helpers.py
+++ b/tests/unit/src/sqlbuild/runtime/observability/helpers.py
@@ -9,6 +9,7 @@ from threading import Lock
 from types import MappingProxyType
 
 from sqlbuild.runtime.observability._helpers.dispatcher import dispatcher_scope
+from sqlbuild.runtime.observability._helpers.factory import create_lifecycle_event
 from sqlbuild.runtime.observability._helpers.identity import invocation_scope
 from sqlbuild.runtime.observability.classes.event_dispatcher import EventDispatcher
 from sqlbuild.runtime.observability.classes.statement_lifecycle import StatementLifecycle
@@ -73,6 +74,12 @@ def _thread_statement() -> None:
     with StatementLifecycle(adapter="thread", sql="SELECT thread", intent="execute") as lifecycle:
         lifecycle.submitted(query_id="query-thread")
         lifecycle.completed(query_id="query-thread")
+
+
+def publish_invocation_started(*, dispatcher: EventDispatcher) -> None:
+    """Create and publish one invocation event for concurrent sequencing tests."""
+
+    dispatcher.publish_lifecycle(create_lifecycle_event(event_type="invocation_started"))
 
 
 def statement_event_types_by_id(

--- a/tests/unit/src/sqlbuild/runtime/observability/test_catalog.py
+++ b/tests/unit/src/sqlbuild/runtime/observability/test_catalog.py
@@ -370,11 +370,11 @@ def test_given_only_started_and_submitted_facts_when_inspecting_then_no_terminal
     "test_case",
     [
         CatalogVersionCase(
-            description="v1 catalog is authoritative and v2 is unsupported",
-            schema_version=1,
+            description="v2 catalog is authoritative and v3 is unsupported",
+            schema_version=2,
             event_type="statement_completed",
             expected_terminal=True,
-            expected_unsupported_version=2,
+            expected_unsupported_version=3,
         ),
     ],
     ids=lambda case: case.description,

--- a/tests/unit/src/sqlbuild/runtime/observability/test_dispatcher_context.py
+++ b/tests/unit/src/sqlbuild/runtime/observability/test_dispatcher_context.py
@@ -1,8 +1,8 @@
 """Tests for dispatcher context and identity-backed lifecycle construction."""
 
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
-from contextvars import copy_context
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextvars import Context, copy_context
 from datetime import UTC, datetime
 from importlib.metadata import version
 from typing import cast
@@ -11,11 +11,14 @@ import pytest
 
 from sqlbuild.observability import (
     EventDispatcher,
+    ExecutionIdentity,
     LifecycleEvent,
     ObservabilityValidationError,
     create_lifecycle_event,
     current_event_dispatcher,
     dispatcher_scope,
+    identity_scope,
+    invocation_external_context_scope,
     invocation_scope,
     log_stream_scope,
     operation_scope,
@@ -27,9 +30,14 @@ from tests.unit.src.sqlbuild.runtime.observability._test_types import (
     DispatchCountCase,
     DispatcherContextCase,
     FactoryCase,
+    InvocationMetadataCase,
     ProducerVersionCase,
+    PublicScopeSequenceCase,
 )
-from tests.unit.src.sqlbuild.runtime.observability.helpers import RecordingSubscriber
+from tests.unit.src.sqlbuild.runtime.observability.helpers import (
+    RecordingSubscriber,
+    publish_invocation_started,
+)
 
 
 @pytest.mark.parametrize(
@@ -135,9 +143,83 @@ def test_given_active_identity_when_factory_defaults_then_id_time_and_version_ar
     assert len(event.event_id) == test_case.expected_lifecycle_count
     assert before <= event.occurred_at <= after
     assert event.occurred_at.utcoffset() is not None
-    assert event.schema_version == test_case.expected_diagnostic_count
+    assert event.schema_version == 2
+    assert event.invocation_sequence == 0
     assert event.producer == "sqlbuild"
     assert event.producer_version == version("sqlbuild")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        InvocationMetadataCase(
+            description="concurrent lifecycle facts share ordered invocation metadata",
+            event_count=100,
+            expected_external_context={
+                "integration": {
+                    "name": "dagster",
+                    "run_id": "dagster-run-1",
+                    "step_key": "build_models",
+                }
+            },
+            expected_first_sequence=0,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_copied_concurrent_context_when_creating_events_then_sequence_is_unique_and_shared(
+    test_case: InvocationMetadataCase,
+) -> None:
+    events: list[LifecycleEvent] = []
+    dispatcher: EventDispatcher = EventDispatcher()
+    _ = dispatcher.subscribe_lifecycle(subscriber=events.append, accepts_opaque=False)
+    with (
+        invocation_scope("inv"),
+        invocation_external_context_scope(external_context=test_case.expected_external_context),
+    ):
+        with pytest.raises(ObservabilityValidationError, match="not allowed"):
+            _ = create_lifecycle_event(
+                event_type="invocation_started", payload={"full_sql": "select secret"}
+            )
+        contexts: list[Context] = [copy_context() for _ in range(test_case.event_count)]
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures: list[Future[object]] = [
+                pool.submit(
+                    context.run,
+                    publish_invocation_started,
+                    dispatcher=dispatcher,
+                )
+                for context in contexts
+            ]
+            for future in futures:
+                _ = future.result()
+
+    assert [event.invocation_sequence for event in events] == list(
+        range(test_case.expected_first_sequence, test_case.event_count)
+    )
+    assert all(event.external_context == test_case.expected_external_context for event in events)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [PublicScopeSequenceCase("standalone public scopes initialize sequence state", 0)],
+    ids=lambda case: case.description,
+)
+def test_given_standalone_public_identity_scopes_when_creating_events_then_each_invocation_is_sequenced(
+    test_case: PublicScopeSequenceCase,
+) -> None:
+    events: list[LifecycleEvent] = []
+    dispatcher: EventDispatcher = EventDispatcher()
+    _ = dispatcher.subscribe_lifecycle(subscriber=events.append, accepts_opaque=False)
+    with run_scope("run"):
+        dispatcher.publish_lifecycle(create_lifecycle_event(event_type="run_started"))
+    with identity_scope(ExecutionIdentity(invocation_id="explicit-invocation")):
+        dispatcher.publish_lifecycle(create_lifecycle_event(event_type="invocation_started"))
+
+    assert [event.invocation_sequence for event in events] == [
+        test_case.expected_sequence,
+        test_case.expected_sequence,
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/runtime/observability/test_models.py
+++ b/tests/unit/src/sqlbuild/runtime/observability/test_models.py
@@ -67,9 +67,9 @@ def test_given_lifecycle_fact_when_mutating_envelope_or_payload_then_it_remains_
         ),
         SchemaVersionCase(
             description="unknown lifecycle version is rejected by the known event type",
-            schema_version=2,
+            schema_version=3,
             expected_error=(
-                "LifecycleEvent only represents known schema version 1; "
+                "LifecycleEvent only represents known schema versions through 2; "
                 "decode other versions as OpaqueLifecycleEvent"
             ),
         ),

--- a/tests/unit/src/sqlbuild/runtime/observability/test_serialization.py
+++ b/tests/unit/src/sqlbuild/runtime/observability/test_serialization.py
@@ -20,6 +20,7 @@ from tests.unit.src.sqlbuild.runtime.observability._test_types import (
     EnvelopeFieldErrorCase,
     EventCase,
     ExactJsonCase,
+    InvocationMetadataCase,
     JsonErrorCase,
     MetadataBoundaryCase,
     OpaqueRoundTripCase,
@@ -151,6 +152,49 @@ def test_given_known_event_when_serializing_and_decoding_then_round_trips(
 @pytest.mark.parametrize(
     "test_case",
     [
+        InvocationMetadataCase(
+            description="v2 invocation ordering and integration context round trip",
+            event_count=1,
+            expected_external_context={
+                "integration": {
+                    "name": "dagster",
+                    "run_id": "dagster-run-1",
+                    "retry_number": 0,
+                }
+            },
+            expected_first_sequence=0,
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_v2_lifecycle_event_when_round_tripping_then_invocation_metadata_is_preserved(
+    test_case: InvocationMetadataCase,
+) -> None:
+    event: LifecycleEvent = LifecycleEvent(
+        event_id="evt-v2",
+        event_type="invocation_started",
+        schema_version=2,
+        producer="sqlbuild",
+        producer_version="0.90.0",
+        occurred_at=OCCURRED_AT,
+        invocation_id="inv-1",
+        invocation_sequence=0,
+        external_context=test_case.expected_external_context,
+        payload={"command": "build"},
+    )
+
+    encoded: str = lifecycle_event_to_json(event)
+    decoded: LifecycleEvent | OpaqueLifecycleEvent = lifecycle_event_from_json(encoded)
+
+    assert decoded == event
+    assert isinstance(decoded, LifecycleEvent)
+    assert decoded.invocation_sequence == test_case.expected_first_sequence
+    assert decoded.external_context == test_case.expected_external_context
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
         OpaqueRoundTripCase(
             description="unknown v1 event name remains opaque",
             raw={
@@ -171,14 +215,14 @@ def test_given_known_event_when_serializing_and_decoding_then_round_trips(
             raw={
                 "event_id": "future-2",
                 "event_type": "run_started",
-                "schema_version": 2,
+                "schema_version": 3,
                 "producer": {"identity": "future-producer"},
                 "future_field": None,
             },
             expected_raw={
                 "event_id": "future-2",
                 "event_type": "run_started",
-                "schema_version": 2,
+                "schema_version": 3,
                 "producer": {"identity": "future-producer"},
                 "future_field": None,
             },


### PR DESCRIPTION
## Why

Orchestrated SQLBuild executions need lifecycle facts that can be correlated directly to their scheduler run and replayed deterministically. Existing lifecycle events lacked orchestration context and an invocation-local order, while command-output records already carried that context.

## Changes

- evolve lifecycle events to schema v2 with `invocation_sequence` and validated `external_context`
- retain strict schema-v1 decoding and opaque handling for unknown future schemas/events
- allocate dense, thread-safe sequence values across nested and copied execution contexts
- load invocation context once for lifecycle emission without changing human command output
- support current Dagster run/op/retry context shapes with legacy fallbacks
- add unit, history integration, and real CLI E2E coverage

## Verification

- `uv run pytest <focused observability, event-exporting, history, CLI-entry, Dagster paths> -n auto --dist loadfile` (622 passed)
- `uv run pytest tests/e2e/src/sqlbuild/cli/commands/main/providers/test_event_exporters.py -n auto --dist loadfile` (4 passed)
- `uv sync --all-extras`
- `make check-ci`
- bounded independent review and focused follow-up completed
