### PR TITLE
fix: complete audit result projection

### DIFF
--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -36,6 +36,9 @@ from sqlbuild.compiler.compile._helpers.deps.dependencies import (
     model_build_deps,
     sql_test_scope_deps,
 )
+from sqlbuild.compiler.compile._helpers.render.context_templates import (
+    resolve_early_model_templates,
+)
 from sqlbuild.compiler.compile._helpers.render.cursor_intrinsics import (
     cursor_intrinsics_analysis_sql,
     get_validated_model_cursor_intrinsics,
@@ -212,19 +215,28 @@ def assemble_compiled_project(
         validate_scope_index(index=scope_index)
     except ScopeValidationError as error:
         raise CompileInputError(str(error)) from error
+    effective_target_values: dict[str, object] = resolve_early_model_templates(
+        values={
+            "database": (
+                (inputs.effective_target.database if inputs.effective_target is not None else None)
+                or _connection_database_fallback(inputs=inputs)
+            ),
+            "schema": (
+                (inputs.effective_target.schema if inputs.effective_target is not None else None)
+                or _str_or_none(inputs.effective_connection.get("schema"))
+            ),
+        },
+        effective_vars=inputs.effective_vars,
+        effective_target_name=inputs.effective_target_name,
+        run_id=inputs.run_id,
+    )
     return CompiledProject(
         run_id=inputs.run_id,
         effective_target_name=inputs.effective_target_name,
         effective_connection=inputs.effective_connection,
         effective_vars=inputs.effective_vars,
-        effective_target_database=(
-            (inputs.effective_target.database if inputs.effective_target is not None else None)
-            or _connection_database_fallback(inputs=inputs)
-        ),
-        effective_target_schema=(
-            (inputs.effective_target.schema if inputs.effective_target is not None else None)
-            or _str_or_none(inputs.effective_connection.get("schema"))
-        ),
+        effective_target_database=_str_or_none(effective_target_values.get("database")),
+        effective_target_schema=_str_or_none(effective_target_values.get("schema")),
         compile_cache_dir=inputs.compile_cache_dir,
         settings=inputs.effective_settings,
         scenario=resolve_effective_scenario_config(

--- a/src/sqlbuild/executor/auditing/_helpers/result_projection.py
+++ b/src/sqlbuild/executor/auditing/_helpers/result_projection.py
@@ -20,6 +20,7 @@ from sqlbuild.executor.audit_results.constants import AUDIT_RESULT_SCHEMA_VERSIO
 from sqlbuild.executor.audit_results.exceptions import AuditResultStorageError
 from sqlbuild.executor.audit_results.main._write import write_audit_result_records
 from sqlbuild.executor.audit_results.models import AuditResultRecord, build_audit_result_id
+from sqlbuild.executor.auditing.exceptions import AuditResultProjectionError
 from sqlbuild.executor.auditing.models import AuditExecutionResult, AuditResultProjection
 from sqlbuild.runtime.observability.classes.operation_lifecycle import OperationLifecycle
 from sqlbuild.runtime.observability.main.current_execution_identity import (
@@ -145,10 +146,9 @@ def _build_records(
             None,
         )
         if entry is None:
-            _LOGGER.warning(
-                "Audit result projection skipped unknown audit result '%s'", result.audit_name
+            raise AuditResultProjectionError(
+                f"audit result '{result.audit_name}' does not match a planned audit entry"
             )
-            continue
         audit_id: AuditIdentity = build_audit_gate_identity(audits=(entry,)).audits[0]
         occurrence_key: tuple[str, str] = (audit_id.binding_key, result.run_scope_phase.value)
         ordinal: int = occurrence[occurrence_key]

--- a/src/sqlbuild/executor/auditing/exceptions.py
+++ b/src/sqlbuild/executor/auditing/exceptions.py
@@ -3,3 +3,7 @@
 
 class AuditMeasurementExecutionError(Exception):
     """Raised when an internally validated measurement contract is unavailable."""
+
+
+class AuditResultProjectionError(Exception):
+    """Raised when executed audit results cannot be projected consistently."""

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
@@ -412,6 +412,8 @@ def test_given_snowflake_local_target_namespace_when_compiling_then_targets_reso
 
     assert project.models[0].destination.database == test_case.expected_database
     assert project.models[0].destination.schema == test_case.expected_schema
+    assert project.effective_target_database == test_case.expected_database
+    assert project.effective_target_schema == test_case.expected_schema
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/executor/auditing/main/test_project_results.py
+++ b/tests/unit/src/sqlbuild/executor/auditing/main/test_project_results.py
@@ -220,6 +220,47 @@ def test_given_record_build_failure_when_projected_then_reports_degradation_with
 
 @pytest.mark.parametrize(
     "test_case",
+    [AuditExecutionCase("unmatched result batch", AuditOutcome.WARN)],
+    ids=lambda case: case.description,
+)
+def test_given_one_unmatched_result_when_projecting_batch_then_publishes_no_partial_batch(
+    test_case: AuditExecutionCase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writer_calls: list[object] = []
+    monkeypatch.setattr(
+        projection_module,
+        "write_audit_result_records",
+        lambda **kwargs: writer_calls.append(kwargs),
+    )
+    dispatcher: EventDispatcher = EventDispatcher()
+    events: list[LifecycleEvent] = []
+    dispatcher.subscribe_lifecycle(subscriber=events.append, accepts_opaque=False)
+
+    with (
+        identity_scope(ExecutionIdentity(invocation_id="invocation", run_id="run")),
+        dispatcher_scope(dispatcher),
+    ):
+        projection: Any = project_audit_result_batch(
+            plan=PlanOutput(audit_entries=(build_projection_entry(),)),
+            results=(
+                build_projection_result(),
+                replace(build_projection_result(), audit_name="unplanned_audit"),
+            ),
+            adapter=cast(Any, object()),
+            connection=object(),
+            storage_schema="analytics",
+        )
+
+    assert projection.attempted_count == 2
+    assert projection.failed_count == 2
+    assert events == []
+    assert writer_calls == []
+    assert build_projection_result().outcome == test_case.expected_outcome
+
+
+@pytest.mark.parametrize(
+    "test_case",
     [AuditExecutionCase("lifecycle validation failure", AuditOutcome.WARN)],
     ids=lambda case: case.description,
 )


### PR DESCRIPTION
## Why
A Snowflake audit-result persistence statement received an unresolved `${ENV:...}` target schema, and projection could silently omit unmatched executed results before lifecycle publication. This left downstream consumers with a partial successful-looking run.

## Changes
- Resolve effective target database and schema templates during compiled-project assembly.
- Treat an unmatched executed audit result as whole-projection degradation before publishing any `audit_completed` events.
- Add focused compiler integration and projection regression coverage.

## Verification
- `uv run pytest tests/unit/src/sqlbuild/executor/auditing/main/test_project_results.py tests/integration/src/sqlbuild/compiler/pipeline/test_main.py -n auto --dist loadfile` (21 passed)
- `uv sync --all-extras`
- `make check-ci`
