### PR TITLE
fix: report contract command progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,23 @@
   explicitly requests it; rely on CI for those suites.
 - Before pushing, run the exact static CI target with all optional dependencies available: `uv sync --all-extras` followed by `make check-ci`.
 
+## Command-Line User Experience
+
+- Keep lifecycle feedback consistent across commands. Potentially slow discovery, connection,
+  inspection, planning, and execution phases must emit a concise start message and an explicit
+  success or failure completion message; do not leave users watching a blank terminal with no
+  indication that work is active.
+- Preserve machine-readable stdout. When JSON or another machine-output mode is active, send
+  lifecycle progress to stderr so redirected output remains valid while interactive users still see
+  meaningful progress.
+- Prefer a few meaningful phase transitions over noisy per-resource narration. Long-running TTY
+  phases should use the shared transient progress facilities where practical.
+- Maintenance notices and unrelated warnings must not be the final visible output of an otherwise
+  successful command. Report them before command execution or ensure the command still prints an
+  unambiguous terminal success state afterward.
+- Use `sqb debug` as the first diagnostic when distinguishing authentication, connection,
+  configuration, and command-specific failures.
+
 ## Subagent Verification
 
 - The primary agent owns the overall verification plan. Do not ask multiple subagents to run the same broad test suites.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sqlbuild-kata-native"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "fensu-policy",
  "globset",

--- a/src/sqlbuild/cli/commands/_helpers/contract/__init__.py
+++ b/src/sqlbuild/cli/commands/_helpers/contract/__init__.py
@@ -1,0 +1,1 @@
+"""Contract command helpers."""

--- a/src/sqlbuild/cli/commands/_helpers/contract/progress.py
+++ b/src/sqlbuild/cli/commands/_helpers/contract/progress.py
@@ -1,0 +1,128 @@
+"""Lifecycle progress for contract inspection and repository updates."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, TextIO
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.cli.commands.models import AdapterConnectionContext, ContractCommandRequest
+from sqlbuild.cli.progress.classes.connection_progress_reporter import (
+    ConnectionProgressReporter,
+)
+from sqlbuild.compiler.compile.models import CompiledModel, CompiledSource
+from sqlbuild.compiler.contract_adoption.main.compare import compare_contracts
+from sqlbuild.compiler.contract_adoption.models import ContractAdoptionResult, ContractEvidence
+from sqlbuild.compiler.pipeline.models import ProjectGraph
+from sqlbuild.presentation.classes.transient_status_reporter import TransientStatusReporter
+
+
+def inspect_contracts_with_progress(
+    *,
+    context: AdapterConnectionContext,
+    request: ContractCommandRequest,
+    selected_models: tuple[CompiledModel, ...],
+    selected_sources: tuple[CompiledSource, ...],
+    progress_stream: TextIO,
+    use_progress_color: bool,
+) -> tuple[ContractEvidence, ...]:
+    """Connect once and report contract inspection lifecycle progress."""
+
+    connection_progress: ConnectionProgressReporter = ConnectionProgressReporter(
+        adapter_name=context.adapter_name,
+        stream=progress_stream,
+        use_color=use_progress_color,
+    )
+    connection_started: float = time.monotonic()
+    connection_progress.on_connection_start(1)
+    try:
+        connection: Any = context.adapter.connect(context.connection_config)
+    except Exception:
+        connection_progress.on_connection_error(
+            connection_count=1,
+            elapsed_seconds=time.monotonic() - connection_started,
+        )
+        raise
+    try:
+        connection_progress.on_connection_complete(
+            connection_count=1,
+            elapsed_seconds=time.monotonic() - connection_started,
+        )
+
+        resource_count: int = len(selected_models) + len(selected_sources)
+        resource_label: str = "contract" if resource_count == 1 else "contracts"
+        inspection_progress: TransientStatusReporter = TransientStatusReporter(
+            stream=progress_stream,
+            use_color=use_progress_color,
+        )
+        inspection_started: float = time.monotonic()
+        inspection_progress.start(
+            f"Inspecting {resource_count} {resource_label} from target '{request.from_target}'..."
+        )
+        try:
+            evidence: tuple[ContractEvidence, ...] = compare_contracts(
+                adapter=context.adapter,
+                connection=connection,
+                models=selected_models,
+                sources=selected_sources,
+            )
+        except Exception:
+            inspection_progress.error(
+                f"Contract inspection failed after {time.monotonic() - inspection_started:.2f}s"
+            )
+            raise
+        inspection_progress.complete(
+            message=(
+                f"Inspected {resource_count} {resource_label} from target "
+                f"'{request.from_target}' ({time.monotonic() - inspection_started:.2f}s)"
+            )
+        )
+    finally:
+        context.adapter.close(connection)
+    return evidence
+
+
+def write_contract_updates_with_progress(
+    *,
+    project_dir: Path,
+    graph: ProjectGraph,
+    result: ContractAdoptionResult,
+    request: ContractCommandRequest,
+    adapter: BaseAdapter,
+    progress_stream: TextIO,
+    use_progress_color: bool,
+) -> ContractAdoptionResult:
+    """Write contract declarations and report repository-update lifecycle progress."""
+
+    from sqlbuild.compiler.contract_adoption.main.write import write_contracts
+
+    write_progress: TransientStatusReporter = TransientStatusReporter(
+        stream=progress_stream,
+        use_color=use_progress_color,
+    )
+    write_started: float = time.monotonic()
+    write_progress.start("Updating repository contracts...")
+    try:
+        updated_result: ContractAdoptionResult = write_contracts(
+            project_dir=project_dir,
+            graph=graph,
+            result=result,
+            overwrite=request.overwrite,
+            adapter=adapter,
+            cli_vars=request.cli_vars,
+        )
+    except Exception:
+        write_progress.error(
+            f"Repository contract update failed after {time.monotonic() - write_started:.2f}s"
+        )
+        raise
+    written_count: int = len(updated_result.written_paths)
+    written_label: str = "file" if written_count == 1 else "files"
+    write_progress.complete(
+        message=(
+            f"Updated repository contracts ({written_count} {written_label}, "
+            f"{time.monotonic() - write_started:.2f}s)"
+        )
+    )
+    return updated_result

--- a/src/sqlbuild/cli/commands/_helpers/entry/dispatch_errors.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/dispatch_errors.py
@@ -34,6 +34,7 @@ def dispatch_and_handle_errors(
 ) -> int:
     """Dispatch once and preserve the CLI's established error projection."""
 
+    _report_skill_freshness(invocation=invocation)
     try:
         return dispatch_with_observability(args=args, handlers=handlers)
     except SystemExit as error:
@@ -65,8 +66,6 @@ def dispatch_and_handle_errors(
             file=sys.stderr,
         )
         return 1
-    finally:
-        _report_skill_freshness(invocation=invocation)
 
 
 def _report_skill_freshness(*, invocation: ParsedCliInvocation) -> None:
@@ -80,7 +79,7 @@ def _report_skill_freshness(*, invocation: ParsedCliInvocation) -> None:
     project_dir: Path = Path(args.project_dir) if args.project_dir is not None else Path.cwd()
     try:
         result: SkillMaintenanceResult = maintain_sqlbuild_skills(project_dir=project_dir)
-    except (CliUserError, OSError):
+    except (CliUserError, OSError, UnicodeError):
         return
     if result.message:
         print(result.message, file=sys.stderr, end="")

--- a/src/sqlbuild/cli/commands/_helpers/skills/update.py
+++ b/src/sqlbuild/cli/commands/_helpers/skills/update.py
@@ -186,7 +186,7 @@ def maintain_sqlbuild_skills(*, project_dir: Path) -> SkillMaintenanceResult:
     if settings.auto_update and stale_paths:
         for path in stale_paths:
             write_skill_file(path=path, content=expected_content)
-        message: str = "\nUpdated stale SQLBuild skill files:\n" + "".join(
+        message: str = "Updated stale SQLBuild skill files:\n" + "".join(
             f"  {path}\n" for path in stale_paths
         )
         if collision_paths:
@@ -203,7 +203,7 @@ def _stale_skill_message(*, collision_paths: list[Path]) -> str:
         collision_detail = "  Custom files were not overwritten:\n" + "".join(
             f"    {path}\n" for path in collision_paths
         )
-    return f"\nSQLBuild skill files are out of date\n{collision_detail}  Run: sqb skills\n"
+    return f"SQLBuild skill files are out of date\n{collision_detail}  Run: sqb skills\n"
 
 
 def _local_install_path(*, project_dir: Path, target_name: str) -> Path:

--- a/src/sqlbuild/cli/commands/main/inspection/_contract.py
+++ b/src/sqlbuild/cli/commands/main/inspection/_contract.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
-from typing import Any
+from typing import TextIO
 
+from sqlbuild.cli.commands._helpers.contract.progress import (
+    inspect_contracts_with_progress,
+    write_contract_updates_with_progress,
+)
 from sqlbuild.cli.commands._helpers.runtime.adapter_context import (
     resolve_adapter_connection_context,
 )
 from sqlbuild.cli.commands.exceptions import CliUserError
 from sqlbuild.cli.commands.models import AdapterConnectionContext, ContractCommandRequest
 from sqlbuild.compiler.compile.models import CompiledModel, CompiledObjectKey, CompiledSource
-from sqlbuild.compiler.contract_adoption.main.compare import compare_contracts
 from sqlbuild.compiler.contract_adoption.models import ContractAdoptionResult, ContractEvidence
 from sqlbuild.compiler.contract_adoption.types import ContractAction
 from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
@@ -22,6 +26,7 @@ from sqlbuild.compiler.pipeline.models import ProjectGraph
 from sqlbuild.compiler.planner.main.selection.selection import (
     resolve_project_selectors,
 )
+from sqlbuild.presentation.main.supports_color import supports_color
 
 
 def run_contract(request: ContractCommandRequest) -> int:
@@ -66,29 +71,29 @@ def run_contract(request: ContractCommandRequest) -> int:
     )
     if not selected_models and not selected_sources:
         raise CliUserError("contract selection contains no models or sources", code="C473")
-    connection: Any = context.adapter.connect(context.connection_config)
-    try:
-        evidence: tuple[ContractEvidence, ...] = compare_contracts(
-            adapter=context.adapter,
-            connection=connection,
-            models=selected_models,
-            sources=selected_sources,
-        )
-    finally:
-        context.adapter.close(connection)
+
+    progress_stream: TextIO = sys.stderr if request.json_output else sys.stdout
+    use_progress_color: bool = not request.no_color and not request.json_output and supports_color()
+    evidence: tuple[ContractEvidence, ...] = inspect_contracts_with_progress(
+        context=context,
+        request=request,
+        selected_models=selected_models,
+        selected_sources=selected_sources,
+        progress_stream=progress_stream,
+        use_progress_color=use_progress_color,
+    )
     result: ContractAdoptionResult = ContractAdoptionResult(
         from_target=request.from_target, evidence=evidence
     )
     if request.action == ContractAction.GENERATE and request.write:
-        from sqlbuild.compiler.contract_adoption.main.write import write_contracts
-
-        result = write_contracts(
+        result = write_contract_updates_with_progress(
             project_dir=project_dir,
             graph=graph,
             result=result,
-            overwrite=request.overwrite,
+            request=request,
             adapter=context.adapter,
-            cli_vars=request.cli_vars,
+            progress_stream=progress_stream,
+            use_progress_color=use_progress_color,
         )
     _write_output(request=request, result=result)
     return 1 if result.findings else 0

--- a/tests/integration/src/sqlbuild/cli/commands/main/test_contract_command.py
+++ b/tests/integration/src/sqlbuild/cli/commands/main/test_contract_command.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import duckdb
 import pytest
+from _pytest.capture import CaptureResult
 
 from sqlbuild.cli.commands.main.entrypoint.entry import main
 from tests.integration.src.sqlbuild.cli.commands.main._test_types import (
@@ -320,11 +321,16 @@ def test_given_prod_target_credentials_when_contract_diffing_then_uses_active_co
         ]
     )
 
-    payload: dict[str, object] = json.loads(capsys.readouterr().out)
+    captured: CaptureResult[str] = capsys.readouterr()
+    payload: dict[str, object] = json.loads(captured.out)
     assert exit_code == test_case.expected_exit_code
     assert payload["from_target"] == "prod"
     assert payload["resources"][0]["relation"].endswith("prod.orders")
     assert all("connection" not in key for key in payload)
+    assert "Connecting to duckdb..." in captured.err
+    assert "Warehouse connected" in captured.err
+    assert "Inspecting 1 contract from target 'prod'..." in captured.err
+    assert "Inspected 1 contract from target 'prod'" in captured.err
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
+++ b/tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -1888,7 +1889,7 @@ def test_given_skills_command_when_running_then_it_dispatches_handler(
     ],
     ids=lambda case: case.description,
 )
-def test_given_stale_configured_skills_when_command_finishes_then_notice_preserves_exit_code(
+def test_given_stale_configured_skills_when_command_starts_then_notice_precedes_command_output(
     test_case: SkillFreshnessNoticeTestCase,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -1898,13 +1899,20 @@ def test_given_stale_configured_skills_when_command_finishes_then_notice_preserv
         encoding="utf-8",
     )
 
+    def run_compile(_request: CompileCommandRequest) -> int:
+        print("command completed", file=sys.stderr)
+        return test_case.expected_exit_code
+
     exit_code: int = _main_with_dependencies(
         argv=["--project-dir", str(tmp_path), "compile"],
-        handlers=build_handlers(run_compile=lambda _request: test_case.expected_exit_code),
+        handlers=build_handlers(run_compile=run_compile),
     )
 
     assert exit_code == test_case.expected_exit_code
-    assert test_case.expected_stderr_fragment in capsys.readouterr().err
+    stderr: str = capsys.readouterr().err
+    assert test_case.expected_stderr_fragment in stderr
+    assert stderr.index(test_case.expected_stderr_fragment) < stderr.index("command completed")
+    assert stderr.rstrip().endswith("command completed")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

`sqb contract diff --json` could spend a long time connecting and inspecting warehouse schemas without visible lifecycle feedback because stdout was redirected to JSON. A stale-skills notice then appeared last, making successful runs look stalled or failed. Authentication diagnosis also lacked a documented `sqb debug` first step.

## Changes

- Report warehouse connection and contract inspection start, success, and failure states.
- Report repository-update lifecycle for `contract generate --write`.
- Route progress to stderr for JSON and disable color for machine output or unsupported terminals.
- Show stale-skill maintenance notices before command execution instead of after completion.
- Add repository CLI UX guidance, including using `sqb debug` first for auth and connection diagnosis.
- Synchronize the native crate lock entry with version `0.91.2`.

## Verification

- `uv run pytest tests/integration/src/sqlbuild/cli/commands/main/test_contract_command.py tests/unit/src/sqlbuild/cli/commands/main/entry/test_main.py tests/unit/src/sqlbuild/cli/commands/main/skills/test_skills.py -n auto --dist loadfile` (133 passed)
- `uv sync --all-extras`
- `make check-ci`
- Independent bounded review and focused follow-up: no remaining findings
