### PR TITLE
fix: quote enforced source identifiers

### DIFF
--- a/src/sqlbuild/adapter/contract/classes/base_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/base_adapter.py
@@ -1907,7 +1907,7 @@ class BaseAdapter(RetentionAdapterMixin, StrictAdapter):
         cast_clause: str = ", ".join(cast_projections)
         if all_columns_cast:
             return f"(SELECT {cast_clause} FROM {source_relation})"
-        exclude_list: str = ", ".join(cast_column_names)
+        exclude_list: str = ", ".join(self.render_identifier(name) for name in cast_column_names)
         return (
             f"(SELECT * {self.star_exclude_keyword()} ({exclude_list}), {cast_clause} "
             f"FROM {source_relation})"

--- a/src/sqlbuild/adapter/contract/classes/duckdb_backed_adapter.py
+++ b/src/sqlbuild/adapter/contract/classes/duckdb_backed_adapter.py
@@ -882,7 +882,7 @@ class DuckDbBackedAdapter(BaseAdapter):
         cast_clause: str = ", ".join(cast_projections)
         if all_columns_cast:
             return f"(SELECT {cast_clause} FROM {source_relation})"
-        exclude_list: str = ", ".join(cast_column_names)
+        exclude_list: str = ", ".join(self.render_identifier(name) for name in cast_column_names)
         return f"(SELECT * EXCLUDE ({exclude_list}), {cast_clause} FROM {source_relation})"
 
     def requires_derived_table_aliases(self) -> bool:

--- a/src/sqlbuild/adapters/bigquery/classes/bigquery_adapter.py
+++ b/src/sqlbuild/adapters/bigquery/classes/bigquery_adapter.py
@@ -1573,7 +1573,7 @@ class BigQueryAdapter(MicrobatchMixin, BaseAdapter):
         cast_clause: str = ", ".join(cast_projections)
         if all_columns_cast:
             return f"(SELECT {cast_clause} FROM {source_relation})"
-        exclude_list: str = ", ".join(cast_column_names)
+        exclude_list: str = ", ".join(self.render_identifier(name) for name in cast_column_names)
         return f"(SELECT * EXCEPT ({exclude_list}), {cast_clause} FROM {source_relation})"
 
     def requires_derived_table_aliases(self) -> bool:

--- a/src/sqlbuild/adapters/databricks/classes/databricks_adapter.py
+++ b/src/sqlbuild/adapters/databricks/classes/databricks_adapter.py
@@ -1576,7 +1576,7 @@ class DatabricksAdapter(MicrobatchMixin, BaseAdapter):
         cast_clause: str = ", ".join(cast_projections)
         if all_columns_cast:
             return f"(SELECT {cast_clause} FROM {source_relation})"
-        exclude_list: str = ", ".join(cast_column_names)
+        exclude_list: str = ", ".join(self.render_identifier(name) for name in cast_column_names)
         return f"(SELECT * EXCEPT ({exclude_list}), {cast_clause} FROM {source_relation})"
 
     def requires_derived_table_aliases(self) -> bool:

--- a/src/sqlbuild/adapters/motherduck/classes/motherduck_adapter.py
+++ b/src/sqlbuild/adapters/motherduck/classes/motherduck_adapter.py
@@ -142,7 +142,7 @@ class MotherDuckAdapter(MicrobatchMixin, DuckDbBackedAdapter):
         cast_clause: str = ", ".join(cast_projections)
         if all_columns_cast:
             return f"(SELECT {cast_clause} FROM {source_relation})"
-        exclude_list: str = ", ".join(cast_column_names)
+        exclude_list: str = ", ".join(self.render_identifier(name) for name in cast_column_names)
         return f"(SELECT * EXCLUDE ({exclude_list}), {cast_clause} FROM {source_relation})"
 
     def connect(self, config: dict[str, Any]) -> Any:

--- a/src/sqlbuild/adapters/postgres/classes/postgres_adapter.py
+++ b/src/sqlbuild/adapters/postgres/classes/postgres_adapter.py
@@ -1789,7 +1789,7 @@ class PostgresAdapter(MicrobatchMixin, BaseAdapter):
         cast_clause: str = ", ".join(cast_projections)
         if all_columns_cast:
             return f"(SELECT {cast_clause} FROM {source_relation})"
-        exclude_list: str = ", ".join(cast_column_names)
+        exclude_list: str = ", ".join(self.render_identifier(name) for name in cast_column_names)
         return f"(SELECT * EXCLUDE ({exclude_list}), {cast_clause} FROM {source_relation})"
 
     def _render_source_relation_cast_subquery_with_columns(
@@ -1810,7 +1810,9 @@ class PostgresAdapter(MicrobatchMixin, BaseAdapter):
         passthrough_columns: tuple[str, ...] = tuple(
             column for column in warehouse_column_names if column not in projection_names
         )
-        passthrough_clause: str = ", ".join(passthrough_columns)
+        passthrough_clause: str = ", ".join(
+            self.render_identifier(name) for name in passthrough_columns
+        )
         projection_clause: str = cast_clause
         if passthrough_clause:
             projection_clause = f"{passthrough_clause}, {cast_clause}"

--- a/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
+++ b/src/sqlbuild/adapters/snowflake/classes/snowflake_adapter.py
@@ -2103,7 +2103,7 @@ class SnowflakeAdapter(MicrobatchMixin, BaseAdapter):
         cast_clause: str = ", ".join(cast_projections)
         if all_columns_cast:
             return f"(SELECT {cast_clause} FROM {source_relation})"
-        exclude_list: str = ", ".join(cast_column_names)
+        exclude_list: str = ", ".join(self.render_identifier(name) for name in cast_column_names)
         return f"(SELECT * EXCLUDE ({exclude_list}), {cast_clause} FROM {source_relation})"
 
     def requires_derived_table_aliases(self) -> bool:

--- a/src/sqlbuild/adapters/sqlserver/classes/sqlserver_adapter.py
+++ b/src/sqlbuild/adapters/sqlserver/classes/sqlserver_adapter.py
@@ -2495,7 +2495,9 @@ class SqlServerAdapter(MicrobatchMixin, BaseAdapter):
         passthrough_columns: tuple[str, ...] = tuple(
             column for column in warehouse_column_names if column not in projection_names
         )
-        passthrough_clause: str = ", ".join(passthrough_columns)
+        passthrough_clause: str = ", ".join(
+            self.render_identifier(name) for name in passthrough_columns
+        )
         projection_clause: str = cast_clause
         if passthrough_clause:
             projection_clause = f"{passthrough_clause}, {cast_clause}"

--- a/src/sqlbuild/cli/output/_helpers/execution_result_document.py
+++ b/src/sqlbuild/cli/output/_helpers/execution_result_document.py
@@ -10,6 +10,8 @@ from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import cast
 
+from sqlbuild.adapter.contract.models import LifeCycleEvent as StatementLifeCycleEvent
+from sqlbuild.adapter.contract.types import LifeCycleEventKind
 from sqlbuild.cli.output._helpers.future_cursor_safety import serialize_future_cursor_safety
 from sqlbuild.cli.output._helpers.integration_result import _render_measurement_thresholds
 from sqlbuild.cli.output._helpers.maximum_start_safety import serialize_maximum_start_safety
@@ -653,6 +655,11 @@ def _format_model_assets(
                 "error_code": result.error_code,
                 "error_help": result.error_help,
                 "error_message": result.error_message,
+                "last_recorded_sql": (
+                    _last_recorded_sql(result.lifecycle_events)
+                    if result.status == ExecutionStatus.FAILED
+                    else None
+                ),
                 "warnings": result.warning_messages,
                 "future_cursor_safety": serialize_future_cursor_safety(result.future_cursor_safety),
                 "maximum_start_safety": serialize_maximum_start_safety(result.maximum_start_safety),
@@ -662,6 +669,14 @@ def _format_model_assets(
         for result in results
         if _result_has_terminal(result=result)
     )
+
+
+def _last_recorded_sql(events: tuple[StatementLifeCycleEvent, ...]) -> str | None:
+    event: StatementLifeCycleEvent
+    for event in reversed(events):
+        if event.kind == LifeCycleEventKind.SQL:
+            return event.content
+    return None
 
 
 def _format_microbatch_result(result: ModelExecutionResult) -> dict[str, object] | None:

--- a/src/sqlbuild/compiler/planner/_helpers/resolve/sources.py
+++ b/src/sqlbuild/compiler/planner/_helpers/resolve/sources.py
@@ -275,9 +275,9 @@ def _build_relation_cast_subquery(
 
     cast_expressions: tuple[str, ...] = tuple(
         adapter.render_source_expression_cast(
-            expression=name,
+            expression=adapter.render_identifier(name),
             target_type=enforced_map[name],
-            alias=name,
+            alias=adapter.render_identifier(name),
         )
         for name in cast_names
     )
@@ -398,16 +398,16 @@ def _build_expression_source_projections(
     for name in expression_names:
         enforced_entry: tuple[str, str] | None = enforced_by_expression_name.get(name)
         if enforced_entry is None:
-            projections.append(name)
+            projections.append(adapter.render_identifier(name))
             continue
         declared_name: str
         column_type: str
         declared_name, column_type = enforced_entry
         projections.append(
             adapter.render_source_expression_cast(
-                expression=name,
+                expression=adapter.render_identifier(name),
                 target_type=column_type,
-                alias=declared_name,
+                alias=adapter.render_identifier(declared_name),
             )
         )
     return projections

--- a/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
+++ b/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import textwrap
 import time
 from collections.abc import Iterator, Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -73,6 +74,10 @@ def _format_asset_failure(asset: Mapping[str, Any]) -> str:
     staging_relation: object = asset.get("staging_relation")
     if staging_relation is not None:
         lines.append(f"  staging relation: {staging_relation}")
+    last_recorded_sql: object = asset.get("last_recorded_sql")
+    if isinstance(last_recorded_sql, str) and last_recorded_sql:
+        lines.append("  last recorded SQL:")
+        lines.append(textwrap.indent(last_recorded_sql, "    "))
     return "\n".join(lines)
 
 

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_expression_sources.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_expression_sources.py
@@ -44,9 +44,9 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
                       - name: raw_orders
                         expression: |
                           SELECT * FROM (VALUES
-                            (1, '1', '2026-01-01 00:30:00', 100),
-                            (2, '2', '2026-01-01 01:30:00', 200)
-                          ) AS orders(order_id, customer_id, ordered_at, amount_cents)
+                            (1, '1', '2026-01-01 00:30:00', 100, 'web'),
+                            (2, '2', '2026-01-01 01:30:00', 200, 'partner')
+                          ) AS orders(order_id, customer_id, ordered_at, amount_cents, "table")
                         type_enforcement: true
                         columns:
                           - name: order_id
@@ -57,6 +57,8 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
                             type: TIMESTAMP
                           - name: amount_cents
                             type: INTEGER
+                          - name: table
+                            type: VARCHAR
                     """
                 ).strip()
                 + "\n",
@@ -68,7 +70,8 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
                       order_id,
                       customer_id,
                       ordered_at,
-                      amount_cents
+                      amount_cents,
+                      "table"
                     FROM __source("raw_orders")
                     """
                 ).strip()
@@ -80,14 +83,15 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
             expected_query_results=(
                 (
                     (
-                        "SELECT order_id, customer_id, amount_cents "
+                        'SELECT order_id, customer_id, amount_cents, "table" '
                         "FROM main.fact_orders ORDER BY order_id"
                     ),
-                    ((1, 1, 100), (2, 2, 200)),
+                    ((1, 1, 100, "web"), (2, 2, 200, "partner")),
                 ),
             ),
             expected_runtime_fragments=(
-                "CAST(customer_id AS INTEGER) AS customer_id",
+                'CAST("customer_id" AS INTEGER) AS "customer_id"',
+                'CAST("table" AS VARCHAR) AS "table"',
                 "FROM (SELECT * FROM (VALUES",
             ),
         )

--- a/tests/unit/src/sqlbuild/adapter/contract/test_loader_types.py
+++ b/tests/unit/src/sqlbuild/adapter/contract/test_loader_types.py
@@ -312,7 +312,7 @@ def test_given_adapter_when_rendering_empty_loader_rows_then_returns_expected_sq
                 "(SELECT CAST(id AS INTEGER) AS id FROM (SELECT 1 AS id) AS __source_expression)"
             ),
             expected_relation_cast_subquery=(
-                "(SELECT * EXCLUDE (id), CAST(id AS INTEGER) AS id FROM raw.orders)"
+                '(SELECT * EXCLUDE ("id"), CAST(id AS INTEGER) AS id FROM raw.orders)'
             ),
         ),
         AdapterSourceExpressionRenderingTestCase(
@@ -323,7 +323,7 @@ def test_given_adapter_when_rendering_empty_loader_rows_then_returns_expected_sq
                 "(SELECT CAST(id AS INTEGER) AS id FROM (SELECT 1 AS id) AS __source_expression)"
             ),
             expected_relation_cast_subquery=(
-                "(SELECT * EXCLUDE (id), CAST(id AS INTEGER) AS id FROM raw.orders)"
+                '(SELECT * EXCLUDE ("id"), CAST(id AS INTEGER) AS id FROM raw.orders)'
             ),
         ),
         AdapterSourceExpressionRenderingTestCase(
@@ -334,7 +334,7 @@ def test_given_adapter_when_rendering_empty_loader_rows_then_returns_expected_sq
                 "(SELECT CAST(id AS INTEGER) AS id FROM (SELECT 1 AS id) AS __source_expression)"
             ),
             expected_relation_cast_subquery=(
-                "(SELECT * EXCLUDE (id), CAST(id AS INTEGER) AS id FROM raw.orders)"
+                '(SELECT * EXCLUDE ("id"), CAST(id AS INTEGER) AS id FROM raw.orders)'
             ),
         ),
         AdapterSourceExpressionRenderingTestCase(
@@ -345,7 +345,7 @@ def test_given_adapter_when_rendering_empty_loader_rows_then_returns_expected_sq
                 "(SELECT CAST(id AS INTEGER) AS id FROM (SELECT 1 AS id) AS __source_expression)"
             ),
             expected_relation_cast_subquery=(
-                "(SELECT * EXCLUDE (id), CAST(id AS INTEGER) AS id FROM raw.orders)"
+                '(SELECT * EXCLUDE ("ID"), CAST(id AS INTEGER) AS id FROM raw.orders)'
             ),
         ),
         AdapterSourceExpressionRenderingTestCase(
@@ -356,7 +356,7 @@ def test_given_adapter_when_rendering_empty_loader_rows_then_returns_expected_sq
                 "(SELECT CAST(id AS INTEGER) AS id FROM (SELECT 1 AS id) AS __source_expression)"
             ),
             expected_relation_cast_subquery=(
-                "(SELECT * EXCEPT (id), CAST(id AS INTEGER) AS id FROM raw.orders)"
+                "(SELECT * EXCEPT (`id`), CAST(id AS INTEGER) AS id FROM raw.orders)"
             ),
         ),
         AdapterSourceExpressionRenderingTestCase(
@@ -367,7 +367,7 @@ def test_given_adapter_when_rendering_empty_loader_rows_then_returns_expected_sq
                 "(SELECT CAST(id AS INT64) AS id FROM (SELECT 1 AS id) AS __source_expression)"
             ),
             expected_relation_cast_subquery=(
-                "(SELECT * EXCEPT (id), CAST(id AS INT64) AS id FROM raw.orders)"
+                "(SELECT * EXCEPT (`id`), CAST(id AS INT64) AS id FROM raw.orders)"
             ),
         ),
     ],

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
@@ -56,3 +56,9 @@ class MeasurementAuditOutputTestCase:
     outcome: AuditOutcome
     expected_status: str
     expected_passed: bool
+
+
+@dataclass(frozen=True)
+class FailedModelSqlOutputTestCase:
+    description: str
+    expected_recorded_sql: str

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_result_document.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_result_document.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from sqlbuild.adapter.contract.models import LifeCycleEvent
+from sqlbuild.adapter.contract.types import LifeCycleEventKind
 from sqlbuild.cli.commands._helpers.test.sql_progress import format_parameterized_test_label
 from sqlbuild.cli.output._helpers.execution_result_document import (
     _format_audit_checks,
@@ -39,6 +41,7 @@ from sqlbuild.executor.run.models import (
     MicrobatchAccountingInterval,
     ModelExecutionResult,
 )
+from sqlbuild.executor.run.types import ExecutionPhase
 from sqlbuild.executor.scheduling.types import ExecutionStatus
 from sqlbuild.executor.testing.models import (
     SqlTestDifferenceSample,
@@ -51,12 +54,42 @@ from sqlbuild.sql_values.models import SqlLogicalType, SqlValue
 from sqlbuild.sql_values.types import SqlValueKind
 from tests.unit.src.sqlbuild.cli.output._helpers._test_types import (
     AuditExecutionProtocolTestCase,
+    FailedModelSqlOutputTestCase,
     FutureCursorExecutionProtocolTestCase,
     MeasurementAuditOutputTestCase,
     MicrobatchExecutionProtocolTestCase,
     SqlTestCaseExecutionProtocolTestCase,
     SqlTestDifferenceOutputTestCase,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        FailedModelSqlOutputTestCase(
+            description="failed staging statement remains available to integrations",
+            expected_recorded_sql="CREATE TABLE staging_orders AS SELECT * FROM raw_orders",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_failed_model_when_formatting_json_then_last_recorded_sql_is_preserved(
+    test_case: FailedModelSqlOutputTestCase,
+) -> None:
+    result: ModelExecutionResult = ModelExecutionResult(
+        model_name="orders",
+        status=ExecutionStatus.FAILED,
+        failed_phase=ExecutionPhase.STAGING,
+        lifecycle_events=(
+            LifeCycleEvent(kind=LifeCycleEventKind.SQL, content=test_case.expected_recorded_sql),
+            LifeCycleEvent(kind=LifeCycleEventKind.LOG, content="staging failed"),
+        ),
+        error_message="syntax error",
+    )
+
+    assets: tuple[dict[str, object], ...] = _format_model_assets(results=(result,), plan=None)
+
+    assert assets[0]["last_recorded_sql"] == test_case.expected_recorded_sql
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/resolve/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/resolve/_test_types.py
@@ -102,6 +102,12 @@ class AdapterSourceResolutionTestCase:
 
 
 @dataclass(frozen=True)
+class ReservedSourceColumnTestCase:
+    description: str
+    expected_sql: str
+
+
+@dataclass(frozen=True)
 class RefResolutionTestCase:
     description: str
     query_sql: str

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/resolve/test_sources.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/resolve/test_sources.py
@@ -9,6 +9,7 @@ from sqlbuild.adapter.contract.types import CursorKind
 from sqlbuild.adapters.bigquery.classes.bigquery_adapter import BigQueryAdapter
 from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
 from sqlbuild.adapters.postgres.classes.postgres_adapter import PostgresAdapter
+from sqlbuild.adapters.snowflake.classes.snowflake_adapter import SnowflakeAdapter
 from sqlbuild.adapters.sqlserver.classes.sqlserver_adapter import SqlServerAdapter
 from sqlbuild.compiler.planner._helpers.resolve.sources import (
     resolve_source_references,
@@ -17,6 +18,7 @@ from sqlbuild.compiler.planner.models import CursorBounds
 from sqlbuild.spec.contracts.models import SourceColumnEntry, SourceEntry
 from tests.unit.src.sqlbuild.compiler.planner._helpers.resolve._test_types import (
     AdapterSourceResolutionTestCase,
+    ReservedSourceColumnTestCase,
     SourceResolutionErrorTestCase,
     SourceResolutionTestCase,
 )
@@ -134,8 +136,8 @@ _ENFORCED_WAREHOUSE_COLUMNS: dict[str, tuple[ColumnInfo, ...]] = {
                 ),
             },
             expected_sql=(
-                "SELECT * FROM (SELECT CAST(order_id AS INTEGER) AS order_id, "
-                "CAST(amount AS DECIMAL) AS amount "
+                'SELECT * FROM (SELECT CAST("order_id" AS INTEGER) AS "order_id", '
+                'CAST("amount" AS DECIMAL) AS "amount" '
                 "FROM (SELECT '1' AS order_id, 12 AS amount) AS __source_expression)"
             ),
         ),
@@ -159,8 +161,8 @@ _ENFORCED_WAREHOUSE_COLUMNS: dict[str, tuple[ColumnInfo, ...]] = {
                 ),
             },
             expected_sql=(
-                "SELECT * FROM (SELECT id, "
-                "CAST(amount_cents AS INTEGER) AS amount_cents, status "
+                'SELECT * FROM (SELECT "id", '
+                'CAST("amount_cents" AS INTEGER) AS "amount_cents", "status" '
                 "FROM (SELECT 1 AS id, '1700' AS amount_cents, 'success' AS status) "
                 "AS __source_expression)"
             ),
@@ -187,7 +189,7 @@ _ENFORCED_WAREHOUSE_COLUMNS: dict[str, tuple[ColumnInfo, ...]] = {
                 ),
             },
             expected_sql=(
-                "SELECT * FROM (SELECT CAST(ID AS INTEGER) AS id, FIRST_NAME "
+                'SELECT * FROM (SELECT CAST("ID" AS INTEGER) AS "id", "FIRST_NAME" '
                 "FROM (SELECT 1 AS id, 'Leslie' AS first_name) AS __source_expression)"
             ),
         ),
@@ -198,9 +200,9 @@ _ENFORCED_WAREHOUSE_COLUMNS: dict[str, tuple[ColumnInfo, ...]] = {
             source_map={"raw_orders": _ENFORCED_SOURCE},
             source_warehouse_columns=_ENFORCED_WAREHOUSE_COLUMNS,
             expected_sql=(
-                "SELECT * FROM (SELECT * EXCLUDE (order_id, status), "
-                "CAST(order_id AS VARCHAR) AS order_id, "
-                "CAST(status AS INTEGER) AS status "
+                'SELECT * FROM (SELECT * EXCLUDE ("order_id", "status"), '
+                'CAST("order_id" AS VARCHAR) AS "order_id", '
+                'CAST("status" AS INTEGER) AS "status" '
                 "FROM raw.public.orders)"
             ),
         ),
@@ -211,9 +213,9 @@ _ENFORCED_WAREHOUSE_COLUMNS: dict[str, tuple[ColumnInfo, ...]] = {
             source_map={"raw_orders": _ENFORCED_SOURCE},
             source_warehouse_columns=_ENFORCED_WAREHOUSE_COLUMNS,
             expected_sql=(
-                "SELECT * FROM (SELECT * EXCLUDE (order_id, status), "
-                "CAST(order_id AS VARCHAR) AS order_id, "
-                "CAST(status AS INTEGER) AS status "
+                'SELECT * FROM (SELECT * EXCLUDE ("order_id", "status"), '
+                'CAST("order_id" AS VARCHAR) AS "order_id", '
+                'CAST("status" AS INTEGER) AS "status" '
                 "FROM raw.public.orders)"
             ),
         ),
@@ -290,8 +292,8 @@ _ENFORCED_WAREHOUSE_COLUMNS: dict[str, tuple[ColumnInfo, ...]] = {
             },
             expected_sql=(
                 "SELECT * FROM (SELECT "
-                "CAST(id AS INTEGER) AS id, "
-                "CAST(name AS VARCHAR) AS name "
+                'CAST("id" AS INTEGER) AS "id", '
+                'CAST("name" AS VARCHAR) AS "name" '
                 "FROM raw.public.all_cols)"
             ),
         ),
@@ -365,8 +367,8 @@ def test_given_source_references_when_resolving_then_returns_expected_sql(
                     ColumnInfo(name="status", type=""),
                 ),
             },
-            expected_sql_fragment="CAST(amount_cents AS INT64) AS amount_cents",
-            forbidden_sql_fragment="CAST(amount_cents AS INTEGER)",
+            expected_sql_fragment="CAST(`amount_cents` AS INT64) AS `amount_cents`",
+            forbidden_sql_fragment="CAST(`amount_cents` AS INTEGER)",
         ),
         AdapterSourceResolutionTestCase(
             description="bigquery relation source casts use adapter-normalized types",
@@ -388,10 +390,10 @@ def test_given_source_references_when_resolving_then_returns_expected_sql(
                 ),
             },
             expected_sql_fragment=(
-                "CAST(first_name AS STRING) AS first_name FROM "
+                "CAST(`first_name` AS STRING) AS `first_name` FROM "
                 "`project-with-hyphens.raw_dataset.customers`"
             ),
-            forbidden_sql_fragment="CAST(first_name AS VARCHAR)",
+            forbidden_sql_fragment="CAST(`first_name` AS VARCHAR)",
         ),
     ],
     ids=lambda case: case.description,
@@ -417,6 +419,54 @@ def test_given_adapter_specific_source_references_when_resolving_then_returns_ad
 
 @pytest.mark.parametrize(
     "test_case",
+    (
+        ReservedSourceColumnTestCase(
+            description="snowflake contract projection quotes reserved source column",
+            expected_sql=(
+                'SELECT order_id FROM (SELECT CAST("ORDER_ID" AS INTEGER) AS "ORDER_ID", '
+                'CAST("TABLE" AS VARCHAR) AS "TABLE" FROM raw.public.orders)'
+            ),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_reserved_source_column_when_resolving_then_quotes_contract_projection(
+    test_case: ReservedSourceColumnTestCase,
+) -> None:
+    result: str = resolve_source_references(
+        query_sql='SELECT order_id FROM __source("raw_orders")',
+        source_map={
+            "raw_orders": SourceEntry(
+                name="raw_orders",
+                database="raw",
+                schema="public",
+                table="orders",
+                type_enforcement=True,
+                columns=(
+                    SourceColumnEntry(name="order_id", type="INTEGER"),
+                    SourceColumnEntry(name="table", type="VARCHAR"),
+                ),
+            )
+        },
+        source_warehouse_columns={
+            "raw_orders": (
+                ColumnInfo(name="order_id", type="VARCHAR"),
+                ColumnInfo(name="table", type="VARCHAR"),
+            )
+        },
+        star_exclude_keyword="EXCLUDE",
+        cursor_bounds=None,
+        cursor_filter_inputs={},
+        adapter=SnowflakeAdapter(),
+        cursor_type=None,
+        lower_bound_inclusive=True,
+    )
+
+    assert result == test_case.expected_sql
+
+
+@pytest.mark.parametrize(
+    "test_case",
     [
         SourceResolutionTestCase(
             description="adds internal alias for type-enforced source without user alias",
@@ -425,9 +475,9 @@ def test_given_adapter_specific_source_references_when_resolving_then_returns_ad
             source_map={"raw_orders": _ENFORCED_SOURCE},
             source_warehouse_columns=_ENFORCED_WAREHOUSE_COLUMNS,
             expected_sql=(
-                "SELECT * FROM (SELECT amount, "
-                "CAST(order_id AS VARCHAR) AS order_id, "
-                "CAST(status AS INTEGER) AS status "
+                "SELECT * FROM (SELECT [amount], "
+                "CAST([order_id] AS VARCHAR) AS [order_id], "
+                "CAST([status] AS INTEGER) AS [status] "
                 "FROM raw.public.orders) AS __sqb_source_raw_orders WHERE status = 1"
             ),
         ),
@@ -438,9 +488,9 @@ def test_given_adapter_specific_source_references_when_resolving_then_returns_ad
             source_map={"raw_orders": _ENFORCED_SOURCE},
             source_warehouse_columns=_ENFORCED_WAREHOUSE_COLUMNS,
             expected_sql=(
-                "SELECT o.order_id FROM (SELECT amount, "
-                "CAST(order_id AS VARCHAR) AS order_id, "
-                "CAST(status AS INTEGER) AS status "
+                "SELECT o.order_id FROM (SELECT [amount], "
+                "CAST([order_id] AS VARCHAR) AS [order_id], "
+                "CAST([status] AS INTEGER) AS [status] "
                 "FROM raw.public.orders) AS o WHERE o.status = 1"
             ),
         ),
@@ -451,9 +501,9 @@ def test_given_adapter_specific_source_references_when_resolving_then_returns_ad
             source_map={"raw_orders": _ENFORCED_SOURCE},
             source_warehouse_columns=_ENFORCED_WAREHOUSE_COLUMNS,
             expected_sql=(
-                "SELECT o.order_id FROM (SELECT amount, "
-                "CAST(order_id AS VARCHAR) AS order_id, "
-                "CAST(status AS INTEGER) AS status "
+                "SELECT o.order_id FROM (SELECT [amount], "
+                "CAST([order_id] AS VARCHAR) AS [order_id], "
+                "CAST([status] AS INTEGER) AS [status] "
                 "FROM raw.public.orders) AS o WHERE o.status = 1"
             ),
         ),
@@ -483,10 +533,10 @@ def test_given_adapter_specific_source_references_when_resolving_then_returns_ad
                 ),
             },
             expected_sql=(
-                "SELECT o.order_id, c.customer_id FROM (SELECT amount, "
-                "CAST(order_id AS VARCHAR) AS order_id, "
-                "CAST(status AS INTEGER) AS status FROM raw.public.orders) AS o "
-                "JOIN (SELECT email, CAST(customer_id AS INTEGER) AS customer_id "
+                "SELECT o.order_id, c.customer_id FROM (SELECT [amount], "
+                "CAST([order_id] AS VARCHAR) AS [order_id], "
+                "CAST([status] AS INTEGER) AS [status] FROM raw.public.orders) AS o "
+                "JOIN (SELECT [email], CAST([customer_id] AS INTEGER) AS [customer_id] "
                 "FROM raw.public.customers) AS c ON o.customer_id = c.customer_id"
             ),
         ),
@@ -565,9 +615,9 @@ def test_given_sqlserver_timestamp_bounds_when_resolving_then_uses_datetime2_lit
             source_map={"raw_orders": _ENFORCED_SOURCE},
             source_warehouse_columns=_ENFORCED_WAREHOUSE_COLUMNS,
             expected_sql=(
-                "SELECT order_id, status, amount FROM (SELECT amount, "
-                "CAST(order_id AS VARCHAR) AS order_id, "
-                "CAST(status AS INTEGER) AS status "
+                'SELECT order_id, status, amount FROM (SELECT "amount", '
+                'CAST("order_id" AS VARCHAR) AS "order_id", '
+                'CAST("status" AS INTEGER) AS "status" '
                 "FROM raw.public.orders)"
             ),
         ),

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
@@ -1604,7 +1604,9 @@ def test_given_blocked_command_when_live_stream_closes_then_subprocess_terminate
                 '{"kind": "model", "name": "customers", '
                 '"status": "failed", "action": "failed", "failed_phase": "staging", '
                 '"error_code": "R002", "error_message": "invalid identifier CUSTOMER_ID", '
-                '"staging_relation": "analytics.customers__staging"}], "checks": []}'
+                '"staging_relation": "analytics.customers__staging", '
+                '"last_recorded_sql": "CREATE TABLE customers AS SELECT customer_id FROM raw.customers"}], '
+                '"checks": []}'
             ),
             expected_materialized_asset_key=("analytics", "orders"),
             expected_incomplete_assets="model:customers (failed)",
@@ -1612,6 +1614,7 @@ def test_given_blocked_command_when_live_stream_closes_then_subprocess_terminate
                 "model:customers (failed) during staging",
                 "[R002] invalid identifier CUSTOMER_ID",
                 "staging relation: analytics.customers__staging",
+                "last recorded SQL:\n    CREATE TABLE customers AS SELECT customer_id FROM raw.customers",
             ),
         )
     ],


### PR DESCRIPTION
## Why

Runtime type enforcement projected source column names as raw SQL. Reserved identifiers therefore caused warehouse syntax errors even when model SQL was valid. Integration failures also omitted the recorded SQL needed to diagnose the generated statement.

## Changes

- render enforced source columns, aliases, exclusion lists, and passthrough columns with adapter-owned identifier quoting
- preserve the last recorded SQL statement for failed model assets in execution JSON
- include that diagnostic SQL in Dagster failure descriptions
- cover reserved source columns through unit and real CLI/DuckDB execution tests

## Verification

- focused unit and E2E tests: 145 passed
- `uv sync --all-extras`
- `make check-ci`
- public repository hygiene scan
