### PR TITLE
fix: attribute failures to exact SQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sqlbuild-policy-native"
-version = "0.91.4"
+version = "0.92.1"
 dependencies = [
  "fensu-policy",
  "globset",

--- a/crates/sqlbuild-policy-native/src/engine/tests/test_domain_layout.rs
+++ b/crates/sqlbuild-policy-native/src/engine/tests/test_domain_layout.rs
@@ -123,7 +123,9 @@ fn given_owner_and_declaration_layouts_when_evaluating_then_returns_expected_fau
             models: json!([]),
             thresholds: json!({}),
             layout: json!({}),
-            scope_index: helpers::scope_with_macros(&["models/commerce/_macros/utils/item.py".into()]),
+            scope_index: helpers::scope_with_macros(&[
+                "models/commerce/_macros/utils/item.py".into()
+            ]),
             expected_codes: &["SQBPD305"],
             expected_message_fragments: &[],
             expected_absent_fragments: &[],

--- a/src/sqlbuild/adapter/contract/classes/connection.py
+++ b/src/sqlbuild/adapter/contract/classes/connection.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Generator
 from typing import Any, ClassVar
 
+from sqlbuild.adapter.contract.main._attribute_failed_sql import attribute_failed_sql
 from sqlbuild.adapter.contract.models import QueryResult
 from sqlbuild.runtime.observability.classes.statement_lifecycle import StatementLifecycle
 
@@ -25,7 +26,13 @@ class ConnectionMixin(ABC):
         """Execute SQL through the framework-owned statement lifecycle."""
 
         with StatementLifecycle(adapter=self.adapter_name, sql=sql, intent="execute") as lifecycle:
-            result: Any = self._execute(connection=connection, sql=sql)
+            try:
+                result: Any = self._execute(connection=connection, sql=sql)
+            except Exception as error:
+                attributed_error: Exception = attribute_failed_sql(error=error, sql=sql)
+                if attributed_error is error:
+                    raise
+                raise attributed_error from error
             lifecycle.completed(affected_rows=self.affected_row_count(cursor=result))
             return result
 

--- a/src/sqlbuild/adapter/contract/exceptions.py
+++ b/src/sqlbuild/adapter/contract/exceptions.py
@@ -17,6 +17,19 @@ class AdapterUserError(ValueError):
         self.help = help
 
 
+class SqlStatementExecutionError(RuntimeError):
+    """Warehouse error attributed to the exact SQL statement that raised it."""
+
+    def __init__(self, *, sql: str, error: Exception) -> None:
+        super().__init__(str(error))
+        self.failed_sql = sql
+        self.original_error = error
+        self.message = str(getattr(error, "message", str(error)))
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.original_error, name)
+
+
 class UnsupportedTypedSqlRenderingError(AdapterUserError, SqlValueRenderingError):
     """Raised when an adapter cannot represent a requested typed SQL value."""
 

--- a/src/sqlbuild/adapter/contract/main/_attribute_failed_sql.py
+++ b/src/sqlbuild/adapter/contract/main/_attribute_failed_sql.py
@@ -1,0 +1,15 @@
+"""Exact failed-SQL attribution without changing mutable driver exception types."""
+
+from __future__ import annotations
+
+from sqlbuild.adapter.contract.exceptions import SqlStatementExecutionError
+
+
+def attribute_failed_sql(*, error: Exception, sql: str) -> Exception:
+    """Attach exact failed SQL without changing the driver's exception type when possible."""
+
+    try:
+        vars(error)["failed_sql"] = sql
+    except (AttributeError, TypeError):
+        return SqlStatementExecutionError(sql=sql, error=error)
+    return error

--- a/src/sqlbuild/cli/output/_helpers/execution_result_document.py
+++ b/src/sqlbuild/cli/output/_helpers/execution_result_document.py
@@ -655,6 +655,7 @@ def _format_model_assets(
                 "error_code": result.error_code,
                 "error_help": result.error_help,
                 "error_message": result.error_message,
+                "failed_sql": result.failed_sql,
                 "last_recorded_sql": (
                     _last_recorded_sql(result.lifecycle_events)
                     if result.status == ExecutionStatus.FAILED

--- a/src/sqlbuild/executor/run/_helpers/execution/hook_phases.py
+++ b/src/sqlbuild/executor/run/_helpers/execution/hook_phases.py
@@ -60,7 +60,7 @@ def run_pre_hook_phase(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.PRE_HOOK,
-            error=str(exc),
+            error=exc,
             warnings=warnings,
             audit_results=audit_results,
             statement_recorder=statement_recorder,
@@ -103,7 +103,7 @@ def run_post_hook_phase(
             failure=build_failed_result(
                 entry=entry,
                 phase=ExecutionPhase.POST_HOOK,
-                error=str(exc),
+                error=exc,
                 staging_relation=staging_relation,
                 promoted_relation=promoted_relation,
                 warnings=warnings,

--- a/src/sqlbuild/executor/run/_helpers/execution/results.py
+++ b/src/sqlbuild/executor/run/_helpers/execution/results.py
@@ -37,6 +37,7 @@ def build_failed_result(
     entry: ModelPlanEntry,
     phase: ExecutionPhase,
     error: str | BaseException,
+    error_prefix: str | None = None,
     staging_relation: str | None = None,
     promoted_relation: str | None = None,
     warnings: list[str],
@@ -49,6 +50,8 @@ def build_failed_result(
     rendered_error, rendered_code, rendered_help = _render_failure_error(
         error=error, fallback_code=_fallback_code_for_phase(phase)
     )
+    if error_prefix is not None:
+        rendered_error = f"{error_prefix}: {rendered_error}"
 
     statement_recorder.log(f"model {entry.name} failed phase={phase.value} error={rendered_error}")
     if staging_relation is not None:
@@ -67,6 +70,7 @@ def build_failed_result(
         error_code=rendered_code,
         error_help=rendered_help,
         error_message=rendered_error,
+        failed_sql=_failed_sql(error),
         future_cursor_safety=_future_cursor_safety(entry),
         maximum_start_safety=_maximum_start_safety(entry=entry, error=error),
         microbatch_limit=entry.microbatch_limit,
@@ -76,6 +80,13 @@ def build_failed_result(
         microbatch_strategy=entry.microbatch_strategy,
         microbatch_plan_reason=entry.reason.value,
     )
+
+
+def _failed_sql(error: str | BaseException) -> str | None:
+    if isinstance(error, str):
+        return None
+    failed_sql: object = getattr(error, "failed_sql", None)
+    return failed_sql if isinstance(failed_sql, str) and failed_sql else None
 
 
 def build_skipped_result(

--- a/src/sqlbuild/executor/run/_helpers/materializations/custom.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/custom.py
@@ -173,7 +173,7 @@ def _run_custom_pre_hooks(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.PRE_HOOK,
-            error=str(exc),
+            error=exc,
             warnings=state.warnings,
             audit_results=state.audit_results,
             statement_recorder=state.statement_recorder,
@@ -250,7 +250,7 @@ def _run_custom_materialization(
             failure=build_failed_result(
                 entry=entry,
                 phase=ExecutionPhase.CUSTOM_MATERIALIZATION,
-                error=str(exc),
+                error=exc,
                 warnings=state.warnings,
                 audit_results=state.audit_results,
                 statement_recorder=state.statement_recorder,
@@ -374,7 +374,7 @@ def _run_custom_post_hooks(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.POST_HOOK,
-            error=str(exc),
+            error=exc,
             promoted_relation=materialization_result.relation,
             warnings=state.warnings,
             audit_results=state.audit_results,

--- a/src/sqlbuild/executor/run/_helpers/materializations/incremental.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/incremental.py
@@ -162,7 +162,7 @@ def execute_incremental_entry(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.STAGING,
-            error=str(exc),
+            error=exc,
             staging_relation=delta_qualified,
             warnings=warnings,
             audit_results=audit_results,
@@ -209,7 +209,7 @@ def execute_incremental_entry(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.TYPE_ENFORCEMENT,
-            error=str(exc),
+            error=exc,
             staging_relation=delta_qualified,
             warnings=warnings,
             audit_results=audit_results,
@@ -241,7 +241,7 @@ def execute_incremental_entry(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.SCHEMA_CHANGE,
-            error=str(exc),
+            error=exc,
             staging_relation=delta_qualified,
             warnings=warnings,
             audit_results=audit_results,
@@ -318,7 +318,7 @@ def execute_incremental_entry(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.DML,
-            error=str(exc),
+            error=exc,
             staging_relation=delta_qualified,
             warnings=warnings,
             audit_results=audit_results,

--- a/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/microbatch.py
@@ -953,7 +953,8 @@ def _publish_pending_reconciliation_events(
         return build_failed_result(
             entry=context.entry,
             phase=ExecutionPhase.MICROBATCH_STATE,
-            error=f"failed to append microbatch reconciliation state: {exc}",
+            error=exc,
+            error_prefix="failed to append microbatch reconciliation state",
             warnings=state.warnings,
             audit_results=state.audit_results,
             statement_recorder=state.statement_recorder,
@@ -1416,7 +1417,8 @@ def _read_microbatch_history(
         return build_failed_result(
             entry=context.entry,
             phase=ExecutionPhase.MICROBATCH_STATE,
-            error=f"failed to read microbatch history: {exc}",
+            error=exc,
+            error_prefix="failed to read microbatch history",
             warnings=state.warnings,
             audit_results=state.audit_results,
             statement_recorder=state.statement_recorder,
@@ -1797,7 +1799,8 @@ def _record_microbatch_completion(
         return build_failed_result(
             entry=context.entry,
             phase=ExecutionPhase.MICROBATCH_STATE,
-            error=f"batch {batch.index}: target DML succeeded but completion write failed: {exc}",
+            error=exc,
+            error_prefix=f"batch {batch.index}: target DML succeeded but completion write failed",
             staging_relation=targets.delta_qualified,
             promoted_relation=targets.target_qualified,
             warnings=state.warnings,
@@ -2237,7 +2240,8 @@ def _physical_cursor_envelope(
         return build_failed_result(
             entry=context.entry,
             phase=ExecutionPhase.MICROBATCH_STATE,
-            error=f"failed to inspect target cursor envelope: {exc}",
+            error=exc,
+            error_prefix="failed to inspect target cursor envelope",
             warnings=state.warnings,
             audit_results=state.audit_results,
             statement_recorder=state.statement_recorder,
@@ -2364,7 +2368,8 @@ def _count_unaccounted_intervals(
             return build_failed_result(
                 entry=context.entry,
                 phase=ExecutionPhase.MICROBATCH_STATE,
-                error=f"failed to count unaccounted microbatch intervals: {exc}",
+                error=exc,
+                error_prefix="failed to count unaccounted microbatch intervals",
                 warnings=state.warnings,
                 audit_results=state.audit_results,
                 statement_recorder=state.statement_recorder,
@@ -2669,7 +2674,8 @@ def _stage_microbatch_delta(
         return build_failed_result(
             entry=context.entry,
             phase=ExecutionPhase.STAGING,
-            error=f"batch {batch.index}: {exc}",
+            error=exc,
+            error_prefix=f"batch {batch.index}",
             staging_relation=targets.delta_qualified,
             warnings=state.warnings,
             audit_results=state.audit_results,
@@ -2725,7 +2731,7 @@ def _apply_microbatch_schema_change(
             failure=build_failed_result(
                 entry=context.entry,
                 phase=ExecutionPhase.SCHEMA_CHANGE,
-                error=str(exc),
+                error=exc,
                 staging_relation=targets.delta_qualified,
                 warnings=state.warnings,
                 audit_results=state.audit_results,
@@ -2770,7 +2776,8 @@ def _enforce_microbatch_types(
         return build_failed_result(
             entry=context.entry,
             phase=ExecutionPhase.TYPE_ENFORCEMENT,
-            error=f"batch {batch.index}: {exc}",
+            error=exc,
+            error_prefix=f"batch {batch.index}",
             staging_relation=targets.delta_qualified,
             warnings=state.warnings,
             audit_results=state.audit_results,
@@ -2876,7 +2883,8 @@ def _apply_microbatch_dml(
         return build_failed_result(
             entry=context.entry,
             phase=ExecutionPhase.DML,
-            error=f"batch {batch.index}: {exc}",
+            error=exc,
+            error_prefix=f"batch {batch.index}",
             staging_relation=targets.delta_qualified,
             warnings=state.warnings,
             audit_results=state.audit_results,
@@ -2974,7 +2982,7 @@ def _prepare_full_refresh_rebuild(
         return build_failed_result(
             entry=context.entry,
             phase=ExecutionPhase.STAGING,
-            error=str(exc),
+            error=exc,
             warnings=state.warnings,
             audit_results=state.audit_results,
             statement_recorder=state.statement_recorder,
@@ -3009,7 +3017,8 @@ def _promote_microbatch_full_refresh(
         return build_failed_result(
             entry=context.entry,
             phase=ExecutionPhase.DML,
-            error=f"failed to promote full-refresh rebuild: {exc}",
+            error=exc,
+            error_prefix="failed to promote full-refresh rebuild",
             staging_relation=relations.rebuild_qualified,
             promoted_relation=relations.target_qualified,
             warnings=state.warnings,

--- a/src/sqlbuild/executor/run/_helpers/materializations/snapshot.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/snapshot.py
@@ -125,7 +125,7 @@ def execute_snapshot_entry(  # noqa: PLR0915
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.PRE_HOOK,
-            error=str(exc),
+            error=exc,
             warnings=warnings,
             audit_results=audit_results,
             statement_recorder=statement_recorder,
@@ -208,7 +208,7 @@ def execute_snapshot_entry(  # noqa: PLR0915
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.STAGING,
-            error=str(exc),
+            error=exc,
             staging_relation=delta_qualified,
             warnings=warnings,
             audit_results=audit_results,
@@ -268,7 +268,7 @@ def execute_snapshot_entry(  # noqa: PLR0915
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.DML,
-            error=str(exc),
+            error=exc,
             staging_relation=delta_qualified,
             warnings=warnings,
             audit_results=audit_results,
@@ -513,7 +513,8 @@ def _reconcile_snapshot_full_refresh_result(
         return build_failed_result(
             entry=context.entry,
             phase=ExecutionPhase.DML,
-            error=f"failed to reconcile snapshot full-refresh rebuild: {exc}",
+            error=exc,
+            error_prefix="failed to reconcile snapshot full-refresh rebuild",
             warnings=warnings,
             audit_results=audit_results,
             statement_recorder=statement_recorder,
@@ -558,7 +559,8 @@ def _snapshot_promotion_failure(
         return build_failed_result(
             entry=context.entry,
             phase=ExecutionPhase.DML,
-            error=f"failed to promote snapshot full-refresh rebuild: {exc}",
+            error=exc,
+            error_prefix="failed to promote snapshot full-refresh rebuild",
             staging_relation=relations.rebuild_qualified,
             promoted_relation=relations.target_qualified,
             warnings=warnings,

--- a/src/sqlbuild/executor/run/_helpers/materializations/view.py
+++ b/src/sqlbuild/executor/run/_helpers/materializations/view.py
@@ -101,7 +101,7 @@ def execute_view_entry(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.PRE_HOOK,
-            error=str(exc),
+            error=exc,
             warnings=warnings,
             audit_results=audit_results,
             statement_recorder=statement_recorder,
@@ -127,7 +127,7 @@ def execute_view_entry(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.STAGING,
-            error=str(exc),
+            error=exc,
             warnings=warnings,
             audit_results=audit_results,
             statement_recorder=statement_recorder,
@@ -203,7 +203,7 @@ def execute_view_entry(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.POST_HOOK,
-            error=str(exc),
+            error=exc,
             promoted_relation=target_qualified,
             warnings=warnings,
             audit_results=audit_results,

--- a/src/sqlbuild/executor/run/main/_execute.py
+++ b/src/sqlbuild/executor/run/main/_execute.py
@@ -90,7 +90,8 @@ def execute_table_entry(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.STAGING,
-            error=f"failed to resolve runtime cursor bounds: {exc}",
+            error=exc,
+            error_prefix="failed to resolve runtime cursor bounds",
             warnings=warnings,
             audit_results=audit_results,
             statement_recorder=statement_recorder,
@@ -114,7 +115,7 @@ def execute_table_entry(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.PRE_HOOK,
-            error=str(exc),
+            error=exc,
             warnings=warnings,
             audit_results=audit_results,
             statement_recorder=statement_recorder,
@@ -203,7 +204,7 @@ def _staged_lifecycle(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.STAGING,
-            error=str(exc),
+            error=exc,
             staging_relation=staging_qualified,
             warnings=warnings,
             audit_results=audit_results,
@@ -231,7 +232,7 @@ def _staged_lifecycle(
             return build_failed_result(
                 entry=entry,
                 phase=ExecutionPhase.TYPE_ENFORCEMENT,
-                error=str(exc),
+                error=exc,
                 staging_relation=staging_qualified,
                 warnings=warnings,
                 audit_results=audit_results,
@@ -308,7 +309,7 @@ def _staged_lifecycle(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.PROMOTION,
-            error=str(exc),
+            error=exc,
             staging_relation=staging_qualified,
             warnings=warnings,
             audit_results=audit_results,
@@ -402,7 +403,7 @@ def _immediate_lifecycle(
         return build_failed_result(
             entry=entry,
             phase=ExecutionPhase.STAGING,
-            error=str(exc),
+            error=exc,
             warnings=warnings,
             audit_results=audit_results,
             statement_recorder=statement_recorder,

--- a/src/sqlbuild/executor/run/models.py
+++ b/src/sqlbuild/executor/run/models.py
@@ -158,6 +158,7 @@ class ModelExecutionResult:
     error_code: str | None = None
     error_help: str | None = None
     error_message: str | None = None
+    failed_sql: str | None = None
     microbatch_run_type: str | None = None
     microbatch_strategy: str | None = None
     microbatch_plan_reason: str | None = None

--- a/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
+++ b/src/sqlbuild/integrations/dagster/classes/sqlbuild_cli_invocation.py
@@ -74,6 +74,10 @@ def _format_asset_failure(asset: Mapping[str, Any]) -> str:
     staging_relation: object = asset.get("staging_relation")
     if staging_relation is not None:
         lines.append(f"  staging relation: {staging_relation}")
+    failed_sql: object = asset.get("failed_sql")
+    if isinstance(failed_sql, str) and failed_sql:
+        lines.append("  failed SQL:")
+        lines.append(textwrap.indent(failed_sql, "    "))
     last_recorded_sql: object = asset.get("last_recorded_sql")
     if isinstance(last_recorded_sql, str) and last_recorded_sql:
         lines.append("  last recorded SQL:")

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/_test_types.py
@@ -343,6 +343,7 @@ class DirectChangesOnlyBuildE2ETestCase:
     expected_output_fragments: tuple[str, ...]
     unexpected_output_fragments: tuple[str, ...] = field(default_factory=tuple)
     expected_query_results: tuple[tuple[object, ...], ...] = field(default_factory=tuple)
+    expected_failed_sql_fragment: str | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_build.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_build.py
@@ -339,6 +339,7 @@ def test_given_source_freshness_changes_during_build_when_appending_then_persist
             description="direct source freshness appends independent successful branch only",
             expected_exit_code=1,
             expected_output_fragments=("orders", "payments", "FAIL"),
+            expected_failed_sql_fragment="CAST('bad' AS INTEGER)",
         )
     ],
     ids=lambda case: case.description,
@@ -414,9 +415,10 @@ def test_given_independent_source_branch_failure_when_building_then_appends_succ
         "MODEL (materialized table);\n\nSELECT CAST('bad' AS INTEGER) AS payment_id\n",
         encoding="utf-8",
     )
+    execution_json_path: Path = project_dir / "target" / "failed-build.json"
 
     build_result: subprocess.CompletedProcess[str] = run_sqb(
-        command=("--no-color", "build"),
+        command=("--no-color", "build", "--json-output", str(execution_json_path)),
         project_dir=project_dir,
     )
 
@@ -426,6 +428,17 @@ def test_given_independent_source_branch_failure_when_building_then_appends_succ
     fragment: str
     for fragment in test_case.expected_output_fragments:
         assert fragment in build_result.stdout + build_result.stderr
+    execution_payload: dict[str, object] = json.loads(
+        execution_json_path.read_text(encoding="utf-8")
+    )
+    assets: dict[str, dict[str, object]] = {
+        str(asset["name"]): asset
+        for asset in execution_payload["assets"]  # type: ignore[index]
+    }
+    failed_asset: dict[str, object] = assets["payments"]
+    assert failed_asset["status"] == "failed"
+    assert test_case.expected_failed_sql_fragment is not None
+    assert test_case.expected_failed_sql_fragment in str(failed_asset["failed_sql"])
     rows: list[tuple[Any, ...]] = query_duckdb(
         db_path=project_dir / "warehouse.duckdb",
         sql=(

--- a/tests/unit/src/sqlbuild/adapter/contract/classes/connection/_test_types.py
+++ b/tests/unit/src/sqlbuild/adapter/contract/classes/connection/_test_types.py
@@ -5,3 +5,10 @@ from dataclasses import dataclass
 class ConnectionContractCase:
     description: str
     expected_abstract: bool
+
+
+@dataclass(frozen=True)
+class SqlExecutionFailureCase:
+    description: str
+    sql: str
+    expected_error: str

--- a/tests/unit/src/sqlbuild/adapter/contract/classes/connection/test_connection.py
+++ b/tests/unit/src/sqlbuild/adapter/contract/classes/connection/test_connection.py
@@ -7,6 +7,7 @@ from sqlbuild.adapter.contract.classes.connection import ConnectionMixin
 from sqlbuild.adapter.contract.models import QueryResult
 from tests.unit.src.sqlbuild.adapter.contract.classes.connection._test_types import (
     ConnectionContractCase,
+    SqlExecutionFailureCase,
 )
 
 
@@ -46,6 +47,12 @@ class _ProtectedExecuteAdapter(ConnectionMixin):
         del connection
 
 
+class _FailingExecuteAdapter(_ProtectedExecuteAdapter):
+    def _execute(self, *, connection: Any, sql: str) -> Any:
+        del connection, sql
+        raise ValueError("warehouse rejected statement")
+
+
 @pytest.mark.parametrize(
     "test_case",
     [
@@ -81,3 +88,26 @@ def test_given_protected_execute_subclass_when_constructed_then_it_is_concrete(
 
     assert inspect.isabstract(_ProtectedExecuteAdapter) is test_case.expected_abstract
     assert adapter.execute(connection=object(), sql="SELECT 1") == "SELECT 1"
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SqlExecutionFailureCase(
+            description="warehouse execute failure retains exact SQL",
+            sql="CREATE TABLE staged_orders AS SELECT * FROM raw_orders",
+            expected_error="warehouse rejected statement",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_warehouse_failure_when_executing_then_exact_sql_is_attributed(
+    test_case: SqlExecutionFailureCase,
+) -> None:
+    adapter: _FailingExecuteAdapter = _FailingExecuteAdapter()
+
+    with pytest.raises(ValueError) as exc_info:
+        adapter.execute(connection=object(), sql=test_case.sql)
+
+    assert vars(exc_info.value)["failed_sql"] == test_case.sql
+    assert str(exc_info.value) == test_case.expected_error

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/_test_types.py
@@ -62,3 +62,4 @@ class MeasurementAuditOutputTestCase:
 class FailedModelSqlOutputTestCase:
     description: str
     expected_recorded_sql: str
+    expected_failed_sql: str

--- a/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_result_document.py
+++ b/tests/unit/src/sqlbuild/cli/output/_helpers/test_execution_result_document.py
@@ -69,6 +69,7 @@ from tests.unit.src.sqlbuild.cli.output._helpers._test_types import (
         FailedModelSqlOutputTestCase(
             description="failed staging statement remains available to integrations",
             expected_recorded_sql="CREATE TABLE staging_orders AS SELECT * FROM raw_orders",
+            expected_failed_sql="CREATE TABLE staging_orders AS SELECT invalid FROM raw_orders",
         ),
     ),
     ids=lambda case: case.description,
@@ -85,11 +86,13 @@ def test_given_failed_model_when_formatting_json_then_last_recorded_sql_is_prese
             LifeCycleEvent(kind=LifeCycleEventKind.LOG, content="staging failed"),
         ),
         error_message="syntax error",
+        failed_sql=test_case.expected_failed_sql,
     )
 
     assets: tuple[dict[str, object], ...] = _format_model_assets(results=(result,), plan=None)
 
     assert assets[0]["last_recorded_sql"] == test_case.expected_recorded_sql
+    assert assets[0]["failed_sql"] == test_case.expected_failed_sql
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/executor/run/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/executor/run/_helpers/_test_types.py
@@ -91,6 +91,8 @@ class BuildFailedResultTestCase:
     expected_error_message: str
     expected_error_code: str
     expected_lifecycle_events: tuple[LifeCycleEvent, ...]
+    expected_failed_sql: str | None = None
+    error_prefix: str | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/executor/run/_helpers/test_results.py
+++ b/tests/unit/src/sqlbuild/executor/run/_helpers/test_results.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from sqlbuild.adapter.contract.classes.statement_recorder import StatementRecorder
+from sqlbuild.adapter.contract.exceptions import SqlStatementExecutionError
 from sqlbuild.adapter.contract.models import LifeCycleEvent
 from sqlbuild.adapter.contract.types import LifeCycleEventKind
 from sqlbuild.errors.contracts.exceptions import ExecutorInputError
@@ -62,6 +63,30 @@ from tests.unit.src.sqlbuild.executor.run._helpers.helpers import build_result_m
                 ),
             ),
         ),
+        BuildFailedResultTestCase(
+            description="preserves exact failed SQL separately from recorded statements",
+            error=SqlStatementExecutionError(
+                sql="CREATE TABLE analytics.orders__staging AS SELECT invalid",
+                error=ValueError("warehouse syntax error"),
+            ),
+            recorded_statements=("CREATE TABLE analytics.orders__staging AS SELECT valid",),
+            warning_messages=(),
+            expected_model_name="orders",
+            expected_error_message="batch 2: warehouse syntax error",
+            expected_error_code="R002",
+            expected_lifecycle_events=(
+                LifeCycleEvent(
+                    kind=LifeCycleEventKind.SQL,
+                    content="CREATE TABLE analytics.orders__staging AS SELECT valid",
+                ),
+                LifeCycleEvent(
+                    kind=LifeCycleEventKind.LOG,
+                    content="model orders failed phase=staging error=batch 2: warehouse syntax error",
+                ),
+            ),
+            expected_failed_sql="CREATE TABLE analytics.orders__staging AS SELECT invalid",
+            error_prefix="batch 2",
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -76,6 +101,7 @@ def test_given_statement_recorder_when_building_failed_result_then_snapshots_sta
         entry=build_result_model_plan_entry(),
         phase=ExecutionPhase.STAGING,
         error=test_case.error,
+        error_prefix=test_case.error_prefix,
         warnings=warnings,
         audit_results=[],
         statement_recorder=recorder,
@@ -88,3 +114,4 @@ def test_given_statement_recorder_when_building_failed_result_then_snapshots_sta
     assert result.error_code == test_case.expected_error_code
     assert result.lifecycle_events == test_case.expected_lifecycle_events
     assert result.warning_messages == test_case.warning_messages
+    assert result.failed_sql == test_case.expected_failed_sql

--- a/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
+++ b/tests/unit/src/sqlbuild/integrations/dagster/test_resource.py
@@ -1605,6 +1605,7 @@ def test_given_blocked_command_when_live_stream_closes_then_subprocess_terminate
                 '"status": "failed", "action": "failed", "failed_phase": "staging", '
                 '"error_code": "R002", "error_message": "invalid identifier CUSTOMER_ID", '
                 '"staging_relation": "analytics.customers__staging", '
+                '"failed_sql": "CREATE TABLE customers AS SELECT invalid FROM raw.customers", '
                 '"last_recorded_sql": "CREATE TABLE customers AS SELECT customer_id FROM raw.customers"}], '
                 '"checks": []}'
             ),
@@ -1614,6 +1615,7 @@ def test_given_blocked_command_when_live_stream_closes_then_subprocess_terminate
                 "model:customers (failed) during staging",
                 "[R002] invalid identifier CUSTOMER_ID",
                 "staging relation: analytics.customers__staging",
+                "failed SQL:\n    CREATE TABLE customers AS SELECT invalid FROM raw.customers",
                 "last recorded SQL:\n    CREATE TABLE customers AS SELECT customer_id FROM raw.customers",
             ),
         )


### PR DESCRIPTION
## Why

Warehouse syntax failures currently expose only adapter diagnostics and a best-effort last recorded statement. Pre-recorded statement batches can make that SQL ambiguous, while non-SQL failures can inherit an unrelated prior statement.

## Changes

- attribute warehouse failures to the exact SQL passed to the failing adapter execution
- preserve mutable driver exception types, traceback, codes, and lifecycle telemetry
- propagate exact failed SQL through model results, structured execution JSON, and Dagster failures
- retain contextual batch and promotion messages without stringifying away attribution
- cover execution attribution, structured output, integration failure rendering, and a real CLI runtime failure
- apply the existing native formatting and lockfile consistency corrections required by static CI

## Verification

- 186 focused unit/integration tests passed
- focused runtime-failure CLI E2E passed
- `uv sync --all-extras`
- `make check-ci`
- `make rust-check`
- public repository hygiene scan
