### PR TITLE
feat: expose caller-scoped declarations to Python macros

### DIFF
--- a/src/sqlbuild/compiler/compile/_helpers/render/declarations.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/declarations.py
@@ -269,7 +269,7 @@ def declaration_usage_records(
             if is_enum
             else declarations.constant_visibility.get(name, ())
         )
-        for record in _usage_visibility(visibility=visibility, consumer=resource):
+        for record in usage_visibility(visibility=visibility, consumer=resource):
             usages.append(
                 UsageRecord(
                     consumer=resource,
@@ -530,7 +530,7 @@ def expand_declaration_references_result(
             visibility = declarations.constant_visibility.get(constant_match.group("name"), ())
             member = None
         if declarations.consumer is not None:
-            for visible in _usage_visibility(
+            for visible in usage_visibility(
                 visibility=visibility,
                 consumer=declarations.consumer,
             ):
@@ -560,7 +560,7 @@ def expand_declaration_references_result(
     )
 
 
-def _usage_visibility(
+def usage_visibility(
     *,
     visibility: tuple[VisibilityRecord, ...],
     consumer: ResourceIdentity | DeclarationIdentity,

--- a/src/sqlbuild/compiler/compile/_helpers/render/macros.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/macros.py
@@ -10,9 +10,11 @@ import inspect
 import re
 import sys
 import threading
-from dataclasses import dataclass, field
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass, field, replace
 from pathlib import Path
-from types import ModuleType
+from types import MappingProxyType, ModuleType
+from typing import cast
 
 from sqlbuild.compiler.compile.constants import (
     DECLARATION_REFERENCE_NAMES,
@@ -22,7 +24,7 @@ from sqlbuild.compiler.compile.constants import (
     SQL_OPEN_PAREN_TOKEN,
     SQL_QUOTE_TOKENS,
 )
-from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.compiler.compile.exceptions import CompileInputError, MacroDeclarationLookupError
 from sqlbuild.compiler.compile.models import (
     DeclarationResolutionContext,
     DeclarationScopeResolver,
@@ -34,7 +36,11 @@ from sqlbuild.compiler.compile.models import (
     StaticMacroFault,
     StaticMacroInventory,
 )
-from sqlbuild.compiler.discovery.models import DiscoveredMacroFile
+from sqlbuild.compiler.discovery.models import (
+    ConstantDeclaration,
+    DiscoveredMacroFile,
+    EnumDeclaration,
+)
 from sqlbuild.compiler.resource_names.main._validate_resource_identity import (
     validate_resource_identity,
 )
@@ -43,8 +49,9 @@ from sqlbuild.compiler.scopes.models import (
     DeclarationRecord,
     ResourceIdentity,
     UsageRecord,
+    VisibilityRecord,
 )
-from sqlbuild.compiler.scopes.types import DeclarationKind, ScopeKind, UsageKind
+from sqlbuild.compiler.scopes.types import DeclarationKind, ResourceKind, ScopeKind, UsageKind
 from sqlbuild.compiler.sql_analysis.main._find_matching_paren import find_matching_paren
 from sqlbuild.compiler.sql_analysis.main._is_identifier_character import (
     is_identifier_character as _is_identifier_continue,
@@ -55,6 +62,8 @@ from sqlbuild.compiler.sql_analysis.main._is_identifier_start import (
 from sqlbuild.compiler.sql_analysis.main._skip_block_comment import skip_block_comment
 from sqlbuild.compiler.sql_analysis.main._skip_line_comment import skip_line_comment
 from sqlbuild.compiler.sql_analysis.main._skip_quoted_text import skip_quoted_text
+from sqlbuild.sql_values.models import SqlValue
+from sqlbuild.sql_values.types import SqlValueKind
 
 _CONTEXT: str = "Macro expansion"
 _LINE_COMMENT_TOKEN: str = "--"
@@ -62,6 +71,7 @@ _BLOCK_COMMENT_TOKEN: str = "/*"
 _STAR_IMPORT_NAME: str = "*"
 _MACRO_SCAN_PATTERN: re.Pattern[str] = re.compile(r"@|--|/\*|'|\"|`")
 _SYNTHETIC_PACKAGE_PREFIX: str = "_sqlbuild_project_macros_"
+_OBJECT_ENTRY_LENGTH: int = 2
 _MACRO_MODULE_LOAD_LOCK: threading.RLock = threading.RLock()
 
 
@@ -111,6 +121,73 @@ class _ExpansionState:
     declarations: DeclarationResolutionContext | None
     facts: _ExpansionFacts
     consumer: ResourceIdentity | DeclarationIdentity | None = None
+
+
+class _MacroDeclarationValues(Mapping[str, object]):
+    def __init__(
+        self,
+        *,
+        values: Mapping[str, object],
+        inaccessible: Mapping[str, DeclarationRecord],
+        declaration_kind: str,
+        file_path: Path,
+        on_access: Callable[[str], None],
+    ) -> None:
+        self._values: Mapping[str, object] = values
+        self._inaccessible: Mapping[str, DeclarationRecord] = inaccessible
+        self._declaration_kind: str = declaration_kind
+        self._file_path: Path = file_path
+        self._on_access: Callable[[str], None] = on_access
+
+    def __getitem__(self, name: str) -> object:
+        if name in self._values:
+            self._on_access(name)
+            return self._values[name]
+        inaccessible: DeclarationRecord | None = self._inaccessible.get(name)
+        if inaccessible is not None:
+            owner: str = inaccessible.owning_path or "global"
+            raise MacroDeclarationLookupError(
+                f"{self._declaration_kind.title()} '{name}' in '{self._file_path}' is "
+                f"inaccessible. Defined at '{inaccessible.path}:{inaccessible.line}:"
+                f"{inaccessible.column}' with scope owner '{owner}'"
+            )
+        visible: str = ", ".join(sorted(self._values)) or "none"
+        raise MacroDeclarationLookupError(
+            f"Unknown {self._declaration_kind} '{name}' in '{self._file_path}'. "
+            f"Visible {self._declaration_kind}s: {visible}"
+        )
+
+    def __iter__(self) -> Iterator[str]:
+        for name in self._values:
+            self._on_access(name)
+            yield name
+
+    def __len__(self) -> int:
+        for name in self._values:
+            self._on_access(name)
+        return len(self._values)
+
+
+class _MacroEnumMembers(Mapping[str, str | int]):
+    def __init__(self, *, enum_name: str, values: Mapping[str, str | int], file_path: Path) -> None:
+        self._enum_name: str = enum_name
+        self._values: Mapping[str, str | int] = values
+        self._file_path: Path = file_path
+
+    def __getitem__(self, name: str) -> str | int:
+        if name in self._values:
+            return self._values[name]
+        available: str = ", ".join(sorted(self._values)) or "none"
+        raise MacroDeclarationLookupError(
+            f"Unknown member '{name}' for enum '{self._enum_name}' in '{self._file_path}'. "
+            f"Available members: {available}"
+        )
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
 
 
 def load_project_macros(macro_files: tuple[DiscoveredMacroFile, ...]) -> dict[str, LoadedMacro]:
@@ -1304,12 +1381,20 @@ def _evaluate_macro_call(
         stack=stack,
     )
     try:
+        invocation_context: MacroContext = _build_macro_invocation_context(
+            macro_context=state.macro_context,
+            declarations=declarations,
+            file_path=file_path,
+            state=state,
+        )
         macro_result: object = _call_loaded_macro(
             loaded_macro=loaded_macro,
-            macro_context=state.macro_context,
+            macro_context=invocation_context,
             args=args,
             kwargs=kwargs,
         )
+    except CompileInputError:
+        raise
     except TypeError as error:
         raise CompileInputError(
             f"Macro '@{macro_name}' in '{file_path}' could not be called: {error}"
@@ -1328,6 +1413,165 @@ def _evaluate_macro_call(
             macro_name=macro_name, file_path=file_path, macro_result=macro_result
         )
     return macro_result, closing_paren_index + 1
+
+
+def _build_macro_invocation_context(
+    *,
+    macro_context: MacroContext,
+    declarations: DeclarationResolutionContext | None,
+    file_path: Path,
+    state: _ExpansionState,
+) -> MacroContext:
+    if declarations is None:
+        return macro_context
+    constant_values: Mapping[str, object] = _build_constant_context_values(declarations.constants)
+    enum_values: Mapping[str, object] = _build_enum_context_values(
+        declarations=declarations.enums, file_path=file_path
+    )
+    constants: Mapping[str, object] = _MacroDeclarationValues(
+        values=constant_values,
+        inaccessible=declarations.inaccessible_constants,
+        declaration_kind="constant",
+        file_path=file_path,
+        on_access=lambda name: _record_macro_declaration_usage(
+            name=name,
+            kind=DeclarationKind.CONSTANT,
+            declarations=declarations,
+            state=state,
+        ),
+    )
+    enum_mapping: Mapping[str, object] = _MacroDeclarationValues(
+        values=enum_values,
+        inaccessible=declarations.inaccessible_enums,
+        declaration_kind="enum",
+        file_path=file_path,
+        on_access=lambda name: _record_macro_declaration_usage(
+            name=name,
+            kind=DeclarationKind.ENUM,
+            declarations=declarations,
+            state=state,
+        ),
+    )
+    return replace(
+        macro_context,
+        constants=constants,
+        enums=cast(Mapping[str, Mapping[str, str | int]], enum_mapping),
+    )
+
+
+def _build_constant_context_values(
+    declarations: Mapping[str, ConstantDeclaration],
+) -> Mapping[str, object]:
+    values: dict[str, object] = {}
+    for name, declaration in declarations.items():
+        values[name] = _constant_python_value(declaration.value)
+    return MappingProxyType(values)
+
+
+def _build_enum_context_values(
+    *,
+    declarations: Mapping[str, EnumDeclaration],
+    file_path: Path,
+) -> Mapping[str, object]:
+    values: dict[str, object] = {}
+    for name, declaration in declarations.items():
+        members: dict[str, str | int] = {}
+        for member in declaration.members:
+            members[member.name] = member.value
+        values[name] = _MacroEnumMembers(
+            enum_name=name,
+            values=MappingProxyType(members),
+            file_path=file_path,
+        )
+    return MappingProxyType(values)
+
+
+def _constant_python_value(value: SqlValue) -> object:
+    if value.kind in {
+        SqlValueKind.STRING,
+        SqlValueKind.INTEGER,
+        SqlValueKind.BOOLEAN,
+        SqlValueKind.FLOAT,
+        SqlValueKind.DECIMAL,
+        SqlValueKind.NULL,
+    }:
+        return value.value
+    if value.kind == SqlValueKind.LIST:
+        return tuple(_constant_python_value(item) for item in _constant_items(value))
+    if value.kind == SqlValueKind.SET:
+        return frozenset(_constant_python_value(item) for item in _constant_items(value))
+    return MappingProxyType(
+        {key: _constant_python_value(item) for key, item in _constant_object_items(value)}
+    )
+
+
+def _constant_items(value: SqlValue) -> tuple[SqlValue, ...]:
+    if not isinstance(value.value, tuple) or not all(
+        isinstance(item, SqlValue) for item in value.value
+    ):
+        raise CompileInputError("Invalid normalized collection constant in macro context")
+    return cast(tuple[SqlValue, ...], value.value)
+
+
+def _constant_object_items(value: SqlValue) -> tuple[tuple[str, SqlValue], ...]:
+    if not isinstance(value.value, tuple) or not all(
+        isinstance(item, tuple)
+        and len(item) == _OBJECT_ENTRY_LENGTH
+        and isinstance(item[0], str)
+        and isinstance(item[1], SqlValue)
+        for item in value.value
+    ):
+        raise CompileInputError("Invalid normalized object constant in macro context")
+    return cast(tuple[tuple[str, SqlValue], ...], value.value)
+
+
+def _record_macro_declaration_usage(
+    *,
+    name: str,
+    kind: DeclarationKind,
+    declarations: DeclarationResolutionContext,
+    state: _ExpansionState,
+) -> None:
+    from sqlbuild.compiler.compile._helpers.render.declarations import usage_visibility
+
+    consumer: ResourceIdentity | DeclarationIdentity | None = (
+        state.consumer or declarations.consumer
+    )
+    if consumer is None:
+        return
+    visibility: tuple[VisibilityRecord, ...] = (
+        declarations.constant_visibility.get(name, ())
+        if kind == DeclarationKind.CONSTANT
+        else declarations.enum_visibility.get(name, ())
+    )
+    if visibility:
+        visible_records: tuple[VisibilityRecord, ...] = usage_visibility(
+            visibility=visibility,
+            consumer=consumer,
+        )
+        for visible in visible_records:
+            _ = state.facts.add_usage(
+                UsageRecord(
+                    consumer=consumer,
+                    declaration=visible.declaration,
+                    kind=UsageKind.RUNTIME,
+                    through=visible.through,
+                )
+            )
+        return
+    else:
+        declaration: ConstantDeclaration | EnumDeclaration = (
+            declarations.constants[name]
+            if kind == DeclarationKind.CONSTANT
+            else declarations.enums[name]
+        )
+        owner: ResourceIdentity | None = (
+            ResourceIdentity(kind=ResourceKind.MODEL, name=declaration.model_name)
+            if declaration.model_name is not None
+            else None
+        )
+        identity: DeclarationIdentity = DeclarationIdentity(kind=kind, name=name, owner=owner)
+    _ = state.facts.add_usage(UsageRecord(consumer, identity, UsageKind.RUNTIME))
 
 
 def _validate_final_macro_sql(*, macro_name: str, file_path: Path, macro_result: str) -> None:

--- a/src/sqlbuild/compiler/compile/exceptions.py
+++ b/src/sqlbuild/compiler/compile/exceptions.py
@@ -15,5 +15,9 @@ class CompileInputError(ValueError):
         self.help = help
 
 
+class MacroDeclarationLookupError(CompileInputError, KeyError):
+    """Retain authored diagnostics while honoring the Mapping lookup contract."""
+
+
 class AnalysisCacheEntryError(ValueError):
     """Raised when a persisted model analysis cache entry is invalid."""

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -252,12 +252,14 @@ class DeclarationScopeBuild:
 
 @dataclass(frozen=True)
 class MacroContext:
-    """Compile-time context passed to adapter-aware SQL macros."""
+    """Expose target settings and caller-visible declarations to a Python SQL macro."""
 
     adapter_name: str
     sql_analysis_enabled: bool
     target_name: str | None
     vars: dict[str, object] = field(default_factory=dict)
+    constants: Mapping[str, object] = field(default_factory=dict)
+    enums: Mapping[str, Mapping[str, str | int]] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
@@ -53,6 +53,7 @@ class RunCompilePipelineIntegrationTestCase:
     expected_model_count: int = 0
     expected_seed_count: int = 0
     expected_manifest_node_count: int = 0
+    expected_declaration_usages: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -79,6 +80,21 @@ class MacroCompositionIntegrationTestCase:
     macro_name: str
     expected_dependencies: tuple[str, ...]
     expected_declaration_resolution_count: int
+
+
+@dataclass(frozen=True)
+class MacroDeclarationContextErrorTestCase:
+    description: str
+    project_files: dict[str, str]
+    expected_error_fragment: str
+
+
+@dataclass(frozen=True)
+class MacroDeclarationResourceTestCase:
+    description: str
+    expected_model_sql_fragment: str
+    expected_test_sql_fragment: str
+    expected_audit_sql_fragment: str
 
 
 @dataclass(frozen=True)

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_declaration_context.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_declaration_context.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.compiler.pipeline.models import CompilePipelineResult
+from tests.integration.src.sqlbuild.compiler.pipeline._test_types import (
+    MacroDeclarationContextErrorTestCase,
+    MacroDeclarationResourceTestCase,
+)
+from tests.integration.src.sqlbuild.compiler.pipeline.helpers import (
+    run_compile_pipeline_for_project,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        MacroDeclarationResourceTestCase(
+            description="models tests and audits receive caller-visible constants",
+            expected_model_sql_fragment="SELECT 2 AS minimum_quantity",
+            expected_test_sql_fragment="SELECT 2 AS minimum_quantity",
+            expected_audit_sql_fragment="minimum_quantity < 2",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_macro_context_declarations_when_compiling_resources_then_all_expand(
+    test_case: MacroDeclarationResourceTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(
+        tmp_path,
+        {
+            "sqlbuild_project.toml": (
+                'name = "demo"\nadapter = "duckdb"\n\n[settings]\nsql_analysis = false\n'
+            ),
+            "constants/policy.sql": "CONSTANT (name minimum_quantity, value 2);\n",
+            "macros/policy.py": (
+                "def minimum_quantity(ctx) -> str:\n"
+                "    return str(ctx.constants['minimum_quantity'])\n"
+            ),
+            "models/summary.sql": (
+                "MODEL (materialized view, audits [minimum_quantity]);\n\n"
+                "SELECT @minimum_quantity() AS minimum_quantity"
+            ),
+            "tests/unit/summary.sql": (
+                "TEST (mode macro);\n\nWITH\n__macro_actual__ AS (\n"
+                "  SELECT @minimum_quantity() AS minimum_quantity\n),\n"
+                "__macro_expected__ AS (\n  SELECT 2 AS minimum_quantity\n)\nSELECT 1"
+            ),
+            "audits/generic/minimum_quantity.sql": (
+                'AUDIT ();\n\nSELECT * FROM __ref("@model") '
+                "WHERE minimum_quantity < @minimum_quantity()"
+            ),
+        },
+    )
+
+    result: CompilePipelineResult = run_compile_pipeline_for_project(
+        project_dir=tmp_path, adapter=DuckDbAdapter()
+    )
+
+    assert test_case.expected_model_sql_fragment in result.project.models[0].query_sql
+    assert test_case.expected_test_sql_fragment in result.project.sql_tests[0].sql_body
+    assert test_case.expected_audit_sql_fragment in result.project.audits[0].sql_body
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        MacroDeclarationContextErrorTestCase(
+            description="sibling private constant remains inaccessible",
+            project_files={
+                "sqlbuild_project.toml": 'name = "demo"\nadapter = "duckdb"\n',
+                "models/orders/_constants/policy.sql": (
+                    "CONSTANT (name minimum_quantity, value 2);\n"
+                ),
+                "macros/policy.py": (
+                    "def minimum_quantity(ctx) -> str:\n"
+                    "    return str(ctx.constants['minimum_quantity'])\n"
+                ),
+                "models/products/summary.sql": (
+                    "MODEL (materialized view);\n\nSELECT @minimum_quantity() AS minimum_quantity"
+                ),
+            },
+            expected_error_fragment="Constant 'minimum_quantity'.*is inaccessible",
+        ),
+        MacroDeclarationContextErrorTestCase(
+            description="unknown constant reports visible alternatives",
+            project_files={
+                "sqlbuild_project.toml": 'name = "demo"\nadapter = "duckdb"\n',
+                "models/_constants/policy.sql": ("CONSTANT (name minimum_quantity, value 2);\n"),
+                "models/_macros/policy.py": (
+                    "def missing_quantity(ctx) -> str:\n"
+                    "    return str(ctx.constants['maximum_quantity'])\n"
+                ),
+                "models/summary.sql": (
+                    "MODEL (materialized view);\n\nSELECT @missing_quantity() AS maximum_quantity"
+                ),
+            },
+            expected_error_fragment=(
+                "Unknown constant 'maximum_quantity'.*Visible constants: minimum_quantity"
+            ),
+        ),
+        MacroDeclarationContextErrorTestCase(
+            description="unknown enum member reports available alternatives",
+            project_files={
+                "sqlbuild_project.toml": 'name = "demo"\nadapter = "duckdb"\n',
+                "models/_enums/status.sql": (
+                    "ENUM (name order_status, members [ACTIVE, PAUSED]);\n"
+                ),
+                "models/_macros/policy.py": (
+                    "def missing_status(ctx) -> str:\n"
+                    "    return str(ctx.enums['order_status']['CLOSED'])\n"
+                ),
+                "models/summary.sql": (
+                    "MODEL (materialized view);\n\nSELECT @missing_status() AS status"
+                ),
+            },
+            expected_error_fragment=(
+                "Unknown member 'CLOSED' for enum 'order_status'.*Available members: ACTIVE, PAUSED"
+            ),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_unavailable_declaration_when_macro_reads_context_then_compile_fails(
+    test_case: MacroDeclarationContextErrorTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, test_case.project_files)
+
+    with pytest.raises(CompileInputError, match=test_case.expected_error_fragment):
+        run_compile_pipeline_for_project(project_dir=tmp_path, adapter=DuckDbAdapter())

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
@@ -176,6 +176,71 @@ _PROJECT_TOML: str = 'name = "demo"\nadapter = "duckdb"\n\n[connection]\ndatabas
             expected_seed_count=0,
             expected_manifest_node_count=2,
         ),
+        RunCompilePipelineIntegrationTestCase(
+            description="Python macro receives constants and enums visible to its caller",
+            project_files={
+                "sqlbuild_project.toml": _PROJECT_TOML,
+                "models/_constants/policy.sql": (
+                    "CONSTANT (name minimum_quantity, value 2);\n"
+                    'CONSTANT (name regions, value ["north", "south"]);\n'
+                    "CONSTANT (name unique_ids, value {2, 1});\n"
+                    'CONSTANT (name labels, value (north "North", south "South"));\n'
+                    'CONSTANT (name adjustment, type decimal, value "2.50");\n'
+                ),
+                "models/_enums/status.sql": (
+                    'ENUM (name order_status, members (ACTIVE "active", PAUSED "paused"));\n'
+                ),
+                "models/_macros/policy.py": (
+                    "from sqlbuild.compiler.compile.models import MacroContext\n\n\n"
+                    "def policy_columns(ctx: MacroContext) -> str:\n"
+                    "    minimum = ctx.constants['minimum_quantity']\n"
+                    "    region_count = len(ctx.constants['regions'])\n"
+                    "    unique_count = len(ctx.constants['unique_ids'])\n"
+                    "    label = ctx.constants['labels']['north']\n"
+                    "    adjustment = ctx.constants['adjustment']\n"
+                    "    active = ctx.enums['order_status']['ACTIVE']\n"
+                    "    optional = ctx.constants.get('maximum_quantity', 7)\n"
+                    "    has_closed = 'CLOSED' in ctx.enums['order_status']\n"
+                    "    return (\n"
+                    '        f"{minimum} AS minimum_quantity, {region_count} AS region_count, "\n'
+                    "        f\"{unique_count} AS unique_count, '{label}' AS label, \"\n"
+                    "        f\"{adjustment} AS adjustment, '{active}' AS active_status, \"\n"
+                    '        f"{optional} AS optional_quantity, {has_closed} AS has_closed"\n'
+                    "    )\n"
+                ),
+                "models/policy_summary.sql": (
+                    "MODEL (materialized view);\n\nSELECT @policy_columns()"
+                ),
+            },
+            expected_models={
+                "policy_summary": ExpectedModelEntry(
+                    description="model expanded with caller-visible declarations",
+                    expected_resolved_sql_fragment=(
+                        "SELECT 2 AS minimum_quantity, 2 AS region_count, 2 AS unique_count, "
+                        "'North' AS label, 2.50 AS adjustment, 'active' AS active_status, "
+                        "7 AS optional_quantity, False AS has_closed"
+                    ),
+                    expected_logical_ddl_fragment="CREATE OR REPLACE VIEW",
+                    expected_manifest_compiled_code_fragment=(
+                        "SELECT 2 AS minimum_quantity, 2 AS region_count, 2 AS unique_count, "
+                        "'North' AS label, 2.50 AS adjustment, 'active' AS active_status, "
+                        "7 AS optional_quantity, False AS has_closed"
+                    ),
+                ),
+            },
+            expected_model_count=1,
+            expected_seed_count=0,
+            expected_manifest_node_count=1,
+            expected_declaration_usages=(
+                "constant:adjustment",
+                "constant:labels",
+                "constant:minimum_quantity",
+                "constant:regions",
+                "constant:unique_ids",
+                "enum:order_status",
+                "macro:policy_columns",
+            ),
+        ),
     ],
     ids=lambda case: case.description,
 )
@@ -193,6 +258,13 @@ def test_given_project_files_when_running_compile_pipeline_then_produces_valid_o
 
     assert len(result.plan_output.model_entries) == test_case.expected_model_count
     assert len(result.plan_output.seed_entries) == test_case.expected_seed_count
+    actual_declaration_usages: tuple[str, ...] = tuple(
+        sorted(
+            f"{usage.declaration.kind.value}:{usage.declaration.name}"
+            for usage in result.project.scope_index.usages
+        )
+    )
+    assert actual_declaration_usages == test_case.expected_declaration_usages
     manifest: dict[str, object] = build_manifest_for_pipeline_result(
         result=result,
         project_name="demo",

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_macros.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_macros.py
@@ -33,6 +33,8 @@ _MACRO_CONTEXT: MacroContext = MacroContext(
     sql_analysis_enabled=True,
     target_name="dev",
     vars={"project_name": "demo"},
+    constants={"minimum_quantity": 2, "regions": ("north", "south")},
+    enums={"order_status": {"ACTIVE": "active", "PAUSED": "paused"}},
 )
 
 
@@ -564,6 +566,19 @@ def context_summary(ctx) -> str:
             + "\n",
             sql="@context_summary()",
             expected_sql="SELECT 'bigquery|True|dev|demo'",
+        ),
+        ExpandSqlMacrosTestCase(
+            description="passes declaration values to ctx-aware macros",
+            macro_file_contents="""
+def declaration_summary(ctx) -> str:
+    minimum = ctx.constants["minimum_quantity"]
+    region_count = len(ctx.constants["regions"])
+    active = ctx.enums["order_status"]["ACTIVE"]
+    return f"SELECT {minimum}, {region_count}, '{active}'"
+""".strip()
+            + "\n",
+            sql="@declaration_summary()",
+            expected_sql="SELECT 2, 2, 'active'",
         ),
         ExpandSqlMacrosTestCase(
             description="ignores generated call text inside comments and quoted strings",


### PR DESCRIPTION
## Why

Python SQL macros can use target settings and variables, but cannot currently read constants or enums visible to the authored SQL caller. This forces callers to repeat declaration references as macro arguments and prevents shared policy declarations from composing naturally with macro logic.

## Changes

- expose caller-visible constants and enum members through `MacroContext`
- preserve typed Python values for scalar and collection constants
- enforce the existing declaration visibility rules and stable inaccessible/unknown diagnostics
- record declaration usages with relationship provenance for scope reporting
- retain normal `Mapping` lookup behavior for optional probes
- cover model, SQL-test, audit, enum, collection, diagnostics, and usage-tracking paths with neutral fixtures

## Verification

- `uv sync --all-extras`
- focused compiler unit and integration tests: 96 passed
- `make check-ci`
- `make test`: 6463 passed
- Ruff, ty, and Fensu checks for affected boundaries
- clean public-tree hygiene scan
- local editable-package consumer compilation against a private project
- one bounded independent review plus focused follow-up verification
