### PR TITLE
fix: render macro declarations safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ unofficial project structure. Keep repository pytest tests outside the SQLBuild 
 directory, which is reserved for SQLBuild SQL tests and scenarios. Documented integration paths
 such as `dagster/`, `rivers_pipeline/`, and their `definitions.py` modules are also supported.
 
+### Python macro declaration context
+
+Python SQL macros receive the constants and enums visible to the SQL resource that calls them.
+Use the typed mappings for Python control flow, and use the rendering methods when inserting a
+declaration into generated SQL so quoting and collection syntax follow the active adapter:
+
+```python
+def minimum_order_filter(ctx) -> str:
+    minimum = ctx.constants["minimum_order_value"]
+    if minimum is None:  # The visible declaration explicitly has a NULL value.
+        return "TRUE"
+    return f"order_value >= {ctx.render_constant('minimum_order_value')}"
+
+
+def active_status_filter(ctx) -> str:
+    status = ctx.render_enum_member(enum_name="order_status", member_name="active")
+    return f"status = {status}"
+```
+
+Callers can still pass explicit `@const(...)` or `@enum(...)` values as macro arguments. Context
+lookups are intended for policy owned by the macro; both forms use the caller's declaration scope.
+
 ## SQL lint and Project Policy
 
 SQL lint evaluates one plain SQL statement. Project Policy evaluates how SQLBuild resources are

--- a/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
+++ b/src/sqlbuild/compiler/compile/_helpers/assembly/project.py
@@ -1519,7 +1519,7 @@ def _build_test_model_query_overrides(
         return {}
     if not test_input.payload.macro_mocks:
         return {}
-    macro_context: MacroContext = MacroContext(
+    macro_context: MacroContext = inputs.macro_context or MacroContext(
         adapter_name=resolve_effective_adapter_name(
             project_config=inputs.project_config,
             local_config=inputs.local_config,

--- a/src/sqlbuild/compiler/compile/_helpers/render/declarations.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/declarations.py
@@ -659,7 +659,7 @@ def _resolve_enum_reference(
             f"Unknown member '{member_name}' for enum '{name}' in '{file_path}'. "
             f"Available members: {available}"
         )
-    return _render_scalar(value=member.value), match.end()
+    return render_enum_member_value(value=member.value), match.end()
 
 
 def _resolve_constant_reference(
@@ -692,6 +692,24 @@ def _resolve_constant_reference(
         raise CompileInputError(
             f"Unknown constant '{name}'{scope_help} in '{file_path}'. Visible constants: {visible}"
         )
+    rendered: str = render_constant_declaration(
+        declaration=declaration,
+        value_renderer=value_renderer,
+        collection_rendering=collection_rendering,
+        file_path=file_path,
+    )
+    return rendered, match.end()
+
+
+def render_constant_declaration(
+    *,
+    declaration: ConstantDeclaration,
+    value_renderer: TypedSqlValueRenderer,
+    collection_rendering: CollectionRendering,
+    file_path: Path | None = None,
+) -> str:
+    """Render one validated constant with the active adapter's typed-value contract."""
+
     selected_rendering: CollectionRendering = declaration.render_as or collection_rendering
     try:
         if declaration.value.kind in {
@@ -718,10 +736,11 @@ def _resolve_constant_reference(
     except (SqlValueRenderingError, SqlValueValidationError) as error:
         raise CompileInputError(
             f"{declaration.relative_path} constant '{declaration.name}' could not be rendered "
-            f"in '{file_path}' by adapter '{value_renderer.adapter_name}' as "
+            f"in '{file_path or declaration.relative_path}' by adapter "
+            f"'{value_renderer.adapter_name}' as "
             f"{selected_rendering.value}: {error}"
         ) from error
-    return rendered, match.end()
+    return rendered
 
 
 def _inaccessible_declaration_message(
@@ -741,7 +760,7 @@ def _inaccessible_declaration_message(
     )
 
 
-def _render_scalar(*, value: str | int) -> str:
+def render_enum_member_value(*, value: str | int) -> str:
     if isinstance(value, int):
         return str(value)
     escaped_value: str = value.replace("'", "''")

--- a/src/sqlbuild/compiler/compile/_helpers/render/macros.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/macros.py
@@ -1456,6 +1456,7 @@ def _build_macro_invocation_context(
         macro_context,
         constants=constants,
         enums=cast(Mapping[str, Mapping[str, str | int]], enum_mapping),
+        _constant_declarations=MappingProxyType(declarations.constants),
     )
 
 

--- a/src/sqlbuild/compiler/compile/main/_build_compile_inputs.py
+++ b/src/sqlbuild/compiler/compile/main/_build_compile_inputs.py
@@ -114,6 +114,8 @@ def build_compile_inputs(
         sql_analysis_enabled=effective_settings.sql_analysis,
         target_name=effective_target_name,
         vars=effective_vars,
+        _value_renderer=adapter_context.value_renderer,
+        _collection_rendering=adapter_context.collection_rendering,
     )
     resolved_run_id: str = resolve_run_id(selected_run_id=run_id)
     loaded_macros: dict[str, LoadedMacro] = load_project_macros(discovered_inputs.macro_files)
@@ -219,6 +221,7 @@ def build_compile_inputs(
         ),
         effective_settings=effective_settings,
         effective_vars=effective_vars,
+        macro_context=macro_context,
         loaded_macros=declaration_scope.loaded_macros,
         public_enums=model_build.declarations.enums,
         public_constants=model_build.declarations.constants,

--- a/src/sqlbuild/compiler/compile/main/sql_expansion_context.py
+++ b/src/sqlbuild/compiler/compile/main/sql_expansion_context.py
@@ -85,6 +85,11 @@ def build_sql_expansion_context(
             sql_analysis_enabled=False,
             target_name=effective_discovered_inputs.project_config.default_target,
             vars=effective_vars,
+            _value_renderer=value_renderer,
+            _collection_rendering=resolve_effective_collection_rendering(
+                project_config=effective_discovered_inputs.project_config,
+                declaration_override=None,
+            ),
         ),
         enums=enums,
         constants=constants,

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from sqlbuild.compiler.auditing.models import MeasurementContract, MeasurementThresholds
 from sqlbuild.compiler.auditing.types import AuditEvaluationMode, AuditSeverity
 from sqlbuild.compiler.compile.constants import DEFAULT_SQL_TEST_MODE
+from sqlbuild.compiler.compile.exceptions import CompileInputError
 from sqlbuild.compiler.compile.types import (
     AttachedAuditTargetKind,
     CompiledResourceType,
@@ -260,6 +261,46 @@ class MacroContext:
     vars: dict[str, object] = field(default_factory=dict)
     constants: Mapping[str, object] = field(default_factory=dict)
     enums: Mapping[str, Mapping[str, str | int]] = field(default_factory=dict)
+    _value_renderer: TypedSqlValueRenderer | None = field(default=None, repr=False, compare=False)
+    _collection_rendering: CollectionRendering = field(
+        default=CollectionRendering.VALUE_LIST, repr=False, compare=False
+    )
+    _constant_declarations: Mapping[str, ConstantDeclaration] = field(
+        default_factory=dict, repr=False, compare=False
+    )
+
+    def render_constant(self, name: str) -> str:
+        """Render one visible constant as an adapter-safe SQL value."""
+
+        if self._value_renderer is None:
+            raise CompileInputError(
+                "Constant SQL rendering is available only during a project macro invocation"
+            )
+        _ = self.constants[name]
+        declaration: ConstantDeclaration | None = self._constant_declarations.get(name)
+        if declaration is None:
+            raise CompileInputError(
+                "Constant SQL rendering requires a declaration resolved for this macro invocation"
+            )
+        from sqlbuild.compiler.compile._helpers.render.declarations import (
+            render_constant_declaration,
+        )
+
+        return render_constant_declaration(
+            declaration=declaration,
+            value_renderer=self._value_renderer,
+            collection_rendering=self._collection_rendering,
+        )
+
+    def render_enum_member(self, *, enum_name: str, member_name: str) -> str:
+        """Render one visible enum member as a SQL scalar literal."""
+
+        value: str | int = self.enums[enum_name][member_name]
+        from sqlbuild.compiler.compile._helpers.render.declarations import (
+            render_enum_member_value,
+        )
+
+        return render_enum_member_value(value=value)
 
 
 @dataclass(frozen=True)
@@ -625,6 +666,7 @@ class CompileProjectInputs:
     effective_connection: dict[str, object] = field(default_factory=dict)
     effective_settings: SettingsConfig = field(default_factory=SettingsConfig)
     effective_vars: dict[str, object] = field(default_factory=dict)
+    macro_context: MacroContext | None = field(default=None, repr=False, compare=False)
     loaded_macros: dict[str, LoadedMacro] = field(default_factory=dict)
     public_enums: dict[str, EnumDeclaration] = field(default_factory=dict)
     public_constants: dict[str, ConstantDeclaration] = field(default_factory=dict)

--- a/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
+
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 
 
 @dataclass(frozen=True)
@@ -95,6 +98,14 @@ class MacroDeclarationResourceTestCase:
     expected_model_sql_fragment: str
     expected_test_sql_fragment: str
     expected_audit_sql_fragment: str
+
+
+@dataclass(frozen=True)
+class MacroDeclarationRenderingTestCase:
+    description: str
+    adapter_name: str
+    adapter_factory: Callable[[], BaseAdapter]
+    expected_sql: str
 
 
 @dataclass(frozen=True)

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_declaration_context.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_declaration_context.py
@@ -5,16 +5,76 @@ from pathlib import Path
 
 import pytest
 
+from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
 from sqlbuild.adapters.duckdb.classes.duckdb_adapter import DuckDbAdapter
+from sqlbuild.adapters.snowflake.classes.snowflake_adapter import SnowflakeAdapter
 from sqlbuild.compiler.compile.exceptions import CompileInputError
+from sqlbuild.compiler.compile.models import CompiledProject
+from sqlbuild.compiler.discovery.main.discover import discover_project_inputs
+from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.compiler.pipeline.main.project import compile_project
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from tests.integration.src.sqlbuild.compiler.pipeline._test_types import (
     MacroDeclarationContextErrorTestCase,
+    MacroDeclarationRenderingTestCase,
     MacroDeclarationResourceTestCase,
 )
 from tests.integration.src.sqlbuild.compiler.pipeline.helpers import (
     run_compile_pipeline_for_project,
 )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        MacroDeclarationRenderingTestCase(
+            description="DuckDB array rendering",
+            adapter_name="duckdb",
+            adapter_factory=DuckDbAdapter,
+            expected_sql="SELECT ['north', 'south'] AS regions",
+        ),
+        MacroDeclarationRenderingTestCase(
+            description="Snowflake array rendering",
+            adapter_name="snowflake",
+            adapter_factory=SnowflakeAdapter,
+            expected_sql="SELECT ARRAY_CONSTRUCT('north', 'south') AS regions",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_active_adapter_when_macro_renders_constant_then_uses_adapter_sql(
+    test_case: MacroDeclarationRenderingTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(
+        tmp_path,
+        {
+            "sqlbuild_project.toml": (
+                f'name = "demo"\nadapter = "{test_case.adapter_name}"\n\n'
+                "[settings]\nsql_analysis = false\n"
+            ),
+            "models/_constants/policy.sql": (
+                'CONSTANT (name regions, value ["north", "south"], render_as array);\n'
+            ),
+            "models/_macros/policy.py": (
+                "def region_array(ctx) -> str:\n    return ctx.render_constant('regions')\n"
+            ),
+            "models/summary.sql": (
+                "MODEL (materialized view, database warehouse, schema analytics);\n\n"
+                "SELECT @region_array() AS regions"
+            ),
+        },
+    )
+    adapter: BaseAdapter = test_case.adapter_factory()
+
+    discovered_inputs: DiscoveredProjectInputs = discover_project_inputs(project_dir=tmp_path)
+    project: CompiledProject = compile_project(
+        discovered_inputs=discovered_inputs,
+        adapter=adapter,
+    )
+
+    assert project.models[0].query_sql == test_case.expected_sql
 
 
 @pytest.mark.parametrize(
@@ -97,7 +157,7 @@ def test_given_macro_context_declarations_when_compiling_resources_then_all_expa
                 "models/_constants/policy.sql": ("CONSTANT (name minimum_quantity, value 2);\n"),
                 "models/_macros/policy.py": (
                     "def missing_quantity(ctx) -> str:\n"
-                    "    return str(ctx.constants['maximum_quantity'])\n"
+                    "    return ctx.render_constant('maximum_quantity')\n"
                 ),
                 "models/summary.sql": (
                     "MODEL (materialized view);\n\nSELECT @missing_quantity() AS maximum_quantity"
@@ -116,7 +176,9 @@ def test_given_macro_context_declarations_when_compiling_resources_then_all_expa
                 ),
                 "models/_macros/policy.py": (
                     "def missing_status(ctx) -> str:\n"
-                    "    return str(ctx.enums['order_status']['CLOSED'])\n"
+                    "    return ctx.render_enum_member(\n"
+                    "        enum_name='order_status', member_name='CLOSED'\n"
+                    "    )\n"
                 ),
                 "models/summary.sql": (
                     "MODEL (materialized view);\n\nSELECT @missing_status() AS status"

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_main.py
@@ -186,6 +186,7 @@ _PROJECT_TOML: str = 'name = "demo"\nadapter = "duckdb"\n\n[connection]\ndatabas
                     "CONSTANT (name unique_ids, value {2, 1});\n"
                     'CONSTANT (name labels, value (north "North", south "South"));\n'
                     'CONSTANT (name adjustment, type decimal, value "2.50");\n'
+                    'CONSTANT (name display_name, value "O\'Reilly");\n'
                 ),
                 "models/_enums/status.sql": (
                     'ENUM (name order_status, members (ACTIVE "active", PAUSED "paused"));\n'
@@ -197,14 +198,20 @@ _PROJECT_TOML: str = 'name = "demo"\nadapter = "duckdb"\n\n[connection]\ndatabas
                     "    region_count = len(ctx.constants['regions'])\n"
                     "    unique_count = len(ctx.constants['unique_ids'])\n"
                     "    label = ctx.constants['labels']['north']\n"
-                    "    adjustment = ctx.constants['adjustment']\n"
-                    "    active = ctx.enums['order_status']['ACTIVE']\n"
+                    "    adjustment_sql = ctx.render_constant('adjustment')\n"
+                    "    display_name_sql = ctx.render_constant('display_name')\n"
+                    "    regions_sql = ctx.render_constant('regions')\n"
+                    "    active_sql = ctx.render_enum_member(\n"
+                    "        enum_name='order_status', member_name='ACTIVE'\n"
+                    "    )\n"
                     "    optional = ctx.constants.get('maximum_quantity', 7)\n"
                     "    has_closed = 'CLOSED' in ctx.enums['order_status']\n"
                     "    return (\n"
                     '        f"{minimum} AS minimum_quantity, {region_count} AS region_count, "\n'
                     "        f\"{unique_count} AS unique_count, '{label}' AS label, \"\n"
-                    "        f\"{adjustment} AS adjustment, '{active}' AS active_status, \"\n"
+                    '        f"{adjustment_sql} AS adjustment, {display_name_sql} AS display_name, "\n'
+                    "        f\"{active_sql} AS active_status, 'north' IN {regions_sql} \"\n"
+                    '        f"AS region_supported, "\n'
                     '        f"{optional} AS optional_quantity, {has_closed} AS has_closed"\n'
                     "    )\n"
                 ),
@@ -217,13 +224,17 @@ _PROJECT_TOML: str = 'name = "demo"\nadapter = "duckdb"\n\n[connection]\ndatabas
                     description="model expanded with caller-visible declarations",
                     expected_resolved_sql_fragment=(
                         "SELECT 2 AS minimum_quantity, 2 AS region_count, 2 AS unique_count, "
-                        "'North' AS label, 2.50 AS adjustment, 'active' AS active_status, "
+                        "'North' AS label, 2.50 AS adjustment, 'O''Reilly' AS display_name, "
+                        "'active' AS active_status, 'north' IN ('north', 'south') "
+                        "AS region_supported, "
                         "7 AS optional_quantity, False AS has_closed"
                     ),
                     expected_logical_ddl_fragment="CREATE OR REPLACE VIEW",
                     expected_manifest_compiled_code_fragment=(
                         "SELECT 2 AS minimum_quantity, 2 AS region_count, 2 AS unique_count, "
-                        "'North' AS label, 2.50 AS adjustment, 'active' AS active_status, "
+                        "'North' AS label, 2.50 AS adjustment, 'O''Reilly' AS display_name, "
+                        "'active' AS active_status, 'north' IN ('north', 'south') "
+                        "AS region_supported, "
                         "7 AS optional_quantity, False AS has_closed"
                     ),
                 ),
@@ -233,6 +244,7 @@ _PROJECT_TOML: str = 'name = "demo"\nadapter = "duckdb"\n\n[connection]\ndatabas
             expected_manifest_node_count=1,
             expected_declaration_usages=(
                 "constant:adjustment",
+                "constant:display_name",
                 "constant:labels",
                 "constant:minimum_quantity",
                 "constant:regions",

--- a/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_macros.py
+++ b/tests/unit/src/sqlbuild/compiler/compile/_helpers/test_macros.py
@@ -634,6 +634,17 @@ def bad_macro() -> list[str]:
             expected_error_fragment="must return a SQL string when used directly in SQL",
         ),
         ExpandSqlMacrosErrorTestCase(
+            description="raises clearly when SQL rendering is used outside project invocation",
+            macro_file_contents=(
+                "def rendered_constant(ctx) -> str:\n"
+                "    return ctx.render_constant('unknown_quantity')\n"
+            ),
+            sql="SELECT @rendered_constant()",
+            expected_error_fragment=(
+                "Constant SQL rendering is available only during a project macro invocation"
+            ),
+        ),
+        ExpandSqlMacrosErrorTestCase(
             description="raises when generated SQL contains an ordinary macro call",
             macro_file_contents=(
                 "def outer_macro() -> str:\n    return '@inner_macro()'\n\n"


### PR DESCRIPTION
## Why

Python macros can inspect caller-visible constants and enums, but generated SQL still needs the active adapter's quoting and collection syntax. Direct string interpolation is safe for numeric policy values but is not a general rendering contract for strings, arrays, objects, or nulls.

## Changes

- add `MacroContext.render_constant()` and `render_enum_member()`
- reuse the same typed adapter renderers as authored `@const(...)` and `@enum(...)` references
- preserve caller scope diagnostics and declaration usage tracking
- retain renderer context during SQL-test macro-mock re-expansion
- document typed access versus generated-SQL rendering
- cover DuckDB and Snowflake collection syntax, escaped strings, enums, unavailable declarations, and non-project diagnostics

## Verification

- focused compiler unit and integration tests: 81 passed
- `make check-ci`
- `make test`
- Ruff, ty, and Fensu checks for affected boundaries
- one bounded independent review with focused follow-up verification
- clean public-tree hygiene scan
