### PR TITLE
fix: activate custom rule family prefixes

### DIFF
--- a/crates/sqlbuild-rules-native/src/rules/_helpers/catalogue.rs
+++ b/crates/sqlbuild-rules-native/src/rules/_helpers/catalogue.rs
@@ -366,10 +366,10 @@ pub(crate) fn select<'a>(
         warn: Vec::new(),
         ignore: Vec::new(),
     };
-    let configured_ruleset =
-        resolve_policy(&references, &(), &configured, &grammar).map_err(rules_error)?;
-    let mut effective_select = selected.to_vec();
-    if configured_ruleset.blocking.iter().any(|rule| rule.custom)
+    let _ = resolve_policy(&references, &(), &configured, &grammar).map_err(rules_error)?;
+    let (mut effective_select, custom_selected) =
+        activate_explicit_custom_matches(catalogue, selected, &grammar);
+    if custom_selected
         && !effective_select
             .iter()
             .any(|code| code == CUSTOM_RULE_COVERAGE_CODE)
@@ -384,6 +384,30 @@ pub(crate) fn select<'a>(
     resolve_policy(&references, &(), &effective, &grammar)
         .map(|ruleset| ruleset.blocking)
         .map_err(rules_error)
+}
+
+fn activate_explicit_custom_matches(
+    catalogue: &[RuleMetadata],
+    selected: &[String],
+    grammar: &RulesCodeGrammar,
+) -> (Vec<String>, bool) {
+    let mut effective = selected.to_vec();
+    let mut custom_selected = false;
+    for rule in catalogue {
+        if !rule.custom {
+            continue;
+        }
+        for selector in selected {
+            if !grammar.code_matches_selector(&rule.code, selector) {
+                continue;
+            }
+            custom_selected = true;
+            if !effective.contains(&rule.code) {
+                effective.push(rule.code.clone());
+            }
+        }
+    }
+    (effective, custom_selected)
 }
 
 pub(crate) fn selected_codes_json(request_json: &str) -> Result<String, String> {

--- a/tests/integration/src/sqlbuild/cli/commands/main/test_rules.py
+++ b/tests/integration/src/sqlbuild/cli/commands/main/test_rules.py
@@ -145,6 +145,52 @@ def test_given_project_when_running_focused_rule_family_then_only_that_family_ru
 
 @pytest.mark.parametrize(
     "test_case",
+    [
+        RulesIntegrationTestCase(
+            "default-off custom family is explicitly selected", 1, "XSQBRARCH001"
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_default_off_custom_rule_when_running_exact_and_prefix_then_both_select_rule(
+    test_case: RulesIntegrationTestCase,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        'name = "orders"\nadapter = "duckdb"\n\n'
+        "[rules.thresholds]\nmin_custom_rule_test_cases = 0\n",
+        encoding="utf-8",
+    )
+    model: Path = tmp_path / "models" / "orders.sql"
+    model.parent.mkdir()
+    model.write_text('MODEL (description "Orders");\nSELECT 1 AS order_id\n', encoding="utf-8")
+    rule_file: Path = tmp_path / "rules" / "architecture.py"
+    rule_file.parent.mkdir()
+    rule_file.write_text(
+        """from sqlbuild.rules import Finding, Model, RuleContext, rule
+
+@rule(code="XSQBRARCH001", message="Forbidden name", remediation="Rename the model.")
+def forbidden_name(*, model: Model, ctx: RuleContext) -> list[Finding]:
+    return [ctx.finding(subject=model)]
+""",
+        encoding="utf-8",
+    )
+
+    exact_exit: int = main(
+        ["--project-dir", str(tmp_path), "rules", "--json", "run", "XSQBRARCH001"]
+    )
+    exact: dict[str, object] = json.loads(capsys.readouterr().out)
+    prefix_exit: int = main(["--project-dir", str(tmp_path), "rules", "--json", "run", "XSQBRARCH"])
+    prefix: dict[str, object] = json.loads(capsys.readouterr().out)
+
+    assert exact_exit == prefix_exit == test_case.expected_exit_code
+    assert exact["findings"][0]["code"] == test_case.expected_code
+    assert prefix["findings"][0]["code"] == test_case.expected_code
+
+
+@pytest.mark.parametrize(
+    "test_case",
     [RulesIntegrationTestCase("SQL rule exception suppresses finding", 0, "SQBRSQL004")],
     ids=lambda case: case.description,
 )

--- a/tests/unit/src/sqlbuild/rule_engine/_helpers/engine/test_custom_rules.py
+++ b/tests/unit/src/sqlbuild/rule_engine/_helpers/engine/test_custom_rules.py
@@ -39,8 +39,10 @@ from tests.unit.src.sqlbuild.rule_engine._helpers.engine.helpers import custom_r
             minimum_custom_rule_cases=1,
         ),
         CustomRuleTestCase(
-            description="default-off custom rule is not activated by prefix",
+            description="explicit prefix activates default-off custom rule",
             body="return [ctx.finding(subject=model)]",
+            expected_fault_codes=("XSQBRT101",),
+            expected_fault_lines=(1,),
             select=("XSQBRT",),
         ),
         CustomRuleTestCase(


### PR DESCRIPTION
## Why

SQLBuild 0.94.0 accepted custom Rule family prefixes such as `XSQBRARCH`, but default-off custom Rules matched by that prefix were not activated. Exact selection worked, while focused and configured family selection could silently evaluate zero Rules. This contradicted the documented exact/prefix selection contract.

## Changes

- expand explicitly selected custom family prefixes to their matching exact codes before policy activation
- preserve selector validation, ignore precedence, empty selection, and custom Rule coverage enforcement
- cover both exact and prefix execution through the real `sqb rules run` CLI
- update the engine regression to require explicit prefixes to activate default-off custom Rules

This applies consistently to focused CLI selection and persistent `[rules] select` configuration.

## Verification

- `uv run pytest tests/integration/src/sqlbuild/cli/commands/main/test_rules.py -n auto --dist loadfile`
- focused custom Rule engine tests
- `cargo test -p sqlbuild-rules-native`
- Rust formatting, Clippy, and architecture checks
- `uv sync --all-extras`
- `make check-ci`
- Ruff, diff, and public-repository hygiene checks
