### PR TITLE
feat: support selector name patterns

### DIFF
--- a/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
+++ b/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
@@ -6490,6 +6490,26 @@ paths, graph expansion (`+orders`, `orders+`, or `+orders+`), and lineage paths 
 `base_orders~customer_orders`. `paths` and `selectors` may be combined in one ignore. Continue to
 use `paths` for SQL tests and audits because those files are not graph resources.
 
+Bare resource names also accept glob patterns. For example, this scopes the ignore to every graph
+resource whose name starts with `intermediate_`:
+
+```toml
+[[rules.rule_ignores]]
+rules = ["SQBRSQL021"]
+selectors = ["intermediate_*"]
+reason = "These intermediate interfaces intentionally preserve upstream columns."
+```
+
+Use `paths` instead when the convention belongs to authored filenames or directories, including
+non-graph SQL files:
+
+```toml
+[[rules.rule_ignores]]
+rules = ["SQBRSQL021"]
+paths = ["models/**/intermediate_*.sql"]
+reason = "These intermediate SQL files intentionally preserve upstream columns."
+```
+
 ### Mandatory correctness
 
 Mandatory compiler correctness is not configurable and cannot be suppressed. A project must first

--- a/src/sqlbuild/compiler/planner/_helpers/graph/selectors.py
+++ b/src/sqlbuild/compiler/planner/_helpers/graph/selectors.py
@@ -386,6 +386,9 @@ def _lookup_keys(
     """Look up object keys for an exact or glob-pattern name selector."""
 
     if parsed.kind == SelectorKind.NAME:
+        if not _is_name_pattern(parsed.value):
+            candidate: CompiledObjectKey | None = all_keys.get(parsed.value)
+            return frozenset() if candidate is None else frozenset((candidate,))
         return frozenset(key for name, key in all_keys.items() if fnmatchcase(name, parsed.value))
 
     resource_type: CompiledResourceType | None = _RESOURCE_TYPE_BY_SELECTOR_KIND.get(parsed.kind)
@@ -395,6 +398,11 @@ def _lookup_keys(
             code="S010",
         )
 
+    if not _is_name_pattern(parsed.value):
+        candidate = all_keys.get(parsed.value)
+        if candidate is not None and candidate.resource_type == resource_type:
+            return frozenset((candidate,))
+        return frozenset()
     return frozenset(
         key
         for name, key in all_keys.items()

--- a/src/sqlbuild/compiler/planner/_helpers/graph/selectors.py
+++ b/src/sqlbuild/compiler/planner/_helpers/graph/selectors.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from fnmatch import fnmatchcase
+
 from sqlbuild.compiler.compile.models import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
 from sqlbuild.compiler.planner._helpers.graph.core import (
@@ -285,15 +287,19 @@ def _resolve_single(
             downstream=downstream,
         )
 
-    key: CompiledObjectKey | None = _lookup_key(parsed=parsed, all_keys=all_keys)
-    if key is None:
-        raise PlannerInputError(f"unknown selector name '{parsed.value}'", code="S007")
+    keys: frozenset[CompiledObjectKey] = _lookup_keys(parsed=parsed, all_keys=all_keys)
+    if not keys:
+        label: str = "pattern" if _is_name_pattern(parsed.value) else "name"
+        raise PlannerInputError(f"unknown selector {label} '{parsed.value}'", code="S007")
 
-    result: set[CompiledObjectKey] = {key}
+    result: set[CompiledObjectKey] = set(keys)
+    key: CompiledObjectKey
     if parsed.upstream:
-        result.update(expand_upstream(key=key, upstream=upstream))
+        for key in keys:
+            result.update(expand_upstream(key=key, upstream=upstream))
     if parsed.downstream:
-        result.update(expand_downstream(key=key, downstream=downstream))
+        for key in keys:
+            result.update(expand_downstream(key=key, downstream=downstream))
     return frozenset(result)
 
 
@@ -372,15 +378,15 @@ def _path_matches(*, indexed_folder: str, selector_folder: str) -> bool:
     return indexed_folder == selector_folder or indexed_folder.startswith(f"{selector_folder}/")
 
 
-def _lookup_key(
+def _lookup_keys(
     *,
     parsed: ParsedSelector,
     all_keys: dict[str, CompiledObjectKey],
-) -> CompiledObjectKey | None:
-    """Look up the object key for a parsed selector."""
+) -> frozenset[CompiledObjectKey]:
+    """Look up object keys for an exact or glob-pattern name selector."""
 
     if parsed.kind == SelectorKind.NAME:
-        return all_keys.get(parsed.value)
+        return frozenset(key for name, key in all_keys.items() if fnmatchcase(name, parsed.value))
 
     resource_type: CompiledResourceType | None = _RESOURCE_TYPE_BY_SELECTOR_KIND.get(parsed.kind)
     if resource_type is None:
@@ -389,7 +395,12 @@ def _lookup_key(
             code="S010",
         )
 
-    candidate: CompiledObjectKey | None = all_keys.get(parsed.value)
-    if candidate is not None and candidate.resource_type == resource_type:
-        return candidate
-    return None
+    return frozenset(
+        key
+        for name, key in all_keys.items()
+        if key.resource_type == resource_type and fnmatchcase(name, parsed.value)
+    )
+
+
+def _is_name_pattern(value: str) -> bool:
+    return any(character in value for character in "*?[")

--- a/src/sqlbuild/compiler/python_nodes/_helpers/selectors.py
+++ b/src/sqlbuild/compiler/python_nodes/_helpers/selectors.py
@@ -13,7 +13,7 @@ from sqlbuild.compiler.python_nodes.constants import (
     EMPTY_SELECTOR_FOLDER,
     UNIFIED_PATH_ROOTS,
 )
-from sqlbuild.compiler.python_nodes.models import PythonNodeGraph
+from sqlbuild.compiler.python_nodes.models import DiscoveredPythonNode, PythonNodeGraph
 from sqlbuild.compiler.python_nodes.types import PythonNodeKind
 
 _PYTHON_NODE_KIND_BY_SELECTOR_KIND: dict[SelectorKind, PythonNodeKind] = {
@@ -150,6 +150,9 @@ def _resolve_tag(*, parsed: ParsedSelector, graph: PythonNodeGraph) -> frozenset
 
 def _lookup_node_names(*, parsed: ParsedSelector, graph: PythonNodeGraph) -> frozenset[str]:
     if parsed.kind == SelectorKind.NAME:
+        if not _is_name_pattern(parsed.value):
+            node: DiscoveredPythonNode | None = graph.nodes_by_name.get(parsed.value)
+            return frozenset() if node is None else frozenset((node.name,))
         return frozenset(
             node.name
             for name, node in graph.nodes_by_name.items()
@@ -163,11 +166,18 @@ def _lookup_node_names(*, parsed: ParsedSelector, graph: PythonNodeGraph) -> fro
             code="S010",
         )
 
+    if not _is_name_pattern(parsed.value):
+        node = graph.nodes_by_typed_selector.get(f"{python_node_kind.value}:{parsed.value}")
+        return frozenset() if node is None else frozenset((node.name,))
     return frozenset(
         node.name
         for node in graph.nodes_by_name.values()
         if node.kind == python_node_kind and fnmatchcase(node.name, parsed.value)
     )
+
+
+def _is_name_pattern(value: str) -> bool:
+    return any(character in value for character in "*?[")
 
 
 def _expand_upstream(*, name: str, graph: PythonNodeGraph) -> frozenset[str]:

--- a/src/sqlbuild/compiler/python_nodes/_helpers/selectors.py
+++ b/src/sqlbuild/compiler/python_nodes/_helpers/selectors.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from fnmatch import fnmatchcase
+
 from sqlbuild.compiler.planner.constants import PATH_SELECTOR_EXPLICIT_ROOT_ERROR
 from sqlbuild.compiler.planner.exceptions import PlannerInputError
 from sqlbuild.compiler.planner.main.selection.selector_parse import parse_project_selector
@@ -11,7 +13,7 @@ from sqlbuild.compiler.python_nodes.constants import (
     EMPTY_SELECTOR_FOLDER,
     UNIFIED_PATH_ROOTS,
 )
-from sqlbuild.compiler.python_nodes.models import DiscoveredPythonNode, PythonNodeGraph
+from sqlbuild.compiler.python_nodes.models import PythonNodeGraph
 from sqlbuild.compiler.python_nodes.types import PythonNodeKind
 
 _PYTHON_NODE_KIND_BY_SELECTOR_KIND: dict[SelectorKind, PythonNodeKind] = {
@@ -77,15 +79,18 @@ def _resolve_single(*, raw: str, graph: PythonNodeGraph) -> frozenset[str]:
     if parsed.kind == SelectorKind.PATH:
         return _resolve_path(parsed=parsed, graph=graph)
 
-    node_name: str | None = _lookup_node_name(parsed=parsed, graph=graph)
-    if node_name is None:
+    node_names: frozenset[str] = _lookup_node_names(parsed=parsed, graph=graph)
+    if not node_names:
         raise PlannerInputError(f"unknown Python node selector '{parsed.value}'", code="S007")
 
-    result: set[str] = {node_name}
+    result: set[str] = set(node_names)
+    node_name: str
     if parsed.upstream:
-        result.update(_expand_upstream(name=node_name, graph=graph))
+        for node_name in node_names:
+            result.update(_expand_upstream(name=node_name, graph=graph))
     if parsed.downstream:
-        result.update(_expand_downstream(name=node_name, graph=graph))
+        for node_name in node_names:
+            result.update(_expand_downstream(name=node_name, graph=graph))
     return frozenset(result)
 
 
@@ -143,10 +148,13 @@ def _resolve_tag(*, parsed: ParsedSelector, graph: PythonNodeGraph) -> frozenset
     return frozenset(result)
 
 
-def _lookup_node_name(*, parsed: ParsedSelector, graph: PythonNodeGraph) -> str | None:
+def _lookup_node_names(*, parsed: ParsedSelector, graph: PythonNodeGraph) -> frozenset[str]:
     if parsed.kind == SelectorKind.NAME:
-        node: DiscoveredPythonNode | None = graph.nodes_by_name.get(parsed.value)
-        return None if node is None else node.name
+        return frozenset(
+            node.name
+            for name, node in graph.nodes_by_name.items()
+            if fnmatchcase(name, parsed.value)
+        )
 
     python_node_kind: PythonNodeKind | None = _PYTHON_NODE_KIND_BY_SELECTOR_KIND.get(parsed.kind)
     if python_node_kind is None:
@@ -155,8 +163,11 @@ def _lookup_node_name(*, parsed: ParsedSelector, graph: PythonNodeGraph) -> str 
             code="S010",
         )
 
-    node = graph.nodes_by_typed_selector.get(f"{python_node_kind.value}:{parsed.value}")
-    return None if node is None else node.name
+    return frozenset(
+        node.name
+        for node in graph.nodes_by_name.values()
+        if node.kind == python_node_kind and fnmatchcase(node.name, parsed.value)
+    )
 
 
 def _expand_upstream(*, name: str, graph: PythonNodeGraph) -> frozenset[str]:

--- a/src/sqlbuild/compiler/python_nodes/_helpers/unified_selectors.py
+++ b/src/sqlbuild/compiler/python_nodes/_helpers/unified_selectors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from fnmatch import fnmatchcase
 
 from sqlbuild.compiler.compile.models import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
@@ -301,11 +302,18 @@ def _resolve_single(
             )
         return atoms
     if parsed.kind in _PYTHON_SELECTOR_KINDS:
-        if parsed.kind == SelectorKind.LOADER and parsed.value in _terminal_loader_by_name(
+        terminal_loader_by_name: dict[str, str] = _terminal_loader_by_name(
             project_graph=project_graph
-        ):
+        )
+        matched_terminal_loaders: tuple[str, ...] = tuple(
+            sorted(name for name in terminal_loader_by_name if fnmatchcase(name, parsed.value))
+        )
+        if parsed.kind == SelectorKind.LOADER and matched_terminal_loaders:
+            loader_name: str = matched_terminal_loaders[0]
+            source_name: str = terminal_loader_by_name[loader_name]
             raise PlannerInputError(
-                f"'{parsed.value}' is a managed source; select it as source:{parsed.value}",
+                f"loader selector '{parsed.value}' matches managed source loader "
+                f"'{loader_name}'; select it as source:{source_name}",
                 code="S007",
             )
         return _resolve_python(raw=raw, python_graph=python_graph)
@@ -404,22 +412,35 @@ def _resolve_name(
     project_graph: ProjectGraph,
     python_graph: PythonNodeGraph,
 ) -> frozenset[_SelectionAtom]:
-    sql_key: CompiledObjectKey | None = project_graph.all_keys.get(parsed.value)
-    python_exists: bool = parsed.value in python_graph.nodes_by_name
     terminal_loader_names: frozenset[str] = frozenset(
         _terminal_loader_by_name(project_graph=project_graph)
     )
-    if sql_key is not None and parsed.value in terminal_loader_names:
-        return _resolve_sql(raw=raw, project_graph=project_graph)
-    if sql_key is not None and python_exists:
+    sql_names: frozenset[str] = frozenset(
+        name for name in project_graph.all_keys if fnmatchcase(name, parsed.value)
+    )
+    python_names: frozenset[str] = frozenset(
+        name for name in python_graph.nodes_by_name if fnmatchcase(name, parsed.value)
+    )
+    conflicting_names: frozenset[str] = (sql_names & python_names) - terminal_loader_names
+    if conflicting_names:
+        conflicting_name: str = sorted(conflicting_names)[0]
         raise PlannerInputError(
-            f"selector name '{parsed.value}' matches both a SQL resource and a Python node; "
+            f"selector name '{conflicting_name}' matches both a SQL resource and a Python node; "
             "resource names must be globally unique"
         )
-    if sql_key is not None:
-        return _resolve_sql(raw=raw, project_graph=project_graph)
-    if python_exists:
-        return _resolve_python(raw=raw, python_graph=python_graph)
+    atoms: set[_SelectionAtom] = set()
+    if sql_names:
+        atoms.update(_resolve_sql(raw=raw, project_graph=project_graph))
+    if python_names:
+        python_atoms: frozenset[_SelectionAtom] = _resolve_python(
+            raw=raw, python_graph=python_graph
+        )
+        duplicate_terminal_atoms: set[_SelectionAtom] = {
+            _python_atom(name) for name in sql_names & terminal_loader_names
+        }
+        atoms.update(python_atoms - duplicate_terminal_atoms)
+    if atoms:
+        return frozenset(atoms)
     raise PlannerInputError(f"unknown selector name '{parsed.value}'", code="S007")
 
 

--- a/src/sqlbuild/compiler/python_nodes/_helpers/unified_selectors.py
+++ b/src/sqlbuild/compiler/python_nodes/_helpers/unified_selectors.py
@@ -412,6 +412,25 @@ def _resolve_name(
     project_graph: ProjectGraph,
     python_graph: PythonNodeGraph,
 ) -> frozenset[_SelectionAtom]:
+    if not _is_name_pattern(parsed.value):
+        sql_key: CompiledObjectKey | None = project_graph.all_keys.get(parsed.value)
+        python_exists: bool = parsed.value in python_graph.nodes_by_name
+        terminal_loader_names: frozenset[str] = frozenset(
+            _terminal_loader_by_name(project_graph=project_graph)
+        )
+        if sql_key is not None and parsed.value in terminal_loader_names:
+            return _resolve_sql(raw=raw, project_graph=project_graph)
+        if sql_key is not None and python_exists:
+            raise PlannerInputError(
+                f"selector name '{parsed.value}' matches both a SQL resource and a Python node; "
+                "resource names must be globally unique"
+            )
+        if sql_key is not None:
+            return _resolve_sql(raw=raw, project_graph=project_graph)
+        if python_exists:
+            return _resolve_python(raw=raw, python_graph=python_graph)
+        raise PlannerInputError(f"unknown selector name '{parsed.value}'", code="S007")
+
     terminal_loader_names: frozenset[str] = frozenset(
         _terminal_loader_by_name(project_graph=project_graph)
     )
@@ -442,6 +461,10 @@ def _resolve_name(
     if atoms:
         return frozenset(atoms)
     raise PlannerInputError(f"unknown selector name '{parsed.value}'", code="S007")
+
+
+def _is_name_pattern(value: str) -> bool:
+    return any(character in value for character in "*?[")
 
 
 def _build_selection(atoms: set[_SelectionAtom]) -> PythonSqlSelection:

--- a/tests/e2e/src/sqlbuild/cli/commands/main/build/test_selector_surface.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/build/test_selector_surface.py
@@ -57,6 +57,19 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
             pre_commands=(("--no-color", "build"),),
         ),
         SelectorSurfaceBuildE2ETestCase(
+            description="resource name glob selects every matching model",
+            command=("--no-color", "build", "--select", "stg_*"),
+            expected_exit_code=0,
+            expected_stdout_fragments=(
+                "Plan ready  3 selected",
+                "stg_customers",
+                "stg_orders",
+                "stg_payments",
+            ),
+            expected_stderr_fragments=(),
+            pre_commands=(("--no-color", "build"),),
+        ),
+        SelectorSurfaceBuildE2ETestCase(
             description="malformed path selector with internal plus fails clearly",
             command=("--no-color", "plan", "--select", "+fact_orders~+daily_activity_rollup"),
             expected_exit_code=1,

--- a/tests/integration/src/sqlbuild/cli/commands/main/test_rules.py
+++ b/tests/integration/src/sqlbuild/cli/commands/main/test_rules.py
@@ -245,7 +245,7 @@ def test_given_graph_scoped_rule_ignore_when_running_rules_then_only_matched_res
         'name = "orders"\nadapter = "duckdb"\n\n'
         "[[rules.rule_ignores]]\n"
         'rules = ["SQBRSQL021"]\n'
-        'selectors = ["+orders"]\n'
+        'selectors = ["+orders*"]\n'
         'reason = "Reviewed upstream interface boundary"\n',
         encoding="utf-8",
     )

--- a/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_selectors.py
+++ b/tests/unit/src/sqlbuild/compiler/planner/_helpers/test_selectors.py
@@ -207,6 +207,24 @@ def test_given_invalid_selector_when_parsing_then_raises(
             expected_names=frozenset({"orders", "joined"}),
         ),
         ResolveSelectorTestCase(
+            description="selects resources by name glob",
+            select=("*orders",),
+            exclude=(),
+            expected_names=frozenset({"orders", "raw_orders"}),
+        ),
+        ResolveSelectorTestCase(
+            description="expands downstream from every name glob match",
+            select=("*orders+",),
+            exclude=(),
+            expected_names=frozenset({"raw_orders", "orders", "joined"}),
+        ),
+        ResolveSelectorTestCase(
+            description="excludes resources by name glob",
+            select=(),
+            exclude=("raw_*",),
+            expected_names=frozenset({"orders", "customers", "joined", "codes"}),
+        ),
+        ResolveSelectorTestCase(
             description="unions multiple select tokens",
             select=("orders", "customers"),
             exclude=(),
@@ -249,6 +267,12 @@ def test_given_invalid_selector_when_parsing_then_raises(
             select=("source:raw_orders",),
             exclude=(),
             expected_names=frozenset({"raw_orders"}),
+        ),
+        ResolveSelectorTestCase(
+            description="selects sources by typed name glob",
+            select=("source:raw_*",),
+            exclude=(),
+            expected_names=frozenset({"raw_orders", "raw_customers"}),
         ),
         ResolveSelectorTestCase(
             description="intersects comma-separated tokens",
@@ -382,6 +406,12 @@ def test_given_model_table_function_dependency_when_selecting_then_graph_expands
         ResolveSelectorErrorTestCase(
             description="raises when selector references unknown name",
             select=("nonexistent_model",),
+            exclude=(),
+            expected_error_type=ValueError,
+        ),
+        ResolveSelectorErrorTestCase(
+            description="raises when selector name glob matches nothing",
+            select=("missing_*",),
             exclude=(),
             expected_error_type=ValueError,
         ),

--- a/tests/unit/src/sqlbuild/compiler/python_nodes/_helpers/helpers.py
+++ b/tests/unit/src/sqlbuild/compiler/python_nodes/_helpers/helpers.py
@@ -111,6 +111,24 @@ def build_external_loader_python_node_graph() -> PythonNodeGraph:
     )
 
 
+def build_terminal_loader_python_node_graph() -> PythonNodeGraph:
+    """Build a graph containing one loader owned by a managed source."""
+    return build_python_node_graph(
+        discovered_inputs=DiscoveredProjectInputs(
+            project_config=ProjectConfig(name="demo", adapter="duckdb"),
+            local_config=LocalConfig(),
+            loader_functions=(
+                DiscoveredLoaderFunction(
+                    file_path=Path("/project/loaders/orders.py"),
+                    relative_path=Path("loaders/orders.py"),
+                    name="raw_orders",
+                    function=raw_orders,
+                ),
+            ),
+        )
+    )
+
+
 def build_orders_python_node_graph() -> PythonNodeGraph:
     return build_python_node_graph(
         discovered_inputs=DiscoveredProjectInputs(

--- a/tests/unit/src/sqlbuild/compiler/python_nodes/_helpers/test_selectors.py
+++ b/tests/unit/src/sqlbuild/compiler/python_nodes/_helpers/test_selectors.py
@@ -72,6 +72,18 @@ def test_given_python_node_typed_selector_when_parsing_then_returns_expected_kin
             expected_names=frozenset({"export_orders"}),
         ),
         PythonNodeSelectorTestCase(
+            description="selects Python nodes by bare name glob",
+            select=("*orders*",),
+            exclude=(),
+            expected_names=frozenset({"prepare_orders", "export_orders", "check_orders_export"}),
+        ),
+        PythonNodeSelectorTestCase(
+            description="selects Python nodes by typed name glob",
+            select=("asset:export_*",),
+            exclude=(),
+            expected_names=frozenset({"export_orders"}),
+        ),
+        PythonNodeSelectorTestCase(
             description="selects upstream Python nodes with leading plus",
             select=("+check_orders_export",),
             exclude=(),

--- a/tests/unit/src/sqlbuild/compiler/python_nodes/_helpers/test_unified_selectors.py
+++ b/tests/unit/src/sqlbuild/compiler/python_nodes/_helpers/test_unified_selectors.py
@@ -21,6 +21,7 @@ from tests.unit.src.sqlbuild.compiler.python_nodes._helpers.helpers import (
     build_python_node_graph_for_case,
     build_sql_downstream_task_to_loader_python_node_graph,
     build_sql_ref_python_node_graph,
+    build_terminal_loader_python_node_graph,
     model_ref,
     source_ref,
 )
@@ -42,6 +43,13 @@ from tests.unit.src.sqlbuild.compiler.python_nodes._helpers.helpers import (
             exclude=(),
             expected_sql_names=frozenset(),
             expected_python_node_names=frozenset({"prepare_orders"}),
+        ),
+        PythonSqlSelectorTestCase(
+            description="selects SQL and Python resources by bare name glob",
+            select=("*orders",),
+            exclude=(),
+            expected_sql_names=frozenset({"raw_orders", "orders"}),
+            expected_python_node_names=frozenset({"prepare_orders", "export_orders"}),
         ),
         PythonSqlSelectorTestCase(
             description="selects expanded Python node by typed selector",
@@ -165,6 +173,34 @@ def test_given_unknown_unified_selector_when_resolving_then_raises_clear_error(
 ) -> None:
     project_graph: ProjectGraph = build_orders_project_graph()
     python_graph: PythonNodeGraph = build_orders_python_node_graph()
+
+    with pytest.raises(test_case.expected_error_type, match=test_case.expected_error_fragment):
+        resolve_python_sql_selectors(
+            select=test_case.select,
+            exclude=test_case.exclude,
+            project_graph=project_graph,
+            python_graph=python_graph,
+        )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        PythonSqlSelectorErrorTestCase(
+            description="typed loader glob cannot select a managed source loader",
+            select=("loader:raw_*",),
+            exclude=(),
+            expected_error_type=ValueError,
+            expected_error_fragment="matches managed source loader 'raw_orders'",
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_managed_source_loader_glob_when_resolving_then_requires_source_selector(
+    test_case: PythonSqlSelectorErrorTestCase,
+) -> None:
+    project_graph: ProjectGraph = build_orders_project_graph()
+    python_graph: PythonNodeGraph = build_terminal_loader_python_node_graph()
 
     with pytest.raises(test_case.expected_error_type, match=test_case.expected_error_fragment):
         resolve_python_sql_selectors(


### PR DESCRIPTION
## Why

Scoped Rules and ordinary CLI selection need a concise way to target resources that follow a project-owned naming convention. Exact names and file globs do not cover that graph-aware use case.

## Changes

- support shell-style globs in bare and typed resource-name selectors
- apply upstream and downstream graph expansion from every matching resource
- resolve bare patterns across SQL and Python resources while deduplicating source-owned terminal loaders
- preserve managed-source routing for typed loader patterns
- document resource-name patterns and authored-file path globs with neutral examples
- add planner, Python-node, unified-selection, Rules integration, and CLI E2E coverage

## Verification

- focused selector, Rules, and CLI tests: 132 passed
- `make check-ci`
- independent bounded review and finding-focused follow-up
- public tree and outgoing-commit hygiene scans
