### PR TITLE
perf: cache structural lineage graphs

### DIFF
--- a/src/sqlbuild/cli/commands/_helpers/entry/observability.py
+++ b/src/sqlbuild/cli/commands/_helpers/entry/observability.py
@@ -87,9 +87,12 @@ def cli_observability_scope(*, args: CliNamespace, project_dir: Path) -> Iterato
         providers: tuple[DiscoveredProvider, ...]
         event_exporters: tuple[DiscoveredEventExporter, ...]
         command_output_sinks: tuple[DiscoveredCommandOutputSink, ...]
-        providers, event_exporters, command_output_sinks = discover_runtime_extensions(
-            project_dir=project_dir
-        )
+        if args.command == LINEAGE_COMMAND:
+            providers, event_exporters, command_output_sinks = (), (), ()
+        else:
+            providers, event_exporters, command_output_sinks = discover_runtime_extensions(
+                project_dir=project_dir
+            )
         if event_exporters or command_output_sinks:
             exporter_delivery: EventExporterDispatcher = EventExporterDispatcher(
                 failure_callback=_log_exporter_failure,

--- a/src/sqlbuild/cli/commands/_helpers/lineage/cache.py
+++ b/src/sqlbuild/cli/commands/_helpers/lineage/cache.py
@@ -1,0 +1,394 @@
+"""Disposable SQLite cache for relation-level project lineage."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import tempfile
+from contextlib import closing
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+
+from sqlbuild.cli.commands.constants import TARGET_DIRECTORY_NAME
+from sqlbuild.cli.commands.models import LineageNode, RelationLineageIndex
+from sqlbuild.compiler.compile.models import CompiledObjectKey, CompiledProject
+from sqlbuild.compiler.pipeline.models import ProjectGraph
+
+_CACHE_SCHEMA_VERSION: int = 1
+_CACHE_ALGORITHM_VERSION: str = "relation-lineage-graph-v4"
+_CACHE_RELATIVE_PATH: Path = Path("cache/lineage/v1/structural-graph.sqlite3")
+_CACHE_MAX_BYTES: int = 50_000_000
+_CACHE_MAX_ROWS: int = 1_000_000
+_SQLITE_TIMEOUT_SECONDS: float = 5.0
+_FINGERPRINT_SUFFIXES: frozenset[str] = frozenset({".csv", ".py", ".sql", ".toml", ".yaml", ".yml"})
+_FINGERPRINT_ROOT_FILES: frozenset[str] = frozenset({".gitignore", ".sqlbuildignore"})
+_EXCLUDED_ROOTS: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "node_modules",
+        "target",
+        "venv",
+    }
+)
+_EXCLUDED_PATH_PARTS: frozenset[str] = frozenset({"__pycache__"})
+_ENVIRONMENT_PATTERN: re.Pattern[bytes] = re.compile(rb"ENV:\s*([A-Za-z0-9_]+)")
+_ENVIRONMENT_MARKER: bytes = b"ENV:"
+_DYNAMIC_CONTEXT_MARKER: bytes = b"CTX:"
+_DYNAMIC_CONTEXT_GRAPH_SUFFIXES: frozenset[str] = frozenset({".py", ".toml"})
+_NON_ASCII_BYTE_START: int = 128
+
+
+def relation_lineage_fingerprint(
+    *, project_dir: Path, cli_vars: dict[str, object] | None
+) -> str | None:
+    """Hash authored project inputs and invocation context without retaining their values."""
+
+    try:
+        digest: Any = hashlib.sha256()
+        digest.update(_CACHE_ALGORITHM_VERSION.encode("ascii"))
+        digest.update(_sqlbuild_version().encode("utf-8"))
+        digest.update(
+            json.dumps(
+                {} if cli_vars is None else cli_vars,
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("ascii")
+        )
+        environment_names: set[str] = set()
+        for path in _authored_files(project_dir=project_dir):
+            relative_path: str = path.relative_to(project_dir).as_posix()
+            contents: bytes = path.read_bytes()
+            if (
+                _DYNAMIC_CONTEXT_MARKER in contents
+                and path.suffix.lower() in _DYNAMIC_CONTEXT_GRAPH_SUFFIXES
+            ):
+                return None
+            environment_matches: list[re.Match[bytes]] = list(
+                _ENVIRONMENT_PATTERN.finditer(contents)
+            )
+            if contents.count(_ENVIRONMENT_MARKER) != len(environment_matches):
+                return None
+            if any(
+                match.end() < len(contents) and contents[match.end()] >= _NON_ASCII_BYTE_START
+                for match in environment_matches
+            ):
+                return None
+            environment_names.update(
+                match.group(1).decode("ascii") for match in environment_matches
+            )
+            digest.update(len(relative_path).to_bytes(8, byteorder="big"))
+            digest.update(relative_path.encode("utf-8"))
+            digest.update(len(contents).to_bytes(8, byteorder="big"))
+            digest.update(contents)
+        for name in sorted(environment_names):
+            digest.update(name.encode("ascii"))
+            digest.update(os.environ.get(name, "<missing>").encode("utf-8"))
+        return digest.hexdigest()
+    except (OSError, TypeError, UnicodeError, ValueError):
+        return None
+
+
+def read_relation_lineage_cache(
+    *, project_dir: Path, fingerprint: str
+) -> RelationLineageIndex | None:
+    """Read a verified structural graph, treating every fault as a cache miss."""
+
+    database_path: Path = _cache_path(project_dir=project_dir)
+    try:
+        if database_path.stat().st_size > _CACHE_MAX_BYTES:
+            return None
+        with closing(
+            sqlite3.connect(
+                f"file:{database_path}?mode=ro",
+                uri=True,
+                timeout=_SQLITE_TIMEOUT_SECONDS,
+            )
+        ) as connection:
+            metadata: dict[str, str] = dict(connection.execute("SELECT key, value FROM metadata"))
+            if metadata != {
+                "algorithm_version": _CACHE_ALGORITHM_VERSION,
+                "input_fingerprint": fingerprint,
+                "schema_version": str(_CACHE_SCHEMA_VERSION),
+            }:
+                return None
+            return _read_index(connection=connection)
+    except (KeyError, OSError, sqlite3.DatabaseError, TypeError, ValueError):
+        return None
+
+
+def write_relation_lineage_cache(
+    *, project_dir: Path, fingerprint: str, graph: ProjectGraph
+) -> RelationLineageIndex:
+    """Build the structural projection and atomically publish its SQLite cache."""
+
+    index: RelationLineageIndex = _relation_index(graph=graph)
+    directory: Path = _cache_path(project_dir=project_dir).parent
+    temporary_path: Path | None = None
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(prefix=".structural-graph-", dir=directory)
+        os.close(descriptor)
+        temporary_path = Path(temporary_name)
+        with closing(
+            sqlite3.connect(temporary_path, timeout=_SQLITE_TIMEOUT_SECONDS)
+        ) as connection:
+            _create_schema(connection=connection)
+            _write_index(connection=connection, fingerprint=fingerprint, index=index)
+            connection.commit()
+        temporary_path.replace(_cache_path(project_dir=project_dir))
+    except (OSError, sqlite3.DatabaseError, TypeError, ValueError):
+        pass
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+    return index
+
+
+def _authored_files(*, project_dir: Path) -> tuple[Path, ...]:
+    return tuple(
+        sorted(
+            path
+            for path in project_dir.rglob("*")
+            if path.is_file()
+            and not _is_excluded(path=path, project_dir=project_dir)
+            and (
+                path.suffix.lower() in _FINGERPRINT_SUFFIXES or path.name in _FINGERPRINT_ROOT_FILES
+            )
+        )
+    )
+
+
+def _is_excluded(*, path: Path, project_dir: Path) -> bool:
+    parts: tuple[str, ...] = path.relative_to(project_dir).parts
+    return (
+        not parts or parts[0] in _EXCLUDED_ROOTS or bool(_EXCLUDED_PATH_PARTS.intersection(parts))
+    )
+
+
+def _cache_path(*, project_dir: Path) -> Path:
+    return project_dir / TARGET_DIRECTORY_NAME / _CACHE_RELATIVE_PATH
+
+
+def _relation_index(*, graph: ProjectGraph) -> RelationLineageIndex:
+    keys: frozenset[CompiledObjectKey] = frozenset(graph.all_keys.values())
+    return RelationLineageIndex(
+        nodes={key: _lineage_node(project=graph.project, key=key) for key in keys},
+        upstream_deps=graph.upstream_deps,
+        downstream_deps=graph.downstream_deps,
+        tag_index=graph.tag_index,
+        path_index=graph.path_index,
+        all_keys=graph.all_keys,
+    )
+
+
+def _lineage_node(*, project: CompiledProject, key: CompiledObjectKey) -> LineageNode:
+    for model in project.models:
+        if model.key == key:
+            return LineageNode(
+                key=key,
+                relative_path=str(model.relative_path),
+                qualified_name=model.destination.qualified_name,
+            )
+    for seed in project.seeds:
+        if seed.key == key:
+            return LineageNode(
+                key=key,
+                relative_path=str(seed.seed_file.relative_path),
+                qualified_name=seed.destination.qualified_name,
+            )
+    for source in project.sources:
+        if source.key == key:
+            return LineageNode(
+                key=key,
+                relative_path=str(source.source_file.relative_path),
+                qualified_name=_source_relation_name(source.source_entry),
+            )
+    return LineageNode(key=key)
+
+
+def _source_relation_name(source: object) -> str | None:
+    database: str | None = getattr(source, "database", None)
+    schema: str | None = getattr(source, "schema", None)
+    table: str | None = getattr(source, "table", None)
+    if table is None:
+        return None
+    if database is not None and schema is not None:
+        return f"{database}.{schema}.{table}"
+    if schema is not None:
+        return f"{schema}.{table}"
+    return table
+
+
+def _create_schema(*, connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE TABLE resources (
+            resource_type TEXT NOT NULL,
+            resource_name TEXT NOT NULL,
+            relative_path TEXT,
+            qualified_name TEXT,
+            PRIMARY KEY (resource_type, resource_name)
+        );
+        CREATE TABLE lookups (
+            lookup_name TEXT PRIMARY KEY,
+            resource_type TEXT NOT NULL,
+            resource_name TEXT NOT NULL
+        );
+        CREATE TABLE edges (
+            upstream_type TEXT NOT NULL,
+            upstream_name TEXT NOT NULL,
+            downstream_type TEXT NOT NULL,
+            downstream_name TEXT NOT NULL,
+            PRIMARY KEY (upstream_type, upstream_name, downstream_type, downstream_name)
+        );
+        CREATE INDEX edges_downstream ON edges (downstream_type, downstream_name);
+        CREATE INDEX edges_upstream ON edges (upstream_type, upstream_name);
+        CREATE TABLE tags (
+            tag TEXT NOT NULL,
+            resource_type TEXT NOT NULL,
+            resource_name TEXT NOT NULL,
+            PRIMARY KEY (tag, resource_type, resource_name)
+        );
+        CREATE TABLE paths (
+            resource_type TEXT NOT NULL,
+            resource_name TEXT NOT NULL,
+            folder TEXT NOT NULL,
+            PRIMARY KEY (resource_type, resource_name)
+        );
+        """
+    )
+
+
+def _write_index(
+    *, connection: sqlite3.Connection, fingerprint: str, index: RelationLineageIndex
+) -> None:
+    connection.executemany(
+        "INSERT INTO metadata (key, value) VALUES (?, ?)",
+        (
+            ("algorithm_version", _CACHE_ALGORITHM_VERSION),
+            ("input_fingerprint", fingerprint),
+            ("schema_version", str(_CACHE_SCHEMA_VERSION)),
+        ),
+    )
+    connection.executemany(
+        "INSERT INTO resources VALUES (?, ?, ?, ?)",
+        (
+            (str(key.resource_type), key.name, node.relative_path, node.qualified_name)
+            for key, node in index.nodes.items()
+        ),
+    )
+    connection.executemany(
+        "INSERT INTO lookups VALUES (?, ?, ?)",
+        ((name, str(key.resource_type), key.name) for name, key in index.all_keys.items()),
+    )
+    connection.executemany(
+        "INSERT INTO edges VALUES (?, ?, ?, ?)",
+        _edge_rows(index=index),
+    )
+    connection.executemany(
+        "INSERT INTO tags VALUES (?, ?, ?)",
+        _tag_rows(index=index),
+    )
+    connection.executemany(
+        "INSERT INTO paths VALUES (?, ?, ?)",
+        ((str(key.resource_type), key.name, folder) for key, folder in index.path_index.items()),
+    )
+
+
+def _edge_rows(*, index: RelationLineageIndex) -> list[tuple[str, str, str, str]]:
+    rows: list[tuple[str, str, str, str]] = []
+    for downstream, upstreams in index.upstream_deps.items():
+        for upstream in upstreams:
+            rows.append(
+                (
+                    str(upstream.resource_type),
+                    upstream.name,
+                    str(downstream.resource_type),
+                    downstream.name,
+                )
+            )
+    return rows
+
+
+def _tag_rows(*, index: RelationLineageIndex) -> list[tuple[str, str, str]]:
+    rows: list[tuple[str, str, str]] = []
+    for tag, keys in index.tag_index.items():
+        for key in keys:
+            rows.append((tag, str(key.resource_type), key.name))
+    return rows
+
+
+def _read_index(*, connection: sqlite3.Connection) -> RelationLineageIndex | None:
+    resource_rows: list[tuple[str, str, str | None, str | None]] = connection.execute(
+        "SELECT resource_type, resource_name, relative_path, qualified_name FROM resources"
+    ).fetchall()
+    edge_rows: list[tuple[str, str, str, str]] = connection.execute(
+        "SELECT upstream_type, upstream_name, downstream_type, downstream_name FROM edges"
+    ).fetchall()
+    lookup_rows: list[tuple[str, str, str]] = connection.execute(
+        "SELECT lookup_name, resource_type, resource_name FROM lookups"
+    ).fetchall()
+    tag_rows: list[tuple[str, str, str]] = connection.execute(
+        "SELECT tag, resource_type, resource_name FROM tags"
+    ).fetchall()
+    path_rows: list[tuple[str, str, str]] = connection.execute(
+        "SELECT resource_type, resource_name, folder FROM paths"
+    ).fetchall()
+    if (
+        sum(map(len, (resource_rows, edge_rows, lookup_rows, tag_rows, path_rows)))
+        > _CACHE_MAX_ROWS
+    ):
+        return None
+    keys: dict[tuple[str, str], CompiledObjectKey] = {
+        (resource_type, name): CompiledObjectKey(resource_type=resource_type, name=name)
+        for resource_type, name, _, _ in resource_rows
+    }
+    nodes: dict[CompiledObjectKey, LineageNode] = {
+        keys[(resource_type, name)]: LineageNode(
+            key=keys[(resource_type, name)],
+            relative_path=relative_path,
+            qualified_name=qualified_name,
+        )
+        for resource_type, name, relative_path, qualified_name in resource_rows
+    }
+    upstream_mutable: dict[CompiledObjectKey, list[CompiledObjectKey]] = {}
+    downstream_mutable: dict[CompiledObjectKey, list[CompiledObjectKey]] = {}
+    for upstream_type, upstream_name, downstream_type, downstream_name in edge_rows:
+        upstream: CompiledObjectKey = keys[(upstream_type, upstream_name)]
+        downstream: CompiledObjectKey = keys[(downstream_type, downstream_name)]
+        upstream_mutable.setdefault(downstream, []).append(upstream)
+        downstream_mutable.setdefault(upstream, []).append(downstream)
+    tags_mutable: dict[str, set[CompiledObjectKey]] = {}
+    for tag, resource_type, name in tag_rows:
+        tags_mutable.setdefault(tag, set()).add(keys[(resource_type, name)])
+    return RelationLineageIndex(
+        nodes=nodes,
+        upstream_deps={key: tuple(value) for key, value in upstream_mutable.items()},
+        downstream_deps={key: tuple(value) for key, value in downstream_mutable.items()},
+        tag_index={tag: frozenset(value) for tag, value in tags_mutable.items()},
+        path_index={
+            keys[(resource_type, name)]: folder for resource_type, name, folder in path_rows
+        },
+        all_keys={
+            lookup_name: keys[(resource_type, name)]
+            for lookup_name, resource_type, name in lookup_rows
+        },
+    )
+
+
+def _sqlbuild_version() -> str:
+    try:
+        return version("sqlbuild")
+    except PackageNotFoundError:
+        return "0+unknown"

--- a/src/sqlbuild/cli/commands/_helpers/lineage/execution.py
+++ b/src/sqlbuild/cli/commands/_helpers/lineage/execution.py
@@ -6,6 +6,11 @@ import json
 from pathlib import Path
 
 from sqlbuild.adapter.contract.classes.base_adapter import BaseAdapter
+from sqlbuild.cli.commands._helpers.lineage.cache import (
+    read_relation_lineage_cache,
+    relation_lineage_fingerprint,
+    write_relation_lineage_cache,
+)
 from sqlbuild.cli.commands._helpers.lineage.output import (
     format_column_lineage_json,
     format_column_lineage_list,
@@ -21,12 +26,17 @@ from sqlbuild.cli.commands._helpers.lineage.selection import (
     select_target_lineage,
 )
 from sqlbuild.cli.commands._helpers.runtime.adapters import resolve_adapter
-from sqlbuild.cli.commands.constants import JSON_OUTPUT_FORMAT, LIST_OUTPUT_FORMAT
+from sqlbuild.cli.commands.constants import (
+    COLUMN_TARGET_SEPARATOR,
+    JSON_OUTPUT_FORMAT,
+    LIST_OUTPUT_FORMAT,
+)
 from sqlbuild.cli.commands.exceptions import CliUserError
 from sqlbuild.cli.commands.models import (
     ColumnLineageTrace,
     LineageCommandRequest,
     LineageGraph,
+    RelationLineageIndex,
 )
 from sqlbuild.compiler.compile.models import CompiledObjectKey
 from sqlbuild.compiler.compile.types import CompiledResourceType
@@ -72,10 +82,27 @@ def _validate_request(*, request: LineageCommandRequest) -> None:
 
 def _prepare_graph(
     *, request: LineageCommandRequest
-) -> tuple[ProjectGraph, BaseAdapter, int | None]:
+) -> tuple[ProjectGraph | RelationLineageIndex, BaseAdapter | None, int | None]:
     parsed_depth: int | None = parse_depth(request.depth)
     project_dir: Path = request.project_dir or Path.cwd()
-    discovered: DiscoveredProjectInputs = discover_project_inputs(project_dir=project_dir)
+    requires_compiled_graph: bool = _requires_compiled_graph(request=request)
+    fingerprint: str | None = (
+        None
+        if requires_compiled_graph
+        else relation_lineage_fingerprint(project_dir=project_dir, cli_vars=request.cli_vars)
+    )
+    if fingerprint is not None:
+        cached: RelationLineageIndex | None = read_relation_lineage_cache(
+            project_dir=project_dir,
+            fingerprint=fingerprint,
+        )
+        if cached is not None:
+            return cached, None, parsed_depth
+    discovered: DiscoveredProjectInputs = discover_project_inputs(
+        project_dir=project_dir,
+        sql_analysis_enabled_override=(None if requires_compiled_graph else False),
+        extract_output_column_locations=False,
+    )
     adapter: BaseAdapter = resolve_adapter(
         adapter_name=resolve_effective_adapter_name(
             project_config=discovered.project_config,
@@ -86,17 +113,42 @@ def _prepare_graph(
     graph: ProjectGraph = build_project_graph(
         discovered_inputs=discovered,
         adapter=adapter,
-        no_sql_validation=request.no_sql_validation,
+        no_sql_validation=request.no_sql_validation or not requires_compiled_graph,
+        skip_column_inference=not requires_compiled_graph,
         cli_vars=request.cli_vars,
     )
+    if fingerprint is not None:
+        return (
+            write_relation_lineage_cache(
+                project_dir=project_dir,
+                fingerprint=fingerprint,
+                graph=graph,
+            ),
+            None,
+            parsed_depth,
+        )
     return graph, adapter, parsed_depth
 
 
+def _requires_compiled_graph(*, request: LineageCommandRequest) -> bool:
+    return request.include_uses or (
+        request.target is not None and COLUMN_TARGET_SEPARATOR in request.target
+    )
+
+
 def _semantic_uses(
-    *, request: LineageCommandRequest, graph: ProjectGraph, adapter: BaseAdapter
+    *,
+    request: LineageCommandRequest,
+    graph: ProjectGraph | RelationLineageIndex,
+    adapter: BaseAdapter | None,
 ) -> tuple[DirectSemanticColumnUse, ...]:
     if not request.include_uses:
         return ()
+    if not isinstance(graph, ProjectGraph) or adapter is None:
+        raise CliUserError(
+            "semantic uses require a compiled project graph",
+            code="C307",
+        )
     return build_direct_semantic_uses(
         project=graph.project,
         dialect=adapter.sql_analysis_dialect(),
@@ -105,7 +157,10 @@ def _semantic_uses(
 
 
 def _render_lineage(
-    *, request: LineageCommandRequest, graph: ProjectGraph, parsed_depth: int | None
+    *,
+    request: LineageCommandRequest,
+    graph: ProjectGraph | RelationLineageIndex,
+    parsed_depth: int | None,
 ) -> str:
     if request.target is not None:
         column_trace: ColumnLineageTrace | None = select_column_target_lineage(

--- a/src/sqlbuild/cli/commands/_helpers/lineage/selection.py
+++ b/src/sqlbuild/cli/commands/_helpers/lineage/selection.py
@@ -27,6 +27,7 @@ from sqlbuild.cli.commands.models import (
     LineageSelectionAnchors,
     ParsedLineagePathSelector,
     ParsedLineageSelector,
+    RelationLineageIndex,
 )
 from sqlbuild.compiler.compile.models import (
     CompiledObjectKey,
@@ -67,7 +68,7 @@ def parse_depth(raw_depth: str) -> int | None:
 
 def select_target_lineage(
     *,
-    graph: ProjectGraph,
+    graph: ProjectGraph | RelationLineageIndex,
     target: str,
     direction: str,
     depth: int | None,
@@ -84,8 +85,7 @@ def select_target_lineage(
     if direction in {DOWNSTREAM_DIRECTION, BOTH_DIRECTIONS}:
         selected.update(_walk_bounded(anchors=(key,), deps=graph.downstream_deps, max_depth=depth))
     return build_lineage_graph(
-        project=graph.project,
-        upstream_deps=graph.upstream_deps,
+        graph=graph,
         selected_keys=frozenset(selected),
         focus_keys=(key,),
         direction=direction,
@@ -94,7 +94,7 @@ def select_target_lineage(
 
 def select_column_target_lineage(
     *,
-    graph: ProjectGraph,
+    graph: ProjectGraph | RelationLineageIndex,
     target: str,
     direction: str,
     depth: int | None,
@@ -104,6 +104,12 @@ def select_column_target_lineage(
 
     if COLUMN_TARGET_SEPARATOR not in target:
         return None
+    if not isinstance(graph, ProjectGraph):
+        raise CliUserError(
+            "column lineage requires a compiled project graph",
+            code="C307",
+            help="enable SQL analysis or install SQLBuild with Polyglot support",
+        )
     resource_name: str
     column_name: str
     resource_name, column_name = target.rsplit(COLUMN_TARGET_SEPARATOR, 1)
@@ -237,7 +243,7 @@ def _trace_column_with_depth(
 
 def select_selector_lineage(
     *,
-    graph: ProjectGraph,
+    graph: ProjectGraph | RelationLineageIndex,
     select: tuple[str, ...],
     exclude: tuple[str, ...],
     depth: int | None,
@@ -274,8 +280,7 @@ def select_selector_lineage(
         sorted(anchors.upstream | anchors.downstream, key=_sort_key)
     )
     return build_lineage_graph(
-        project=graph.project,
-        upstream_deps=graph.upstream_deps,
+        graph=graph,
         selected_keys=selected_keys,
         focus_keys=focus_keys,
         direction=None,
@@ -284,8 +289,7 @@ def select_selector_lineage(
 
 def build_lineage_graph(
     *,
-    project: CompiledProject,
-    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]],
+    graph: ProjectGraph | RelationLineageIndex,
     selected_keys: frozenset[CompiledObjectKey],
     focus_keys: tuple[CompiledObjectKey, ...] = (),
     direction: str | None = None,
@@ -293,11 +297,11 @@ def build_lineage_graph(
     """Build display nodes and selected edges."""
 
     nodes: tuple[LineageNode, ...] = tuple(
-        _build_node(project=project, key=key) for key in sorted(selected_keys, key=_sort_key)
+        _build_node(graph=graph, key=key) for key in sorted(selected_keys, key=_sort_key)
     )
     selected_edges: list[tuple[CompiledObjectKey, CompiledObjectKey]] = []
     for downstream_key in sorted(selected_keys, key=_sort_key):
-        for upstream_key in upstream_deps.get(downstream_key, ()):
+        for upstream_key in graph.upstream_deps.get(downstream_key, ()):
             if upstream_key in selected_keys:
                 selected_edges.append((upstream_key, downstream_key))
     return LineageGraph(
@@ -685,7 +689,12 @@ def _match_path(
     )
 
 
-def _build_node(*, project: CompiledProject, key: CompiledObjectKey) -> LineageNode:
+def _build_node(
+    *, graph: ProjectGraph | RelationLineageIndex, key: CompiledObjectKey
+) -> LineageNode:
+    if isinstance(graph, RelationLineageIndex):
+        return graph.nodes.get(key, LineageNode(key=key))
+    project: CompiledProject = graph.project
     for model in project.models:
         if model.key == key:
             return LineageNode(

--- a/src/sqlbuild/cli/commands/models.py
+++ b/src/sqlbuild/cli/commands/models.py
@@ -917,6 +917,18 @@ class LineageGraph:
 
 
 @dataclass(frozen=True)
+class RelationLineageIndex:
+    """Cacheable structural graph used by relation-level lineage inspection."""
+
+    nodes: dict[CompiledObjectKey, LineageNode]
+    upstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]]
+    downstream_deps: dict[CompiledObjectKey, tuple[CompiledObjectKey, ...]]
+    tag_index: dict[str, frozenset[CompiledObjectKey]]
+    path_index: dict[CompiledObjectKey, str]
+    all_keys: dict[str, CompiledObjectKey]
+
+
+@dataclass(frozen=True)
 class LineageSelectionAnchors:
     """Selector anchors used for optional post-selection depth trimming."""
 

--- a/tests/e2e/src/sqlbuild/cli/commands/main/lineage/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/lineage/_test_types.py
@@ -10,3 +10,17 @@ class LineageCliTestCase:
     expected_exit_code: int
     expected_node_ids: tuple[str, ...]
     expected_edge_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class LineageCacheCliTestCase:
+    description: str
+    command: tuple[str, ...]
+    expected_node_id: str
+
+
+@dataclass(frozen=True)
+class ColumnLineageCacheCliTestCase:
+    description: str
+    command: tuple[str, ...]
+    expected_source_resource: str

--- a/tests/e2e/src/sqlbuild/cli/commands/main/lineage/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/lineage/helpers.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import prepare_inline_project
+
+
+def prepare_lineage_cache_project(*, tmp_path: Path) -> Path:
+    return prepare_inline_project(
+        tmp_path=tmp_path,
+        project_name="lineage_cache_project",
+        repo_files={
+            "sqlbuild_project.toml": 'name = "lineage_cache_project"\nadapter = "duckdb"\n',
+            "models/stg_orders.sql": (
+                "MODEL (materialized view);\n\nSELECT 1 AS order_id, 10 AS customer_id\n"
+            ),
+            "models/stg_customers.sql": (
+                "MODEL (materialized view);\n\nSELECT 10 AS customer_id\n"
+            ),
+            "models/fact_orders.sql": (
+                'MODEL (materialized view);\n\nSELECT * FROM __ref("stg_orders")\n'
+            ),
+        },
+    )
+
+
+def lineage_node_ids(*, payload: dict[str, object]) -> tuple[str, ...]:
+    nodes: list[dict[str, object]] = cast(list[dict[str, object]], payload["nodes"])
+    return tuple(str(node["id"]) for node in nodes)

--- a/tests/e2e/src/sqlbuild/cli/commands/main/lineage/test_lineage.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/lineage/test_lineage.py
@@ -6,8 +6,21 @@ from pathlib import Path
 
 import pytest
 
-from tests.e2e.src.sqlbuild.cli.commands.main.lineage._test_types import LineageCliTestCase
-from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import prepare_waffle_shop, run_sqb
+from tests.e2e.src.sqlbuild.cli.commands.main.lineage._test_types import (
+    ColumnLineageCacheCliTestCase,
+    LineageCacheCliTestCase,
+    LineageCliTestCase,
+)
+from tests.e2e.src.sqlbuild.cli.commands.main.lineage.helpers import (
+    lineage_node_ids,
+    prepare_lineage_cache_project,
+)
+from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
+    prepare_waffle_shop,
+    run_sqb,
+)
+
+_LINEAGE_CACHE_RELATIVE_PATH: Path = Path("target/cache/lineage/v1/structural-graph.sqlite3")
 
 
 @pytest.mark.parametrize(
@@ -84,3 +97,139 @@ def test_given_lineage_command_when_running_then_outputs_expected_json_graph(
     )
     assert node_ids == test_case.expected_node_ids
     assert edge_ids == test_case.expected_edge_ids
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        LineageCacheCliTestCase(
+            description="unchanged project reuses structural lineage cache",
+            command=("lineage", "fact_orders", "--format", "json"),
+            expected_node_id="model:stg_orders",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_unchanged_project_when_lineage_runs_twice_then_reuses_structural_cache(
+    test_case: LineageCacheCliTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_lineage_cache_project(tmp_path=tmp_path)
+
+    first: subprocess.CompletedProcess[str] = run_sqb(
+        command=test_case.command,
+        project_dir=project_dir,
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    cache_path: Path = project_dir / _LINEAGE_CACHE_RELATIVE_PATH
+    first_modified_ns: int = cache_path.stat().st_mtime_ns
+    second: subprocess.CompletedProcess[str] = run_sqb(
+        command=test_case.command,
+        project_dir=project_dir,
+    )
+
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert json.loads(first.stdout) == json.loads(second.stdout)
+    assert test_case.expected_node_id in lineage_node_ids(payload=json.loads(second.stdout))
+    assert cache_path.stat().st_mtime_ns == first_modified_ns
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        LineageCacheCliTestCase(
+            description="authored dependency change invalidates structural lineage cache",
+            command=("lineage", "fact_orders", "--format", "json"),
+            expected_node_id="model:stg_customers",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_authored_dependency_change_when_lineage_runs_then_rebuilds_structural_cache(
+    test_case: LineageCacheCliTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_lineage_cache_project(tmp_path=tmp_path)
+    first: subprocess.CompletedProcess[str] = run_sqb(
+        command=test_case.command,
+        project_dir=project_dir,
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    (project_dir / "models/fact_orders.sql").write_text(
+        "MODEL (materialized view);\n\n"
+        'SELECT orders.order_id FROM __ref("stg_orders") AS orders\n'
+        'JOIN __ref("stg_customers") AS customers USING (customer_id)\n',
+        encoding="utf-8",
+    )
+
+    second: subprocess.CompletedProcess[str] = run_sqb(
+        command=test_case.command,
+        project_dir=project_dir,
+    )
+
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert test_case.expected_node_id in lineage_node_ids(payload=json.loads(second.stdout))
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        LineageCacheCliTestCase(
+            description="corrupt structural cache falls back to graph rebuild",
+            command=("lineage", "fact_orders", "--format", "json"),
+            expected_node_id="model:stg_orders",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_corrupt_structural_cache_when_lineage_runs_then_rebuilds_safely(
+    test_case: LineageCacheCliTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_lineage_cache_project(tmp_path=tmp_path)
+    first: subprocess.CompletedProcess[str] = run_sqb(
+        command=test_case.command,
+        project_dir=project_dir,
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    cache_path: Path = project_dir / _LINEAGE_CACHE_RELATIVE_PATH
+    cache_path.write_bytes(b"not a sqlite database")
+
+    second: subprocess.CompletedProcess[str] = run_sqb(
+        command=test_case.command,
+        project_dir=project_dir,
+    )
+
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert test_case.expected_node_id in lineage_node_ids(payload=json.loads(second.stdout))
+    assert cache_path.read_bytes().startswith(b"SQLite format 3")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        ColumnLineageCacheCliTestCase(
+            description="column target retains analyzed lineage path",
+            command=("lineage", "fact_orders.order_id", "--format", "json"),
+            expected_source_resource="stg_orders",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_column_target_when_lineage_runs_then_bypasses_structural_cache(
+    test_case: ColumnLineageCacheCliTestCase,
+    tmp_path: Path,
+) -> None:
+    project_dir: Path = prepare_lineage_cache_project(tmp_path=tmp_path)
+
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=test_case.command,
+        project_dir=project_dir,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload: dict[str, object] = json.loads(result.stdout)
+    trace: list[dict[str, object]] = payload["trace"]  # type: ignore[assignment]
+    source: dict[str, object] = trace[0]["source"]  # type: ignore[assignment]
+    assert source["resource_name"] == test_case.expected_source_resource
+    assert not (project_dir / _LINEAGE_CACHE_RELATIVE_PATH).exists()

--- a/tests/e2e/src/sqlbuild/cli/commands/main/providers/_test_types.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/providers/_test_types.py
@@ -22,6 +22,13 @@ class NoExporterCommandE2ETestCase:
 
 
 @dataclass(frozen=True)
+class ReadOnlyProviderE2ETestCase:
+    description: str
+    command: tuple[str, ...]
+    expected_exit_code: int
+
+
+@dataclass(frozen=True)
 class ProviderCommandE2ETestCase:
     description: str
     expected_exit_code: int

--- a/tests/e2e/src/sqlbuild/cli/commands/main/providers/test_event_exporters.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/providers/test_event_exporters.py
@@ -13,6 +13,7 @@ from tests.e2e.src.sqlbuild.cli.commands.main.providers._test_types import (
     CommandOutputE2ETestCase,
     EventExporterE2ETestCase,
     NoExporterCommandE2ETestCase,
+    ReadOnlyProviderE2ETestCase,
 )
 from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import prepare_inline_project, run_sqb
 
@@ -209,6 +210,60 @@ def test_given_command_output_sink_when_compiling_then_multiline_chunks_reconstr
     assert len(stdout_records) < len(result.stdout.splitlines())
     assert any(str(record["message"]).count("\n") > 1 for record in stdout_records)
     assert all(record["external_context"] == test_case.expected_context for record in records)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        ReadOnlyProviderE2ETestCase(
+            description="lineage does not initialize configured providers or output sinks",
+            command=("lineage", "orders", "--format", "json"),
+            expected_exit_code=0,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_configured_provider_and_sink_when_lineage_runs_then_skips_extension_initialization(
+    test_case: ReadOnlyProviderE2ETestCase,
+    tmp_path: Path,
+) -> None:
+    provider_marker: Path = tmp_path / "provider-initialized"
+    project_dir: Path = prepare_inline_project(
+        tmp_path=tmp_path,
+        project_name="read_only_lineage_project",
+        repo_files={
+            "sqlbuild_project.toml": 'name = "read_only_lineage_project"\nadapter = "duckdb"\n',
+            "providers/output.py": (
+                "from pathlib import Path\n"
+                "from sqlbuild.providers import Provider\n"
+                "class OutputProvider(Provider):\n"
+                "    def setup(self, ctx):\n"
+                "        del ctx\n"
+                f"        Path({str(provider_marker)!r}).write_text('initialized', encoding='utf-8')\n"
+                "    def write(self, record):\n"
+                "        del record\n"
+                "    def teardown(self):\n"
+                "        pass\n"
+            ),
+            "sinks/output.py": (
+                "from providers.output import OutputProvider\n"
+                "from sqlbuild.sinks import command_output_sink\n"
+                "@command_output_sink\n"
+                "def export_output(record, output_provider: OutputProvider):\n"
+                "    output_provider.write(record)\n"
+            ),
+            "models/orders.sql": "MODEL (materialized view);\n\nSELECT 1 AS order_id\n",
+        },
+    )
+
+    result: subprocess.CompletedProcess[str] = run_sqb(
+        command=("--no-color", *test_case.command),
+        project_dir=project_dir,
+    )
+
+    assert result.returncode == test_case.expected_exit_code, result.stdout + result.stderr
+    assert '"id": "model:orders"' in result.stdout
+    assert not provider_marker.exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/lineage/_test_types.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/lineage/_test_types.py
@@ -56,3 +56,30 @@ class LargeColumnLineageOutputTestCase:
     expected_excluded_fragment: str
     expected_summary_fragment: str
     expected_json_tip_fragment: str
+
+
+@dataclass(frozen=True)
+class LineageCompiledGraphRequirementTestCase:
+    description: str
+    target: str | None
+    select: tuple[str, ...]
+    include_uses: bool
+    expected_compiled_graph_required: bool
+
+
+@dataclass(frozen=True)
+class LineageFingerprintEnvironmentTestCase:
+    description: str
+    config: str
+    environment_name: str
+    first_value: str
+    second_value: str
+    expected_equal: bool
+
+
+@dataclass(frozen=True)
+class LineageFingerprintAvailabilityTestCase:
+    description: str
+    relative_path: str
+    config: str
+    expected_available: bool

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/lineage/test_cache.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/lineage/test_cache.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sqlbuild.cli.commands._helpers.lineage.cache import relation_lineage_fingerprint
+from tests.unit.src.sqlbuild.cli.commands._helpers.lineage._test_types import (
+    LineageFingerprintAvailabilityTestCase,
+    LineageFingerprintEnvironmentTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        LineageFingerprintEnvironmentTestCase(
+            description="referenced environment value participates in cache identity",
+            config=(
+                'name = "orders"\nadapter = "duckdb"\n'
+                '[targets.dev]\nschema = "${if(eq( ENV:ORDERS_SCHEMA, '
+                "'orders_dev'), 'dev', 'test')}\"\n"
+            ),
+            environment_name="ORDERS_SCHEMA",
+            first_value="orders_dev",
+            second_value="orders_test",
+            expected_equal=False,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_referenced_environment_change_when_fingerprinting_then_invalidates_cache_identity(
+    test_case: LineageFingerprintEnvironmentTestCase,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(test_case.config, encoding="utf-8")
+    monkeypatch.setenv(test_case.environment_name, test_case.first_value)
+    first: str | None = relation_lineage_fingerprint(project_dir=tmp_path, cli_vars=None)
+    monkeypatch.setenv(test_case.environment_name, test_case.second_value)
+
+    second: str | None = relation_lineage_fingerprint(project_dir=tmp_path, cli_vars=None)
+
+    assert (first == second) is test_case.expected_equal
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        LineageFingerprintAvailabilityTestCase(
+            description="dynamic invocation context disables structural cache",
+            relative_path="sqlbuild_project.toml",
+            config=(
+                'name = "orders"\nadapter = "duckdb"\n'
+                '[targets.dev]\nschema = "orders_${CTX:run_id}"\n'
+            ),
+            expected_available=False,
+        ),
+        LineageFingerprintAvailabilityTestCase(
+            description="unicode environment name disables structural cache",
+            relative_path="sqlbuild_project.toml",
+            config=(
+                'name = "orders"\nadapter = "duckdb"\n[targets.dev]\nschema = "${ENV:ORDERS_ÉTÉ}"\n'
+            ),
+            expected_available=False,
+        ),
+        LineageFingerprintAvailabilityTestCase(
+            description="SQL output context preserves structural cache availability",
+            relative_path="models/orders.sql",
+            config=(
+                "MODEL (materialized view);\n\n"
+                "SELECT '${CTX:run_id}' AS invocation_id, 1 AS order_id\n"
+            ),
+            expected_available=True,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_dynamic_invocation_context_when_fingerprinting_then_disables_cache(
+    test_case: LineageFingerprintAvailabilityTestCase,
+    tmp_path: Path,
+) -> None:
+    authored_path: Path = tmp_path / test_case.relative_path
+    authored_path.parent.mkdir(parents=True, exist_ok=True)
+    authored_path.write_text(test_case.config, encoding="utf-8")
+
+    observed: str | None = relation_lineage_fingerprint(project_dir=tmp_path, cli_vars=None)
+
+    assert (observed is not None) is test_case.expected_available

--- a/tests/unit/src/sqlbuild/cli/commands/_helpers/lineage/test_execution.py
+++ b/tests/unit/src/sqlbuild/cli/commands/_helpers/lineage/test_execution.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from sqlbuild.cli.commands._helpers.lineage.execution import _requires_compiled_graph
+from sqlbuild.cli.commands.models import LineageCommandRequest
+from tests.unit.src.sqlbuild.cli.commands._helpers.lineage._test_types import (
+    LineageCompiledGraphRequirementTestCase,
+)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        LineageCompiledGraphRequirementTestCase(
+            description="relation target uses structural lineage",
+            target="fact_orders",
+            select=(),
+            include_uses=False,
+            expected_compiled_graph_required=False,
+        ),
+        LineageCompiledGraphRequirementTestCase(
+            description="selector uses structural lineage",
+            target=None,
+            select=("fact_orders+",),
+            include_uses=False,
+            expected_compiled_graph_required=False,
+        ),
+        LineageCompiledGraphRequirementTestCase(
+            description="column target retains column analysis",
+            target="fact_orders.order_id",
+            select=(),
+            include_uses=False,
+            expected_compiled_graph_required=True,
+        ),
+        LineageCompiledGraphRequirementTestCase(
+            description="semantic uses retain the compiled graph",
+            target="fact_orders",
+            select=(),
+            include_uses=True,
+            expected_compiled_graph_required=True,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_lineage_request_when_checking_analysis_requirement_then_matches_target_granularity(
+    test_case: LineageCompiledGraphRequirementTestCase,
+) -> None:
+    request: LineageCommandRequest = LineageCommandRequest(
+        project_dir=None,
+        target=test_case.target,
+        select=test_case.select,
+        include_uses=test_case.include_uses,
+    )
+
+    observed: bool = _requires_compiled_graph(request=request)
+
+    assert observed is test_case.expected_compiled_graph_required


### PR DESCRIPTION
## Why

Relation-level `sqb lineage` rebuilt a fully analyzed project graph on every invocation and initialized configured output providers. This made interactive lineage lookup unnecessarily slow and could trigger unrelated provider activity for a read-only command.

## Changes

- skip SQL validation, column inference, and output-location extraction for relation and selector lineage
- retain the full compiler path for column lineage and `--include-uses`
- add a dedicated versioned SQLite structural-graph cache with content, CLI-variable, and referenced-environment fingerprinting
- rebuild safely on authored changes, incompatible metadata, corruption, oversized payloads, or read/write failures
- disable caching for dynamic configuration or Python invocation context
- stop initializing lifecycle and command-output providers for lineage
- add unit and real CLI coverage for reuse, invalidation, corruption recovery, column bypass, and provider isolation

## Verification

- focused lineage/provider unit and E2E tests: 15 passed
- cache cold/warm output comparison
- cache corruption and authored-change invalidation regressions
- bounded independent review and finding-focused follow-up
- `uv sync --all-extras`
- `make check-ci`
- public tree and outgoing-history hygiene scans
