### PR TITLE
fix: allow typed nulls without nullability metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ SELECT 1
 ```
 
 Relation fixtures can omit a column when the compiled test or scenario closure requires it and
-SQLBuild knows both its adapter type and that it is nullable. SQLBuild completes that test-only
-fixture column with a typed null such as `CAST(NULL AS VARCHAR)`; it never changes model SQL or
-warehouse defaults. Required non-nullable columns and columns with unknown type or nullability must
-be supplied explicitly. When the relation's complete column set is authoritative, misspelled or
-unknown supplied fixture columns are rejected.
+SQLBuild knows its adapter type, unless the column is explicitly non-nullable. SQLBuild completes
+that test-only fixture column with a typed null such as `CAST(NULL AS VARCHAR)`; it never changes
+model SQL or warehouse defaults. Required columns declared with `nullable false` and columns with
+unknown types must be supplied explicitly. When the relation's complete column set is authoritative,
+misspelled or unknown supplied fixture columns are rejected.
 
 See the [documentation](https://docs.sqlbuild.com) for incremental models, scenarios, loaders, and more.
 

--- a/src/sqlbuild/compiler/planner/_helpers/fixtures/completion.py
+++ b/src/sqlbuild/compiler/planner/_helpers/fixtures/completion.py
@@ -31,7 +31,7 @@ def build_relation_fixture_completion(
     ordered_model_names: tuple[str, ...],
     fixture_groups: FixtureGroups,
 ) -> RelationFixtureCompletion:
-    """Complete only required omitted columns with authoritative nullable typed nulls."""
+    """Complete required omitted columns with typed nulls unless explicitly non-nullable."""
 
     model_map: dict[str, CompiledModel] = {model.name: model for model in project.models}
     fixture_sql_by_key: dict[FixtureKey, str] = {}
@@ -94,12 +94,12 @@ def build_relation_fixture_completion(
         non_nullable: list[str] = []
         for name in missing:
             column: FixtureColumnMetadata | None = metadata_by_name.get(name.casefold())
-            if column is None or column.type is None or column.nullable is None:
+            if column is None or column.type is None:
                 unknown.append(name)
-            elif column.nullable:
-                nullable_columns.append(column)
-            else:
+            elif column.nullable is False:
                 non_nullable.append(name)
+            else:
+                nullable_columns.append(column)
         if unknown:
             read_by: tuple[str, ...] = _models_reading_columns(
                 column_names=tuple(unknown),
@@ -110,8 +110,8 @@ def build_relation_fixture_completion(
                     key=key,
                     message=(
                         f"mock {key[0].value} '{key[1]}' is missing required columns: "
-                        f"{', '.join(unknown)}; provide explicit values because their types or "
-                        f"nullability are not authoritative (read by: {', '.join(read_by)})"
+                        f"{', '.join(unknown)}; provide explicit values because their types are "
+                        f"not authoritative (read by: {', '.join(read_by)})"
                     ),
                 )
             )

--- a/tests/e2e/src/sqlbuild/cli/commands/main/scenario/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/scenario/helpers.py
@@ -94,7 +94,7 @@ def build_partial_fixture_scenario_project_files() -> dict[str, str]:
             "    table: raw_orders\n"
             "    columns:\n"
             "      - name: order_id\n        type: INTEGER\n        nullable: false\n"
-            "      - name: status\n        type: VARCHAR\n        nullable: true\n"
+            "      - name: status\n        type: VARCHAR\n"
         ),
         "models/orders.sql": ('MODEL ();\n\nSELECT order_id, status FROM __source("raw_orders")\n'),
         "tests/scenarios/partial_orders.sql": (

--- a/tests/e2e/src/sqlbuild/cli/commands/main/scenario/test_scenario.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/scenario/test_scenario.py
@@ -46,7 +46,7 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
     "test_case",
     (
         ScenarioPartialFixtureE2ETestCase(
-            description="required nullable source column receives a typed null",
+            description="required typed source column with unspecified nullability gets a null",
             repo_files=build_partial_fixture_scenario_project_files(),
             expected_stdout_fragment="PASS=1  FAIL=0  TOTAL=1",
             expected_artifact_fragments=(
@@ -57,7 +57,7 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
     ),
     ids=lambda case: case.description,
 )
-def test_given_partial_scenario_fixture_when_required_column_is_nullable_then_typed_null_is_used(
+def test_given_partial_scenario_fixture_when_required_type_is_known_then_typed_null_is_used(
     test_case: ScenarioPartialFixtureE2ETestCase,
     tmp_path: Path,
 ) -> None:

--- a/tests/e2e/src/sqlbuild/cli/commands/main/test/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/test/helpers.py
@@ -165,8 +165,8 @@ def build_missing_mock_columns_project_files() -> dict[str, str]:
             "    schema: main\n"
             "    table: raw_orders\n"
             "    columns:\n"
-            "      - name: customer_id\n        type: INTEGER\n"
-            "      - name: status\n        type: VARCHAR\n"
+            "      - name: customer_id\n"
+            "      - name: status\n"
         ),
         "tests/unit/test_orders.sql": (
             "TEST();\n\n"
@@ -208,6 +208,17 @@ def build_partial_source_fixture_project_files() -> dict[str, str]:
             "SELECT 1\n"
         ),
     }
+
+
+def build_unspecified_nullability_fixture_project_files() -> dict[str, str]:
+    """Build a typed partial source fixture whose nullability is unspecified."""
+
+    files: dict[str, str] = build_partial_source_fixture_project_files()
+    files["sources/raw_orders.yml"] = files["sources/raw_orders.yml"].replace(
+        "        type: VARCHAR\n        nullable: true\n",
+        "        type: VARCHAR\n",
+    )
+    return files
 
 
 def build_partial_ref_fixture_project_files() -> dict[str, str]:

--- a/tests/e2e/src/sqlbuild/cli/commands/main/test/test_test.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/test/test_test.py
@@ -41,6 +41,7 @@ from tests.e2e.src.sqlbuild.cli.commands.main.test.helpers import (
     build_star_partial_fixture_project_files,
     build_transformed_collection_project_files,
     build_unsatisfied_leaf_test_project_files,
+    build_unspecified_nullability_fixture_project_files,
 )
 from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
     assert_fragments_in_order,
@@ -56,6 +57,15 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
         PartialFixtureE2ETestCase(
             description="known nullable source column receives an implicit typed null",
             repo_files=build_partial_source_fixture_project_files(),
+            expected_stdout_fragment="PASS=1",
+            expected_artifact_fragments=(
+                'CAST(NULL AS TEXT) AS "status"',
+                "__sqlbuild_partial_fixture",
+            ),
+        ),
+        PartialFixtureE2ETestCase(
+            description="known source type with unspecified nullability receives a typed null",
+            repo_files=build_unspecified_nullability_fixture_project_files(),
             expected_stdout_fragment="PASS=1",
             expected_artifact_fragments=(
                 'CAST(NULL AS TEXT) AS "status"',
@@ -134,7 +144,7 @@ from tests.e2e.src.sqlbuild.cli.commands.shared.helpers import (
     ),
     ids=lambda case: case.description,
 )
-def test_given_required_nullable_column_omitted_when_testing_then_completes_fixture_implicitly(
+def test_given_required_typed_column_omitted_when_testing_then_completes_fixture_implicitly(
     test_case: PartialFixtureE2ETestCase,
     tmp_path: Path,
 ) -> None:
@@ -297,17 +307,7 @@ def test_given_complex_strings_in_values_when_processing_then_literals_remain_in
             ),
             expected_stderr_fragments=(
                 "missing required columns: status",
-                "types or nullability are not authoritative",
-            ),
-        ),
-        SqlTestFixtureValidationE2ETestCase(
-            description="required source column with unknown nullability is not completed",
-            repo_files=build_invalid_partial_fixture_project_files(
-                status_column_attributes="        type: VARCHAR\n"
-            ),
-            expected_stderr_fragments=(
-                "missing required columns: status",
-                "types or nullability are not authoritative",
+                "types are not authoritative",
             ),
         ),
         SqlTestFixtureValidationE2ETestCase(


### PR DESCRIPTION
## Why

Partial fixtures should be capability-based on authoritative column types. Requiring explicit `nullable: true` prevents safe typed-null completion for schemas where nullability is intentionally unspecified.

## Changes

- complete a required omitted column when its type is known and nullability is true or unspecified
- continue rejecting explicit `nullable: false` columns and unknown types
- update SQL-test and scenario E2E coverage and documentation
- preserve authoritative stale/misspelled supplied-column validation

## Verification

- 76 focused SQL-test and scenario CLI E2E tests passed
- complete private-project planner audit across 133 SQL tests
- `uv sync --all-extras`
- `make check-ci`
- bounded independent review
- public tree and introduced-history hygiene scans
