### PR TITLE
fix: withhold unsafe multi-branch case fixes

### DIFF
--- a/crates/sqlbuild-rules-native/src/sql_lint/_helpers/engine.rs
+++ b/crates/sqlbuild-rules-native/src/sql_lint/_helpers/engine.rs
@@ -1665,6 +1665,25 @@ fn simple_boolean_case_fix(sql: &str, tokens: &[Token], span: Span) -> Option<Li
     if contains_comment(source) {
         return None;
     }
+    let case_tokens = &tokens[case_index..=end_index];
+    if case_tokens
+        .iter()
+        .filter(|token| token.token_type == TokenType::When)
+        .count()
+        != 1
+        || case_tokens
+            .iter()
+            .filter(|token| token.token_type == TokenType::Then)
+            .count()
+            != 1
+        || case_tokens
+            .iter()
+            .filter(|token| token.token_type == TokenType::Else)
+            .count()
+            != 1
+    {
+        return None;
+    }
     let when_index =
         (case_index + 1..end_index).find(|&index| tokens[index].token_type == TokenType::When)?;
     let then_index =

--- a/crates/sqlbuild-rules-native/src/sql_lint/tests/test_sql_lint.rs
+++ b/crates/sqlbuild-rules-native/src/sql_lint/tests/test_sql_lint.rs
@@ -899,6 +899,15 @@ fn given_additional_rule_cases_when_linting_then_findings_and_fixes_match() -> R
             expected_replacement: None,
         },
         test_types::AdditionalLintRuleTestCase {
+            description: "multi-branch boolean case is diagnosed without an unsafe partial fix",
+            sql: "SELECT CASE WHEN status = 'open' THEN TRUE WHEN priority = 'high' THEN TRUE ELSE FALSE END AS actionable FROM support_tickets",
+            rule: "SQBRSQL030",
+            expected_anchor: Some(
+                "CASE WHEN status = 'open' THEN TRUE WHEN priority = 'high' THEN TRUE ELSE FALSE END",
+            ),
+            expected_replacement: None,
+        },
+        test_types::AdditionalLintRuleTestCase {
             description: "case nested directly in else",
             sql: "SELECT CASE WHEN a THEN 1 ELSE CASE WHEN b THEN 2 END END FROM items",
             rule: "SQBRSQL031",

--- a/tests/unit/src/sqlbuild/lint/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/lint/_helpers/_test_types.py
@@ -88,6 +88,15 @@ class ReservedCteLintTestCase:
 
 
 @dataclass(frozen=True)
+class NativeSqlFixTestCase:
+    """Native SQL diagnostic whose fix availability is part of the contract."""
+
+    description: str
+    sql: str
+    expected_code: str
+
+
+@dataclass(frozen=True)
 class GeneratedRangeFallbackTestCase:
     """Test case for a diagnostic that crosses generated SQL."""
 

--- a/tests/unit/src/sqlbuild/lint/_helpers/test_native_sql.py
+++ b/tests/unit/src/sqlbuild/lint/_helpers/test_native_sql.py
@@ -16,6 +16,7 @@ from tests.unit.src.sqlbuild.lint._helpers._test_types import (
     GeneratedRangeFallbackTestCase,
     InvalidNativeSqlResponseTestCase,
     NativeParseIsolationTestCase,
+    NativeSqlFixTestCase,
     NativeSqlReuseTestCase,
     ReservedCteLintTestCase,
 )
@@ -220,6 +221,51 @@ def test_given_reserved_harness_cte_when_linting_then_framework_input_is_not_rep
     )
 
     assert sum(len(entries) for entries in result.values()) == test_case.expected_violation_count
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        NativeSqlFixTestCase(
+            description="multi-branch boolean case has no unsafe partial fix",
+            sql=(
+                "SELECT CASE "
+                "WHEN status = 'open' THEN TRUE "
+                "WHEN priority = 'high' THEN TRUE "
+                "ELSE FALSE END AS actionable "
+                "FROM support_tickets"
+            ),
+            expected_code="SQBRSQL030",
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_multi_branch_boolean_case_when_linting_then_partial_fix_is_withheld(
+    test_case: NativeSqlFixTestCase,
+    tmp_path: Path,
+) -> None:
+    target: Path = tmp_path / "support_tickets.sql"
+    body: LintBody = LintBody(
+        file_path=target,
+        body_start=0,
+        body_end=len(test_case.sql),
+        lint_text=test_case.sql,
+        passes=(),
+    )
+
+    result: dict[Path, tuple[LintViolation, ...]] = native_sql.run_native_sql_lint(
+        bodies=(body,),
+        contents_by_path={target: test_case.sql},
+        config=LintConfig(
+            dialect="duckdb",
+            enabled_native_rules=(test_case.expected_code,),
+        ),
+    )
+
+    assert len(result[target]) == 1
+    violation: LintViolation = result[target][0]
+    assert violation.code == test_case.expected_code
+    assert violation.fix is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

`SQBRSQL030` correctly identifies boolean `CASE` expressions, but its suggested edit used only the first `WHEN` condition. On a multi-branch expression, applying that edit silently discarded later branches and changed query results.

## Changes

- withhold the automatic edit unless the `CASE` contains exactly one `WHEN`, `THEN`, and `ELSE`
- continue reporting non-canonical multi-branch expressions for authored remediation
- preserve automatic fixes for canonical single-branch expressions
- cover the Rust engine and real Python/native boundary with neutral support-ticket examples

## Verification

- focused Rust SQL lint module: 10 passed
- focused Python/native boundary tests: 11 passed
- `cargo clippy -p sqlbuild-rules-native --all-targets -- -D warnings`
- `uv sync --all-extras`
- `make check-ci`
- bounded independent review
- public tree and introduced-history hygiene scans
