### PR TITLE
fix: count filtered join references

### DIFF
--- a/crates/sqlbuild-rules-native/src/sql_lint/_helpers/additional.rs
+++ b/crates/sqlbuild-rules-native/src/sql_lint/_helpers/additional.rs
@@ -695,15 +695,40 @@ fn unused_join_spans(query: &QuerySlice<'_>, query_start: usize, query_end: usiz
         let Some(alias) = relation_alias_after_join(tokens, direct, position) else {
             continue;
         };
-        let used = references.windows(2).any(|window| {
-            tokens[window[0]].text.eq_ignore_ascii_case(&alias)
-                && tokens[window[1]].token_type == TokenType::Dot
+        let used_outside_relation_clause =
+            contains_qualified_reference(tokens, &references, &alias);
+        let downstream_relation_start = direct[position + 1..relation_end]
+            .iter()
+            .position(|&candidate| {
+                matches!(
+                    tokens[candidate].token_type,
+                    TokenType::Join | TokenType::Comma
+                )
+            })
+            .map(|offset| position + 1 + offset);
+        let used_by_downstream_relation = downstream_relation_start.is_some_and(|start| {
+            let downstream_start_index = direct[start];
+            let downstream_end_index = direct.get(relation_end).copied().unwrap_or(query_end);
+            let downstream_references: Vec<usize> = (downstream_start_index..downstream_end_index)
+                .filter(|&candidate| {
+                    !is_layout(&tokens[candidate]) && !is_comment(&tokens[candidate])
+                })
+                .collect();
+            contains_qualified_reference(tokens, &downstream_references, &alias)
         });
+        let used = used_outside_relation_clause || used_by_downstream_relation;
         if !used {
             spans.push(tokens[index].span);
         }
     }
     spans
+}
+
+fn contains_qualified_reference(tokens: &[Token], references: &[usize], alias: &str) -> bool {
+    references.windows(2).any(|window| {
+        tokens[window[0]].text.eq_ignore_ascii_case(alias)
+            && tokens[window[1]].token_type == TokenType::Dot
+    })
 }
 
 fn is_after_relation_clause(token_type: TokenType) -> bool {
@@ -941,6 +966,7 @@ fn relation_alias_after_join(
         .iter()
         .position(|&index| {
             is_relation_condition_start(&tokens[index])
+                || is_after_relation_clause(tokens[index].token_type)
                 || matches!(tokens[index].token_type, TokenType::Join | TokenType::Comma)
         })
         .unwrap_or(relation.len());

--- a/crates/sqlbuild-rules-native/src/sql_lint/tests/test_sql_lint.rs
+++ b/crates/sqlbuild-rules-native/src/sql_lint/tests/test_sql_lint.rs
@@ -929,6 +929,20 @@ fn given_additional_rule_cases_when_linting_then_findings_and_fixes_match() -> R
             expected_replacement: None,
         },
         test_types::AdditionalLintRuleTestCase {
+            description: "cross joined relation contributes through a filter predicate",
+            sql: "SELECT orders.order_id FROM orders CROSS JOIN processing_cutoff AS cutoff WHERE orders.created_at < cutoff.created_at",
+            rule: "SQBRSQL032",
+            expected_anchor: None,
+            expected_replacement: None,
+        },
+        test_types::AdditionalLintRuleTestCase {
+            description: "lateral relation contributes through a downstream join condition",
+            sql: "SELECT orders.order_id, products.name FROM orders CROSS JOIN LATERAL UNNEST(orders.product_ids) AS item INNER JOIN products ON (products.product_id = item.product_id)",
+            rule: "SQBRSQL032",
+            expected_anchor: None,
+            expected_replacement: None,
+        },
+        test_types::AdditionalLintRuleTestCase {
             description: "explicit union is clean",
             sql: "SELECT 1 UNION ALL SELECT 2",
             rule: "SQBRSQL008",

--- a/tests/integration/src/sqlbuild/cli/commands/main/test_rules.py
+++ b/tests/integration/src/sqlbuild/cli/commands/main/test_rules.py
@@ -192,6 +192,48 @@ WHERE current_orders.created_at >= start_date
 
 @pytest.mark.parametrize(
     "test_case",
+    [RulesIntegrationTestCase("cross join used by filter is not unused", 0, "SQBRSQL032")],
+    ids=lambda case: case.description,
+)
+def test_given_cross_join_used_by_filter_when_running_unused_join_rule_then_no_finding_is_reported(
+    test_case: RulesIntegrationTestCase,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        'name = "orders"\nadapter = "duckdb"\n', encoding="utf-8"
+    )
+    model: Path = tmp_path / "models" / "recent_orders.sql"
+    model.parent.mkdir()
+    model.write_text(
+        """MODEL (description "Recent orders");
+SELECT orders.order_id
+FROM orders
+CROSS JOIN processing_cutoff AS cutoff
+WHERE orders.created_at < cutoff.created_at
+""",
+        encoding="utf-8",
+    )
+
+    exit_code: int = main(
+        [
+            "--project-dir",
+            str(tmp_path),
+            "rules",
+            "--json",
+            "run",
+            test_case.expected_code,
+        ]
+    )
+
+    assert exit_code == test_case.expected_exit_code
+    captured: CaptureResult[str] = capsys.readouterr()
+    payload: dict[str, object] = json.loads(captured.out)
+    assert payload["findings"] == []
+
+
+@pytest.mark.parametrize(
+    "test_case",
     [RulesIntegrationTestCase("ceremonial SQL test select is ignored", 0, "SQBRSQL022")],
     ids=lambda case: case.description,
 )

--- a/tests/unit/src/sqlbuild/lint/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/lint/_helpers/_test_types.py
@@ -97,6 +97,16 @@ class NativeSqlFixTestCase:
 
 
 @dataclass(frozen=True)
+class NativeSqlFindingTestCase:
+    """Native SQL query with an expected finding count for one selected rule."""
+
+    description: str
+    sql: str
+    selected_rule: str
+    expected_violation_count: int
+
+
+@dataclass(frozen=True)
 class GeneratedRangeFallbackTestCase:
     """Test case for a diagnostic that crosses generated SQL."""
 

--- a/tests/unit/src/sqlbuild/lint/_helpers/test_native_sql.py
+++ b/tests/unit/src/sqlbuild/lint/_helpers/test_native_sql.py
@@ -16,6 +16,7 @@ from tests.unit.src.sqlbuild.lint._helpers._test_types import (
     GeneratedRangeFallbackTestCase,
     InvalidNativeSqlResponseTestCase,
     NativeParseIsolationTestCase,
+    NativeSqlFindingTestCase,
     NativeSqlFixTestCase,
     NativeSqlReuseTestCase,
     ReservedCteLintTestCase,
@@ -266,6 +267,61 @@ def test_given_multi_branch_boolean_case_when_linting_then_partial_fix_is_withhe
     violation: LintViolation = result[target][0]
     assert violation.code == test_case.expected_code
     assert violation.fix is None
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        NativeSqlFindingTestCase(
+            description="cross joined relation used by filter is not reported as unused",
+            sql=(
+                "SELECT orders.order_id "
+                "FROM orders "
+                "CROSS JOIN processing_cutoff AS cutoff "
+                "WHERE orders.created_at < cutoff.created_at"
+            ),
+            selected_rule="SQBRSQL032",
+            expected_violation_count=0,
+        ),
+        NativeSqlFindingTestCase(
+            description="lateral relation used by parenthesized later join is not reported",
+            sql=(
+                "SELECT orders.order_id, products.name "
+                "FROM orders "
+                "CROSS JOIN LATERAL UNNEST(orders.product_ids) AS item "
+                "INNER JOIN products ON (products.product_id = item.product_id)"
+            ),
+            selected_rule="SQBRSQL032",
+            expected_violation_count=0,
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_cross_join_used_downstream_when_linting_then_no_unused_join_is_reported(
+    test_case: NativeSqlFindingTestCase,
+    tmp_path: Path,
+) -> None:
+    target: Path = tmp_path / "orders.sql"
+    body: LintBody = LintBody(
+        file_path=target,
+        body_start=0,
+        body_end=len(test_case.sql),
+        lint_text=test_case.sql,
+        passes=(),
+    )
+
+    result: dict[Path, tuple[LintViolation, ...]] = native_sql.run_native_sql_lint(
+        bodies=(body,),
+        contents_by_path={target: test_case.sql},
+        config=LintConfig(
+            dialect="duckdb",
+            enabled_native_rules=(test_case.selected_rule,),
+        ),
+    )
+
+    assert sum(len(violations) for violations in result.values()) == (
+        test_case.expected_violation_count
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

`SQBRSQL032` could report a joined relation as unused when a `CROSS JOIN` alias contributed through a later filter or downstream join condition.

## Changes

- stop alias parsing at the end of the relation clause
- count qualified references in filters and downstream relation expressions
- preserve findings when a relation appears only in its own join condition
- add native, Python-boundary, and CLI integration regressions

## Verification

- `cargo test -p sqlbuild-rules-native sql_lint::tests::sql_lint`
- `uv run pytest tests/unit/src/sqlbuild/lint/_helpers/test_native_sql.py -n auto --dist loadfile`
- focused CLI integration test
- `cargo clippy -p sqlbuild-rules-native --all-targets -- -D warnings`
- `make test` (6,530 passed)
- `uv sync --all-extras && make check-ci`
- public repository hygiene scans
