### PR TITLE
fix: preserve scalar subquery scope

### DIFF
--- a/crates/sqlbuild-rules-native/src/sql_lint/_helpers/additional.rs
+++ b/crates/sqlbuild-rules-native/src/sql_lint/_helpers/additional.rs
@@ -608,7 +608,8 @@ fn is_scalar_subquery(tokens: &[Token], depths: &[usize], select_index: usize) -
     let parent_depth = depths[previous];
     let relation_boundary = (0..previous).rev().find(|&index| {
         depths[index] == parent_depth
-            && (is_query_from(tokens, index)
+            && (tokens[index].token_type == TokenType::Select
+                || is_query_from(tokens, index)
                 || matches!(
                     tokens[index].token_type,
                     TokenType::Join | TokenType::Semicolon

--- a/crates/sqlbuild-rules-native/src/sql_lint/tests/test_sql_lint.rs
+++ b/crates/sqlbuild-rules-native/src/sql_lint/tests/test_sql_lint.rs
@@ -822,6 +822,13 @@ fn given_additional_rule_cases_when_linting_then_findings_and_fixes_match() -> R
             expected_replacement: None,
         },
         test_types::AdditionalLintRuleTestCase {
+            description: "scalar subquery after a prior CTE relation remains in projection scope",
+            sql: "WITH products_used AS (SELECT product_id FROM products), ticket_totals AS (SELECT ticket.ticket_id, (SELECT MAX(change_id) FROM support_changes) AS latest_change_id FROM support_tickets AS ticket) SELECT * FROM ticket_totals",
+            rule: "SQBRSQL022",
+            expected_anchor: None,
+            expected_replacement: None,
+        },
+        test_types::AdditionalLintRuleTestCase {
             description: "comma-derived table calculation still requires an alias",
             sql: "SELECT derived.value FROM items, (SELECT amount + tax FROM totals) AS derived",
             rule: "SQBRSQL022",

--- a/tests/integration/src/sqlbuild/cli/commands/main/test_rules.py
+++ b/tests/integration/src/sqlbuild/cli/commands/main/test_rules.py
@@ -275,6 +275,54 @@ def test_given_ceremonial_test_select_when_running_alias_rule_then_control_proje
 
 @pytest.mark.parametrize(
     "test_case",
+    [RulesIntegrationTestCase("scalar subquery after prior CTE is stable", 0, "SQBRSQL022")],
+    ids=lambda case: case.description,
+)
+def test_given_prior_cte_when_scalar_subquery_is_aliased_then_inner_aggregate_is_not_reported(
+    test_case: RulesIntegrationTestCase,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        'name = "support"\nadapter = "duckdb"\n', encoding="utf-8"
+    )
+    model: Path = tmp_path / "models" / "ticket_totals.sql"
+    model.parent.mkdir()
+    model.write_text(
+        """MODEL (description "Support ticket totals");
+WITH products_used AS (
+    SELECT product_id FROM products
+),
+ticket_totals AS (
+    SELECT
+        ticket.ticket_id,
+        (SELECT MAX(change_id) FROM support_changes) AS latest_change_id
+    FROM support_tickets AS ticket
+)
+SELECT * FROM ticket_totals
+""",
+        encoding="utf-8",
+    )
+
+    exit_code: int = main(
+        [
+            "--project-dir",
+            str(tmp_path),
+            "rules",
+            "--json",
+            "run",
+            test_case.expected_code,
+        ]
+    )
+
+    assert exit_code == test_case.expected_exit_code
+    captured: CaptureResult[str] = capsys.readouterr()
+    payload: dict[str, object] = json.loads(captured.out)
+    assert payload["findings"] == []
+
+
+@pytest.mark.parametrize(
+    "test_case",
     [RulesIntegrationTestCase("upstream graph selector scopes an ignore", 1, "SQBRSQL021")],
     ids=lambda case: case.description,
 )


### PR DESCRIPTION
## Why

`SQBRSQL022` could report an aggregate inside an aliased scalar subquery when an earlier CTE contained a relation clause. The backward scope scan crossed the current `SELECT` into the sibling CTE.

## Changes

- stop scalar-subquery boundary discovery at the nearest same-depth `SELECT`
- preserve findings for actual comma-derived relation subqueries
- add native and real CLI integration regressions

## Verification

- `cargo test -p sqlbuild-rules-native sql_lint::tests::sql_lint`
- focused CLI integration test
- `cargo clippy -p sqlbuild-rules-native --all-targets -- -D warnings`
- private cache-free dogfood: 409 selected models, 0 `SQBRSQL022` findings
- `make test` (6,531 passed)
- `uv sync --all-extras && make check-ci`
- public repository hygiene scans
