### PR TITLE
feat: wrap model descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ selected custom Python rules, before completing compile artifacts. `sqb compile`
 build and execution commands enforce the same configuration. Rules report findings and never rewrite
 SQL. `sqb format` remains a separate source-rewriting command.
 
+Long model and scenario descriptions are reflowed deterministically. Ordinary authored line breaks
+are normalized as spaces, while blank lines preserve paragraph boundaries. Configure the maximum
+physical line width in `sqlbuild_project.toml` (the default is `100`):
+
+```toml
+[format]
+line_width = 100
+```
+
 Select rules in `sqlbuild_project.toml` by exact code or derived family prefix:
 
 ```toml

--- a/src/sqlbuild/cli/commands/_helpers/lint/runs.py
+++ b/src/sqlbuild/cli/commands/_helpers/lint/runs.py
@@ -11,10 +11,12 @@ from sqlbuild.compiler.discovery.constants import LOCAL_CONFIG_FILENAME
 from sqlbuild.lint.constants import (
     ADAPTER_CONFIG_KEY,
     ADAPTER_DIALECT_TRANSLATIONS,
+    DEFAULT_LINE_WIDTH,
     DEFAULT_MAX_DESCRIPTION_LINES,
     FIX_STATUS_APPLIED,
     FIX_STATUS_SKIPPED,
     FORMAT_SECTION_KEY,
+    LINE_WIDTH_KEY,
     MAX_DESCRIPTION_LINES_KEY,
     PROJECT_CONFIG_FILENAME_KEY,
 )
@@ -32,6 +34,7 @@ def resolve_lint_config(*, project_dir: Path) -> LintConfig:
     """Resolve native lint and format configuration from project settings."""
 
     max_description_lines: int = DEFAULT_MAX_DESCRIPTION_LINES
+    line_width: int = DEFAULT_LINE_WIDTH
     dialect: str = "generic"
     config_file: Path = project_dir / PROJECT_CONFIG_FILENAME_KEY
     if config_file.is_file():
@@ -42,6 +45,11 @@ def resolve_lint_config(*, project_dir: Path) -> LintConfig:
         if isinstance(raw_adapter, str):
             dialect = ADAPTER_DIALECT_TRANSLATIONS.get(raw_adapter, raw_adapter)
         if isinstance(format_section, dict):
+            line_width = _resolve_int(
+                section=format_section,
+                key=LINE_WIDTH_KEY,
+                current=line_width,
+            )
             max_description_lines = _resolve_int(
                 section=format_section,
                 key=MAX_DESCRIPTION_LINES_KEY,
@@ -55,6 +63,7 @@ def resolve_lint_config(*, project_dir: Path) -> LintConfig:
         if isinstance(local_adapter, str):
             dialect = ADAPTER_DIALECT_TRANSLATIONS.get(local_adapter, local_adapter)
     return LintConfig(
+        line_width=line_width,
         max_description_lines=max_description_lines,
         dialect=dialect,
     )

--- a/src/sqlbuild/lint/_helpers/native.py
+++ b/src/sqlbuild/lint/_helpers/native.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+import textwrap
 from bisect import bisect_right
 from dataclasses import dataclass
 from pathlib import Path
@@ -9,11 +11,14 @@ from pathlib import Path
 from sqlbuild.compiler.discovery._helpers.sql.model_files import (
     parse_header_values,  # noqa: FFL102 - the compiler owns the canonical native header grammar
 )
+from sqlbuild.compiler.discovery.exceptions import ModelSqlParseError
 from sqlbuild.lint.constants import (
+    CLOSING_PAREN_CHARACTER,
     DESCRIPTION_HEADER_KINDS,
     DESCRIPTION_REQUIRED_HEADER_KINDS,
     HEADER_KIND_FUNCTION,
     HEADER_KIND_MODEL,
+    IDENTIFIER_SEPARATOR_CHARACTER,
     RULE_DESCRIPTION_LENGTH,
     RULE_DESCRIPTION_PRESENT,
     RULE_HEADER_PARSE,
@@ -94,7 +99,13 @@ def format_native_headers(
         config=config,
         headers=headers,
     )
-    return relocation.contents, relocation.faults
+    relocated_headers: tuple[HeaderSpan, ...] = scan_headers(contents=relocation.contents)
+    wrapped: str = _format_description_wrapping(
+        contents=relocation.contents,
+        headers=relocated_headers,
+        config=config,
+    )
+    return wrapped, relocation.faults
 
 
 def _lint_header_values(
@@ -127,7 +138,9 @@ def _lint_header_values(
 
     violations: list[LintViolation] = []
     description: object | None = values.get(_DESCRIPTION_KEY)
-    if header.kind in DESCRIPTION_REQUIRED_HEADER_KINDS and not isinstance(description, str):
+    if header.kind in DESCRIPTION_REQUIRED_HEADER_KINDS and (
+        not isinstance(description, str) or not description.strip()
+    ):
         violations.append(
             _violation_for_header_start(
                 contents=contents,
@@ -139,7 +152,18 @@ def _lint_header_values(
             )
         )
     if header.kind in DESCRIPTION_HEADER_KINDS and isinstance(description, str):
-        if description.count("\n") + 1 > config.max_description_lines:
+        span: tuple[int, int] | None = _top_level_description_value_span(header_text=header_text)
+        formatted_description: str = (
+            _wrap_header_description(
+                description=description,
+                header_text=header_text,
+                span=span,
+                line_width=config.line_width,
+            )
+            if span is not None
+            else description
+        )
+        if formatted_description.count("\n") + 1 > config.max_description_lines:
             violations.append(
                 _violation_for_header_start(
                     contents=contents,
@@ -221,6 +245,143 @@ def _format_header_whitespace(*, contents: str, headers: tuple[HeaderSpan, ...])
     return "".join(pieces)
 
 
+def _format_description_wrapping(
+    *, contents: str, headers: tuple[HeaderSpan, ...], config: LintConfig
+) -> str:
+    updated: str = contents
+    for header in reversed(headers):
+        if header.kind not in DESCRIPTION_HEADER_KINDS:
+            continue
+        header_text: str = updated[header.start : header.end]
+        span: tuple[int, int] | None = _top_level_description_value_span(header_text=header_text)
+        if span is None:
+            continue
+        try:
+            description: object | None = _parse_header_values(
+                kind=header.kind,
+                header_text=header_text,
+            ).get(_DESCRIPTION_KEY)
+        except ModelSqlParseError:
+            continue
+        if not isinstance(description, str):
+            continue
+        value_start, value_end = span
+        wrapped: str = _wrap_header_description(
+            description=description,
+            header_text=header_text,
+            span=span,
+            line_width=config.line_width,
+        )
+        quote: str = header_text[value_start - 1]
+        escaped: str = _escape_quoted_value(value=wrapped, quote=quote)
+        rewritten_header: str = header_text[:value_start] + escaped + header_text[value_end:]
+        updated = updated[: header.start] + rewritten_header + updated[header.end :]
+    return updated
+
+
+def _wrap_header_description(
+    *, description: str, header_text: str, span: tuple[int, int], line_width: int
+) -> str:
+    value_start, value_end = span
+    line_start: int = header_text.rfind(_NEWLINE, 0, value_start) + 1
+    line_end: int = header_text.find(_NEWLINE, value_end)
+    if line_end < 0:
+        line_end = len(header_text)
+    closing_suffix_width: int = len(header_text[value_end:line_end].rstrip())
+    wrapped_line_width: int = max(1, line_width - closing_suffix_width)
+    first_line_width: int = max(
+        1,
+        line_width - (value_start - line_start) - closing_suffix_width,
+    )
+    return _wrap_description(
+        description=description,
+        first_line_width=first_line_width,
+        line_width=wrapped_line_width,
+    )
+
+
+def _top_level_description_value_span(*, header_text: str) -> tuple[int, int] | None:
+    delimiters: list[str] = []
+    closing_delimiters: dict[str, str] = {"(": ")", "[": "]", "{": "}"}
+    index: int = 0
+    while index < len(header_text):
+        character: str = header_text[index]
+        if character in _QUOTE_CHARACTERS:
+            index = _quoted_value_end(text=header_text, start=index)
+            continue
+        if character in closing_delimiters:
+            delimiters.append(closing_delimiters[character])
+            index += 1
+            continue
+        if delimiters and character == delimiters[-1]:
+            delimiters.pop()
+            index += 1
+            continue
+        if delimiters == [CLOSING_PAREN_CHARACTER] and (
+            character.isalpha() or character == IDENTIFIER_SEPARATOR_CHARACTER
+        ):
+            word_end: int = index + 1
+            while word_end < len(header_text) and (
+                header_text[word_end].isalnum()
+                or header_text[word_end] == IDENTIFIER_SEPARATOR_CHARACTER
+            ):
+                word_end += 1
+            if header_text[index:word_end].lower() == _DESCRIPTION_KEY:
+                quote_start: int = word_end
+                while quote_start < len(header_text) and header_text[quote_start].isspace():
+                    quote_start += 1
+                if quote_start < len(header_text) and header_text[quote_start] in _QUOTE_CHARACTERS:
+                    quote_end: int = _quoted_value_end(text=header_text, start=quote_start)
+                    return quote_start + 1, quote_end - 1
+            index = word_end
+            continue
+        index += 1
+    return None
+
+
+def _quoted_value_end(*, text: str, start: int) -> int:
+    quote: str = text[start]
+    index: int = start + 1
+    while index < len(text):
+        if text[index] == _ESCAPE_CHARACTER and index + 1 < len(text):
+            index += 2
+            continue
+        if text[index] == quote:
+            return index + 1
+        index += 1
+    return len(text)
+
+
+def _wrap_description(*, description: str, first_line_width: int, line_width: int) -> str:
+    normalized: str = description.replace("\r\n", _NEWLINE).strip()
+    paragraphs: list[str] = re.split(r"\n\s*\n", normalized)
+    wrapped_paragraphs: list[str] = []
+    for paragraph_index, paragraph in enumerate(paragraphs):
+        prose: str = " ".join(paragraph.split())
+        if not prose:
+            continue
+        available_first_width: int = first_line_width if paragraph_index == 0 else line_width
+        synthetic_indent: str = " " * max(0, line_width - available_first_width)
+        wrapper: textwrap.TextWrapper = textwrap.TextWrapper(
+            width=line_width,
+            initial_indent=synthetic_indent,
+            subsequent_indent="",
+            break_long_words=False,
+            break_on_hyphens=False,
+        )
+        lines: list[str] = wrapper.wrap(prose)
+        if lines and synthetic_indent:
+            lines[0] = lines[0][len(synthetic_indent) :]
+        wrapped_paragraphs.append(_NEWLINE.join(lines))
+    return f"{_NEWLINE}{_NEWLINE}".join(wrapped_paragraphs)
+
+
+def _escape_quoted_value(*, value: str, quote: str) -> str:
+    return value.replace(_ESCAPE_CHARACTER, _ESCAPE_CHARACTER * 2).replace(
+        quote, _ESCAPE_CHARACTER + quote
+    )
+
+
 def _relocate_leading_comment(
     *, contents: str, file_path: Path, config: LintConfig, headers: tuple[HeaderSpan, ...]
 ) -> _RelocationOutcome:
@@ -239,7 +400,16 @@ def _relocate_leading_comment(
     if isinstance(values.get(_DESCRIPTION_KEY), str):
         return _RelocationOutcome(contents=contents, faults=())
 
-    relocated_description: str = comment_text.strip("\n").strip()
+    description_prefix_width: int = len(_HEADER_INDENT) + len(_DESCRIPTION_KEY) + 2
+    closing_description_syntax_width: int = len('",')
+    relocated_description: str = _wrap_description(
+        description=comment_text,
+        first_line_width=max(
+            1,
+            config.line_width - description_prefix_width - closing_description_syntax_width,
+        ),
+        line_width=max(1, config.line_width - closing_description_syntax_width),
+    )
     faults: list[LintViolation] = []
     if relocated_description.count("\n") + 1 > config.max_description_lines:
         position: tuple[int, int] = _offset_to_position(

--- a/src/sqlbuild/lint/constants.py
+++ b/src/sqlbuild/lint/constants.py
@@ -40,6 +40,7 @@ DESCRIPTION_HEADER_KINDS: frozenset[str] = frozenset({HEADER_KIND_MODEL, HEADER_
 DESCRIPTION_REQUIRED_HEADER_KINDS: frozenset[str] = frozenset({HEADER_KIND_MODEL})
 
 DEFAULT_MAX_DESCRIPTION_LINES: int = 10
+DEFAULT_LINE_WIDTH: int = 100
 
 LINT_DIRECTORY_NAMES: tuple[str, ...] = (
     "models",
@@ -61,6 +62,7 @@ RULE_HEADER_PARSE: str = "header-parse"
 PROJECT_CONFIG_FILENAME_KEY: str = "sqlbuild_project.toml"
 FORMAT_SECTION_KEY: str = "format"
 MAX_DESCRIPTION_LINES_KEY: str = "max_description_lines"
+LINE_WIDTH_KEY: str = "line_width"
 
 ADAPTER_DIALECT_TRANSLATIONS: dict[str, str] = {
     "duckdb": "duckdb",

--- a/src/sqlbuild/lint/models.py
+++ b/src/sqlbuild/lint/models.py
@@ -101,6 +101,7 @@ class LintConfig:
 
     native_enabled: bool = True
     max_description_lines: int = 10
+    line_width: int = 100
     dialect: str = "generic"
     enabled_native_rules: tuple[str, ...] | None = None
     ignored_native_rules: tuple[str, ...] = ()

--- a/tests/integration/src/sqlbuild/cli/commands/main/_test_types.py
+++ b/tests/integration/src/sqlbuild/cli/commands/main/_test_types.py
@@ -23,6 +23,16 @@ class FormatCompileIntegrationTestCase:
 
 
 @dataclass(frozen=True)
+class DescriptionFormatIntegrationTestCase:
+    """One description wrapping expectation through the real CLI and compiler."""
+
+    description: str
+    line_width: int
+    authored_description: str
+    expected_formatted_description: str
+
+
+@dataclass(frozen=True)
 class ContractCommandIntegrationTestCase:
     """One target-backed contract CLI expectation."""
 

--- a/tests/integration/src/sqlbuild/cli/commands/main/test_format.py
+++ b/tests/integration/src/sqlbuild/cli/commands/main/test_format.py
@@ -8,6 +8,7 @@ import pytest
 
 from sqlbuild.cli.commands.main.entrypoint.entry import main
 from tests.integration.src.sqlbuild.cli.commands.main._test_types import (
+    DescriptionFormatIntegrationTestCase,
     FormatCompileIntegrationTestCase,
 )
 
@@ -57,3 +58,46 @@ def test_given_sql_test_string_when_formatting_then_project_still_compiles(
     assert format_exit == 0
     assert compile_exit == 0
     assert test_case.expected_literal in test.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        DescriptionFormatIntegrationTestCase(
+            description="configured width wraps and compiles model description",
+            line_width=60,
+            authored_description=(
+                "Builds canonical customer records from every available source while retaining "
+                "unmatched customers."
+            ),
+            expected_formatted_description=(
+                "Builds canonical customer records from every\n"
+                "available source while retaining unmatched customers."
+            ),
+        )
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_description_width_when_formatting_then_wrapped_model_compiles(
+    test_case: DescriptionFormatIntegrationTestCase,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "sqlbuild_project.toml").write_text(
+        f'name = "orders"\nadapter = "duckdb"\n[format]\nline_width = {test_case.line_width}\n',
+        encoding="utf-8",
+    )
+    model: Path = tmp_path / "models" / "orders.sql"
+    model.parent.mkdir()
+    model.write_text(
+        f'MODEL (\n  description "{test_case.authored_description}"\n);\nSELECT 1 AS order_id\n',
+        encoding="utf-8",
+    )
+
+    format_exit: int = main(["--project-dir", str(tmp_path), "format"])
+    compile_exit: int = main(["--project-dir", str(tmp_path), "compile", "--no-cache"])
+
+    assert format_exit == 0
+    assert compile_exit == 0
+    assert f'description "{test_case.expected_formatted_description}"' in model.read_text(
+        encoding="utf-8"
+    )

--- a/tests/unit/src/sqlbuild/lint/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/lint/_helpers/_test_types.py
@@ -53,6 +53,16 @@ class FormatNativeTestCase:
 
 
 @dataclass(frozen=True)
+class FormatDescriptionTestCase:
+    """Test case for deterministic description wrapping."""
+
+    description: str
+    contents: str
+    line_width: int
+    expected_contents: str
+
+
+@dataclass(frozen=True)
 class InvalidNativeSqlResponseTestCase:
     """Test case for rejecting malformed native SQL lint responses."""
 

--- a/tests/unit/src/sqlbuild/lint/_helpers/test_native.py
+++ b/tests/unit/src/sqlbuild/lint/_helpers/test_native.py
@@ -13,6 +13,7 @@ from sqlbuild.lint._helpers.headers import scan_headers
 from sqlbuild.lint._helpers.native import format_native_headers, lint_native_headers
 from sqlbuild.lint.models import LintConfig
 from tests.unit.src.sqlbuild.lint._helpers._test_types import (
+    FormatDescriptionTestCase,
     FormatNativeTestCase,
     LintNativeTestCase,
 )
@@ -40,22 +41,27 @@ DEFAULT_CONFIG: LintConfig = LintConfig()
             expected_codes=(),
         ),
         LintNativeTestCase(
-            description="long single-line scenario description passes",
+            description="long single-line scenario description faults by formatted length",
             contents=(
                 'SCENARIO (description "'
                 + " ".join(f"word{index}" for index in range(400))
                 + '");\nSELECT 1\n'
             ),
-            expected_codes=(),
+            expected_codes=("description-length",),
         ),
         LintNativeTestCase(
-            description="oversized multiline scenario description faults",
+            description="short manually wrapped scenario description passes",
             contents=(
                 'SCENARIO (description "'
                 + "\n ".join(f"line {index}" for index in range(11))
                 + '");\nSELECT 1\n'
             ),
-            expected_codes=("description-length",),
+            expected_codes=(),
+        ),
+        LintNativeTestCase(
+            description="whitespace-only model description faults as missing",
+            contents='MODEL (description "   ");\nSELECT 1\n',
+            expected_codes=("description-present",),
         ),
         LintNativeTestCase(
             description="broken model header faults with parse error",
@@ -130,7 +136,7 @@ def test_given_legacy_scenario_header_when_linting_and_compiling_then_both_rejec
             description="leading line comments relocate into description",
             contents="-- One.\n-- Two.\nMODEL (\n  materialized table\n);\nSELECT 1\n",
             expected_contents=(
-                'MODEL (\n  description "One.\nTwo.",\n  materialized table\n);\nSELECT 1\n'
+                'MODEL (\n  description "One. Two.",\n  materialized table\n);\nSELECT 1\n'
             ),
             expected_fault_codes=(),
         ),
@@ -172,8 +178,91 @@ def test_given_contents_when_formatting_then_contents_match_expected(
 @pytest.mark.parametrize(
     "test_case",
     [
+        FormatDescriptionTestCase(
+            description="long description wraps at the configured line width",
+            contents=(
+                'MODEL (\n  description "Builds canonical customer records from every available '
+                'source while retaining unmatched customers."\n);\nSELECT 1\n'
+            ),
+            line_width=60,
+            expected_contents=(
+                'MODEL (\n  description "Builds canonical customer records from every\n'
+                'available source while retaining unmatched customers."\n);\nSELECT 1\n'
+            ),
+        ),
+        FormatDescriptionTestCase(
+            description="inconsistent authored wrapping normalizes deterministically",
+            contents=(
+                'MODEL (\n  description "Builds canonical customer\nrecords from every available '
+                'source while retaining\nunmatched customers."\n);\nSELECT 1\n'
+            ),
+            line_width=60,
+            expected_contents=(
+                'MODEL (\n  description "Builds canonical customer records from every\n'
+                'available source while retaining unmatched customers."\n);\nSELECT 1\n'
+            ),
+        ),
+        FormatDescriptionTestCase(
+            description="blank lines preserve intentional paragraphs",
+            contents=(
+                'MODEL (\n  description "Builds canonical customer records from every source.\n\n'
+                'Retains unmatched customers for complete downstream coverage."\n);\nSELECT 1\n'
+            ),
+            line_width=60,
+            expected_contents=(
+                'MODEL (\n  description "Builds canonical customer records from every\n'
+                "source.\n\nRetains unmatched customers for complete downstream\n"
+                'coverage."\n);\nSELECT 1\n'
+            ),
+        ),
+        FormatDescriptionTestCase(
+            description="short description remains compact",
+            contents='MODEL (description "Canonical customer records.");\nSELECT 1\n',
+            line_width=60,
+            expected_contents='MODEL (description "Canonical customer records.");\nSELECT 1\n',
+        ),
+        FormatDescriptionTestCase(
+            description="nested column description is not treated as the model description",
+            contents=(
+                'MODEL (\n  columns (\n    customer_id (type BIGINT, description "A deliberately '
+                'long column description that remains authored text.")\n  ),\n  description "Builds '
+                'canonical customer records from every available source."\n);\nSELECT 1\n'
+            ),
+            line_width=60,
+            expected_contents=(
+                'MODEL (\n  columns (\n    customer_id (type BIGINT, description "A deliberately '
+                'long column description that remains authored text.")\n  ),\n  description "Builds '
+                'canonical customer records from every\navailable source."\n);\nSELECT 1\n'
+            ),
+        ),
+    ],
+    ids=lambda case: case.description,
+)
+def test_given_description_when_formatting_then_wrapping_is_uniform(
+    test_case: FormatDescriptionTestCase,
+) -> None:
+    updated, faults = format_native_headers(
+        contents=test_case.contents,
+        file_path=FILE_PATH,
+        config=LintConfig(line_width=test_case.line_width),
+    )
+
+    assert updated == test_case.expected_contents
+    assert faults == ()
+    reformatted, reformat_faults = format_native_headers(
+        contents=updated,
+        file_path=FILE_PATH,
+        config=LintConfig(line_width=test_case.line_width),
+    )
+    assert reformatted == updated
+    assert reformat_faults == ()
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
         FormatNativeTestCase(
-            description="oversized relocated comment faults for a human to trim",
+            description="manually wrapped leading comments reflow as prose",
             contents=(
                 "-- "
                 + "\n-- ".join(f"line {index}" for index in range(11))
@@ -181,15 +270,15 @@ def test_given_contents_when_formatting_then_contents_match_expected(
             ),
             expected_contents=(
                 'MODEL (\n  description "'
-                + "\n".join(f"line {index}" for index in range(11))
+                + " ".join(f"line {index}" for index in range(11))
                 + '",\n  materialized table\n);\nSELECT 1\n'
             ),
-            expected_fault_codes=("leading-comment-description",),
+            expected_fault_codes=(),
         ),
     ],
     ids=lambda case: case.description,
 )
-def test_given_oversized_leading_comment_when_formatting_then_relocates_and_faults(
+def test_given_wrapped_leading_comment_when_formatting_then_reflows_as_prose(
     test_case: FormatNativeTestCase,
 ) -> None:
     updated: str


### PR DESCRIPTION
## Why

Description formatting currently preserves arbitrary authored line breaks and allows long prose to extend beyond a readable terminal width. Equivalent descriptions therefore produce inconsistent source formatting.

## Changes

- Reflow model and scenario descriptions deterministically during `sqb format`.
- Preserve blank-line paragraph boundaries while normalizing ordinary whitespace.
- Add `[format].line_width`, defaulting to 100 characters.
- Measure description-length diagnostics against canonical formatted output.
- Treat whitespace-only required model descriptions as missing.
- Document the configuration and behavior.

## Verification

- `uv run pytest tests/unit/src/sqlbuild/lint/_helpers/test_native.py tests/integration/src/sqlbuild/cli/commands/main/test_format.py -n auto --dist loadfile`
- `uv sync --all-extras`
- `make check-ci`
- Public repository tree and outgoing-commit hygiene scans
- Independent bounded diff review and finding-focused follow-up
