### PR TITLE
feat: group scoped declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,29 @@ def active_status_filter(ctx) -> str:
 Callers can still pass explicit `@const(...)` or `@enum(...)` values as macro arguments. Context
 lookups are intended for policy owned by the macro; both forms use the caller's declaration scope.
 
+## Grouped declarations
+
+Keep folder-scoped macros, enums, and constants together without mixing declaration directories into
+resource listings:
+
+```text
+models/orders/
+├── _sqlbuild/
+│   ├── macros/       # visible in orders/ and its descendants
+│   ├── enums/
+│   ├── constants/
+│   ├── _macros/      # visible only to resources directly in orders/
+│   ├── _enums/
+│   └── _constants/
+├── intermediate/
+└── mart/
+```
+
+The containing `orders/` directory remains the declaration owner. Existing declaration directories
+directly below an owner remain supported. Placement diagnostics recommend the grouped layout.
+`_sqlbuild/` is reserved for the six declaration-role directories shown above; other direct entries
+are rejected rather than silently treated as resources.
+
 ## Compiler-integrated Rules
 
 Rules turn repeatable SQL and project review decisions into compile-time diagnostics. Mandatory

--- a/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
+++ b/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
@@ -6345,9 +6345,9 @@ need to execute SQL against controlled data. Use an audit when the answer depend
 A finding contains a stable code, project-relative path, line, column, explanation, and remediation.
 This makes the same requirement usable in a terminal, JSON output, CI annotation, or agent workflow.
 
-Intentional departures remain explicit. Exact exceptions and path-scoped ignores require a reason;
-exact exceptions are stale-checked so obsolete suppressions do not silently accumulate. Mandatory
-compiler correctness cannot be suppressed.
+Intentional departures remain explicit. Exact exceptions and path- or resource-scoped ignores
+require a reason; exact exceptions are stale-checked so obsolete suppressions do not silently
+accumulate. Mandatory compiler correctness cannot be suppressed.
 
 See [Findings and exceptions](/concepts/rules/findings-and-exceptions) for configuration examples.
 
@@ -6475,23 +6475,7 @@ reason = "Examples retain intentionally minimal SQL."
 Path ignores accept exact codes and family prefixes. Keep their scope narrow and explain why the
 project differs from the selected requirement.
 
-Use resource selectors when the exception follows project structure or lineage rather than a
-directory boundary:
-
-```toml
-[[rules.rule_ignores]]
-rules = ["SQBRSQL021"]
-selectors = ["+orders"]
-reason = "The reviewed orders interface preserves its upstream column contract."
-```
-
-Resource ignores use the same selector grammar as other SQLBuild commands, including names, tags,
-paths, graph expansion (`+orders`, `orders+`, or `+orders+`), and lineage paths such as
-`base_orders~customer_orders`. `paths` and `selectors` may be combined in one ignore. Continue to
-use `paths` for SQL tests and audits because those files are not graph resources.
-
-Bare resource names also accept glob patterns. For example, this scopes the ignore to every graph
-resource whose name starts with `intermediate_`:
+Use `selectors` when the exception follows graph-resource identities or lineage rather than files:
 
 ```toml
 [[rules.rule_ignores]]
@@ -6500,8 +6484,9 @@ selectors = ["intermediate_*"]
 reason = "These intermediate interfaces intentionally preserve upstream columns."
 ```
 
-Use `paths` instead when the convention belongs to authored filenames or directories, including
-non-graph SQL files:
+Selectors use the same grammar as SQLBuild commands, including exact names, name globs, tags,
+resource paths, and graph expansion such as `+intermediate_*`. Use `paths` for authored-file glob
+matching, including SQL tests and audits that are not graph resources:
 
 ```toml
 [[rules.rule_ignores]]
@@ -6509,6 +6494,8 @@ rules = ["SQBRSQL021"]
 paths = ["models/**/intermediate_*.sql"]
 reason = "These intermediate SQL files intentionally preserve upstream columns."
 ```
+
+`paths` and `selectors` may be combined in one scoped ignore. Both forms require a reason.
 
 ### Mandatory correctness
 
@@ -7439,11 +7426,22 @@ When no `--select` is provided, all models are selected.
 
 #### Name
 
-Select a single model by name:
+Select a single resource by name:
 
 ```bash
 sqb build --select fact_orders
 ```
+
+Bare names accept glob patterns. This selects every resource whose name starts with
+`intermediate_`:
+
+```bash
+sqb build --select "intermediate_*"
+```
+
+Name globs compose with graph expansion. For example, `+intermediate_*` selects every matching
+resource and all of their upstream dependencies. Quote patterns in shell commands so your shell
+does not expand `*` against files in the current directory.
 
 #### Tag
 
@@ -7547,10 +7545,12 @@ sqb build --select +fact_orders --exclude tag:staging
 
 ### Error handling
 
-Unknown model names, empty paths, and malformed selectors produce clear error messages:
+Unknown resource names, name patterns with no matches, empty paths, and malformed selectors produce
+clear error messages:
 
 ```
 unknown selector name 'nonexistent_model'
+unknown selector pattern 'missing_*'
 no models found under path 'models/nonexistent'.
 no models found with tag 'nonexistent_tag'
 path selector 'fact_orders~' requires names on both sides of '~'
@@ -8157,8 +8157,8 @@ decide which files can access it. No TOML configuration is required.
 | Where the declaration lives | Who can use it |
 |-------------------------------------|--------------------|
 | Top-level `macros/`, `constants/`, or `enums/` | The whole project |
-| Nested `macros/`, `constants/`, or `enums/` | Files in that folder and folders below it |
-| Nested `_macros/`, `_constants/`, or `_enums/` | Files directly in that folder only |
+| Nested `_sqlbuild/macros/`, `_sqlbuild/constants/`, or `_sqlbuild/enums/` | Files in the owner folder and folders below it |
+| Nested `_sqlbuild/_macros/`, `_sqlbuild/_constants/`, or `_sqlbuild/_enums/` | Files directly in the owner folder only |
 | An underscored constant or enum inside `MODEL()` | That model and its inline SQL hooks only |
 
 Macro declarations are Python files (`.py`). Constant and enum declarations are SQL files
@@ -8173,22 +8173,27 @@ models/
 ├── constants/                 published throughout models/
 │   └── warehouse.sql
 └── commerce/
-    ├── macros/                published throughout commerce/
-    │   └── currency.py
-    ├── _enums/                exact commerce/ directory only
-    │   └── grain.sql
+    ├── _sqlbuild/
+    │   ├── macros/            published throughout commerce/
+    │   │   └── currency.py
+    │   └── _enums/            exact commerce/ directory only
+    │       └── grain.sql
     ├── orders.sql              sees warehouse, currency, and grain
     ├── finance/
-    │   ├── macros/            published throughout finance/
-    │   │   └── tax.py
+    │   ├── _sqlbuild/
+    │   │   └── macros/        published throughout finance/
+    │   │       └── tax.py
     │   └── revenue.sql         sees warehouse, currency, and tax
     └── fulfillment/
         └── shipments.sql       sees warehouse and currency
 ```
 
-A nested unprefixed role applies to its folder and everything below it. An underscored role applies
-only to files directly beside it. The same unprefixed role name applies to the whole project only
-when it is at the project root.
+The folder containing `_sqlbuild/` is the declaration owner. An unprefixed role applies to that
+owner and everything below it. An underscored role applies only to files directly in the owner.
+Legacy declaration roles directly below an owner remain supported.
+
+`_sqlbuild/` is reserved for the six declaration-role directories shown above. Other direct files or
+folders are rejected, and a project-root `_sqlbuild/` is invalid because it has no resource owner.
 
 | Resource | Visible from the example tree | Not visible |
 |----------|-------------------------------|-------------|
@@ -8223,8 +8228,8 @@ versioned JSON schema rather than parsing text labels.
 | Where the value is needed | Placement |
 |---------------------------|-----------|
 | One model only | In that model's `MODEL()` header |
-| Files directly in one folder | In an underscored role beside those files |
-| Files across one folder tree | In an unprefixed role at their nearest shared parent folder |
+| Files directly in one folder | In an underscored role under the owner's `_sqlbuild/` folder |
+| Files across one folder tree | In an unprefixed role under the nearest shared owner's `_sqlbuild/` folder |
 | Different resource trees, such as models and tests | In a top-level declaration role |
 
 SQLBuild computes the lowest common owner of every declaration's runtime consumers. A project-wide
@@ -8249,8 +8254,9 @@ See which enums, constants, and macros are available to each SQL file.
 
 For most SQL, the rule is simple:
 
-> A file can use declarations available to the whole project, declarations in unprefixed role
-> folders beside or above it, and declarations in an underscored role folder directly beside it.
+> A file can use declarations available to the whole project, declarations in unprefixed roles
+> under `_sqlbuild/` folders owned beside or above it, and declarations in an underscored role owned
+> directly beside it.
 
 ### Start from the SQL file
 
@@ -8262,10 +8268,11 @@ models/
 ├── constants/                 available throughout models/
 │   └── warehouse.sql
 └── commerce/
-    ├── enums/                 available throughout commerce/
-    │   └── order_status.sql
-    ├── _constants/       available directly in commerce/ only
-    │   └── minimum_value.sql
+    ├── _sqlbuild/
+    │   ├── enums/             available throughout commerce/
+    │   │   └── order_status.sql
+    │   └── _constants/        available directly in commerce/ only
+    │       └── minimum_value.sql
     ├── orders.sql
     └── history/
         └── archived_orders.sql
@@ -8278,12 +8285,12 @@ From this tree:
 | `orders.sql` | `warehouse`, `order_status`, and `minimum_value` |
 | `history/archived_orders.sql` | `warehouse` and `order_status` |
 
-`minimum_value` is not available in `history/` because `_constants/` applies only to files
-directly beside it.
+`minimum_value` is not available in `history/` because `_sqlbuild/_constants/` applies only to files
+directly in the `_sqlbuild/` owner's folder.
 
 ### Supported resource trees
 
-Scoped declaration directories can be placed below these SQL resource roots:
+Grouped declaration directories can be placed below these SQL resource roots:
 
 | Root | Contents |
 |------|----------|
@@ -8300,6 +8307,11 @@ under `tests/`. Put a declaration in the top-level `constants/`, `enums/`, or `m
 when it must be available across different resource trees. Project-root `_constants/`, `_enums/`,
 and `_macros/` directories are invalid because there is no owner folder at the project root for
 them to be private to.
+
+Existing scoped declaration roles directly below an owner remain supported. `_sqlbuild/` is the
+preferred layout because it keeps all declarations together without changing their visibility.
+Only the six public/private declaration-role directories are valid directly under `_sqlbuild/`;
+other entries are rejected. A project-root `_sqlbuild/` is invalid because it has no resource owner.
 
 ### Which file controls visibility?
 
@@ -8407,8 +8419,8 @@ tree.
 | Where it is needed | Location |
 |--------------------|----------|
 | One model only | Inside that model's `MODEL()` header, for enums and constants |
-| SQL files directly in one directory | `_macros/`, `_enums/`, or `_constants/` |
-| A directory and its descendants | `macros/`, `enums/`, or `constants/` |
+| SQL files directly in one directory | `_sqlbuild/_macros/`, `_sqlbuild/_enums/`, or `_sqlbuild/_constants/` |
+| A directory and its descendants | `_sqlbuild/macros/`, `_sqlbuild/enums/`, or `_sqlbuild/constants/` |
 | Different trees, such as models and tests | Top-level `macros/`, `enums/`, or `constants/` |
 
 ### One directory
@@ -8418,13 +8430,14 @@ These two models use the same constant and both sit directly in `commerce/`:
 ```text
 models/
 └── commerce/
-    ├── _constants/
-    │   └── minimum_value.sql
+    ├── _sqlbuild/
+    │   └── _constants/
+    │       └── minimum_value.sql
     ├── orders.sql
     └── customers.sql
 ```
 
-Use `_constants/` because no descendant directory needs the value.
+Use `_sqlbuild/_constants/` because no descendant directory needs the value.
 
 ### One directory tree
 
@@ -8433,15 +8446,16 @@ These models use the same constant across two child directories:
 ```text
 models/
 └── commerce/
-    ├── constants/
-    │   └── reporting_day.sql
+    ├── _sqlbuild/
+    │   └── constants/
+    │       └── reporting_day.sql
     ├── finance/
     │   └── revenue.sql
     └── fulfillment/
         └── shipments.sql
 ```
 
-Use `constants/` in `commerce/` so both child directories can use it.
+Use `_sqlbuild/constants/` in `commerce/` so both child directories can use it.
 
 ### Different resource trees
 
@@ -8633,7 +8647,7 @@ Explanation
      Promotion impact: model:orders
 
 Diagnostics (1)
-  ERROR S008 models/commerce/macros/orders.py: Declaration 'macro:formatted_order_total' is currently descendant-public at 'models/commerce' (models/commerce/macros/orders.py); required exact-owner-private at 'models/commerce'. Consumers: model:orders. Move it to 'models/commerce/_macros/'
+  ERROR S008 models/commerce/macros/orders.py: Declaration 'macro:formatted_order_total' is currently descendant-public at 'models/commerce' (models/commerce/macros/orders.py); required exact-owner-private at 'models/commerce'. Consumers: model:orders. Move it to 'models/commerce/_sqlbuild/_macros/'
 Completeness: complete
 ```
 

--- a/src/sqlbuild/compiler/discovery/_helpers/filesystem/core.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/filesystem/core.py
@@ -93,6 +93,7 @@ from sqlbuild.compiler.resource_names.main._validate_resource_identity import (
 )
 from sqlbuild.compiler.scopes.constants import (
     DECLARATION_DIRECTORY_FACTS,
+    DECLARATION_GROUP_DIRECTORY,
     GLOBAL_DECLARATION_DIRECTORIES,
     INHERITED_DECLARATION_DIRECTORIES,
     LOCAL_DECLARATION_DIRECTORIES,
@@ -180,6 +181,7 @@ _SCOPED_DECLARATION_DIRECTORIES: frozenset[str] = (
 def _discover_declaration_file_facts(
     *, project_dir: Path, declaration_kind: DeclarationKind | None = None
 ) -> tuple[_DeclarationFileFacts, ...]:
+    _validate_declaration_groups(project_dir=project_dir)
     for directory_name in sorted(LOCAL_DECLARATION_DIRECTORIES):
         directory_kind, _scope_kind = DECLARATION_DIRECTORY_FACTS[directory_name]
         if (declaration_kind is None or directory_kind is declaration_kind) and (
@@ -226,16 +228,50 @@ def _discover_declaration_file_facts(
                     f"Declaration root {relative_directory.as_posix()}/ is nested inside another "
                     "declaration tree"
                 )
+            owning_path: Path = relative_directory.parent
+            if relative_directory.parent.name == DECLARATION_GROUP_DIRECTORY:
+                owning_path = relative_directory.parent.parent
             facts.extend(
                 _declaration_files_under_root(
                     project_dir=project_dir,
                     ownership_root=Path(*root_components),
                     declaration_root=directory,
-                    owning_path=relative_directory.parent,
+                    owning_path=owning_path,
                     scope_kind=directory_scope_kind,
                 )
             )
     return tuple(sorted(facts, key=lambda item: item.relative_path.as_posix()))
+
+
+def _validate_declaration_groups(*, project_dir: Path) -> None:
+    root_group: Path = project_dir / DECLARATION_GROUP_DIRECTORY
+    if root_group.exists():
+        raise DeclarationParseError(
+            f"Grouped declaration root {DECLARATION_GROUP_DIRECTORY}/ must be below a canonical "
+            "authored root"
+        )
+    for root_components in CANONICAL_AUTHORED_ROOTS:
+        authored_root: Path = project_dir.joinpath(*root_components)
+        if not authored_root.is_dir():
+            continue
+        for group in sorted(
+            path for path in authored_root.rglob(DECLARATION_GROUP_DIRECTORY) if path.is_dir()
+        ):
+            unsupported: tuple[Path, ...] = tuple(
+                sorted(
+                    child
+                    for child in group.iterdir()
+                    if not child.is_dir() or child.name not in _SCOPED_DECLARATION_DIRECTORIES
+                )
+            )
+            if unsupported:
+                rendered: str = ", ".join(
+                    path.relative_to(project_dir).as_posix() for path in unsupported
+                )
+                raise DeclarationParseError(
+                    f"Declaration group {group.relative_to(project_dir).as_posix()}/ contains "
+                    f"unsupported entries: {rendered}"
+                )
 
 
 def _declaration_files_under_root(
@@ -284,7 +320,7 @@ def _is_in_scoped_declaration_tree(*, file_path: Path, project_dir: Path) -> boo
         if relative_parts[: len(root_components)] != root_components:
             continue
         return any(
-            component in _SCOPED_DECLARATION_DIRECTORIES
+            component == DECLARATION_GROUP_DIRECTORY or component in _SCOPED_DECLARATION_DIRECTORIES
             for component in relative_parts[len(root_components) : -1]
         )
     return False

--- a/src/sqlbuild/compiler/scopes/_helpers/placement.py
+++ b/src/sqlbuild/compiler/scopes/_helpers/placement.py
@@ -7,6 +7,7 @@ from dataclasses import replace
 from pathlib import PurePosixPath
 
 from sqlbuild.compiler.scopes._helpers.identities import format_identity
+from sqlbuild.compiler.scopes.constants import DECLARATION_GROUP_DIRECTORY
 from sqlbuild.compiler.scopes.models import (
     DeclarationIdentity,
     DeclarationRecord,
@@ -262,7 +263,10 @@ def _message(
         target: str = f"top-level {declaration.identity.kind.value}s/"
     else:
         prefix: str = "_" if required_scope is ScopeKind.LOCAL else ""
-        target = f"{required_path}/{prefix}{declaration.identity.kind.value}s/"
+        target = (
+            f"{required_path}/{DECLARATION_GROUP_DIRECTORY}/"
+            f"{prefix}{declaration.identity.kind.value}s/"
+        )
     return (
         f"Declaration '{format_identity(identity=declaration.identity)}' is currently "
         f"{_scope_label(declaration.scope)} at '{current_path}' ({declaration.path}); required "

--- a/src/sqlbuild/compiler/scopes/_helpers/report_projection.py
+++ b/src/sqlbuild/compiler/scopes/_helpers/report_projection.py
@@ -8,6 +8,7 @@ from typing import cast
 from sqlbuild.compiler.scopes._helpers.identities import format_identity
 from sqlbuild.compiler.scopes._helpers.paths import normalize_path
 from sqlbuild.compiler.scopes.constants import (
+    DECLARATION_GROUP_DIRECTORY,
     DEFAULT_ENUM_MEMBER_PREVIEW,
     SCOPE_METADATA_SCHEMA_VERSION,
 )
@@ -257,6 +258,8 @@ def _declaration_container(
     role: str = f"{record.identity.kind.value}s"
     parts: tuple[str, ...] = tuple(safe_scope_path(path=record.path).split("/"))
     role_index: int = len(record.owning_path.split("/")) if record.owning_path else 0
+    if parts[role_index] == DECLARATION_GROUP_DIRECTORY:
+        role_index += 1
     role_root: str = "/".join(parts[: role_index + 1])
     bucket: str = "/".join(parts[role_index + 1 : -1])
     return role, visibility, role_root, bucket or None

--- a/src/sqlbuild/compiler/scopes/constants.py
+++ b/src/sqlbuild/compiler/scopes/constants.py
@@ -59,6 +59,7 @@ METADATA_FIELD: str = "metadata"
 KIND_COUNTS_FIELD: str = "kind_counts"
 DECLARATION_KIND_VALUES: frozenset[str] = frozenset(item.value for item in DeclarationKind)
 
+DECLARATION_GROUP_DIRECTORY: str = "_sqlbuild"
 GLOBAL_DECLARATION_DIRECTORIES: frozenset[str] = frozenset({"macros", "enums", "constants"})
 INHERITED_DECLARATION_DIRECTORIES: frozenset[str] = GLOBAL_DECLARATION_DIRECTORIES
 LOCAL_DECLARATION_DIRECTORIES: frozenset[str] = frozenset({"_macros", "_enums", "_constants"})

--- a/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
@@ -118,6 +118,15 @@ class MacroDeclarationRenderingTestCase:
 
 
 @dataclass(frozen=True)
+class GroupedDeclarationCompileTestCase:
+    """Compilation expectation for declarations under one _sqlbuild group."""
+
+    description: str
+    project_files: dict[str, str]
+    expected_sql: str
+
+
+@dataclass(frozen=True)
 class CompileProgressIntegrationTestCase:
     description: str
     project_files: dict[str, str]

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_declaration_context.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_declaration_context.py
@@ -15,6 +15,7 @@ from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
 from sqlbuild.compiler.pipeline.main.project import compile_project
 from sqlbuild.compiler.pipeline.models import CompilePipelineResult
 from tests.integration.src.sqlbuild.compiler.pipeline._test_types import (
+    GroupedDeclarationCompileTestCase,
     MacroDeclarationContextErrorTestCase,
     MacroDeclarationRenderingTestCase,
     MacroDeclarationResourceTestCase,
@@ -75,6 +76,66 @@ def test_given_active_adapter_when_macro_renders_constant_then_uses_adapter_sql(
     )
 
     assert project.models[0].query_sql == test_case.expected_sql
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        GroupedDeclarationCompileTestCase(
+            description="grouped private macro reads grouped private constant and enum",
+            project_files={
+                "sqlbuild_project.toml": 'name = "orders"\nadapter = "duckdb"\n',
+                "models/orders/_sqlbuild/_constants/policy.sql": (
+                    "CONSTANT (name minimum_quantity, value 2);\n"
+                ),
+                "models/orders/_sqlbuild/_enums/status.sql": (
+                    "ENUM (name order_status, members [ACTIVE]);\n"
+                ),
+                "models/orders/_sqlbuild/_macros/policy.py": (
+                    "def order_policy(ctx) -> str:\n"
+                    "    quantity = ctx.render_constant('minimum_quantity')\n"
+                    "    status = ctx.render_enum_member(\n"
+                    "        enum_name='order_status', member_name='ACTIVE'\n"
+                    "    )\n"
+                    '    return f"{quantity} AS minimum_quantity, {status} AS status"\n'
+                ),
+                "models/orders/summary.sql": (
+                    'MODEL (description "Order summary.");\nSELECT @order_policy()'
+                ),
+            },
+            expected_sql="SELECT 2 AS minimum_quantity, 'ACTIVE' AS status",
+        ),
+        GroupedDeclarationCompileTestCase(
+            description="grouped public macro is visible to descendant model",
+            project_files={
+                "sqlbuild_project.toml": (
+                    'name = "orders"\nadapter = "duckdb"\n[scopes]\nenforce_placement = false\n'
+                ),
+                "models/orders/_sqlbuild/macros/policy.py": (
+                    "def minimum_quantity() -> str:\n    return '2'\n"
+                ),
+                "models/orders/history/summary.sql": (
+                    'MODEL (description "Historical order summary.");\n'
+                    "SELECT @minimum_quantity() AS minimum_quantity"
+                ),
+            },
+            expected_sql="SELECT 2 AS minimum_quantity",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_grouped_declarations_when_compiling_then_scope_resolves_from_owner(
+    test_case: GroupedDeclarationCompileTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, test_case.project_files)
+
+    result: CompilePipelineResult = run_compile_pipeline_for_project(
+        project_dir=tmp_path, adapter=DuckDbAdapter()
+    )
+
+    assert result.project.models[0].query_sql == test_case.expected_sql
 
 
 @pytest.mark.parametrize(
@@ -149,6 +210,20 @@ def test_given_macro_context_declarations_when_compiling_resources_then_all_expa
                 ),
             },
             expected_error_fragment="Constant 'minimum_quantity'.*is inaccessible",
+        ),
+        MacroDeclarationContextErrorTestCase(
+            description="grouped private macro remains inaccessible to descendant model",
+            project_files={
+                "sqlbuild_project.toml": 'name = "demo"\nadapter = "duckdb"\n',
+                "models/orders/_sqlbuild/_macros/policy.py": (
+                    "def minimum_quantity() -> str:\n    return '2'\n"
+                ),
+                "models/orders/history/summary.sql": (
+                    'MODEL (description "Historical order summary.");\n'
+                    "SELECT @minimum_quantity() AS minimum_quantity"
+                ),
+            },
+            expected_error_fragment="Macro '@minimum_quantity'.*is inaccessible",
         ),
         MacroDeclarationContextErrorTestCase(
             description="unknown constant reports visible alternatives",

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/_test_types.py
@@ -144,6 +144,17 @@ class DiscoverScopedDeclarationTestCase:
 
 
 @dataclass(frozen=True)
+class DiscoverGroupedDeclarationTestCase:
+    """Discovery expectation for one declaration inside a grouped root."""
+
+    description: str
+    declaration_kind: str
+    directory_name: str
+    expected_scope_kind: str
+    expected_owning_path: str
+
+
+@dataclass(frozen=True)
 class DiscoverGlobalDeclarationTestCase:
     description: str
     declaration_kind: str

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_filesystem_scoped_declarations.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_filesystem_scoped_declarations.py
@@ -30,6 +30,7 @@ from sqlbuild.compiler.discovery.models import (
 )
 from tests.unit.src.sqlbuild.compiler.discovery._helpers._test_types import (
     DiscoverGlobalDeclarationTestCase,
+    DiscoverGroupedDeclarationTestCase,
     DiscoverScopedDeclarationTestCase,
     DiscoveryPathInventoryTestCase,
     InvalidScopedDeclarationRootTestCase,
@@ -95,6 +96,51 @@ def test_given_declaration_below_authored_root_when_discovering_then_records_bou
 @pytest.mark.parametrize(
     "test_case",
     (
+        DiscoverGroupedDeclarationTestCase(
+            "public_macro", "macro", "macros", "inherited", "models/orders"
+        ),
+        DiscoverGroupedDeclarationTestCase(
+            "private_macro", "macro", "_macros", "local", "models/orders"
+        ),
+        DiscoverGroupedDeclarationTestCase(
+            "public_enum", "enum", "enums", "inherited", "models/orders"
+        ),
+        DiscoverGroupedDeclarationTestCase(
+            "private_enum", "enum", "_enums", "local", "models/orders"
+        ),
+        DiscoverGroupedDeclarationTestCase(
+            "public_constant", "constant", "constants", "inherited", "models/orders"
+        ),
+        DiscoverGroupedDeclarationTestCase(
+            "private_constant", "constant", "_constants", "local", "models/orders"
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_grouped_declaration_when_discovering_then_owner_is_above_sqlbuild_group(
+    test_case: DiscoverGroupedDeclarationTestCase,
+    tmp_path: Path,
+) -> None:
+    suffix, contents = declaration_contents(kind=test_case.declaration_kind)
+    declaration_root: Path = Path("models/orders/_sqlbuild") / test_case.directory_name
+    file_path: Path = tmp_path / declaration_root / f"policy{suffix}"
+    file_path.parent.mkdir(parents=True)
+    file_path.write_text(contents, encoding="utf-8")
+
+    discovered: tuple[DiscoveredMacroFile | DiscoveredEnumFile | DiscoveredConstantFile, ...] = (
+        discover_declarations(project_dir=tmp_path, kind=test_case.declaration_kind)
+    )
+
+    assert len(discovered) == 1
+    assert discovered[0].relative_path == declaration_root / f"policy{suffix}"
+    assert discovered[0].scope_kind.value == test_case.expected_scope_kind
+    assert discovered[0].owning_path == Path(test_case.expected_owning_path)
+    assert discovered[0].declaration_root == declaration_root
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
         DiscoverGlobalDeclarationTestCase("macro", "macro", "macros", "global"),
         DiscoverGlobalDeclarationTestCase("enum", "enum", "enums", "global"),
         DiscoverGlobalDeclarationTestCase("constant", "constant", "constants", "global"),
@@ -145,6 +191,21 @@ def test_given_top_level_public_declarations_when_discovering_then_scope_remains
             "global_root_below_scoped_tree",
             "models/macros/organization/enums/value.sql",
             "nested inside another declaration tree",
+        ),
+        InvalidScopedDeclarationRootTestCase(
+            "grouped_root_with_intermediate_folder",
+            "models/orders/_sqlbuild/organization/macros/value.py",
+            "contains unsupported entries",
+        ),
+        InvalidScopedDeclarationRootTestCase(
+            "top_level_grouped_root",
+            "_sqlbuild/_macros/value.py",
+            "must be below a canonical authored root",
+        ),
+        InvalidScopedDeclarationRootTestCase(
+            "grouped_root_with_unsupported_entry",
+            "models/orders/_sqlbuild/notes.py",
+            "contains unsupported entries",
         ),
     ),
     ids=lambda case: case.description,
@@ -227,6 +288,13 @@ def test_given_invalid_scoped_root_when_discovering_project_inputs_then_strict_d
         OrdinaryDiscoveryExclusionTestCase(
             "model",
             "models/domain/_constants/value.sql",
+            "CONSTANT (name scoped_value, value 1);\n",
+            "model",
+            (),
+        ),
+        OrdinaryDiscoveryExclusionTestCase(
+            "grouped_model",
+            "models/domain/_sqlbuild/constants/value.sql",
             "CONSTANT (name scoped_value, value 1);\n",
             "model",
             (),

--- a/tests/unit/src/sqlbuild/compiler/scopes/_test_types.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/_test_types.py
@@ -67,6 +67,17 @@ class ExpectedBooleanCase:
 
 
 @dataclass(frozen=True)
+class DeclarationContainerProjectionCase:
+    """Expected report container fields for one declaration path."""
+
+    description: str
+    path: str
+    owning_path: str
+    expected_role_root: str
+    expected_bucket_path: str | None
+
+
+@dataclass(frozen=True)
 class ScopeReportTargetCase:
     """Expected target resolution result for one scope report query."""
 
@@ -127,6 +138,7 @@ class PlacementValidationCase:
     consumer_paths: tuple[str, ...]
     expected_codes: tuple[ScopeDiagnosticCode, ...]
     expected_direct_codes: tuple[ScopeDiagnosticCode, ...] = ()
+    expected_message_fragment: str = ""
 
 
 @dataclass(frozen=True)

--- a/tests/unit/src/sqlbuild/compiler/scopes/test_lookup_and_metadata.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/test_lookup_and_metadata.py
@@ -11,15 +11,20 @@ import pytest
 from sqlbuild.compiler.scopes.main.build_scope_lookup import build_scope_lookup
 from sqlbuild.compiler.scopes.main.scope_metadata import scope_metadata_projection
 from sqlbuild.compiler.scopes.models import (
+    DeclarationIdentity,
     DeclarationRecord,
+    OwnershipRoot,
     ResourceIdentity,
     ScopeIndex,
     ScopeLookup,
 )
 from sqlbuild.compiler.scopes.types import (
+    DeclarationKind,
     ResourceKind,
+    ScopeKind,
 )
 from tests.unit.src.sqlbuild.compiler.scopes._test_types import (
+    DeclarationContainerProjectionCase,
     ExpectedBooleanCase,
     ExpectedErrorCase,
 )
@@ -130,6 +135,48 @@ def test_given_typed_constant_when_projecting_default_metadata_then_value_is_abs
     }
     assert projection["complete"] is test_case.expected_result
     assert projection["completeness"]["runtime_usage"] is test_case.expected_result
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        DeclarationContainerProjectionCase(
+            description="legacy declaration role has no navigation bucket",
+            path="models/orders/constants/policy.sql",
+            owning_path="models/orders",
+            expected_role_root="models/orders/constants",
+            expected_bucket_path=None,
+        ),
+        DeclarationContainerProjectionCase(
+            description="grouped declaration role has no navigation bucket",
+            path="models/orders/_sqlbuild/constants/policy.sql",
+            owning_path="models/orders",
+            expected_role_root="models/orders/_sqlbuild/constants",
+            expected_bucket_path=None,
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_declaration_path_when_projecting_then_role_container_is_canonical(
+    test_case: DeclarationContainerProjectionCase,
+) -> None:
+    declaration: DeclarationRecord = DeclarationRecord(
+        identity=DeclarationIdentity(DeclarationKind.CONSTANT, "policy"),
+        path=test_case.path,
+        line=1,
+        column=1,
+        scope=ScopeKind.INHERITED,
+        ownership_root=OwnershipRoot("models", resource_kind=ResourceKind.MODEL),
+        owning_path=test_case.owning_path,
+    )
+
+    projection: dict[str, Any] = cast(
+        dict[str, Any], scope_metadata_projection(index=ScopeIndex(declarations=(declaration,)))
+    )
+    declaration_projection: dict[str, Any] = projection["declarations"][0]
+
+    assert declaration_projection["role_root"] == test_case.expected_role_root
+    assert declaration_projection["bucket_path"] == test_case.expected_bucket_path
 
 
 if __name__ == "__main__":

--- a/tests/unit/src/sqlbuild/compiler/scopes/test_placement.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/test_placement.py
@@ -126,12 +126,23 @@ def test_given_non_placement_error_when_placement_enforcement_disabled_then_vali
             None,
             ("models/domain/orders.sql",),
             (ScopeDiagnosticCode.OVER_BROAD_GLOBAL,),
+            expected_message_fragment="models/domain/_sqlbuild/_constants/",
         ),
         PlacementValidationCase(
             "exact local is accepted",
             ScopeKind.LOCAL,
             "models/domain",
             "models/domain/_constants/limit.sql",
+            "models",
+            ResourceKind.MODEL,
+            ("models/domain/orders.sql",),
+            (),
+        ),
+        PlacementValidationCase(
+            "grouped exact local is accepted",
+            ScopeKind.LOCAL,
+            "models/domain",
+            "models/domain/_sqlbuild/_constants/limit.sql",
             "models",
             ResourceKind.MODEL,
             ("models/domain/orders.sql",),
@@ -152,6 +163,16 @@ def test_given_non_placement_error_when_placement_enforcement_disabled_then_vali
             ScopeKind.INHERITED,
             "models/domain",
             "models/domain/constants/limit.sql",
+            "models",
+            ResourceKind.MODEL,
+            ("models/domain/a/orders.sql", "models/domain/b/customers.sql"),
+            (),
+        ),
+        PlacementValidationCase(
+            "grouped inherited multi child lca is accepted",
+            ScopeKind.INHERITED,
+            "models/domain",
+            "models/domain/_sqlbuild/constants/limit.sql",
             "models",
             ResourceKind.MODEL,
             ("models/domain/a/orders.sql", "models/domain/b/customers.sql"),
@@ -209,6 +230,10 @@ def test_given_complete_usage_when_validating_then_exact_placement_is_enforced(
     )
 
     assert tuple(diagnostic.code for diagnostic in result.diagnostics) == test_case.expected_codes
+    assert all(
+        test_case.expected_message_fragment in diagnostic.message
+        for diagnostic in result.diagnostics
+    )
     assert result.completeness.runtime_usage
     assert result.completeness.placement
 


### PR DESCRIPTION
## Why

Folder-scoped `macros/`, `enums/`, and `constants/` directories blend into resource folders. Their public/private scope remains useful, but declaration files need a clearly grouped home.

## Changes

- Support `OWNER/_sqlbuild/{macros,enums,constants}` as descendant-public declarations.
- Support `OWNER/_sqlbuild/{_macros,_enums,_constants}` as exact-owner-private declarations.
- Preserve the containing resource folder as the scope owner.
- Keep existing direct declaration directories compatible.
- Reserve `_sqlbuild/` for the six declaration roles and reject invalid placement.
- Recommend grouped paths in placement diagnostics.
- Keep scope report role and bucket metadata canonical.
- Document the layout and regenerate the bundled SQLBuild skill.

## Verification

- 73 focused discovery, visibility, placement, report, and compile tests
- Cache-free compile of a real grouped project: 974 models, 46 seeds, 23 functions, 0 errors
- `uv sync --all-extras`
- `make check-ci`
- Public tree and outgoing-commit hygiene scans
- Independent bounded review and finding-focused follow-up
