### PR TITLE
fix: align scoped macro tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,14 @@ models/orders/
 The containing `orders/` directory remains the declaration owner. Existing declaration directories
 directly below an owner remain supported. Placement diagnostics recommend the grouped layout.
 `_sqlbuild/` is reserved for the six declaration-role directories shown above; other direct entries
-are rejected rather than silently treated as resources.
+are rejected rather than silently treated as resources. A grouped directory must sit below a
+concrete owner: `models/_sqlbuild/` is invalid because declarations at that boundary belong in the
+project-wide `macros/`, `enums/`, or `constants/` roots.
+
+SQL tests retain their own lexical declaration scope and also receive the deterministic union of
+file-based declarations visible to their inferred tested resources. This lets model and macro tests
+exercise scoped production macros without promoting those macros globally. Mock fixture resources
+do not broaden test visibility.
 
 ## Compiler-integrated Rules
 

--- a/crates/sqlbuild-rules-native/src/engine/tests/test_sql_test_rules.rs
+++ b/crates/sqlbuild-rules-native/src/engine/tests/test_sql_test_rules.rs
@@ -44,6 +44,37 @@ fn given_sql_test_facts_when_evaluating_project_rules_then_returns_expected_faul
     );
     macro_test["mode"] = json!("macro");
     macro_test["tested_resources"] = json!([{"kind": "macro", "name": "normalize_status"}]);
+    let mut scoped_macro_test = helpers::sql_test_fact(
+        "tests/unit/macros/models/commerce/staging/test_order_policy__applies.sql",
+        Some("order_policy__applies"),
+        json!([]),
+    );
+    scoped_macro_test["mode"] = json!("macro");
+    scoped_macro_test["tested_resources"] = json!([{"kind": "macro", "name": "order_policy"}]);
+    scope["declarations"]
+        .as_array_mut()
+        .ok_or_else(|| "scope declarations must be an array".to_owned())?
+        .push(json!({
+            "identity": "macro:order_policy",
+            "kind": "macro",
+            "name": "order_policy",
+            "owner": null,
+            "path": "models/commerce/staging/_sqlbuild/_macros/policy.py",
+            "line": 1,
+            "column": 1,
+            "scope": "local",
+            "role": "macros",
+            "visibility": "exact_owner_private",
+            "role_root": "models/commerce/staging/_sqlbuild/_macros",
+            "bucket_path": null,
+            "ownership_root": "models",
+            "owning_path": "models/commerce/staging",
+            "metadata": {"macro": {
+                "parameters": [],
+                "dependencies": [],
+                "source_digest": "digest"
+            }}
+        }));
     let test_cases = [
         test_types::SqlTestRulesTestCase {
             description: "canonical roots run without a model anchor",
@@ -113,7 +144,8 @@ fn given_sql_test_facts_when_evaluating_project_rules_then_returns_expected_faul
                     Some("pipeline__calculates_revenue"),
                     json!(["stg_orders", "daily_revenue"])
                 ),
-                macro_test
+                macro_test,
+                scoped_macro_test
             ]),
             scenarios: json!([]),
             scope_index: scope,

--- a/crates/sqlbuild-rules-native/src/models.rs
+++ b/crates/sqlbuild-rules-native/src/models.rs
@@ -243,6 +243,7 @@ pub(crate) enum UsageKind {
 #[serde(rename_all = "snake_case")]
 pub(crate) enum GrantKind {
     ExpectedModel,
+    TestedMacro,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -253,6 +254,7 @@ pub(crate) enum VisibilityReason {
     LocalOwner,
     PrivateOwner,
     ExpectedModel,
+    TestedMacro,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sqlbuild-rules-native/src/rules/_helpers/sql_test_rules.rs
+++ b/crates/sqlbuild-rules-native/src/rules/_helpers/sql_test_rules.rs
@@ -270,10 +270,12 @@ fn macro_parent_components(
             .find(|item| {
                 matches!(item.kind, DeclarationKind::Macro) && item.name == resource.name
             })?;
-        parents.push(direct_parent_components(
-            &declaration.path,
-            &declaration.ownership_root,
-        )?);
+        parents.push(match &declaration.owning_path {
+            Some(owner) => std::iter::once("macros".to_owned())
+                .chain(owner.split('/').map(str::to_owned))
+                .collect(),
+            None => direct_parent_components(&declaration.path, &declaration.ownership_root)?,
+        });
     }
     Some(parents)
 }

--- a/scripts/rules_benchmark/_helpers/workflow.py
+++ b/scripts/rules_benchmark/_helpers/workflow.py
@@ -277,7 +277,7 @@ def _ci_five_thousand_invalidation_results(*, project_dir: Path) -> tuple[Benchm
             project_dir=project_dir,
             iterations=1,
             mutate=lambda iteration: _set_macro_offset(
-                path=project_dir / "models" / "macros" / "macro_00000.py",
+                path=project_dir / "macros" / "macro_00000.py",
                 iteration=iteration,
             ),
         ),
@@ -707,7 +707,7 @@ def _run_scenarios(
             project_dir=project_dir,
             iterations=iterations,
             mutate=lambda iteration: _set_macro_offset(
-                path=project_dir / "models" / "macros" / "macro_00000.py",
+                path=project_dir / "macros" / "macro_00000.py",
                 iteration=iteration,
             ),
         )
@@ -1153,7 +1153,7 @@ def _workload_counts(*, project_dir: Path) -> dict[str, int]:
         "sources": sources_text.count("  - name: source_"),
         "seeds": sum(1 for _ in (project_dir / "seeds").rglob("*.csv")),
         "functions": sum(1 for _ in (project_dir / "functions").rglob("*.sql")),
-        "macros": sum(1 for _ in (project_dir / "models" / "macros").rglob("*.py")),
+        "macros": sum(1 for _ in (project_dir / "macros").rglob("*.py")),
         "tests": sum(path.read_text(encoding="utf-8").count("TEST (") for path in test_paths),
         "audits": sum(path.read_text(encoding="utf-8").count("audits [") for path in model_paths),
         "hooks": sum(1 for _ in (project_dir / "hooks").rglob("*.sql")),

--- a/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
+++ b/src/sqlbuild/.agents/skills/sqlbuild/SKILL.md
@@ -8193,7 +8193,9 @@ owner and everything below it. An underscored role applies only to files directl
 Legacy declaration roles directly below an owner remain supported.
 
 `_sqlbuild/` is reserved for the six declaration-role directories shown above. Other direct files or
-folders are rejected, and a project-root `_sqlbuild/` is invalid because it has no resource owner.
+folders are rejected. It must also sit below a concrete owner directory. A project-root
+`_sqlbuild/` or authored-root path such as `models/_sqlbuild/` is invalid; declarations at that
+boundary belong in the project-wide `macros/`, `enums/`, or `constants/` roots.
 
 | Resource | Visible from the example tree | Not visible |
 |----------|-------------------------------|-------------|
@@ -8311,7 +8313,9 @@ them to be private to.
 Existing scoped declaration roles directly below an owner remain supported. `_sqlbuild/` is the
 preferred layout because it keeps all declarations together without changing their visibility.
 Only the six public/private declaration-role directories are valid directly under `_sqlbuild/`;
-other entries are rejected. A project-root `_sqlbuild/` is invalid because it has no resource owner.
+other entries are rejected. `_sqlbuild/` must sit below a concrete owner directory. A project-root
+`_sqlbuild/` or authored-root path such as `models/_sqlbuild/` is invalid; use the project-wide
+`macros/`, `enums/`, or `constants/` roots at that boundary.
 
 ### Which file controls visibility?
 
@@ -8319,7 +8323,8 @@ other entries are rejected. A project-root `_sqlbuild/` is invalid because it ha
 |--------------------|----------------------|
 | Model query | The model file |
 | Inline SQL hook in a model | The model file |
-| Unit test or scenario SQL | The test or scenario file |
+| Unit test SQL | The test file, plus inferred tested-resource relationships |
+| Scenario SQL | The scenario file, plus expected-model enum and constant relationships |
 | Named SQL hook | The hook file under `hooks/sql/` |
 | SQL function | The function file under `functions/sql/` |
 | Audit | The audit file |
@@ -8330,8 +8335,8 @@ hook uses declarations available where the hook itself is stored.
 
 ### Tests and expected output
 
-A test first sees declarations available from its own folder tree. It may also use file-based enums
-and constants available to a model for which it defines expected output.
+A test first sees declarations available from its own folder tree. It may also use file-based
+macros, enums, and constants available to a model for which it defines expected output.
 
 ```sql
 TEST();
@@ -8340,25 +8345,48 @@ WITH
 __expected__orders AS (
   SELECT
     1 AS order_id,
+    @normalize_order_status("'completed'") AS normalized_status,
     @enum("order_status").COMPLETED AS status
 )
 SELECT 1
 ```
 
-Because the test defines `__expected__orders`, the test may use file-based enums and constants
-available to `orders`, including declarations in exact-folder `_enums/` and `_constants/` roles.
+Because the test defines `__expected__orders`, the test may use file-based macros, enums, and
+constants available to `orders`, including declarations in exact-owner-private roles.
 Scope Explorer describes this as **available through expected output for model `orders`**. This is
 an additional relationship, not another visibility level.
 
 This additional access does **not** include:
 
-- Macros available only to the model
 - Enums or constants declared privately inside the model's `MODEL()` header
 - Declarations from a model merely mentioned by filename or directory layout
 
-Only an explicit `__expected__model_name` section adds the model's eligible file-based enums and
-constants. When a test checks several models, SQLBuild combines the declarations available through
-all expected models and makes that deterministic union available while compiling the entire test.
+Only an explicit `__expected__model_name` section adds the model's eligible file-based declarations.
+When a test checks several models, SQLBuild combines the declarations available through all
+expected models and makes that deterministic union available while compiling the entire test.
+
+Macro-mode tests receive the tested macro and the file-based declarations available from that
+macro's production owner. SQLBuild infers tested macros from calls in `__macro_actual__`; the test's
+filename or directory does not grant production visibility.
+
+```text
+models/orders/_sqlbuild/_macros/order_policy.py
+tests/unit/macros/models/orders/test_order_policy__returns_quantity.sql
+```
+
+The macro test can call `order_policy` without promoting it to the project-wide `macros/` root. A
+test can also use helper macros scoped to its own test directory:
+
+```text
+tests/unit/orders/
+├── _sqlbuild/
+│   └── macros/
+│       └── fixtures.py
+└── test_orders__calculates_total.sql
+```
+
+Those helpers remain unavailable to production resources. Mocked model, source, seed, and dbt
+fixture CTEs do not grant declarations from the mocked resource's production scope.
 
 ### Macros importing macros
 
@@ -8689,10 +8717,11 @@ shows whether the declaration is placed more broadly than its real consumers req
 
 ### See declarations available through expected output
 
-Tests and scenarios can use file-based enums and constants available to a model when they define
-that model's expected output. This includes eligible exact-folder declarations, but not declarations
-inside `MODEL()`. The access applies to the whole test or scenario and remains separate from
-declarations visible through its own folder tree. The relevant report sections are:
+Tests can use file-based macros, enums, and constants available to a model when they define that
+model's expected output. Scenarios receive the model's file-based enums and constants but not its
+macros. Neither receives declarations inside `MODEL()`. The access applies to the whole test or
+scenario and remains separate from declarations visible through its own folder tree. The relevant
+report sections are:
 
 ```console
 $ sqb scope test:orders__completed_only --used-only
@@ -8705,8 +8734,11 @@ Relationship grants (1 of 1)
 
 The compact reason `expected_model through model:orders` means **available through expected output
 for model `orders`**. With multiple expected models, SQLBuild combines their eligible file-based
-enums and constants into one deterministic set for the test or scenario. These relationships do
-not grant macros or declarations defined inside a model's `MODEL()` header.
+declarations into one deterministic set. Tests include macros in that union; scenarios include only
+enums and constants. Neither receives declarations defined inside a model's `MODEL()` header.
+
+Macro-mode tests also report `tested_macro through macro:<name>` relationships. Those grants contain
+the tested macro and scoped file-based declarations available from its production owner.
 
 ### Preview a resource move
 
@@ -13278,15 +13310,20 @@ sqb scope model:stg_orders --used-only
 ### Expected-output access
 
 Tests and scenarios have two independent ways to reach declarations. Their own folder paths provide
-ordinary visibility. Each explicit `__expected__<model>` section adds the eligible file-based enums
-and constants available to that model. This includes exact-folder `_enums/` and `_constants/`
-declarations, despite their private visibility label.
+ordinary visibility. For tests, each explicit `__expected__<model>` section adds the eligible
+file-based macros, enums, and constants available to that model. Scenarios receive the model's
+file-based enums and constants but not its macros. These relationships include eligible
+exact-owner-private declarations.
 
 `sqb scope` reports this additional access separately under **Relationship grants** and names the
 model that provides it. With multiple expected models, SQLBuild makes the deterministic union of
 their eligible declarations available while compiling the whole test or scenario. It never includes
-macros or declarations defined inside a model's `MODEL()` header. A test filename, mirrored path,
-or mock does not provide this access by itself.
+declarations defined inside a model's `MODEL()` header. A test filename, mirrored path, or mock does
+not provide this access by itself.
+
+For macro-mode tests, **Relationship grants** also reports
+`tested_macro through macro:<name>`. This grants the tested macro and the scoped file-based
+declarations available from its production owner, as inferred from calls in `__macro_actual__`.
 
 ```bash
 sqb scope test:orders__completed_only

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/declaration_scope.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/declaration_scope.py
@@ -38,7 +38,8 @@ def build_declaration_scope(
         raise CompileInputError(str(error)) from error
     has_scoped_relationship_declarations: bool = any(
         declaration.scope is not ScopeKind.GLOBAL
-        and declaration.identity.kind in {DeclarationKind.ENUM, DeclarationKind.CONSTANT}
+        and declaration.identity.kind
+        in {DeclarationKind.ENUM, DeclarationKind.CONSTANT, DeclarationKind.MACRO}
         for declaration in index.declarations
     )
     relationships: ScopeRelationshipBuild = (

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/scope_relationships.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/scope_relationships.py
@@ -9,12 +9,12 @@ from sqlbuild.compiler.compile._helpers.scenarios.core import (
     extract_sql_scenario_expected_model_names,
 )
 from sqlbuild.compiler.compile._helpers.sql_tests.core import (
-    extract_sql_test_ctes,
     extract_sql_test_expected_model_names,
+    extract_unclassified_sql_test_ctes,
 )
+from sqlbuild.compiler.compile.constants import MACRO_ACTUAL_TEST_CTE_NAME
 from sqlbuild.compiler.compile.models import (
-    CompileDirectLogicSqlTestCtes,
-    CompileSqlTestCtes,
+    CompileSqlTestCte,
     ScopeRelationshipBuild,
     ScopeRelationshipFault,
 )
@@ -151,14 +151,15 @@ def _expected_model_grants(
 def _tested_macro_grants(
     *, lookup: ScopeLookup, resource: ResourceIdentity, sql: str, file_label: str
 ) -> list[GrantRecord]:
-    test_ctes: CompileSqlTestCtes = extract_sql_test_ctes(
-        sql=sql, file_label=file_label, mode=SqlTestMode.MACRO
+    test_ctes: tuple[CompileSqlTestCte, ...] = extract_unclassified_sql_test_ctes(
+        sql=sql, file_label=file_label
     )
-    if not isinstance(test_ctes.payload, CompileDirectLogicSqlTestCtes):
+    actual_cte: CompileSqlTestCte | None = next(
+        (cte for cte in test_ctes if cte.name == MACRO_ACTUAL_TEST_CTE_NAME), None
+    )
+    if actual_cte is None:
         return []
-    tested_macro_names: tuple[str, ...] = find_macro_call_names(
-        test_ctes.payload.actual_cte.sql_body
-    )
+    tested_macro_names: tuple[str, ...] = find_macro_call_names(actual_cte.sql_body)
     direct_resolution: VisibilityResolution = resolve_scope_visibility(
         lookup=lookup, target=resource
     )

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/scope_relationships.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/scope_relationships.py
@@ -2,15 +2,31 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from sqlbuild.compiler.compile._helpers.render.macros import find_macro_call_names
 from sqlbuild.compiler.compile._helpers.scenarios.core import (
     extract_sql_scenario_expected_model_names,
 )
-from sqlbuild.compiler.compile._helpers.sql_tests.core import extract_sql_test_expected_model_names
-from sqlbuild.compiler.compile.models import ScopeRelationshipBuild, ScopeRelationshipFault
+from sqlbuild.compiler.compile._helpers.sql_tests.core import (
+    extract_sql_test_ctes,
+    extract_sql_test_expected_model_names,
+)
+from sqlbuild.compiler.compile.models import (
+    CompileDirectLogicSqlTestCtes,
+    CompileSqlTestCtes,
+    ScopeRelationshipBuild,
+    ScopeRelationshipFault,
+)
+from sqlbuild.compiler.compile.types import SqlTestMode
 from sqlbuild.compiler.discovery.models import DiscoveredProjectInputs
+from sqlbuild.compiler.scopes.main._resolve_scope_path_visibility import (
+    resolve_scope_path_visibility,
+)
 from sqlbuild.compiler.scopes.main._resolve_scope_visibility import resolve_scope_visibility
 from sqlbuild.compiler.scopes.main.build_scope_lookup import build_scope_lookup
 from sqlbuild.compiler.scopes.models import (
+    DeclarationIdentity,
     DeclarationRecord,
     GrantRecord,
     ResourceIdentity,
@@ -18,7 +34,7 @@ from sqlbuild.compiler.scopes.models import (
     ScopeLookup,
     VisibilityResolution,
 )
-from sqlbuild.compiler.scopes.types import DeclarationKind, ResourceKind, ScopeKind
+from sqlbuild.compiler.scopes.types import DeclarationKind, GrantKind, ResourceKind, ScopeKind
 
 
 def build_scope_relationship_grants(
@@ -59,8 +75,20 @@ def _test_relationship_grants(
                             ResourceKind.TEST, block.name or test_file.relative_path.stem
                         ),
                         expected_model_names=expected_names,
+                        include_macros=True,
                     )
                 )
+                if block.mode is SqlTestMode.MACRO:
+                    grants.extend(
+                        _tested_macro_grants(
+                            lookup=lookup,
+                            resource=ResourceIdentity(
+                                ResourceKind.TEST, block.name or test_file.relative_path.stem
+                            ),
+                            sql=block.sql_body,
+                            file_label=str(test_file.relative_path),
+                        )
+                    )
             except Exception as error:
                 faults.append(ScopeRelationshipFault(test_file.relative_path, str(error)))
     return tuple(grants), tuple(faults)
@@ -93,6 +121,7 @@ def _expected_model_grants(
     lookup: ScopeLookup,
     resource: ResourceIdentity,
     expected_model_names: tuple[str, ...],
+    include_macros: bool = False,
 ) -> list[GrantRecord]:
     grants: list[GrantRecord] = []
     for model_name in expected_model_names:
@@ -105,16 +134,56 @@ def _expected_model_grants(
             if not records:
                 continue
             declaration: DeclarationRecord = records[0]
-            if declaration.scope is ScopeKind.PRIVATE or declaration.identity.kind not in {
-                DeclarationKind.ENUM,
-                DeclarationKind.CONSTANT,
-            }:
+            if declaration.scope is ScopeKind.PRIVATE or (
+                declaration.identity.kind is DeclarationKind.MACRO and not include_macros
+            ):
                 continue
             grants.append(
                 GrantRecord(
                     resource=resource,
                     declaration=declaration.identity,
                     through=through,
+                )
+            )
+    return grants
+
+
+def _tested_macro_grants(
+    *, lookup: ScopeLookup, resource: ResourceIdentity, sql: str, file_label: str
+) -> list[GrantRecord]:
+    test_ctes: CompileSqlTestCtes = extract_sql_test_ctes(
+        sql=sql, file_label=file_label, mode=SqlTestMode.MACRO
+    )
+    if not isinstance(test_ctes.payload, CompileDirectLogicSqlTestCtes):
+        return []
+    tested_macro_names: tuple[str, ...] = find_macro_call_names(
+        test_ctes.payload.actual_cte.sql_body
+    )
+    direct_resolution: VisibilityResolution = resolve_scope_visibility(
+        lookup=lookup, target=resource
+    )
+    directly_visible: frozenset[DeclarationIdentity] = frozenset(
+        visible.declaration for visible in direct_resolution.visible
+    )
+    grants: list[GrantRecord] = []
+    for macro_name in tested_macro_names:
+        records: tuple[DeclarationRecord, ...] = lookup.declarations.get(
+            DeclarationIdentity(DeclarationKind.MACRO, macro_name), ()
+        )
+        if not records:
+            continue
+        tested_macro: DeclarationRecord = records[0]
+        lexical_path: Path = Path(tested_macro.owning_path or ".") / "__macro_test__.sql"
+        visible, _inaccessible = resolve_scope_path_visibility(lookup=lookup, path=lexical_path)
+        for declaration in visible:
+            if declaration.scope is ScopeKind.PRIVATE or declaration.identity in directly_visible:
+                continue
+            grants.append(
+                GrantRecord(
+                    resource=resource,
+                    declaration=declaration.identity,
+                    through=tested_macro.identity,
+                    kind=GrantKind.TESTED_MACRO,
                 )
             )
     return grants

--- a/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
+++ b/src/sqlbuild/compiler/compile/_helpers/attachment/sql_tests.py
@@ -20,6 +20,7 @@ from sqlbuild.compiler.compile._helpers.render.cursor_intrinsics import reject_c
 from sqlbuild.compiler.compile._helpers.render.declarations import (
     declaration_usage_records,
     resolve_declaration_expansion,
+    usage_visibility,
 )
 from sqlbuild.compiler.compile._helpers.render.macros import (
     find_macro_call_names,
@@ -68,7 +69,12 @@ from sqlbuild.compiler.discovery.models import (
 )
 from sqlbuild.compiler.profiling.main.record import record_compile_timing
 from sqlbuild.compiler.references.types import ExternalSqlReferenceResolver, SqlReferenceKind
-from sqlbuild.compiler.scopes.models import ResourceIdentity, UsageRecord, VisibilityRecord
+from sqlbuild.compiler.scopes.models import (
+    DeclarationIdentity,
+    ResourceIdentity,
+    UsageRecord,
+    VisibilityRecord,
+)
 from sqlbuild.compiler.scopes.types import ResourceKind, ScopeKind, UsageKind
 
 _HOOK_TEMPLATE_PATTERN: re.Pattern[str] = re.compile(r"\$\{[^}]+\}")
@@ -316,6 +322,9 @@ def _rebind_test_declarations(
             constant_visibility=_rebind_visibility(
                 visibility=declarations.constant_visibility, consumer=consumer
             ),
+            macro_visibility=_rebind_visibility(
+                visibility=declarations.macro_visibility, consumer=consumer
+            ),
         ),
     )
 
@@ -342,20 +351,28 @@ def _macro_test_declaration_usages(
         resource=resource,
         declarations=declarations,
     )
-    return tuple(
-        dict.fromkeys(
-            (
-                *usages,
-                *(
-                    UsageRecord(
-                        resource, declarations.macro_records[name].identity, UsageKind.RUNTIME
-                    )
-                    for name in find_macro_call_names(sql=sql)
-                    if name in declarations.macro_records
-                ),
-            )
+    macro_usages: list[UsageRecord] = []
+    for name in find_macro_call_names(sql=sql):
+        if name not in declarations.macro_records:
+            continue
+        identity: DeclarationIdentity = declarations.macro_records[name].identity
+        visibility: tuple[VisibilityRecord, ...] = declarations.macro_visibility.get(name, ())
+        visible_records: tuple[VisibilityRecord, ...] = usage_visibility(
+            visibility=visibility, consumer=resource
         )
-    )
+        if visible_records:
+            macro_usages.extend(
+                UsageRecord(
+                    resource,
+                    identity,
+                    UsageKind.RUNTIME,
+                    through=visible.through,
+                )
+                for visible in visible_records
+            )
+        else:
+            macro_usages.append(UsageRecord(resource, identity, UsageKind.RUNTIME))
+    return tuple(dict.fromkeys((*usages, *macro_usages)))
 
 
 def _build_test_input_payload(

--- a/src/sqlbuild/compiler/compile/_helpers/render/declarations.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/declarations.py
@@ -216,6 +216,7 @@ def resolve_declaration_context(
             inaccessible_macros[record.identity.name] = record
     enum_visibility: dict[str, tuple[VisibilityRecord, ...]] = {}
     constant_visibility: dict[str, tuple[VisibilityRecord, ...]] = {}
+    macro_visibility: dict[str, tuple[VisibilityRecord, ...]] = {}
     for record in visible_records:
         records: tuple[VisibilityRecord, ...] = tuple(
             visibility_by_declaration.get(record.identity, ())
@@ -224,6 +225,8 @@ def resolve_declaration_context(
             enum_visibility[record.identity.name] = records
         elif record.identity.kind is DeclarationKind.CONSTANT:
             constant_visibility[record.identity.name] = records
+        elif record.identity.kind is DeclarationKind.MACRO:
+            macro_visibility[record.identity.name] = records
     return DeclarationResolutionContext(
         enums=enums,
         constants=constants,
@@ -233,6 +236,7 @@ def resolve_declaration_context(
         constant_visibility=constant_visibility,
         macros=macros,
         macro_records=macro_records,
+        macro_visibility=macro_visibility,
         inaccessible_macros=inaccessible_macros,
         consumer=(
             resource

--- a/src/sqlbuild/compiler/compile/_helpers/render/macros.py
+++ b/src/sqlbuild/compiler/compile/_helpers/render/macros.py
@@ -1369,7 +1369,23 @@ def _evaluate_macro_call(
             UsageRecord(stack[-1], identity, UsageKind.DECLARATION_DEPENDENCY),
         )
     elif state.consumer is not None:
-        _ = state.facts.add_usage(UsageRecord(state.consumer, identity, UsageKind.RUNTIME))
+        visibility: tuple[VisibilityRecord, ...] = (
+            declarations.macro_visibility.get(macro_name, ()) if declarations is not None else ()
+        )
+        if visibility:
+            from sqlbuild.compiler.compile._helpers.render.declarations import usage_visibility
+
+            for visible in usage_visibility(visibility=visibility, consumer=state.consumer):
+                _ = state.facts.add_usage(
+                    UsageRecord(
+                        state.consumer,
+                        identity,
+                        UsageKind.RUNTIME,
+                        through=visible.through,
+                    )
+                )
+        else:
+            _ = state.facts.add_usage(UsageRecord(state.consumer, identity, UsageKind.RUNTIME))
     args_source: str = sql[opening_paren_index + 1 : closing_paren_index]
     args: tuple[object, ...]
     kwargs: dict[str, object]

--- a/src/sqlbuild/compiler/compile/models.py
+++ b/src/sqlbuild/compiler/compile/models.py
@@ -350,6 +350,7 @@ class DeclarationResolutionContext:
     constant_visibility: dict[str, tuple[VisibilityRecord, ...]] = field(default_factory=dict)
     macros: dict[str, LoadedMacro] = field(default_factory=dict)
     macro_records: dict[str, DeclarationRecord] = field(default_factory=dict)
+    macro_visibility: dict[str, tuple[VisibilityRecord, ...]] = field(default_factory=dict)
     inaccessible_macros: dict[str, DeclarationRecord] = field(default_factory=dict)
     consumer: ResourceIdentity | DeclarationIdentity | None = None
 

--- a/src/sqlbuild/compiler/discovery/_helpers/filesystem/core.py
+++ b/src/sqlbuild/compiler/discovery/_helpers/filesystem/core.py
@@ -176,6 +176,9 @@ class _DeclarationFileFacts:
 _SCOPED_DECLARATION_DIRECTORIES: frozenset[str] = (
     INHERITED_DECLARATION_DIRECTORIES | LOCAL_DECLARATION_DIRECTORIES
 )
+_MACRO_TEST_DIRECTORY: str = f"{DeclarationKind.MACRO.value}s"
+_SQL_FILE_SUFFIX: str = ".sql"
+_SQL_TEST_ROOT_COMPONENTS: tuple[str, ...] = Path(SQL_TESTS_OWNERSHIP_ROOT).parts
 
 
 def _discover_declaration_file_facts(
@@ -257,6 +260,12 @@ def _validate_declaration_groups(*, project_dir: Path) -> None:
         for group in sorted(
             path for path in authored_root.rglob(DECLARATION_GROUP_DIRECTORY) if path.is_dir()
         ):
+            if group.parent == authored_root:
+                raise DeclarationParseError(
+                    f"Grouped declaration root {group.relative_to(project_dir).as_posix()}/ must "
+                    "be below a concrete owner directory; use the project-wide macros/, enums/, "
+                    "or constants/ root instead"
+                )
             unsupported: tuple[Path, ...] = tuple(
                 sorted(
                     child
@@ -319,9 +328,16 @@ def _is_in_scoped_declaration_tree(*, file_path: Path, project_dir: Path) -> boo
     for root_components in CANONICAL_AUTHORED_ROOTS:
         if relative_parts[: len(root_components)] != root_components:
             continue
+        scoped_components: tuple[str, ...] = relative_parts[len(root_components) : -1]
+        if (
+            root_components == _SQL_TEST_ROOT_COMPONENTS
+            and file_path.suffix == _SQL_FILE_SUFFIX
+            and scoped_components[:1] == (_MACRO_TEST_DIRECTORY,)
+        ):
+            return False
         return any(
             component == DECLARATION_GROUP_DIRECTORY or component in _SCOPED_DECLARATION_DIRECTORIES
-            for component in relative_parts[len(root_components) : -1]
+            for component in scoped_components
         )
     return False
 

--- a/src/sqlbuild/compiler/scopes/_helpers/cache.py
+++ b/src/sqlbuild/compiler/scopes/_helpers/cache.py
@@ -314,12 +314,9 @@ def _usage(payload: object) -> UsageRecord:
     consumer: ResourceIdentity | DeclarationIdentity = _identity(item.get("consumer"))
     declaration: ResourceIdentity | DeclarationIdentity = _identity(item.get("declaration"))
     through_payload: object = item.get("through")
-    through: ResourceIdentity | None = None
+    through: ResourceIdentity | DeclarationIdentity | None = None
     if through_payload is not None:
-        decoded: ResourceIdentity | DeclarationIdentity = _identity(through_payload)
-        if not isinstance(decoded, ResourceIdentity):
-            raise ScopeCacheDecodeError("Invalid cached usage through identity")
-        through = decoded
+        through = _identity(through_payload)
     if not isinstance(declaration, DeclarationIdentity):
         raise ScopeCacheDecodeError("Invalid cached usage declaration")
     return UsageRecord(
@@ -350,7 +347,9 @@ def _grant(payload: object) -> GrantRecord:
         _identity(item.get("declaration")),
         _identity(item.get("through")),
     )
-    if not isinstance(resource, ResourceIdentity) or not isinstance(through, ResourceIdentity):
+    if not isinstance(resource, ResourceIdentity) or not isinstance(
+        through, ResourceIdentity | DeclarationIdentity
+    ):
         raise ScopeCacheDecodeError("Invalid cached grant resource")
     if not isinstance(declaration, DeclarationIdentity):
         raise ScopeCacheDecodeError("Invalid cached grant declaration")
@@ -378,8 +377,6 @@ def _visibility(payload: object) -> VisibilityRecord:
         declaration, DeclarationIdentity
     ):
         raise ScopeCacheDecodeError("Invalid cached visibility identity")
-    if through is not None and not isinstance(through, ResourceIdentity):
-        raise ScopeCacheDecodeError("Invalid cached visibility through identity")
     return VisibilityRecord(
         resource,
         declaration,

--- a/src/sqlbuild/compiler/scopes/_helpers/placement.py
+++ b/src/sqlbuild/compiler/scopes/_helpers/placement.py
@@ -6,6 +6,7 @@ from collections import deque
 from dataclasses import replace
 from pathlib import PurePosixPath
 
+from sqlbuild.compiler.discovery.constants import CANONICAL_AUTHORED_ROOTS
 from sqlbuild.compiler.scopes._helpers.identities import format_identity
 from sqlbuild.compiler.scopes.constants import DECLARATION_GROUP_DIRECTORY
 from sqlbuild.compiler.scopes.models import (
@@ -32,6 +33,9 @@ _PLACEMENT_CODES: frozenset[ScopeDiagnosticCode] = frozenset(
         ScopeDiagnosticCode.REQUIRES_GLOBAL_PLACEMENT,
         ScopeDiagnosticCode.OVER_BROAD_GLOBAL,
     }
+)
+_AUTHORED_ROOT_PATHS: frozenset[str] = frozenset(
+    PurePosixPath(*parts).as_posix() for parts in CANONICAL_AUTHORED_ROOTS
 )
 
 
@@ -189,13 +193,21 @@ def _required_placement_for_record(
     consumers: tuple[str, ...] = tuple(
         sorted({_consumer_label(usage) for usage in declaration_usages})
     )
-    if len({root for root, _path in anchors}) != 1:
+    roots: set[OwnershipRoot] = {root for root, _path in anchors}
+    if len(roots) != 1:
         return ScopeKind.GLOBAL, None, consumers
+    ownership_root: OwnershipRoot = next(iter(roots))
     paths: tuple[str, ...] = tuple(path for _root, path in anchors)
     distinct: set[str] = set(paths)
     if len(distinct) == 1:
-        return ScopeKind.LOCAL, next(iter(distinct)), consumers
-    return ScopeKind.INHERITED, _lca(paths), consumers
+        required_path: str = next(iter(distinct))
+        return ScopeKind.LOCAL, required_path, consumers
+    required_path = _lca(paths)
+    return (
+        (ScopeKind.GLOBAL, None, consumers)
+        if required_path == ownership_root.path
+        else (ScopeKind.INHERITED, required_path, consumers)
+    )
 
 
 def _anchor_sets(*, index: ScopeIndex, usages_by_declaration: _UsagesByDeclaration) -> _AnchorSets:
@@ -204,11 +216,24 @@ def _anchor_sets(*, index: ScopeIndex, usages_by_declaration: _UsagesByDeclarati
     resources: dict[ResourceIdentity, ResourceRecord] = {
         item.identity: item for item in index.resources
     }
+    declarations: dict[DeclarationIdentity, DeclarationRecord] = {
+        item.identity: item for item in index.declarations
+    }
     anchors: dict[DeclarationIdentity, set[_Anchor]] = {}
     dependents: dict[DeclarationIdentity, set[DeclarationIdentity]] = {}
     for identity, declaration_usages in usages_by_declaration.items():
         direct: set[_Anchor] = anchors.setdefault(identity, set())
         for usage in declaration_usages:
+            if isinstance(usage.through, DeclarationIdentity):
+                through_declaration: DeclarationRecord | None = declarations.get(usage.through)
+                if through_declaration is not None and through_declaration.owning_path is not None:
+                    direct.add(
+                        (
+                            through_declaration.ownership_root,
+                            through_declaration.owning_path,
+                        )
+                    )
+                continue
             resource_identity: ResourceIdentity | None = usage.through
             if resource_identity is None and isinstance(usage.consumer, ResourceIdentity):
                 resource_identity = usage.consumer
@@ -263,9 +288,11 @@ def _message(
         target: str = f"top-level {declaration.identity.kind.value}s/"
     else:
         prefix: str = "_" if required_scope is ScopeKind.LOCAL else ""
+        role: str = f"{prefix}{declaration.identity.kind.value}s/"
         target = (
-            f"{required_path}/{DECLARATION_GROUP_DIRECTORY}/"
-            f"{prefix}{declaration.identity.kind.value}s/"
+            f"{required_path}/{role}"
+            if required_path in _AUTHORED_ROOT_PATHS
+            else f"{required_path}/{DECLARATION_GROUP_DIRECTORY}/{role}"
         )
     return (
         f"Declaration '{format_identity(identity=declaration.identity)}' is currently "

--- a/src/sqlbuild/compiler/scopes/_helpers/report_query.py
+++ b/src/sqlbuild/compiler/scopes/_helpers/report_query.py
@@ -48,6 +48,7 @@ from sqlbuild.compiler.scopes.models import (
     VisibilityProvenance,
 )
 from sqlbuild.compiler.scopes.types import (
+    GrantKind,
     ResourceKind,
     ScopeDiagnosticCode,
     ScopeKind,
@@ -295,8 +296,13 @@ def explain_declaration(
                 if grant.declaration == record.identity
             )
             if matching_grants:
+                grant_reason: VisibilityReason = (
+                    VisibilityReason.TESTED_MACRO
+                    if all(grant.kind is GrantKind.TESTED_MACRO for grant in matching_grants)
+                    else VisibilityReason.EXPECTED_MODEL
+                )
                 visibility = VisibilityProvenance(
-                    VisibilityReason.EXPECTED_MODEL.value,
+                    grant_reason.value,
                     ",".join(
                         sorted(format_identity(identity=grant.through) for grant in matching_grants)
                     ),
@@ -418,10 +424,10 @@ def _classify(
     tuple[tuple[DeclarationRecord, str], ...],
 ]:
     grants: tuple[GrantRecord, ...] = lookup.grants_by_resource.get(resource.identity, ())
-    granted: dict[DeclarationIdentity, tuple[str, ...]] = {}
+    granted: dict[DeclarationIdentity, tuple[GrantRecord, ...]] = {}
     for grant in grants:
         granted.setdefault(grant.declaration, ())
-        granted[grant.declaration] += (format_identity(identity=grant.through),)
+        granted[grant.declaration] += (grant,)
     direct: list[tuple[DeclarationRecord, VisibilityProvenance]] = []
     relationships: list[tuple[DeclarationRecord, VisibilityProvenance]] = []
     unavailable: list[tuple[DeclarationRecord, str]] = []
@@ -432,12 +438,23 @@ def _classify(
         if reason is not None:
             direct.append((declaration, VisibilityProvenance(reason.value)))
         if declaration.identity in granted and declaration.scope is not ScopeKind.PRIVATE:
+            declaration_grants: tuple[GrantRecord, ...] = granted[declaration.identity]
+            grant_reason: VisibilityReason = (
+                VisibilityReason.TESTED_MACRO
+                if all(grant.kind is GrantKind.TESTED_MACRO for grant in declaration_grants)
+                else VisibilityReason.EXPECTED_MODEL
+            )
             relationships.append(
                 (
                     declaration,
                     VisibilityProvenance(
-                        VisibilityReason.EXPECTED_MODEL.value,
-                        ",".join(sorted(granted[declaration.identity])),
+                        grant_reason.value,
+                        ",".join(
+                            sorted(
+                                format_identity(identity=grant.through)
+                                for grant in declaration_grants
+                            )
+                        ),
                     ),
                 )
             )

--- a/src/sqlbuild/compiler/scopes/_helpers/visibility.py
+++ b/src/sqlbuild/compiler/scopes/_helpers/visibility.py
@@ -25,6 +25,7 @@ from sqlbuild.compiler.scopes.models import (
     VisibilityResolution,
 )
 from sqlbuild.compiler.scopes.types import (
+    GrantKind,
     InaccessibleReason,
     OwnershipRootKind,
     ResourceKind,
@@ -80,7 +81,11 @@ def resolve_visibility(
                     VisibilityRecord(
                         resource.identity,
                         declaration.identity,
-                        VisibilityReason.EXPECTED_MODEL,
+                        (
+                            VisibilityReason.TESTED_MACRO
+                            if grant.kind is GrantKind.TESTED_MACRO
+                            else VisibilityReason.EXPECTED_MODEL
+                        ),
                         grant.through,
                     )
                     for grant in lookup.grants_by_resource.get(resource.identity, ())

--- a/src/sqlbuild/compiler/scopes/models.py
+++ b/src/sqlbuild/compiler/scopes/models.py
@@ -114,7 +114,7 @@ class UsageRecord:
     consumer: ResourceIdentity | DeclarationIdentity
     declaration: DeclarationIdentity
     kind: UsageKind = UsageKind.RUNTIME
-    through: ResourceIdentity | None = None
+    through: ResourceIdentity | DeclarationIdentity | None = None
     enum_member: str | None = None
 
 
@@ -124,7 +124,7 @@ class GrantRecord:
 
     resource: ResourceIdentity
     declaration: DeclarationIdentity
-    through: ResourceIdentity
+    through: ResourceIdentity | DeclarationIdentity
     kind: GrantKind = GrantKind.EXPECTED_MODEL
 
 
@@ -135,7 +135,7 @@ class VisibilityRecord:
     resource: ResourceIdentity
     declaration: DeclarationIdentity
     reason: VisibilityReason
-    through: ResourceIdentity | None = None
+    through: ResourceIdentity | DeclarationIdentity | None = None
 
 
 @dataclass(frozen=True)

--- a/src/sqlbuild/compiler/scopes/types.py
+++ b/src/sqlbuild/compiler/scopes/types.py
@@ -63,6 +63,7 @@ class GrantKind(StrEnum):
     """Compiler relationships that grant additional public vocabulary."""
 
     EXPECTED_MODEL = "expected_model"
+    TESTED_MACRO = "tested_macro"
 
 
 class VisibilityReason(StrEnum):
@@ -73,6 +74,7 @@ class VisibilityReason(StrEnum):
     LOCAL_OWNER = "local_owner"
     PRIVATE_OWNER = "private_owner"
     EXPECTED_MODEL = "expected_model"
+    TESTED_MACRO = "tested_macro"
 
 
 class InaccessibleReason(StrEnum):

--- a/tests/e2e/src/sqlbuild/cli/commands/main/compile/helpers.py
+++ b/tests/e2e/src/sqlbuild/cli/commands/main/compile/helpers.py
@@ -220,7 +220,7 @@ def run_layered_production_compile_benchmark(
         project_dir=project_dir,
         expected_max_seconds=expected_edit_max_seconds,
     )
-    macro_path: Path = project_dir / "models" / "macros" / "macro_00000.py"
+    macro_path: Path = project_dir / "macros" / "macro_00000.py"
     _replace_benchmark_text(
         path=macro_path,
         old='return f"({expression} + 0)"',
@@ -795,7 +795,7 @@ input_value + 1
 
 
 def _layered_write_macros(*, project_dir: Path, macro_count: int) -> None:
-    macros_dir: Path = project_dir / "models" / "macros"
+    macros_dir: Path = project_dir / "macros"
     macros_dir.mkdir(parents=True)
     for index in range(macro_count):
         composed_dependency: str = {

--- a/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/_test_types.py
@@ -127,6 +127,26 @@ class GroupedDeclarationCompileTestCase:
 
 
 @dataclass(frozen=True)
+class MacroTestDiscoveryIntegrationTestCase:
+    """Compilation expectation for a macro test stored in its mirrored path."""
+
+    description: str
+    project_files: dict[str, str]
+    expected_test_name: str
+    expected_macro_name: str
+
+
+@dataclass(frozen=True)
+class SqlTestProductionScopeIntegrationTestCase:
+    """Expected production and helper declaration visibility for one SQL test."""
+
+    description: str
+    project_files: dict[str, str]
+    expected_test_name: str
+    expected_sql_fragments: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class CompileProgressIntegrationTestCase:
     description: str
     project_files: dict[str, str]

--- a/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_declaration_context.py
+++ b/tests/integration/src/sqlbuild/compiler/pipeline/test_macro_declaration_context.py
@@ -19,6 +19,8 @@ from tests.integration.src.sqlbuild.compiler.pipeline._test_types import (
     MacroDeclarationContextErrorTestCase,
     MacroDeclarationRenderingTestCase,
     MacroDeclarationResourceTestCase,
+    MacroTestDiscoveryIntegrationTestCase,
+    SqlTestProductionScopeIntegrationTestCase,
 )
 from tests.integration.src.sqlbuild.compiler.pipeline.helpers import (
     run_compile_pipeline_for_project,
@@ -141,6 +143,165 @@ def test_given_grouped_declarations_when_compiling_then_scope_resolves_from_owne
 @pytest.mark.parametrize(
     "test_case",
     (
+        MacroTestDiscoveryIntegrationTestCase(
+            description="project macro test is discovered from mirrored macro path",
+            project_files={
+                "sqlbuild_project.toml": 'name = "orders"\nadapter = "duckdb"\n',
+                "macros/orders/policy.py": "def order_policy() -> str:\n    return '2'\n",
+                "models/orders/summary.sql": (
+                    'MODEL (description "Order summary.");\nSELECT @order_policy() AS quantity'
+                ),
+                "tests/unit/macros/orders/test_order_policy__returns_quantity.sql": (
+                    'TEST (mode macro, name "order_policy__returns_quantity");\n\n'
+                    "WITH\n"
+                    "__macro_actual__ AS (SELECT @order_policy() AS quantity),\n"
+                    "__macro_expected__ AS (SELECT 2 AS quantity)\n"
+                    "SELECT 1\n"
+                ),
+            },
+            expected_test_name="order_policy__returns_quantity",
+            expected_macro_name="order_policy",
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_macro_test_in_mirrored_path_when_compiling_then_test_is_attached(
+    test_case: MacroTestDiscoveryIntegrationTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, test_case.project_files)
+
+    result: CompilePipelineResult = run_compile_pipeline_for_project(
+        project_dir=tmp_path, adapter=DuckDbAdapter()
+    )
+
+    assert tuple(test.name for test in result.project.sql_tests) == (test_case.expected_test_name,)
+    tested_macro_names: list[str] = []
+    for test in result.project.sql_tests:
+        tested_macro_names.extend(resource.name for resource in test.tested_resources)
+    assert tuple(tested_macro_names) == (test_case.expected_macro_name,)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
+        SqlTestProductionScopeIntegrationTestCase(
+            description="macro test inherits tested scoped macro declaration context",
+            project_files={
+                "sqlbuild_project.toml": (
+                    'name = "orders"\nadapter = "duckdb"\n[scopes]\nenforce_placement = true\n'
+                ),
+                "models/orders/_sqlbuild/_constants/policy.sql": (
+                    "CONSTANT (name minimum_quantity, value 2);\n"
+                ),
+                "models/orders/_sqlbuild/_macros/policy.py": (
+                    "def order_policy(ctx) -> str:\n"
+                    "    return ctx.render_constant('minimum_quantity')\n"
+                ),
+                "models/orders/summary.sql": (
+                    'MODEL (description "Order summary.");\nSELECT @order_policy() AS quantity'
+                ),
+                "tests/unit/macros/models/orders/test_order_policy__returns_quantity.sql": (
+                    'TEST (mode macro, name "order_policy__returns_quantity");\n\n'
+                    "WITH\n"
+                    "__macro_actual__ AS (SELECT @order_policy() AS quantity),\n"
+                    "__macro_expected__ AS (SELECT 2 AS quantity)\n"
+                    "SELECT 1\n"
+                ),
+            },
+            expected_test_name="order_policy__returns_quantity",
+            expected_sql_fragments=("SELECT 2 AS quantity",),
+        ),
+        SqlTestProductionScopeIntegrationTestCase(
+            description="model test combines target production scope and lexical test helpers",
+            project_files={
+                "sqlbuild_project.toml": (
+                    'name = "orders"\nadapter = "duckdb"\n[scopes]\nenforce_placement = false\n'
+                ),
+                "models/orders/_sqlbuild/_macros/policy.py": (
+                    "def order_policy() -> str:\n    return '2'\n"
+                ),
+                "models/orders/order_summary.sql": (
+                    'MODEL (description "Order summary.");\n'
+                    'SELECT @order_policy() AS quantity FROM __ref("order_input")'
+                ),
+                "models/order_input.sql": (
+                    'MODEL (description "Order input.");\nSELECT 1 AS order_id'
+                ),
+                "tests/unit/orders/_sqlbuild/macros/fixtures.py": (
+                    "def fixture_quantity() -> str:\n    return '2'\n"
+                ),
+                "tests/unit/orders/test_order_summary__uses_policy.sql": (
+                    'TEST (name "order_summary__uses_policy");\n\n'
+                    "WITH\n"
+                    "__ref__order_input AS (SELECT 1 AS order_id),\n"
+                    "__expected__order_summary AS (\n"
+                    "  SELECT @order_policy() + @fixture_quantity() AS quantity\n"
+                    ")\n"
+                    "SELECT 1\n"
+                ),
+            },
+            expected_test_name="order_summary__uses_policy",
+            expected_sql_fragments=("SELECT 2 + 2 AS quantity",),
+        ),
+        SqlTestProductionScopeIntegrationTestCase(
+            description="multi-model test receives union of target production scopes",
+            project_files={
+                "sqlbuild_project.toml": (
+                    'name = "orders"\nadapter = "duckdb"\n[scopes]\nenforce_placement = false\n'
+                ),
+                "models/orders/_sqlbuild/_macros/policy.py": (
+                    "def order_policy() -> str:\n    return '2'\n"
+                ),
+                "models/orders/order_summary.sql": (
+                    'MODEL (description "Order summary.");\n'
+                    'SELECT @order_policy() AS quantity FROM __ref("order_input")'
+                ),
+                "models/order_input.sql": (
+                    'MODEL (description "Order input.");\nSELECT 1 AS order_id'
+                ),
+                "models/products/_sqlbuild/_macros/policy.py": (
+                    "def product_policy() -> str:\n    return '3'\n"
+                ),
+                "models/products/product_summary.sql": (
+                    'MODEL (description "Product summary.");\n'
+                    'SELECT @product_policy() AS quantity FROM __ref("order_input")'
+                ),
+                "tests/unit/test_summaries__use_policies.sql": (
+                    'TEST (name "summaries__use_policies");\n\n'
+                    "WITH\n"
+                    "__ref__order_input AS (SELECT 1 AS order_id),\n"
+                    "__expected__order_summary AS (SELECT @order_policy() AS quantity),\n"
+                    "__expected__product_summary AS (SELECT @product_policy() AS quantity)\n"
+                    "SELECT 1\n"
+                ),
+            },
+            expected_test_name="summaries__use_policies",
+            expected_sql_fragments=("SELECT 2 AS quantity", "SELECT 3 AS quantity"),
+        ),
+    ),
+    ids=lambda case: case.description,
+)
+def test_given_inferred_targets_when_compiling_test_then_production_scopes_are_combined(
+    test_case: SqlTestProductionScopeIntegrationTestCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(tmp_path, test_case.project_files)
+
+    result: CompilePipelineResult = run_compile_pipeline_for_project(
+        project_dir=tmp_path, adapter=DuckDbAdapter()
+    )
+
+    assert tuple(test.name for test in result.project.sql_tests) == (test_case.expected_test_name,)
+    for expected_fragment in test_case.expected_sql_fragments:
+        assert expected_fragment in result.project.sql_tests[0].sql_body
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (
         MacroDeclarationResourceTestCase(
             description="models tests and audits receive caller-visible constants",
             expected_model_sql_fragment="SELECT 2 AS minimum_quantity",
@@ -224,6 +385,34 @@ def test_given_macro_context_declarations_when_compiling_resources_then_all_expa
                 ),
             },
             expected_error_fragment="Macro '@minimum_quantity'.*is inaccessible",
+        ),
+        MacroDeclarationContextErrorTestCase(
+            description="mocked dependency does not grant its production macro scope",
+            project_files={
+                "sqlbuild_project.toml": (
+                    'name = "demo"\nadapter = "duckdb"\n[scopes]\nenforce_placement = false\n'
+                ),
+                "models/products/_sqlbuild/_macros/policy.py": (
+                    "def product_policy() -> str:\n    return '3'\n"
+                ),
+                "models/products/product_input.sql": (
+                    'MODEL (description "Product input.");\nSELECT 1 AS product_id'
+                ),
+                "models/orders/order_summary.sql": (
+                    'MODEL (description "Order summary.");\n'
+                    'SELECT product_id FROM __ref("product_input")'
+                ),
+                "tests/unit/orders/test_order_summary__uses_input.sql": (
+                    'TEST (name "order_summary__uses_input");\n\n'
+                    "WITH\n"
+                    "__ref__product_input AS (SELECT 1 AS product_id),\n"
+                    "__expected__order_summary AS (\n"
+                    "  SELECT @product_policy() AS product_id\n"
+                    ")\n"
+                    "SELECT 1\n"
+                ),
+            },
+            expected_error_fragment="Macro '@product_policy'.*is inaccessible",
         ),
         MacroDeclarationContextErrorTestCase(
             description="unknown constant reports visible alternatives",

--- a/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_filesystem_scoped_declarations.py
+++ b/tests/unit/src/sqlbuild/compiler/discovery/_helpers/test_filesystem_scoped_declarations.py
@@ -203,6 +203,11 @@ def test_given_top_level_public_declarations_when_discovering_then_scope_remains
             "must be below a canonical authored root",
         ),
         InvalidScopedDeclarationRootTestCase(
+            "authored_root_grouped_root",
+            "models/_sqlbuild/macros/value.py",
+            "must be below a concrete owner directory",
+        ),
+        InvalidScopedDeclarationRootTestCase(
             "grouped_root_with_unsupported_entry",
             "models/orders/_sqlbuild/notes.py",
             "contains unsupported entries",
@@ -355,10 +360,24 @@ def test_given_invalid_scoped_root_when_discovering_project_inputs_then_strict_d
             "python_hook",
             (),
         ),
+        OrdinaryDiscoveryExclusionTestCase(
+            "project_macro_sql_test",
+            "tests/unit/macros/orders/test_order_policy__returns_quantity.sql",
+            'TEST (mode macro, name "order_policy__returns_quantity");\nSELECT 1\n',
+            "test",
+            ("tests/unit/macros/orders/test_order_policy__returns_quantity.sql",),
+        ),
+        OrdinaryDiscoveryExclusionTestCase(
+            "sql_file_in_test_helper_role",
+            "tests/unit/orders/_sqlbuild/macros/not_a_test.sql",
+            'TEST (mode macro, name "order_policy__returns_quantity");\nSELECT 1\n',
+            "test",
+            (),
+        ),
     ),
     ids=lambda case: case.description,
 )
-def test_given_scoped_declaration_file_when_discovering_resources_then_excludes_it(
+def test_given_file_in_declaration_role_when_discovering_resources_then_returns_expected_files(
     test_case: OrdinaryDiscoveryExclusionTestCase,
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/src/sqlbuild/compiler/scopes/test_offline_cache.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/test_offline_cache.py
@@ -12,8 +12,13 @@ import pytest
 from sqlbuild.compiler.scopes._helpers.cache import scope_index_fingerprint
 from sqlbuild.compiler.scopes.constants import SCOPE_CACHE_DIRECTORY, SCOPE_CACHE_FILENAME
 from sqlbuild.compiler.scopes.main.load_or_build_scope_index import load_or_build_scope_index
-from sqlbuild.compiler.scopes.models import ScopeIndex
-from sqlbuild.compiler.scopes.types import DiagnosticSeverity, ResourceKind, ScopeDiagnosticCode
+from sqlbuild.compiler.scopes.models import DeclarationIdentity, ScopeIndex
+from sqlbuild.compiler.scopes.types import (
+    DiagnosticSeverity,
+    GrantKind,
+    ResourceKind,
+    ScopeDiagnosticCode,
+)
 from tests.unit.src.sqlbuild.compiler.scopes._test_types import (
     CacheFaultCase,
     FingerprintMutationCase,
@@ -56,6 +61,46 @@ def test_given_valid_project_when_loading_twice_then_warm_cache_reconstructs_exa
 
     assert (cold == warm and cold.completeness.complete) is test_case.expected_result
     assert cache_path.read_bytes() == first_bytes
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (OfflineScopeCase("tested macro grant round trips through persistent cache"),),
+    ids=lambda case: case.description,
+)
+def test_given_scoped_macro_test_when_loading_warm_cache_then_grant_provenance_is_preserved(
+    test_case: OfflineScopeCase,
+    tmp_path: Path,
+    write_repo_files: Callable[[Path, dict[str, str]], None],
+) -> None:
+    write_repo_files(
+        tmp_path,
+        {
+            "sqlbuild_project.toml": (
+                'name = "orders"\nadapter = "duckdb"\n[scopes]\nenforce_placement = false\n'
+            ),
+            "models/orders/_sqlbuild/_macros/policy.py": (
+                "def order_policy() -> str:\n    return '2'\n"
+            ),
+            "models/orders/summary.sql": (
+                'MODEL (description "Order summary.");\nSELECT @order_policy() AS quantity'
+            ),
+            "tests/unit/macros/models/orders/test_order_policy__returns_quantity.sql": (
+                'TEST (mode macro, name "order_policy__returns_quantity");\n\n'
+                "WITH\n"
+                "__macro_actual__ AS (SELECT @order_policy() AS quantity),\n"
+                "__macro_expected__ AS (SELECT 2 AS quantity)\n"
+                "SELECT 1\n"
+            ),
+        },
+    )
+
+    cold: ScopeIndex = load_or_build_scope_index(project_dir=tmp_path)
+    warm: ScopeIndex = load_or_build_scope_index(project_dir=tmp_path)
+
+    assert (cold == warm) is test_case.expected_result
+    assert cold.grants[0].kind is GrantKind.TESTED_MACRO
+    assert isinstance(cold.grants[0].through, DeclarationIdentity)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/src/sqlbuild/compiler/scopes/test_placement.py
+++ b/tests/unit/src/sqlbuild/compiler/scopes/test_placement.py
@@ -30,6 +30,7 @@ from sqlbuild.compiler.scopes.types import (
 from tests.unit.src.sqlbuild.compiler.scopes._test_types import (
     DeclarationChainPlacementCase,
     DiamondLadderPlacementCase,
+    ExpectedBooleanCase,
     PlacementEnforcementCase,
     PlacementValidationCase,
 )
@@ -53,6 +54,51 @@ def test_given_placement_policy_when_validating_then_diagnostic_severity_matches
 
     assert result.diagnostics[0].code is ScopeDiagnosticCode.UNUSED_DECLARATION
     assert result.diagnostics[0].severity is test_case.expected_severity
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    (ExpectedBooleanCase("test usage through scoped macro preserves production anchor", True),),
+    ids=lambda case: case.description,
+)
+def test_given_test_usage_through_macro_when_validating_placement_then_test_path_is_not_anchor(
+    test_case: ExpectedBooleanCase,
+) -> None:
+    macro_identity: DeclarationIdentity = DeclarationIdentity(DeclarationKind.MACRO, "order_policy")
+    model_identity: ResourceIdentity = ResourceIdentity(ResourceKind.MODEL, "orders")
+    test_identity: ResourceIdentity = ResourceIdentity(
+        ResourceKind.TEST, "order_policy__returns_quantity"
+    )
+    ownership_root: OwnershipRoot = OwnershipRoot("models", resource_kind=ResourceKind.MODEL)
+    declaration: DeclarationRecord = DeclarationRecord(
+        identity=macro_identity,
+        path="models/orders/_sqlbuild/_macros/policy.py",
+        line=1,
+        column=1,
+        scope=ScopeKind.LOCAL,
+        ownership_root=ownership_root,
+        owning_path="models/orders",
+    )
+    index: ScopeIndex = ScopeIndex(
+        resources=(
+            ResourceRecord(model_identity, "models/orders/orders.sql", ownership_root),
+            ResourceRecord(
+                test_identity,
+                "tests/unit/macros/models/orders/test_order_policy__returns_quantity.sql",
+                OwnershipRoot("tests/unit", resource_kind=ResourceKind.TEST),
+            ),
+        ),
+        declarations=(declaration,),
+        usages=(
+            UsageRecord(model_identity, macro_identity),
+            UsageRecord(test_identity, macro_identity, through=macro_identity),
+        ),
+        completeness=ScopeCompleteness(runtime_usage=True, placement=False),
+    )
+
+    result: ScopeIndex = get_placement_validated_scope_index(index=index)
+
+    assert (not result.diagnostics) is test_case.expected_result
 
 
 @pytest.mark.parametrize(
@@ -127,6 +173,38 @@ def test_given_non_placement_error_when_placement_enforcement_disabled_then_vali
             ("models/domain/orders.sql",),
             (ScopeDiagnosticCode.OVER_BROAD_GLOBAL,),
             expected_message_fragment="models/domain/_sqlbuild/_constants/",
+        ),
+        PlacementValidationCase(
+            "global across authored root children is accepted",
+            ScopeKind.GLOBAL,
+            None,
+            "constants/limit.sql",
+            "constants",
+            None,
+            ("models/orders/orders.sql", "models/products/products.sql"),
+            (),
+        ),
+        PlacementValidationCase(
+            "global used by authored root model recommends compatible legacy role",
+            ScopeKind.GLOBAL,
+            None,
+            "constants/limit.sql",
+            "constants",
+            None,
+            ("models/orders.sql",),
+            (ScopeDiagnosticCode.OVER_BROAD_GLOBAL,),
+            expected_message_fragment="models/_constants/",
+        ),
+        PlacementValidationCase(
+            "authored root inherited scope must be project global",
+            ScopeKind.INHERITED,
+            "models",
+            "models/constants/limit.sql",
+            "models",
+            ResourceKind.MODEL,
+            ("models/orders/orders.sql", "models/products/products.sql"),
+            (ScopeDiagnosticCode.REQUIRES_GLOBAL_PLACEMENT,),
+            expected_message_fragment="top-level constants/",
         ),
         PlacementValidationCase(
             "exact local is accepted",


### PR DESCRIPTION
## Why

SQL macro tests under the documented mirror directory were excluded as declaration files, and tests could not exercise scoped production macros without promoting them globally. Grouped declarations at an authored-root boundary also created a confusing resource-tree-only pseudo-global scope.

## Changes

- Discover SQL macro tests under the leading `tests/unit/macros/` mirror tree.
- Give model tests the union of file-based declarations visible to inferred expected-model targets.
- Give macro tests the tested macro and declarations visible from its production owner.
- Keep mocked resources from broadening test scope and preserve lexical test helpers.
- Preserve relationship provenance through cache, reports, placement, and native rules.
- Mirror scoped macro tests by concrete owner rather than `_sqlbuild` storage paths.
- Reject authored-root `_sqlbuild/` and require project-global declarations at a multi-consumer authored-root boundary.
- Preserve compatible legacy single-owner declaration placement.

## Verification

- 114 focused Python tests
- 2 focused native rule tests
- Cache-free real-project compile: 974 models, 0 errors
- Focused real-project `SQBRTEST103` check
- `uv sync --all-extras`
- `make check-ci`
- Public tree and outgoing-history hygiene scans
- Independent bounded review and finding-focused follow-up
