### PR TITLE
fix: isolate nested SQL rule contexts

### DIFF
--- a/crates/sqlbuild-rules-native/src/sql_lint/_helpers/additional.rs
+++ b/crates/sqlbuild-rules-native/src/sql_lint/_helpers/additional.rs
@@ -652,7 +652,13 @@ fn is_scalar_subquery(tokens: &[Token], depths: &[usize], select_index: usize) -
         return true;
     }
     let parent_depth = depths[previous];
-    let relation_boundary = (0..previous).rev().find(|&index| {
+    let query_start = (0..previous)
+        .rev()
+        .find(|&index| {
+            tokens[index].token_type == TokenType::Select && depths[index] < parent_depth
+        })
+        .map_or(0, |index| index + 1);
+    let relation_boundary = (query_start..previous).rev().find(|&index| {
         depths[index] == parent_depth
             && (tokens[index].token_type == TokenType::Select
                 || is_query_from(tokens, index)

--- a/crates/sqlbuild-rules-native/src/sql_lint/_helpers/engine.rs
+++ b/crates/sqlbuild-rules-native/src/sql_lint/_helpers/engine.rs
@@ -416,8 +416,7 @@ fn collect_token_query_facts(tokens: &[Token], sql: &str) -> QueryFacts {
         let end = query_end(tokens, &depths, select_index, depth);
         let direct = direct_indices(&depths, select_index + 1, end, depth);
         let order = first_type(tokens, &direct, TokenType::Order);
-        let limit = first_type(tokens, &direct, TokenType::Limit)
-            .or_else(|| first_type(tokens, &direct, TokenType::Offset));
+        let limit = first_row_selection_clause(tokens, &direct);
         if order.is_none()
             && let Some(index) = limit
         {
@@ -662,6 +661,25 @@ fn first_type(tokens: &[Token], indices: &[usize], token_type: TokenType) -> Opt
         .iter()
         .copied()
         .find(|&index| tokens[index].token_type == token_type)
+}
+
+fn first_row_selection_clause(tokens: &[Token], direct: &[usize]) -> Option<usize> {
+    let from = direct
+        .iter()
+        .copied()
+        .find(|&index| is_query_from(tokens, index));
+    direct.iter().copied().find(|&index| {
+        matches!(
+            tokens[index].token_type,
+            TokenType::Limit | TokenType::Offset
+        ) && from.is_none_or(|from_index| index > from_index)
+            && significant_before(tokens, index).is_none_or(|previous| {
+                !matches!(
+                    tokens[previous].token_type,
+                    TokenType::Colon | TokenType::DColon | TokenType::Dot | TokenType::DotColon
+                )
+            })
+    })
 }
 
 pub(super) fn is_query_from(tokens: &[Token], index: usize) -> bool {

--- a/crates/sqlbuild-rules-native/src/sql_lint/tests/test_sql_lint.rs
+++ b/crates/sqlbuild-rules-native/src/sql_lint/tests/test_sql_lint.rs
@@ -84,6 +84,24 @@ fn given_sql_cases_when_linting_then_diagnostics_match() -> Result<(), String> {
             expected_anchors: &[("SQBRSQL004", "LIMIT")],
         },
         test_types::LintTestCase {
+            description: "semi-structured limit and offset keys are not row selection clauses",
+            sql: "SELECT payload:Limit::VARCHAR AS order_limit, payload:Offset::NUMBER AS order_offset FROM orders",
+            expected_codes: &[],
+            expected_anchors: &[],
+        },
+        test_types::LintTestCase {
+            description: "semi-structured limit key does not hide a later row limit clause",
+            sql: "SELECT payload:Limit::VARCHAR AS order_limit FROM orders LIMIT 1",
+            expected_codes: &["SQBRSQL004"],
+            expected_anchors: &[("SQBRSQL004", "LIMIT")],
+        },
+        test_types::LintTestCase {
+            description: "semi-structured limit key in a filter is not a row limit clause",
+            sql: "SELECT order_id FROM orders WHERE payload:Limit::NUMBER > 3",
+            expected_codes: &[],
+            expected_anchors: &[],
+        },
+        test_types::LintTestCase {
             description: "unused CTE",
             sql: "WITH unused AS (SELECT 1) SELECT 1",
             expected_codes: &["SQBRSQL005"],
@@ -866,6 +884,27 @@ fn given_additional_rule_cases_when_linting_then_findings_and_fixes_match() -> R
         test_types::AdditionalLintRuleTestCase {
             description: "scalar subquery output does not require an alias inside its scope",
             sql: "SELECT (SELECT MAX(child.value) FROM child WHERE child.id = parent.id) AS maximum_value FROM parent",
+            rule: "SQBRSQL022",
+            expected_anchor: None,
+            expected_replacement: None,
+        },
+        test_types::AdditionalLintRuleTestCase {
+            description: "later scalar function argument does not require an inner alias",
+            sql: "SELECT COALESCE((SELECT MAX(change_id) FROM first_changes), (SELECT MAX(change_id) FROM second_changes), 0) AS latest_change_id FROM support_tickets",
+            rule: "SQBRSQL022",
+            expected_anchor: None,
+            expected_replacement: None,
+        },
+        test_types::AdditionalLintRuleTestCase {
+            description: "scalar aggregate nested in conditional coalesce does not require an inner alias",
+            sql: "SELECT CASE WHEN batch.layout = 'fallback' THEN COALESCE((SELECT MAX(change.line_id) FROM first_changes AS change WHERE change.batch_id = batch.batch_id AND change.line_id < batch.line_id), (SELECT MAX(archive.line_id) FROM archived_changes AS archive WHERE archive.batch_id = batch.batch_id AND archive.line_id < batch.line_id), header.line_id) + 1 ELSE batch.start_line END AS start_line FROM support_batches AS batch LEFT JOIN support_headers AS header ON header.batch_id = batch.batch_id",
+            rule: "SQBRSQL022",
+            expected_anchor: None,
+            expected_replacement: None,
+        },
+        test_types::AdditionalLintRuleTestCase {
+            description: "prior nested relation does not contaminate a later scalar function argument",
+            sql: "WITH prior_changes AS (SELECT (SELECT MAX(change_id) FROM support_changes) AS latest_change_id FROM support_tickets), current_changes AS (SELECT COALESCE((SELECT MAX(change_id) FROM first_changes), (SELECT MAX(change_id) FROM second_changes), 0) AS latest_change_id FROM current_tickets) SELECT * FROM current_changes",
             rule: "SQBRSQL022",
             expected_anchor: None,
             expected_replacement: None,


### PR DESCRIPTION
## Why

Token context could mistake semi-structured fields named `Limit` or `Offset` for row-selection clauses. A scalar subquery used as a later function argument could also inherit stale relation context from an earlier nested query.

## Changes

- Restrict row-selection diagnostics to clause positions and exclude semi-structured path separators.
- Bound scalar-subquery relationship scans to the containing query.
- Preserve diagnostics for real trailing limits and comma-derived tables.
- Add neutral Snowflake regressions for projection/filter paths, nested CTEs, scalar arguments, and derived relations.

## Verification

- Focused native SQL lint tests
- `uv sync --all-extras`
- `make check-ci`
- Public tree and outgoing-history hygiene scans
- Independent bounded review and finding-focused follow-up
